### PR TITLE
User engine is not loaded at drush updb.

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -69,6 +69,7 @@ class DrushBatchContext extends ArrayObject {
  */
 function drush_backend_batch_process($command = 'batch-process', $args = array(), $options = array()) {
   // Command line options to pass to the command.
+  drush_include_engine('drupal', 'user', drush_drupal_major_version());
   $options['u'] = drush_get_user_id();
 
   drush_include_engine('drupal', 'batch', drush_drupal_major_version());


### PR DESCRIPTION
This makes the command to crash on Drupal 7 with the following error:

Error: Call to undefined function drush_get_user_id() in /usr/share/drush/includes/batch.inc, line 72
