### PR TITLE
sql-sanitize should show the sanitization operations prior to prompting

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -989,9 +989,6 @@ function drush_sql_cli() {
  * @see hook_drush_sql_sync_sanitize() for adding custom sanitize routines.
  */
 function drush_sql_sanitize() {
-  if (!drush_confirm(dt('Do you really want to sanitize the current database?'))) {
-    return drush_user_abort();
-  }
   drush_sql_bootstrap_further();
   drush_include(DRUSH_BASE_PATH . '/commands/sql', 'sync.sql');
   drush_command_invoke_all('drush_sql_sync_sanitize', 'default');
@@ -1004,6 +1001,9 @@ function drush_sql_sanitize() {
         drush_print($messages);
       }
     }
+  }
+  if (!drush_confirm(dt('Do you really want to sanitize the current database?'))) {
+    return drush_user_abort();
   }
 
   $sanitize_query = '';


### PR DESCRIPTION
I'm not sure why, but sql-sanitize prompt the user and asks if they want to sanitize, and does not show the operations that will be performed until after the user confirms -- by which time it is, of course, too late.

This PR moves the confirm down a few lines in the code, so the user can read the sanitization operations before deciding whether to go ahead with it or not.
