### PR TITLE
use drush_op() instead of call_user_func()

### DIFF
--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -103,7 +103,7 @@ function drush_cache_command_clear($type = NULL) {
     }
     $type = drush_choice($types, 'Enter a number to choose which cache to clear.', '!key');
     if ($type !== FALSE) {
-      call_user_func($types[$type]);
+      drush_op($types[$type]);
     }
   }
   if ($type !== FALSE) {


### PR DESCRIPTION
Not sure why we're using drush_op() in one place in drush_cache_command_clear(), and call_user_func() further down for a similar call.
