### PR TITLE
Split table list returned by _drush_sql_get_db_table_list() correctly when on windows (installer)

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -810,7 +810,7 @@ function _drush_sql_get_db_table_list($db_spec, $site_record = NULL) {
     'override-simulated' => TRUE,
   );
   $result = drush_invoke_process($target_site, 'sql-query', array($query), $options, $backend_options);
-  $tables_raw = explode("\n", rtrim($result['output']));
+  $tables_raw = preg_split('/\r\n|\r|\n/', rtrim($result['output']));
 
   $tables = array();
   if (!empty($tables_raw)) {


### PR DESCRIPTION
Exploding the newline-seperated string of table names only on newline characters (\n) leaves all corresponding carriage return (\r) chars behind, thus confusing all checks performed directly on the array, such as those done by in_array. As e.g "sessions" != "sessions\r", $skip_tables oder $structure_tables will only contain the respective setting's last element. This patch replaces explode by preg_split and uses an os-independent regex.
