### PR TITLE
Honour the working-copy flag for a git checkout.

### DIFF
--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -316,10 +316,10 @@ class DrushMakeProject {
   }
 
   /**
-   * Remove the .git directory from a project.
+   * Remove the .git directory from a project, unless working-copy was specified.
    */
   function removeGitDirectory() {
-    if (isset($this->download['type']) && $this->download['type'] == 'git' && file_exists($this->download_location . '/.git')) {
+    if (!empty($this->download['working-copy']) && isset($this->download['type']) && $this->download['type'] == 'git' && file_exists($this->download_location . '/.git')) {
       drush_delete_dir($this->download_location . '/.git', TRUE);
     }
   }


### PR DESCRIPTION
Drush deletes the .git directory from cloned projects without checking whether the working-copy option was specified . This patch adds that check, so the working-copy option actually leaves a working copy.
