### PR TITLE
Consider supporting composer as the recommended install method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,5 @@
   },
   "require-dev": {
     "phpunit/phpunit": ">=3.5"
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "7.x-dev"
-    }
   }
 }


### PR DESCRIPTION
Related to #127 

Now that composer allows for global installs, should we consider that this might be a good time to transition to recommending it as the install method?

https://github.com/composer/composer/pull/2172

```
➜  drush git:(pear-composer) echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> ~/.zshrc
➜  drush git:(pear-composer) source ~/.zshrc
➜  drush git:(pear-composer) composer global require drush/drush:dev-master
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Installing drush/drush (dev-master d8ae4d7)
    Cloning d8ae4d72222c010b39f53469a74f9429af3e40cc

Writing lock file
Generating autoload files
➜  drush git:(pear-composer) drush --version
 Drush Version   :  7.0-dev 
```

cc: @robloach
