### PR TITLE
Remove the description of the 'command hook' property from the documentation

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -78,14 +78,6 @@ are shown below.
      primary command name, so pm-download will still be used
      to generate the command hook, etc.
 
-<li>'command hook':
-
-     Change the name of the function drush will
-     call to execute the command from drush_COMMANDFILE_COMMANDNAME()
-     to drush_COMMANDFILE_COMMANDHOOK(), where COMMANDNAME is the
-     original name of the command, and COMMANDHOOK is the value
-     of the 'command hook' item.
-
 <li>'callback':
 
      Name of function to invoke for this command.  The callback


### PR DESCRIPTION
I think the `'command hook'` key is not used any more in the hook_drush_command(), but the documentation is still refers to it. (I am not sure.)

```
$ drush topic docs-commands
```

I think the `'command hook'` is changed to `'callback'`, is it right or I misunderstood something?
