### PR TITLE
If a Drush command returns a string value, then print it

### DIFF
--- a/includes/command.inc
+++ b/includes/command.inc
@@ -458,16 +458,19 @@ function drush_handle_command_output($command, $structured_output) {
   // Only handle output here if the command defined an output format
   // engine.  If no engine was declared, then we presume that the command
   // handled its own output.
-  if ((!empty($structured_output) || ($structured_output === 0)) && !empty($command['engines']['outputformat'])) {
+  if ((!empty($structured_output) || ($structured_output === 0))) {
     // If the command specifies a default pipe format and
     // returned a result, then output the formatted output when
     // in --pipe mode.
     $formatter = drush_get_outputformat();
+    if (!$formatter && is_string($structured_output)) {
+      $formatter = drush_load_engine('outputformat', 'string');
+    }
     if ($formatter) {
       if ($formatter === TRUE) {
         return drush_set_error(dt('No outputformat class defined for !format', array('!format' => $format)));
       }
-      if (!in_array($formatter->selected_engine, $command['engines']['outputformat']['usable'])) {
+      if ((!empty($command['engines']['outputformat'])) && (!in_array($formatter->selected_engine, $command['engines']['outputformat']['usable']))) {
         return $formatter->format_error(dt("The command '!command' does not produce output in a structure usable by this output format.", array('!command' => $command['command'])));
       }
       // Add any user-specified options to the metadata passed to the formatter.


### PR DESCRIPTION
... even if the command does not define an outputformat record in its command definition.

Previously, a command needed to define an outputformat record in order to get the string to print. e.g.:

```
'outputformat' => array(
  'default' => 'string',
),
```

With this patch, this definition may be omitted; however, omitting the outputformat record is not quite the same as including a simple 'string' definition, as shown above.  If the outputformat record is included, then the help text for the command will include the option for --format, and it will be possible to format using universal formatters such as var-export and json.  Without the outputformat record, the --format option will not appear in the help text, and --format cannot be used with the command.

For simple commands that output only strings, it is probably most appropriate to omit the outputformat record, to keep the command help definition simple.
