### PR TITLE
No field labels

### DIFF
--- a/commands/core/outputformat.drush.inc
+++ b/commands/core/outputformat.drush.inc
@@ -208,6 +208,7 @@ function outputformat_drush_engine_outputformat() {
     'machine-parsable' => TRUE,
     'engine-class' => 'list',
     'list-item-type' => 'nested-csv',
+    'labeled-list' => TRUE,
     'description' => 'A list of values, one per row, each of which is a comma-separated list of values.',
     'engine-capabilities' => array('format-table'),
     'topic-example' => array(array('a', 12, 'a@one.com'),array('b', 17, 'b@two.com')),

--- a/commands/core/outputformat.drush.inc
+++ b/commands/core/outputformat.drush.inc
@@ -64,8 +64,10 @@ function outputformat_drush_engine_type_info() {
         'description' => 'In nested lists of lists, specify how the outer lists ("lines") should be separated.',
         'hidden' => TRUE,
       ),
-      'no-field-labels' => array(
-        'description' => 'Leave off the field labels.',
+      'field-labels' => array(
+        'description' => 'Add field labels before first line of data. Default is on; --field-labels=0 to disable.',
+        'default' => '1',
+        'key' => 'include-field-labels',
       ),
     ),
     // Allow output formats to declare their
@@ -281,14 +283,14 @@ function outputformat_drush_help_alter(&$command) {
       if (isset($outputformat['require-engine-capability']) && is_array($outputformat['require-engine-capability'])) {
         if (!in_array('format-table', $outputformat['require-engine-capability'])) {
           unset($command['options']['fields']);
-          unset($command['options']['no-field-labels']);
+          unset($command['options']['field-labels']);
         }
       }
       // If the command does define output formats, but does not
       // define fields, then just hide the help for the --fields option.
       else {
         $command['options']['fields']['hidden'] = TRUE;
-        $command['options']['no-field-labels']['hidden'] = TRUE;
+        $command['options']['field-labels']['hidden'] = TRUE;
       }
     }
 

--- a/commands/core/outputformat.drush.inc
+++ b/commands/core/outputformat.drush.inc
@@ -64,6 +64,9 @@ function outputformat_drush_engine_type_info() {
         'description' => 'In nested lists of lists, specify how the outer lists ("lines") should be separated.',
         'hidden' => TRUE,
       ),
+      'no-field-labels' => array(
+        'description' => 'Leave off the field labels.',
+      ),
     ),
     // Allow output formats to declare their
     // "output data type" instead of their
@@ -278,12 +281,14 @@ function outputformat_drush_help_alter(&$command) {
       if (isset($outputformat['require-engine-capability']) && is_array($outputformat['require-engine-capability'])) {
         if (!in_array('format-table', $outputformat['require-engine-capability'])) {
           unset($command['options']['fields']);
+          unset($command['options']['no-field-labels']);
         }
       }
       // If the command does define output formats, but does not
       // define fields, then just hide the help for the --fields option.
       else {
         $command['options']['fields']['hidden'] = TRUE;
+        $command['options']['no-field-labels']['hidden'] = TRUE;
       }
     }
 

--- a/commands/core/outputformat/key_value.inc
+++ b/commands/core/outputformat/key_value.inc
@@ -69,8 +69,8 @@ class drush_outputformat_key_value extends drush_outputformat {
     if ((!isset($kv_metadata['key-value-item'])) && (isset($metadata['field-labels']))) {
       $input = drush_select_output_fields($input, $metadata['field-labels'], $metadata['field-mappings']);
     }
-    if (isset($metadata['no-field-labels'])) {
-      $kv_metadata['no-field-labels'] = $metadata['no-field-labels'];
+    if (isset($metadata['include-field-labels'])) {
+      $kv_metadata['include-field-labels'] = $metadata['include-field-labels'];
     }
     $formatted_table = drush_key_value_to_array_table($input, $kv_metadata);
     if ($formatted_table === FALSE) {

--- a/commands/core/outputformat/key_value.inc
+++ b/commands/core/outputformat/key_value.inc
@@ -57,6 +57,9 @@
  */
 class drush_outputformat_key_value extends drush_outputformat {
   function format($input, $metadata) {
+    if (isset($metadata['no-field-labels'])) {
+      return drush_format($input, $metadata, 'list');
+    }
     if (!is_array($input)) {
       if (isset($metadata['label'])) {
         $input = array(dt($metadata['label']) => $input);

--- a/commands/core/outputformat/key_value.inc
+++ b/commands/core/outputformat/key_value.inc
@@ -57,9 +57,6 @@
  */
 class drush_outputformat_key_value extends drush_outputformat {
   function format($input, $metadata) {
-    if (isset($metadata['no-field-labels'])) {
-      return drush_format($input, $metadata, 'list');
-    }
     if (!is_array($input)) {
       if (isset($metadata['label'])) {
         $input = array(dt($metadata['label']) => $input);
@@ -71,6 +68,9 @@ class drush_outputformat_key_value extends drush_outputformat {
     $kv_metadata = isset($metadata['table-metadata']) ? $metadata['table-metadata'] : array();
     if ((!isset($kv_metadata['key-value-item'])) && (isset($metadata['field-labels']))) {
       $input = drush_select_output_fields($input, $metadata['field-labels'], $metadata['field-mappings']);
+    }
+    if (isset($metadata['no-field-labels'])) {
+      $kv_metadata['no-field-labels'] = $metadata['no-field-labels'];
     }
     $formatted_table = drush_key_value_to_array_table($input, $kv_metadata);
     if ($formatted_table === FALSE) {

--- a/commands/core/outputformat/list.inc
+++ b/commands/core/outputformat/list.inc
@@ -106,7 +106,7 @@ class drush_outputformat_list extends drush_outputformat {
       }
 
       // Include field labels, if specified
-      if (!isset($metadata['list-item']) && is_array($input) && isset($metadata['field-labels'])) {
+      if (!isset($metadata['list-item']) && isset($metadata['labeled-list']) && is_array($input) && isset($metadata['field-labels'])) {
         if (isset($metadata['include-field-labels']) && $metadata['include-field-labels']) {
           array_unshift($input, $metadata['field-labels']);
         }

--- a/commands/core/outputformat/list.inc
+++ b/commands/core/outputformat/list.inc
@@ -105,6 +105,12 @@ class drush_outputformat_list extends drush_outputformat {
         }
       }
 
+      // Include field labels, if specified
+      if (!isset($metadata['list-item']) && is_array($input) && isset($metadata['field-labels'])) {
+        if (isset($metadata['include-field-labels']) && $metadata['include-field-labels']) {
+          array_unshift($input, $metadata['field-labels']);
+        }
+      }
       foreach ($input as $label => $data) {
         // If this output formatter is set to print a single item from each
         // element, select that item here.

--- a/commands/core/outputformat/table.inc
+++ b/commands/core/outputformat/table.inc
@@ -41,6 +41,11 @@ class drush_outputformat_table extends drush_outputformat {
       }
       ++$col;
     }
-    return drush_format_table(drush_rows_of_key_value_to_array_table($input, $field_list, $metadata), TRUE, $widths);
+    $rows = drush_rows_of_key_value_to_array_table($input, $field_list, $metadata);
+    $field_labels = !array_key_exists('no-field-labels', $metadata);
+    if (!$field_labels) {
+      array_shift($rows);
+    }
+    return drush_format_table($rows, $field_labels, $widths);
   }
 }

--- a/commands/core/outputformat/table.inc
+++ b/commands/core/outputformat/table.inc
@@ -42,7 +42,7 @@ class drush_outputformat_table extends drush_outputformat {
       ++$col;
     }
     $rows = drush_rows_of_key_value_to_array_table($input, $field_list, $metadata);
-    $field_labels = !array_key_exists('no-field-labels', $metadata);
+    $field_labels = array_key_exists('include-field-labels', $metadata) && $metadata['include-field-labels'];
     if (!$field_labels) {
       array_shift($rows);
     }

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -493,6 +493,9 @@ function drush_handle_command_output($command, $structured_output) {
         // Determine the --format, and options relevant for that format.
         foreach ($formatter->engine_config['options'] as $option => $option_info) {
           $default_value = isset($formatter->engine_config[$option . '-default']) ? $formatter->engine_config[$option . '-default'] : FALSE;
+          if (($default_value === FALSE) && array_key_exists('default', $option_info)) {
+            $default_value = $option_info['default'];
+          }
           if (isset($option_info['list'])) {
             $user_specified_value = drush_get_option_list($option, $default_value);
           }
@@ -500,6 +503,9 @@ function drush_handle_command_output($command, $structured_output) {
             $user_specified_value = drush_get_option($option, $default_value);
           }
           if ($user_specified_value !== FALSE) {
+            if (array_key_exists('key', $option_info)) {
+              $option = $option_info['key'];
+            }
             $metadata[$option] =$user_specified_value;
           }
         }

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -315,7 +315,7 @@ function drush_key_value_to_array_table($keyvalue_table, $metadata = array()) {
         $value = drush_format($value, $metadata, 'list');
       }
     }
-    if (isset($metadata['no-field-labels'])) {
+    if (isset($metadata['include-field-labels']) && !$metadata['include-field-labels']) {
       $table[] = array(isset($value) ? $value : '');
     }
     elseif (isset($value)) {

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -314,6 +314,11 @@ function drush_key_value_to_array_table($keyvalue_table, $metadata = array()) {
       if (is_array($value)) {
         $value = drush_format($value, $metadata, 'list');
       }
+    }
+    if (isset($metadata['no-field-labels'])) {
+      $table[] = array(isset($value) ? $value : '');
+    }
+    elseif (isset($value)) {
       $table[] = array($key, ' :', $value);
     }
     else {


### PR DESCRIPTION
A user may want to see just the command output data, without any extra field labels; it should therefore be possible to tell Drush to omit the field labels.

Example:

```
$ drush status 'Drush configuration'
 Drush configuration   :  /home/ga/local/config/drushrc.php /home/ga/.drush/drushrc.php 

$ drush status 'Drush configuration' --no-field-labels
 /home/ga/local/config/drushrc.php /home/ga/.drush/drushrc.php 
```

The --no-field-labels version could more easily be processed in a bash for loop, for example.
