### PR TITLE
Cache clear: adjust nesting of call to drush_op to avoid it being called twice

### DIFF
--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -107,10 +107,7 @@ function drush_cache_clear_pre_validate($type = NULL) {
 function drush_cache_command_clear($type = NULL) {
   $types = drush_cache_clear_types(drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_FULL));
 
-  if ($type) {
-    drush_op($types[$type]);
-  }
-  else {
+  if (!isset($type)) {
     // Don't offer 'all' unless Drush has bootstrapped the Drupal site
     if (!drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_FULL)) {
       unset($types['all']);
@@ -119,9 +116,9 @@ function drush_cache_command_clear($type = NULL) {
     if (empty($type)) {
       return drush_user_abort();
     }
-    // Do it.
-    drush_op($types[$type]);
   }
+  // Do it.
+  drush_op($types[$type]);
   if ($type == 'all' && !drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_FULL)) {
     drush_log(dt("No Drupal site found, only 'drush' cache was cleared."), 'warning');
   }


### PR DESCRIPTION
I was looking for something else and noticed this, introduced in commit 917a50ed31, which would result in caches being cleared twice if they are specified on the command line.
