### PR TITLE
Fix user argument handling

### DIFF
--- a/commands/user/user.drush.inc
+++ b/commands/user/user.drush.inc
@@ -522,7 +522,7 @@ function _drush_user_print_info($account) {
 function _drush_user_get_users_from_arguments($users) {
   $uids = array();
   if ($users !== '') {
-    $users = explode(',', $users);
+    $users = _convert_csv_to_array($users);
     foreach($users as $user) {
       $uid = _drush_user_get_uid($user);
       if ($uid !== FALSE) {


### PR DESCRIPTION
Certain user commands explode when passed a UID of `0`. Example below. Turns out the changing the user arguments helper function to use the csv-to-array helper function fixes the problem.

``` bash
$ drush uublk 0
WD user: PDOException: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '' for key 'name': INSERT INTO {users} (uid, name, pass, mail, theme, signature, signature_format,      [error]
created, access, login, status, timezone, language, picture, init, data) VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2, :db_insert_placeholder_3,
:db_insert_placeholder_4, :db_insert_placeholder_5, :db_insert_placeholder_6, :db_insert_placeholder_7, :db_insert_placeholder_8, :db_insert_placeholder_9, :db_insert_placeholder_10,
:db_insert_placeholder_11, :db_insert_placeholder_12, :db_insert_placeholder_13, :db_insert_placeholder_14, :db_insert_placeholder_15); Array
(
    [:db_insert_placeholder_0] => 16
    [:db_insert_placeholder_1] => 
    [:db_insert_placeholder_2] => 
    [:db_insert_placeholder_3] => 
    [:db_insert_placeholder_4] => 
    [:db_insert_placeholder_5] => 
    [:db_insert_placeholder_6] => 
    [:db_insert_placeholder_7] => 0
    [:db_insert_placeholder_8] => 0
    [:db_insert_placeholder_9] => 0
    [:db_insert_placeholder_10] => 1
    [:db_insert_placeholder_11] => 
    [:db_insert_placeholder_12] => 
    [:db_insert_placeholder_13] => 0
    [:db_insert_placeholder_14] => 
    [:db_insert_placeholder_15] => b:0;
)
 in drupal_write_record() (line 7170 of /var/www/html/d7.dev/docroot/includes/common.inc).
```
