### PR TITLE
User-specific temp directories

### DIFF
--- a/drush.complete.sh
+++ b/drush.complete.sh
@@ -9,7 +9,7 @@
 which drush > /dev/null || alias drush &> /dev/null || return
 
 __drush_ps1() {
-  f="${TMPDIR:-/tmp/}/drush-env/drush-drupal-site-$$"
+  f="${TMPDIR:-/tmp/}/drush-env-${USER}/drush-drupal-site-$$"
   if [ -f $f ]
   then
     DRUPAL_SITE=$(cat "$f")

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -2075,7 +2075,9 @@ function drush_sitealias_get_envar_filename($filename_prefix = 'drush-drupal-sit
   }
 
   $tmp = getenv('TMPDIR') ? getenv('TMPDIR') : '/tmp/';
-  return "{$tmp}/drush-env/{$filename_prefix}" . posix_getppid();
+  $username = drush_get_username();
+
+  return "{$tmp}/drush-env-{$username}/{$filename_prefix}" . posix_getppid();
 }
 
 /**

--- a/tests/siteSetUnitTest.php
+++ b/tests/siteSetUnitTest.php
@@ -13,8 +13,9 @@ class siteSetUnitTest extends Drush_UnitTestCase {
     $tmp_path = UNISH_TMP;
     putenv("TMPDIR=$tmp_path");
     $posix_pid = posix_getppid();
+    $username = drush_get_username();
 
-    $expected_file = UNISH_TMP . '/drush-env/drush-drupal-site-' . $posix_pid;
+    $expected_file = UNISH_TMP . '/drush-env-' . $username . '/drush-drupal-site-' . $posix_pid;
     $filename = drush_sitealias_get_envar_filename();
 
     $this->assertEquals($expected_file, $filename);


### PR DESCRIPTION
The "drush use @site-alias" feature does not work on a system with more than one user account using the feature.

From a real life experience today:

```bash
$ whoami
arne
$ ls -ld /tmp/drush-env
drwxr-xr-x 2 root root 4096 2013-09-04 18:25 /tmp/drush-env
```
Since another user has already created the `drush-env` folder I'm not able to set my environment.

This pull request incorporates the user ID in the folder name.
