### PR TITLE
Issue #376: Allow to alter list of modules to be updated.

### DIFF
--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -638,6 +638,8 @@ function drush_get_projects(&$extensions = NULL) {
     }
   }
 
+  // Allow to alter final list of modules to be updated.
+  drupal_alter('drush_get_projects', $projects);
   return $projects;
 }
 


### PR DESCRIPTION
Adding simple drupal_alter('drush_get_projects', $projects); in function drush_get_projects().
