### PR TITLE
Issue #46: Fix pmi command

### DIFF
--- a/commands/pm/info.pm.inc
+++ b/commands/pm/info.pm.inc
@@ -64,7 +64,7 @@ function _drush_pm_info_extension($info) {
   $data['config'] = isset($info->info['configure']) ? $info->info['configure'] : dt('None');
   $data['description'] = $info->info['description'];
   $data['version'] = $info->info['version'];
-  $data['date'] = format_date($info->info['datestamp'], 'custom', 'Y-m-d');
+  $data['date'] = isset($info->info['datestamp']) ? format_date($info->info['datestamp'], 'custom', 'Y-m-d') : '';
   $data['package'] = $info->info['package'];
   $data['core'] = $info->info['core'];
   $data['php'] = $info->info['php'];


### PR DESCRIPTION
Modules clones from git have no datestamp property in their info file and format_date throws an Exception for non Numeric values. This patch implements a consistent behavior across all Drupal versions.
