### PR TITLE
#176: sql-sync dump files stored to --dump-dir should not be temporary.

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -189,7 +189,7 @@ function sql_drush_command() {
           'hidden' => TRUE,
       ),
       'temp' => 'Use a temporary file to hold dump files.  Implies --no-cache.',
-      'dump-dir' => 'Directory to store sql dump files in when --source-dump or --target-dump are not used.  Takes precedence over --temp.',
+      'dump-dir' => 'Directory to store sql dump files in when --source-dump or --target-dump are not used.',
       'create-db' => 'Create a new database before importing the database dump on the target machine.',
       'db-su' => array(
         'description' => 'Account to use when creating a new database. Optional.',
@@ -1132,7 +1132,7 @@ function drush_sql_dump_file(&$site_record) {
     // If the user has set the --dump-dir option, then
     // store persistant sql dump files there.
     $dump_dir = drush_sitealias_get_path_option($site_record, 'dump-dir');
-    $site_record['dump-is-temp'] = !$dump_dir;
+    $use_temp_file = drush_sitealias_get_path_option($site_record, 'temp') || !$dump_dir;
     $remote = isset($site_record['remote-host']);
     // If this is a remote site, try to find a writable tmpdir.
     if (!isset($dump_dir) && $remote) {
@@ -1157,7 +1157,7 @@ function drush_sql_dump_file(&$site_record) {
         $dump_dir = $result['object'];
       }
     }
-    if ($site_record['dump-is-temp']) {
+    if ($use_temp_file) {
       $dump_file = drush_tempnam($filename_pattern, $dump_dir, $remote ? '.sql' : '');
       // If $dump_dir does not exist, tempname will use the system
       // directory instead.  That is the behavior we want on the local
@@ -1166,6 +1166,7 @@ function drush_sql_dump_file(&$site_record) {
       if ($remote) {
         $dump_file = $dump_dir . '/' . basename($dump_file);
       }
+      $site_record['dump-is-temp'] = TRUE;
     }
     else {
       $dump_file = $dump_dir . '/' . $filename_pattern . '.sql';


### PR DESCRIPTION
This simple change brings back the intended behavior of --dump-dir from Drush 4.x. Recommend committing to master, 6.x and 5.x.
