### PR TITLE
Fixes for cache-set command

### DIFF
--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -156,6 +156,14 @@ function drush_cache_command_set($cid = NULL, $data = '', $bin = NULL, $expire =
     $data = stream_get_contents(STDIN);
   }
 
+  // Convert the "expire" argument to a valid value for Drupal's cache_set().
+  if ($expire == 'CACHE_TEMPORARY') {
+    $expire = CACHE_TEMPORARY;
+  }
+  if ($expire == 'CACHE_PERMANENT') {
+    $expire = CACHE_PERMANENT;
+  }
+
   // Now, we parse the object.
   switch (drush_get_option('format', 'string')) {
     case 'json':
@@ -164,7 +172,19 @@ function drush_cache_command_set($cid = NULL, $data = '', $bin = NULL, $expire =
   }
 
   if (drush_get_option('cache-get')) {
-    $data = $data->data;
+    // $data might be an object.
+    if (is_object($data) && $data->data) {
+      $data = $data->data;
+    }
+    // But $data returned from `drush cache-get --format=json` will be an array.
+    elseif (is_array($data) && isset($data['data'])) {
+      $data = $data['data'];
+    }
+    else {
+      // If $data is neither object nor array and cache-get was specified, then
+      // there is a problem.
+      return drush_set_error('CACHE_INVALID_FORMAT', dt("'cache-get' was specified as an option, but the data is neither an object or an array."));
+    }
   }
 
   cache_set($cid, $data, $bin, $expire);


### PR DESCRIPTION
Earlier today, I did the following:

```
$ drush cache-get my_cache_id my_cache_bin --format=json > /tmp/example.json
$ # In MySQL, deleted the entry for my_cache_id from my_cache_bin.
$ cat /tmp/example.json | drush cache-set my_cache_id - my_cache_bin CACHE_PERMANENT --format=json --cache-get
```

Reloading the data into the cache failed, for two reasons.
1. Drupal's `cache_set()`  (see `set()` in `cache.inc`) complained with this error: "SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: 'CACHE_PERMANENT' for column 'expire' at row 1"
2. In Drush's `drush_cache_command_set()`, `$data` is assumed to be an object when `cache-get` is specified. But in my case, because I passed `--format=json`, it's an array.

This PR fixes both issues.
