### PR TITLE
Enable cache while making the core projects in-place

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -404,7 +404,14 @@ function make_projects($recursion, $contrib_destination, $info, $build_path, $ma
       else {
         make_error('PROJECT-TYPE', dt('Non-existent project type %type on project %project.', array('%type' => $project['type'], '%project' => $project['name'])));
       }
+      // Set the cache option based on our '--no-cache' option.
+      $cache_before = drush_get_option('cache');
+      if (!drush_get_option('no-cache', FALSE)) {
+        drush_set_option('cache', TRUE);
+      }
       $project->make();
+      // Restore the previous '--cache' option value.
+      drush_set_option('cache', $cache_before);
     }
   }
 


### PR DESCRIPTION
Contrib projects are made in a subprocess using the `make-process`
backend command, and they get the `'cache'` parameter set properly.
This is not the case of core, which is built separately.

This means that, in particular, any specified core patch will
not be cached.

Note: The pattern of enabling the cache / restoring the old value seems
weird and unnecessary to me, but it is the same used above in the
same function for fetching release information.
