### PR TITLE
Drush fails if there is a settings.php file somewhere above the Drupal Root.

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -246,7 +246,9 @@ function drush_site_path($path = NULL) {
   }
   else {
     // Move up dir by dir and check each.
-    while ($path = _drush_shift_path_up($path)) {
+    // Stop if we get to a Drupal root.   We don't care
+    // if it is DRUSH_SELECTED_DRUPAL_ROOT or some other root.
+    while ($path = _drush_shift_path_up($path) && !drush_valid_drupal_root($path)) {
       if (file_exists($path . '/settings.php')) {
         $site_path = $path;
         break;


### PR DESCRIPTION
From https://drupal.org/node/538702.  This stalled because we could not reproduce the condition that caused this error.  Recently, Moshe encountered this problem on his system; a misplaced settings.php above his document root caused uri to be miss-set, and as a result, the system would not bootstrap.  On my system, a misplaced settings.php would cause uri to be miss-set, but strangely enough, the correct sites folder would be selected, and bootstrapping would succeed (except with an incorrect uri).

This patch solves the problem of miss-setting the uri.  In theory, this should also prevent the problems caused that prevented the siits from bootstrapping.
