### PR TITLE
Also preserve .git dir if working-copy was specified on the project only

### DIFF
--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -158,7 +158,7 @@ class DrushMakeProject {
       $this->processGitInfoFiles();
     }
     // Clean-up .git directories.
-    if (!drush_get_option('working-copy')) {
+    if (!drush_get_option('working-copy') && empty($this->download['working-copy'])) {
       $this->removeGitDirectory();
     }
     if (!$this->recurse($this->download_location)) {


### PR DESCRIPTION
Drush deletes the .git directory from cloned projects without checking whether the working-copy option was specified. This patch adds that check, so the working-copy option actually leaves a working copy. 6.x already performs this check, but uses a project attribute that isn't present in 5.x.
