### PR TITLE
drush_valid_drupal_root() is not rigorous enough

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -391,16 +391,27 @@ function drush_valid_drupal_root($path) {
     // grant it is not a Drupal 7 site with a base folder named "core".
     $candidate = 'core/includes/common.inc';
     if (file_exists($path . '/' . $candidate) && file_exists($path . '/composer.json')) {
-      return $candidate;
+      return _drush_valid_drupal_root_extra_checks($path, $candidate);
     }
     // Drupal 7 root. Additional check for the absence of core/composer.json to
     // grant $path is not core/ of a Drupal 8 root.
     $candidate = 'includes/common.inc';
     if (file_exists($path . '/' . $candidate) && ((basename($path) != 'core') || !file_exists($path . '/../composer.json'))) {
-      return $candidate;
+      return _drush_valid_drupal_root_extra_checks($path, $candidate);
     }
   }
   return FALSE;
+}
+
+// Extra checks to insure that the candidate is in fact part of a Drupal root,
+// and not some other non-Drupal directory
+function _drush_valid_drupal_root_extra_checks($path, $candidate) {
+  // We also require that there must be a file misc/drupal.js in a sibling
+  // folder of the candidate file.
+  if (!file_exists(dirname(dirname($path . '/' . $candidate)) . '/misc/drupal.js')) {
+    return FALSE;
+  }
+  return $candidate;
 }
 
 /**


### PR DESCRIPTION
drush_valid_drupal_root() requires only a file called includes/common.inc to match a Drupal directory, which causes problems when this file pattern appears elsewhere, in non-Drupal root contexts (e.g. in module_builder module).

To fix this problem, this patch enhances the tests done by drush_valid_drupal_root() to also require a file misc/drupal.js.  I picked this file because it occurs in D6, D7 and D8, and it has the name "Drupal" in it.
