### PR TITLE
Separation of re-usable code in test.drush.inc into extra function.

### DIFF
--- a/commands/core/test.drush.inc
+++ b/commands/core/test.drush.inc
@@ -183,8 +183,9 @@ function simpletest_drush_run_test($class) {
           || (isset($test->results['#exception']) && $test->results['#exception'] > 0) ? 'error' : 'ok');
   drush_log($info['name'] . ' ' . _simpletest_format_summary_line($test->results), $status);
 
+  $test_suites = drush_test_get_results($test_id, $info);
   if ($dir = drush_get_option('xml')) {
-    drush_test_xml_results($test_id, $dir, $info);
+    drush_test_xml_results($test_id, $test_suites, $dir);
   }
 }
 
@@ -226,12 +227,10 @@ function drush_test_get_all_tests() {
   return array($groups, $all_tests);
 }
 
-/**
- * Write test results in jUnit XML format.
+/*
+ * Compile the test results data structure
  */
-function drush_test_xml_results($test_id, $dir, $info) {
-  $dir = is_string($dir) ? $dir : '.';
-
+function drush_test_get_results($test_id, $info) {
   // Get an array of test result objects from the database.
   if (drush_drupal_major_version() >= 7) {
     $results = db_query("SELECT * FROM {simpletest} WHERE test_id = :test_id ORDER BY test_class, message_id", array(':test_id' => $test_id));
@@ -284,10 +283,10 @@ function drush_test_xml_results($test_id, $dir, $info) {
     if (substr($root, -1) !== '/') {
       $root .= '/';
     }
-    $filename = str_replace($root, '', $result->file);
+    $result->file = str_replace($root, '', $result->file);
     $message = strip_tags($result->message, '<a>');  // Jenkins encodes the output so don't use any tags.
     $message = preg_replace('/<a.*?href="([^"]+)".*?>(.*?)<\/a>/', '$1 $2', $message); // Jenkins will turn urls into clickable links.
-    $message = $status . ' [' . $result->message_group . '] ' . $message . ' [' . $filename . ':' . $result->line . "]\n";
+    $message = $status . ' [' . $result->message_group . '] ' . $message . ' [' . $result->file . ':' . $result->line . "]\n";
     // Everything is logged in system_out.
     $test_case->system_out .= $message;
     // Failures go to failures.
@@ -300,7 +299,14 @@ function drush_test_xml_results($test_id, $dir, $info) {
       $test_case->system_err .= $message;
     }
   }
+  return $test_suites;
+}
 
+/**
+ * Write test results in jUnit XML format.
+ */
+function drush_test_xml_results($test_id, $test_suites, $dir) {
+  $dir = is_string($dir) ? $dir : '.';
   // Build an XML document from our results.
   $xml = new DOMDocument('1.0', 'UTF-8');
   foreach ($test_suites as $test_suite) {


### PR DESCRIPTION
I moved the compilation of test results from `drush_test_xml_results()` into a separate function `drush_test_get_results()`.

Thus the data structure `$test_suite`, which contains all information about the test results, can be used for other reports as well.
