### PR TITLE
Add "rebuild" command (and deprecate "cc all") for Drupal 8

### DIFF
--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -61,7 +61,6 @@ function cache_drush_command() {
     'arguments' => array(),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION,
     'core' => array('8+'),
-    'callback' => 'drush_cache_rebuild',
   );
 
   return $items;


### PR DESCRIPTION
Drupal 8 has recently added a way to ["rebuild" a Drupal 8 site](https://drupal.org/node/2153725) after changes such as rebasing get the CMI files out of sync with the database (at least, I _think_ that's what goes wrong; as a D8 n00b I'm not entirely sure). Unfortunately, the recommended core method is a bit of a pain. I bet Drush can do it better.

As per Moshe's suggestions in #drupal, since rebuilding won't work unless the site is bootstraped to a lover level than the `cache-clear` command, and since `drush_rebuild()` calls `drupal_flush_all_caches()` anyway, I've made `cache-clear all` deprecated; calling it under Drupal 8 will prompt the user to use the "rebuild" command instead. This may not be desirable after all, however, since I'm noticing that a rebuild takes a noticeably longer time to execute than just a cache clear.
