### PR TITLE
Suppress output of `which uname` check in pseudo terminal

### DIFF
--- a/drush
+++ b/drush
@@ -12,7 +12,7 @@ SELF_DIRNAME="`dirname -- "$0"`"
 SELF_PATH="`cd -P -- "$SELF_DIRNAME" && pwd -P`/`basename -- "$0"`"
 
 # Decide if we are running a Unix shell on Windows
-if [ `which uname` ]; then
+if [ `which uname 2>&1 /dev/null` ]; then
   case "`uname -a`" in
     CYGWIN*)
       CYGWIN=1 ;;


### PR DESCRIPTION
When drush is executed in a pseudo terminal with no PATH defined, uname displays a message directly to standard output:

```
which: no uname in ((null))
```

The complaint from which is technically accurate, but there's no reason to show it to the user. There is no functional difference otherwise. This bug affects 6.x as well.
