### PR TITLE
Fix __drush_ps1 so that prompt is cleared after unuse.

### DIFF
--- a/drush.complete.sh
+++ b/drush.complete.sh
@@ -12,10 +12,12 @@ __drush_ps1() {
   f="${TMPDIR:-/tmp/}/drush-env/drush-drupal-site-$$"
   if [ -f $f ]
   then
-    DRUPAL_SITE=$(cat "$f")
+    __DRUPAL_SITE=$(cat "$f")
+  else
+    __DRUPAL_SITE="$DRUPAL_SITE"
   fi
 
-  [[ -n "$DRUPAL_SITE" ]] && printf "${1:- (%s)}" "$DRUPAL_SITE"
+  [[ -n "$__DRUPAL_SITE" ]] && printf "${1:- (%s)}" "$__DRUPAL_SITE"
 }
 
 # Completion function, uses the "drush complete" command to retrieve


### PR DESCRIPTION
The problem with the current code is that the DRUSH_SITE environment variable persists, even after the file is removed.  This version insures that the prompt disappears when the file does.
