### PR TITLE
Encourage the practice of using the Drupal issue node id as patch array key

### DIFF
--- a/examples/example.make
+++ b/examples/example.make
@@ -94,7 +94,7 @@ projects[admin_menu][subdir] = custom
 ; To apply a patch to a project, use the `patch` attribute and pass in the URL
 ; of the patch.
 
-projects[admin_menu][patch][] = "http://drupal.org/files/issues/admin_menu.long_.31.patch"
+projects[admin_menu][patch][687750] = "http://drupal.org/files/issues/admin_menu.long_.31.patch"
 
 ; If all projects or libraries share common attributes, the `defaults`
 ; array can be used to specify these globally, rather than


### PR DESCRIPTION
Often times patch files don't reference back to any particular issue for explanation. To ease discovery of issues originating a given patch, the best practice of using the Drupal.org node id of the issue should be encouraged.
