### PR TITLE
Provides a better user experience when `cc all` called outside Drupal dir

### DIFF
--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -106,7 +106,7 @@ function drush_cache_command_clear($type = NULL) {
   if ($type == 'all' && !drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_FULL)) {
     $type = 'drush';
     drush_log(dt("No Drupal site found, only '!name' cache was cleared.", array('!name' => $type)), 'warning');
-  } else {
+  } else if ($type !== FALSE) {
     drush_log(dt("'!name' cache was cleared.", array('!name' => $type)), 'success');
   }
 }


### PR DESCRIPTION
This is to stop the issue of calling Drush cache clear outside a Drupal directory and not realising it.   

For instance a Drupal site is located in /var/www/oursite/html/ and you navigate into /var/www/oursite/ and call `drush cc all`.   

Currently calling `drush cc all` in a non Drupal directory  

`'drush' cache was cleared.          [success]`

Is pretty easy to confuse with calling `drush cc all` in a Drupal directory. (Even though they have slightly different messages they both return success)

`'all' cache was cleared in /var/www/mch/mch/htdocs#mch  [success]`

I have modifed the command to return 

`No Drupal site found, only 'drush' cache was cleared.  [warning]`
