### PR TITLE
Ensuring that "project status url" is set regardless of project nesting.

### DIFF
--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -562,12 +562,12 @@ function drush_get_projects(&$extensions = NULL) {
         'status' => $extension->status,
         'extensions' => array(),
       );
-      if (isset($extension->info['project status url'])) {
-        $projects[$project]['status url'] = $extension->info['project status url'];
-      }
     }
     elseif ($extension->status != 0) {
       $projects[$project]['status'] = $extension->status;
+    }
+    if (isset($extension->info['project status url'])) {
+      $projects[$project]['status url'] = $extension->info['project status url'];
     }
     $projects[$project]['extensions'][] = $extension->name;
   }


### PR DESCRIPTION
In particular, this fixes cases wherein sub-extensions' names happen to come prior to the primary extension's name alphabetically (e.g. the "bulk_export" submodule of ctools).

See #18 