### PR TITLE
Add a rebuild command

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -369,6 +369,17 @@ function core_drush_command() {
   );
   // Add in options/engines.
   drush_core_quick_drupal_options($items);
+
+  $items['drupal-rebuild'] = array(
+    'description' => 'Performs a rebuild of php storage and caches.',
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION,
+    'examples' => array(
+      'drush drupal-rebuild' => 'Rebuilds site php storage and caches.',
+    ),
+    'aliases' => array('dr'),
+    'core' => array('8+'),
+  );
+
   // Add in topics for engines
   $items += drush_get_engine_topics();
   return $items;
@@ -1268,6 +1279,15 @@ function drush_core_execute() {
     return drush_set_error('CORE_EXECUTE_FAILED', dt("Command !command failed.", array('!command' => $cmd)));
   }
   return $result;
+}
+
+/**
+ * Command callback, drupal-rebuild.
+ */
+function drush_core_drupal_rebuild() {
+  require_once DRUSH_DRUPAL_CORE . '/includes/utility.inc';
+  drupal_rebuild();
+  drush_log(dt('Drupal rebuild complete.'), 'ok');
 }
 
 /**


### PR DESCRIPTION
Now that https://drupal.org/node/2097189 is done, we now have a drupal_rebuild() function that we can use to rebuild the DIC, twig dumped php caches, and regular caches.

If you have an out of date container or something, this is a must to quickly get your working again. So we might as well have a drush command for this too that utilises this as well as the rebuild.php script that ships with D8.
