### PR TITLE
ConfigImporter needs config.typed service

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -296,7 +296,8 @@ function _drush_config_import(StorageComparer $storage_comparer) {
     Drupal::service('config.factory'),
     Drupal::entityManager(),
     Drupal::lock(),
-    Drupal::service('uuid')
+    Drupal::service('uuid'),
+    Drupal::serivce('config.typed')
   );
   if ($config_importer->alreadyImporting()) {
     drush_log('Another request may be synchronizing configuration already.', 'warning');


### PR DESCRIPTION
The ConfigImporter has new dependencies.Lets add the config.typed service.

[Drupal.org Issue #2130811: Use config schema in saving and validating configuration form to ensure data is consistent and correct](http://drupal.org/node/2130811), Commit [141cb6f3](http://drupalcode.org/project/drupal.git/commitdiff/141cb6f304b1ab2087c75154e8d67057b8cd03bb)
