### PR TITLE
fixes uname quoting

### DIFF
--- a/drush
+++ b/drush
@@ -11,7 +11,7 @@ SELF_DIRNAME="`dirname -- "$0"`"
 SELF_PATH="`cd -P -- "$SELF_DIRNAME" && pwd -P`/`basename -- "$0"`"
 
 # Decide if we are running a Unix shell on Windows
-if [ `which uname 2>&1 /dev/null` ]; then
+if [ "$(which uname 2>&1 /dev/null)" ]; then
   case "`uname -a`" in
     CYGWIN*)
       CYGWIN=1 ;;


### PR DESCRIPTION
Quoting a sub-shell avoids errors, but I'm not sure whether it works under windows :poop:
