### PR TITLE
Force the creation of a pseudo-tty for all remote commands.

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -6,6 +6,7 @@
 function cli_drush_command() {
   $items['core-cli'] = array(
     'description' => 'Open an interactive shell on a Drupal site.',
+    'remote-tty' => TRUE,
     'aliases' => array('cli', 'php'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
   );

--- a/commands/core/topic.drush.inc
+++ b/commands/core/topic.drush.inc
@@ -23,6 +23,7 @@ function topic_drush_command() {
       'drush docs-context' => 'Show documentation for the drush context API',
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+    'remote-tty' => TRUE,
     'aliases' => array('topic'),
     'topics' => array('docs-readme'),
   );

--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -224,6 +224,7 @@ function sql_drush_command() {
       'drush sql-cli' => "Open a SQL command-line interface using Drupal's credentials.",
       'drush sql-cli -A' => "Open a SQL command-line interface using Drupal's credentials and skip reading table information.",
     ),
+    'remote-tty' => TRUE,
   );
   $items['sql-sanitize'] = array(
     'description' => "Run sanitization operations on the current database.",

--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1097,6 +1097,9 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
     'ssh-options' => NULL,
     'path-aliases' => array(),
   );
+  $backend_options += array(
+    '#tty' => FALSE,
+  );
 
   $hostname = $site_record['remote-host'];
   $username = $site_record['remote-user'];
@@ -1140,7 +1143,7 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
 
       $ssh_cmd[] = "ssh";
       $ssh_cmd[] = $ssh_options;
-      if (!empty($backend_options['interactive'])) {
+      if ($backend_options['#tty']) {
         $ssh_cmd[] = '-t';
       }
       $ssh_cmd[] = $username . drush_escapeshellarg($hostname, "LOCAL");

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1043,6 +1043,7 @@ function drush_command_defaults($key, $commandfile, $path) {
     'drupal dependencies' => array(),
     'drush dependencies' => array(),
     'handle-remote-commands' => FALSE,
+    'remote-tty' => FALSE,
     'strict-option-handling' => FALSE,
     'bootstrap_errors' => array(),
     'topics' => array(),
@@ -1117,6 +1118,9 @@ function _drush_command_translate($source) {
  *   locally rather than remotely dispatched.  When this mode is set, the target site
  *   can be obtained via:
  *     drush_get_context('DRUSH_TARGET_SITE_ALIAS')
+ * - remote-tty: set to TRUE if Drush should force ssh to allocate a pseudo-tty
+ *   when this command is being called remotely.  Important for interactive commands.
+ *   Remote commands that allocate a psedo-tty always print "Connection closed..." when done.
  * - strict-option-handling: set to TRUE if drush should strictly separate local command
  *   cli options from the global options.  Usually, drush allows global cli options and
  *   command cli options to be interspersed freely on the commandline.  For commands where

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -272,7 +272,8 @@ function drush_get_global_options($brief = FALSE) {
   if (!$brief) {
     $options['version']            = array('description' => "Show drush version.");
     $options['php']                = array('description' => "The absolute path to your PHP intepreter, if not 'php' in the path.", 'example-value' => '/path/to/file', 'never-propagate' => TRUE);
-    $options['interactive']        = array('short-form' => 'ia', 'description' => "Force interactive mode for commands run on multiple targets (e.g. `drush @site1,@site2 cc --ia`).");
+    $options['interactive']        = array('short-form' => 'ia', 'description' => "Force interactive mode for commands run on multiple targets (e.g. `drush @site1,@site2 cc --ia`).", 'never-propagate' => TRUE);
+    $options['tty']                = array('hidden' => TRUE, 'description' => "Force allocation of tty for remote commands", 'never-propagate' => TRUE);
     $options['quiet']               = array('short-form' => 'q', 'description' => 'Suppress non-error messages.');
     $options['include']             = array('short-form' => 'i', 'short-has-arg' => TRUE, 'context' => 'DRUSH_INCLUDE', 'local-context-only' => TRUE, 'never-post' => TRUE, 'propagate-cli-value' => TRUE, 'merge-pathlist' => TRUE, 'description' => "A list of additional directory paths to search for drush commands.", 'example-value' => '/path/dir');
     $options['config']              = array('short-form' => 'c', 'short-has-arg' => TRUE, 'context' => 'DRUSH_CONFIG', 'local-context-only' => TRUE, 'merge-pathlist' => TRUE, 'description' => "Specify an additional config file to load. See example.drushrc.php.", 'example-value' => '/path/file');
@@ -1161,8 +1162,9 @@ function drush_preflight_command_dispatch() {
     $remote_user = drush_get_option('remote-user');
 
     // Force interactive mode if there is a single remote target.  #interactive is added by drush_do_command_redispatch
+    $user_interactive = drush_get_option('interactive');
     drush_set_option('interactive', TRUE);
-    $values = drush_do_command_redispatch(is_array($command) ? $command : $command_name, $args, $remote_host, $remote_user);
+    $values = drush_do_command_redispatch(is_array($command) ? $command : $command_name, $args, $remote_host, $remote_user, $user_interactive);
     // In 'interactive' mode, $values is the result code from drush_shell_proc_open.
     // @todo: in _drush_backend_invoke, return array('error_status' => $ret) instead for uniformity.
     if (!is_array($values) && ($values != 0)) {
@@ -1352,7 +1354,7 @@ function drush_do_site_command($site_record, $command, $args = array(), $command
  * Redispatch the specified command using the same
  * options that were passed to this invocation of drush.
  */
-function drush_do_command_redispatch($command, $args = array(), $remote_host = NULL, $remote_user = NULL, $drush_path = NULL) {
+function drush_do_command_redispatch($command, $args = array(), $remote_host = NULL, $remote_user = NULL, $drush_path = NULL, $user_interactive = FALSE) {
   $additional_global_options = array();
   $command_options = drush_redispatch_get_options();
   if (is_array($command)) {
@@ -1382,7 +1384,14 @@ function drush_do_command_redispatch($command, $args = array(), $remote_host = N
     }
   }
   $backend_options = array('drush-script' => $drush_path, 'remote-host' => $remote_host, 'remote-user' => $remote_user, 'integrate' => TRUE, 'additional-global-options' => $additional_global_options);
-  if (drush_get_option('interactive')) {
+  // Set the tty if requested, if the command necessitates it,
+  // or if the user explicitly asks for interactive mode, but
+  // not if interactive mode is forced.  tty implies interactive
+  if (drush_get_option('tty') || $user_interactive || !empty($command['remote-tty'])) {
+    $backend_options['#tty'] = TRUE;
+    $backend_options['interactive'] = TRUE;
+  }
+  elseif (drush_get_option('interactive')) {
     $backend_options['interactive'] = TRUE;
   }
 

--- a/tests/backendTest.php
+++ b/tests/backendTest.php
@@ -61,7 +61,7 @@ EOD;
     $exec = sprintf('%s %s version arg1 arg2 --simulate --ssh-options=%s 2>/dev/null | grep ssh', UNISH_DRUSH, self::escapeshellarg('user@server/path/to/drupal#sitename'), self::escapeshellarg('-i mysite_dsa'));
     $this->execute($exec);
     $bash = $this->escapeshellarg('drush  --uri=sitename --root=/path/to/drupal  version arg1 arg2 2>&1');
-    $expected = "Simulating backend invoke: ssh -i mysite_dsa -t user@server $bash 2>&1";
+    $expected = "Simulating backend invoke: ssh -i mysite_dsa user@server $bash 2>&1";
     $output = $this->getOutput();
     $this->assertEquals($expected, $output, 'Expected ssh command was built');
   }


### PR DESCRIPTION
This PR cleans up the implementation of the remote case of the core-cli command, and makes the sql-cli command work remotely.  core-topic also works remotely now, for what that is worth.

This is accomplished by forcing pseudo-tty creation for all remote drush commands.  Doing this universally does not have any negative impact on Drush (e.g. sql-sync can still successfully retrieve remote db info via sql-conf, etc), but it does have the side effect that remote commands (e.g. `drush @remote cc all`) now print "Connection closed by ..." when finished.

We could get rid of the "Connection closed by..." if we introduced a new command record flag, 'create-terminal-for-remote', which would be set similarly to (but never at the same time as) the existing 'handle-remote-commands' flag.  Our new flag would signal backend invoke to create the pseudo-tty.  The disadvantage of this implementation is that the local Drush instance must have a local implementation of command "foo" available in order to run a remote "foo" command with a pseudo-tty.  Since there are only a few commands that really need the pseudo-tty, this is probably preferable, but I thought I'd ask opinions before implementing it that way, since the "Connection closed" message is innocuous.
