### PR TITLE
drush should not print which system calls it is calling unless it is in ...

### DIFF
--- a/includes/exec.inc
+++ b/includes/exec.inc
@@ -25,7 +25,7 @@
  * @see drush_shell_exec()
  */
 function drush_op_system($exec) {
-  if (drush_get_context('DRUSH_VERBOSE') || drush_get_context('DRUSH_SIMULATE')) {
+  if (drush_get_context('DRUSH_VERBOSE')) {
     drush_print("Calling system($exec);", 0, STDERR);
   }
   if (drush_get_context('DRUSH_SIMULATE')) {


### PR DESCRIPTION
...verbose mode. Simulate mode is not verbose mode. Currently running drush in simulate mode produces unwanted output.
