### PR TITLE
Allow downloading directly to a profile directory

### DIFF
--- a/commands/pm/download.pm.inc
+++ b/commands/pm/download.pm.inc
@@ -339,8 +339,7 @@ function _pm_download_destination($type) {
     }
     // Attempt 2: If the user is inside a profile download to that.
     if (empty($destination) && $drupal_root && strpos(drush_cwd(), "/profiles/")) {
-      $profiledir = ltrim(drush_cwd(), $full_site_root);
-      $profiledir = explode("/", $profiledir);
+      $profiledir = explode("/", ltrim(drush_cwd(), $full_site_root));
       $profiledir = $profiledir[0] . "/" . $profiledir[1];
       $destination = _pm_download_destination_lookup($type, $drupal_root, $profiledir);
     }


### PR DESCRIPTION
If you use profiles for your site builds drush has no way to download to the profile directory without adding a custom destination path on every drush call, this patch allows you to download directly to the profile when you are inside it's directory.

If you are in the /profiles directory downloads fall back to default behaviour.
