### PR TITLE
Fix undefined function drush_get_user_id() error

### DIFF
--- a/commands/runserver/runserver.drush.inc
+++ b/commands/runserver/runserver.drush.inc
@@ -199,7 +199,8 @@ function drush_core_runserver($uri = NULL) {
 
   // We log in with the specified user ID (if set) via the password reset URL.
   $user_message = '';
-  if (drush_get_option('user', FALSE) && drush_get_user_id()) {
+  drush_include_engine('drupal', 'user', drush_drupal_major_version());
+  if (drush_get_user_id()) {
     $options = array('query' => array('destination' => $path));
     $browse = url(user_pass_reset_url($user) . '/login', $options);
     $user_message = ', logged in as ' . drush_get_user_name();


### PR DESCRIPTION
If I run `drush @example.local runserver` I get this error:

`PHP Fatal error:  Call to undefined function drush_get_user_id() in /home/kosta/src/drupal/drush/commands/runserver/runserver.drush.inc on line 202`

This patch checks if the user has passed the `--user` flag (and therefore bootstrapped to DRUPAL_LOGIN phase) before trying to use `drush_get_user_id()`.
