### PR TITLE
Add a 'site-get' shell alias to show the site being used

### DIFF
--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -68,6 +68,12 @@ function sitealias_drush_command() {
     'handle-remote-commands' => TRUE,
     'aliases' => array('unuse'),
   );
+  $items['site-show'] = array(
+    'description' => 'Show the site currently in use.  Prints nothing if "use" is not in effect.',
+    'callback' => 'drush_sitealias_site_get',
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+    'aliases' => array('using'),
+  );
   return $items;
 }
 


### PR DESCRIPTION
This is a simple command definition wrapped around the existing 'drush_sitealias_site_get()' function.  Thanks to the way the 'callback' and output formats work now, this is all that is needed.
