### PR TITLE
fix which uname condition (attempt 2)

### DIFF
--- a/drush
+++ b/drush
@@ -11,7 +11,7 @@ SELF_DIRNAME="`dirname -- "$0"`"
 SELF_PATH="`cd -P -- "$SELF_DIRNAME" && pwd -P`/`basename -- "$0"`"
 
 # Decide if we are running a Unix shell on Windows
-if [ "`which uname 2>&1 /dev/null`" ]; then
+if `which uname > /dev/null 2>&1`; then
   case "`uname -a`" in
     CYGWIN*)
       CYGWIN=1 ;;


### PR DESCRIPTION
fixes #270/#272 by consuming all output and just relying on return which return code.  an equivalent alternative would be to just quell stderr (`2> /dev/null`).
