### PR TITLE
Added option 'test-filename-path' and make filename path customizable in junit xml files.

### DIFF
--- a/commands/core/test.drush.inc
+++ b/commands/core/test.drush.inc
@@ -280,9 +280,14 @@ function drush_test_xml_results($test_id, $dir, $info) {
     }
     // Prepare message.
     $status = str_pad($result->status . ':', 10);
+    $root = drush_get_option('root');
+    if (substr($root, -1) !== '/') {
+      $root .= '/';
+    }
+    $filename = str_replace($root, '', $result->file);
     $message = strip_tags($result->message, '<a>');  // Jenkins encodes the output so don't use any tags.
     $message = preg_replace('/<a.*?href="([^"]+)".*?>(.*?)<\/a>/', '$1 $2', $message); // Jenkins will turn urls into clickable links.
-    $message = $status . ' [' . $result->message_group . '] ' . $message . ' [' . basename($result->file) . ':' . $result->line . "]\n";
+    $message = $status . ' [' . $result->message_group . '] ' . $message . ' [' . $filename . ':' . $result->line . "]\n";
     // Everything is logged in system_out.
     $test_case->system_out .= $message;
     // Failures go to failures.


### PR DESCRIPTION
There is an option 'test-filename-path', which can have the values 'absolute', 'relative' and 'basename' and defaults to
'basename'. Thus the current behavior is conserved, while relative or absoltue filenames can be set via drushrc.php.
