### PR TITLE
#1989174 Prevent makefile recursion through per-project properties

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -53,6 +53,7 @@ function make_drush_command() {
       'no-cache' => 'Do not use the pm-download caching (defaults to cache enabled).',
       'no-clean' => 'Leave temporary build directories in place instead of cleaning up after completion.',
       'no-core' => 'Do not require a Drupal core project to be specified.',
+      'no-recursion' => 'Do not recurse into the makefiles of any downloaded projects; you can also set [do_recursion] = 0 on a per-project basis in the makefile.',
       'no-patch-txt' => 'Do not write a PATCHES.txt file in the directory of each patched project.',
       'no-gitinfofile' => 'Do not modify .info files when cloning from Git.',
       'prepare-install' => 'Prepare the built site for installation. Generate a properly permissioned settings.php and files directory.',

--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -49,6 +49,11 @@ class DrushMakeProject {
   protected $overwrite = TRUE;
 
   /**
+   * Recursively process any makefiles found in downloaded projects.
+   */
+  protected $do_recursion = TRUE;
+
+  /**
    * Set attributes and retrieve project information.
    */
   protected function __construct($project) {
@@ -519,6 +524,11 @@ class DrushMakeProject {
    * processing.
    */
   function recurse($path) {
+    if (!$this->do_recursion || drush_get_option('no-recursion')) {
+      drush_log(dt("Preventing recursive makefile parsing for !project",
+                array("!project" => $this->name)), 'notice');
+      return TRUE;
+    }
     $makefile = $this->download_location . '/' . $this->name . '.make';
     if (!file_exists($makefile)) {
       $makefile = $this->download_location . '/drupal-org.make';

--- a/tests/makeTest.php
+++ b/tests/makeTest.php
@@ -124,6 +124,15 @@ class makeMakefileCase extends Drush_CommandTestCase {
     $this->runMakefileTest('recursion-override');
   }
 
+  function testMakeNoRecursion() {
+    $config = $this->getMakefile('recursion');
+    $makefile = $this->makefile_path . DIRECTORY_SEPARATOR . $config['makefile'];
+
+    $install_directory = UNISH_SANDBOX . DIRECTORY_SEPARATOR . 'norecursion';
+    $this->drush('make', array('--no-core', '--no-recursion', $makefile, $install_directory));
+    $this->assertNotContains("ctools", $this->getOutput(), "Make with --no-recursion does not recurse into drupal_forum to download ctools.");
+  }
+
   function testMakeSvn() {
     // Silently skip svn test if svn is not installed.
     exec('which svn', $output, $whichSvnErrorCode);


### PR DESCRIPTION
Porting patch from https://drupal.org/node/1989174
