### PR TITLE
Drush enable module broken

### DIFF
--- a/commands/core/drupal/environment.inc
+++ b/commands/core/drupal/environment.inc
@@ -145,7 +145,7 @@ function drush_module_enable($modules) {
   // The list of modules already have all the dependencies, but they might not
   // be in the correct order. Still pass $enable_dependencies = TRUE so that
   // Drupal will enable the modules in the correct order.
-  module_enable($modules);
+  Drupal::moduleHandler()->install($modules);
   // Flush all caches.
   drupal_flush_all_caches();
 }
@@ -160,7 +160,7 @@ function drush_module_disable($modules) {
   // The list of modules already have all the dependencies, but they might not
   // be in the correct order. Still pass $enable_dependencies = TRUE so that
   // Drupal will enable the modules in the correct order.
-  module_disable($modules);
+  Drupal::moduleHandler()->uninstall($modules);
   // Flush all caches.
   drupal_flush_all_caches();
 }


### PR DESCRIPTION
The function to enable a module is broken. I get the following error trying to enable a module:

```
[drupal] (8.x) $ drush en simpletest
The following extensions will be enabled: simpletest
Do you really want to continue? (y/n): y
PHP Fatal error:  Call to undefined function module_enable() in /home/herjan/Apps/drush/commands/core/drupal/environment.inc on line 148

Fatal error: Call to undefined function module_enable() in /home/herjan/Apps/drush/commands/core/drupal/environment.inc on line 148
Drush command terminated abnormally due to an unrecoverable error.                                                                                                                         [error]
Error: Call to undefined function module_enable() in /home/herjan/Apps/drush/commands/core/drupal/environment.inc, line 148
```
