### PR TITLE
Upped PEAR Console_Table to 1.1.6

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -13,7 +13,7 @@
 /**
  * Supported version of Console Table. This is displayed in the manual install help.
  */
-define('DRUSH_TABLE_VERSION', '1.1.3');
+define('DRUSH_TABLE_VERSION', '1.1.6');
 
 /**
  * Base URL for automatic file download of PEAR packages.


### PR DESCRIPTION
Hi, the PEAR Console Table 1.1.6 has been released.

It fixes the following PEAR bug:
Bug #20092      Table output inserts bogus \r character when not on Windows
https://pear.php.net/bugs/bug.php?id=20092
For the exact code changed see this commit:

https://github.com/pear/Console_Table/commit/332867db680716f8a60eb933deac6bfb1ae6b8f7

Once this new version of the PEAR library is in drush, drush users on OSX will
no longer have to ^Ms in the default drush table output.
