### PR TITLE
Created uuid command to generate new UUIDs.

### DIFF
--- a/commands/core/uuid.drush.inc
+++ b/commands/core/uuid.drush.inc
@@ -1,0 +1,39 @@
+<?php
+
+use Drupal\Component\Uuid\Uuid;
+
+/**
+ * Implementation of hook_drush_help().
+ */
+function uuid_drush_help($section) {
+  switch ($section) {
+    case 'meta:uuid:title':
+      return dt('UUID commands');
+    case 'meta:UUID:summary':
+      return dt('Generates Universally Unique IDentifiers.');
+  }
+}
+
+/**
+ * Implementation of hook_drush_command().
+ */
+function uuid_drush_command() {
+  $items['generate-uuid'] = array(
+    'description' => 'Generate a UUID.',
+    'examples' => array(
+      "drush generate-uuid" => "Outputs a Universally Unique IDentifier.",
+    ),
+    'aliases' => array('uuid'),
+  );
+
+  return $items;
+}
+
+/**
+ * Generates and prints a new UUID.
+ */
+function drush_uuid_generate_uuid() {
+  $uuid = new Uuid();
+  drush_print($uuid->generate());
+  return TRUE;
+}


### PR DESCRIPTION
In Drupal 8 we will be dealing with UUIDs, see for example [Add UUIDs to default configuration](https://drupal.org/node/1969800). Here is a simple drush command that will output a fresh UUID on the command line.

```
$ drush uuid
81779421-39c3-422e-8500-d1e7854ce8df
```
