### PR TITLE
Multiple release-history sources

### DIFF
--- a/commands/pm/download.pm.inc
+++ b/commands/pm/download.pm.inc
@@ -84,6 +84,21 @@ function drush_pm_download() {
 
   // Get release history for each request and download the project.
   $source = drush_get_option('source', RELEASE_INFO_DEFAULT_URL);
+  // this assumes that drush_get_option will ALWAYS return a string
+  $source = array(explode(',', $source));
+  
+  // support for prepending sources
+  $plus_source = drush_get_option('source+', RELEASE_INFO_DEFAULT_URL);
+  if (isset($plus_source)){
+    $source = array_merge(explode(',', $plus_source), $source);
+  }
+
+  // support for appending source
+  $source_plus = drush_get_option('source++', RELEASE_INFO_DEFAULT_URL);
+  if (isset($source_plus)){
+    $source = array_merge($source, explode(',', $source_plus));
+  }
+  
   $restrict_to = drush_get_option('dev', FALSE) ? 'dev' : '';
   $select = drush_get_option('select', 'auto');
   $all = drush_get_option('all', FALSE);

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -1510,6 +1510,8 @@ function pm_drush_engine_release_info() {
       'description' => 'Drush release info engine for update.drupal.org and compatible services.',
       'options' => array(
         'source' => 'The base URL which provides project release history in XML. Defaults to http://updates.drupal.org/release-history.',
+        'source+' => 'Prepends the provided set of urls (seperated by a comma[,]) to the default source option.  See the --source option for details.',
+        'source++' => 'Appends the provided set of urls (seperated by a comma[,]) to the default source option.  See the --source option for details.',
         'dev' => 'Work with development releases solely.',
       ),
       'sub-options' => array(

--- a/commands/pm/release_info/updatexml.inc
+++ b/commands/pm/release_info/updatexml.inc
@@ -451,29 +451,46 @@ function updatexml_best_release_found($releases) {
 }
 
 /**
- * Download the release history xml for the specified request.
+ * Attempt to download XML release history from a single url
  */
-function updatexml_get_release_history_xml($request) {
-  $status_url = isset($request['status url'])?$request['status url']:RELEASE_INFO_DEFAULT_URL;
-  $url =  $status_url . '/' . $request['name'] . '/' . $request['drupal_version'];
+function _updatexml_get_release_history_xml($u, $request){
+  $url =  $u . '/' . $request['name'] . '/' . $request['drupal_version'];
   drush_log('Downloading release history from ' . $url);
   // Some hosts have allow_url_fopen disabled.
+  $xml = FALSE;
   if ($path = drush_download_file($url, drush_tempnam($request['name']), drush_get_option('cache-duration-releasexml', 24*3600))) {
     $xml = simplexml_load_file($path);
   }
   if (!$xml) {
-    // We are not getting here since drupal.org always serves an XML response.
-    return drush_set_error('DRUSH_PM_DOWNLOAD_FAILED', dt('Could not download project status information from !url', array('!url' => $url)));
+    // urls may not always server XML (maybe there was an network error?)
+    drush_log(dt('Could not download project status information from !url', array('!url' => $url)), 'warning'); // 'DRUSH_PM_DOWNLOAD_FAILED'
+    return FALSE;
   }
   if ($error = $xml->xpath('/error')) {
-    // Don't set an error here since it stops processing during site-upgrade.
-    drush_log($error[0], 'warning'); // 'DRUSH_PM_COULD_NOT_LOAD_UPDATE_FILE',
+    drush_log(dt('!url: !err', array('!url' => $url, '!err' => $error[0])), 'warning'); // 'DRUSH_PM_COULD_NOT_LOAD_UPDATE_FILE'
     return FALSE;
   }
   // Unpublished project?
   $project_status = $xml->xpath('/project/project_status');
   if ($project_status[0][0] == 'unpublished') {
-    return drush_set_error('DRUSH_PM_PROJECT_UNPUBLISHED', dt("Project !project is unpublished and has no releases available.", array('!project' => $request['name'])), 'warning');
+    drush_log(dt("Project !project is unpublished and has no releases available.", array('!project' => $request['name'])), 'warning'); // 'DRUSH_PM_PROJECT_UNPUBLISHED'
+    return FALSE;
+  }
+  return $xml;
+}
+
+/**
+ * Download the release history xml for the specified request.
+ */
+function updatexml_get_release_history_xml($request) {
+  $status_url = isset($request['status url'])?$request['status url']:RELEASE_INFO_DEFAULT_URL;
+  if (!is_array($status_url)){
+    // TODO: find a better way to facilitate this.
+    $status_url = explode(',', $status_url);
+  }
+  foreach($status_url as $u){
+    $xml = _updatexml_get_release_history_xml($u, $request);
+    if ($xml !== FALSE) break;
   }
 
   return $xml;


### PR DESCRIPTION
Currently there is no way to specify multiple urls for sources.  If a project is not found in a custom repository, a pm-download fails.  This patch adds the ability to have several sources in sequence.

--source is split using explode(',' $source), but still defaults to RELEASE_INFO_DEFAULT_URL
--source+ is split using explode(',' $source), and then prepended to --source
--source++ is split using explode(',' $source), and then appended to --source

Prepending is done before appending.
