### PR TITLE
Remove the unnecessary _drush_cache_get_object() call in drush_cache_get()

### DIFF
--- a/includes/cache.inc
+++ b/includes/cache.inc
@@ -67,7 +67,7 @@ function drush_cache_get($cid, $bin = 'default') {
   $ret = _drush_cache_get_object($bin)->get($cid);
   $mess = $ret ? "HIT" : "MISS";
   drush_log(dt("Cache !mess cid: !cid", array('!mess' => $mess, '!cid' => $cid)), 'debug');
-  return _drush_cache_get_object($bin)->get($cid);
+  return $ret;
 }
 
 /**


### PR DESCRIPTION
The required value is already available in a local variable so the second function call is unnecessary.
