### PR TITLE
Issue #348 - Improve the error message when some of the required argumen...

### DIFF
--- a/includes/command.inc
+++ b/includes/command.inc
@@ -603,10 +603,16 @@ function _drush_verify_cli_arguments($command) {
     if ($required_arg_count === TRUE) {
       $required_arg_count = count($command['argument-description']);
     }
-    if ((count($command['arguments'])) < $required_arg_count) {
-      $missing = count($required_arg_count) > 1 ? dt('Missing required arguments') : dt('Missing required argument');
-      $required = implode("', '", array_keys($command['argument-description']));
-      return drush_set_error(dt("@missing: '@required'.  See `drush help @command` for information on usage.", array('@missing' => $missing, '@required' => $required, '@command' => $command['command'])));
+
+    if (count($command['arguments']) < $required_arg_count) {
+      $missing = $required_arg_count > 1 ? dt('Missing required arguments') : dt('Missing required argument');
+      $required = array_slice(array_keys($command['argument-description']), 0, $required_arg_count);
+
+      return drush_set_error(dt("@missing: '@required'.  See `drush help @command` for information on usage.", array(
+        '@missing' => $missing,
+        '@required' => implode("', '", $required),
+        '@command' => $command['command'],
+      )));
     }
   }
   return TRUE;


### PR DESCRIPTION
Issue #348

Fix the wrong error message.
And then `$required_arg_count` variable is already an integer therefore the `count($required_arg_count) > 1` condition is always FALSE.
