### PR TITLE
drush ul does not work on subdirectory (d8)

### DIFF
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -761,8 +761,11 @@ function _drush_bootstrap_drupal_site_validate() {
 
     if ($drupal_base_url['port']) {
       $_SERVER['HTTP_HOST'] .= ':' . $drupal_base_url['port'];
+      $_SERVER['SERVER_PORT'] = $drupal_base_url['port'];
     }
-    $_SERVER['SERVER_PORT'] = $drupal_base_url['port'];
+    else {
+      $_SERVER['SERVER_PORT'] = 80;
+    }
 
     if (array_key_exists('path', $drupal_base_url)) {
       $_SERVER['PHP_SELF'] = $drupal_base_url['path'] . '/index.php';


### PR DESCRIPTION
If you use drush uli with Drupal 8 on a subdirectory drush uli generates
the following url:

```
http://www:/user/reset/1/1378548300/PPxZXqpSCWbeDxAY6kiSpYwJvbnOrkRaMwJR4Xi6RZ4/login
```

The drushrc.php looks like the following: 

```
<?php
$options['l'] = 'http://www/d8';
$options['url'] = 'http://www/d8';
```

This change currently changes the url to use:

```
http://www/user/reset/1/1378548300/PPxZXqpSCWbeDxAY6kiSpYwJvbnOrkRaMwJR4Xi6RZ4/login
```

NOTE: This does not work yet.
