### PR TITLE
Fix for Drupal.org change to release note nodes classes.

### DIFF
--- a/commands/pm/release_info/updatexml.inc
+++ b/commands/pm/release_info/updatexml.inc
@@ -200,7 +200,7 @@ function release_info_print_releasenotes($requests, $print_status = TRUE, $tmpfi
         continue;
       }
       $xml = simplexml_import_dom($dom);
-      $node_content = $xml->xpath('//*/div[@class="node-content"]');
+      $node_content = $xml->xpath('//div[@class="node node-project-release clearfix"]');
 
       // Prepare the project notes to print.
       $notes_last_update = $node_content[0]->div[1]->div[0]->asXML();


### PR DESCRIPTION
Was giving a fatal "Call to a member function asXML() on a non-object" error when running.

drush pm-updatecode --notes
