### PR TITLE
Installation instructions for setting the PATH in composer install bad for remote calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ INSTALL - COMPOSER
 * [Install Composer globally](http://getcomposer.org/doc/00-intro.md#system-requirements) (if needed).
 * Make sure Composer's global bin directory is on the system PATH (recommended):
 
-        echo 'export PATH=$HOME/.composer/vendor/bin:$PATH' >> $HOME/.bashrc
+        sed -i '1i[ "$PATH" == "${PATH/.composer/}" ] && export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc 
 
 * To install Drush 6.x (stable), run `composer global require drush/drush:6.*`
 


### PR DESCRIPTION
The composer installation instructions in the README provides a simple bash snippet to add the path to the composer components in the user's .bashrc file.  The problem with this advise is that on most systems, the default .bashrc file contains some code near the top that causes execution to stop when not called in interactive mode.  This will have the effect of making the `drush` script unfindable to remote calls, most of which do not use interactive mode.

One solution is to put the line at the beginning of the .bashrc file.  That is what this PR does, utilizing sed -i (in-place) with a 1i (insert on the first line) directive.  The line inserted is also altered so that it will not change the PATH if there is already an item containing ".composer" in it. Without this, the PATH will grow longer and longer every time the .bashrc is sourced.

Potential alternate solutions:
- Add the line to .profile instead of .bashrc (.profile not always sourced).
- Add the line to /etc/profile.d/composer.sh (requires root access).
- Do not provide a script to insert the line -- just give the user the line itself, with instructions on where to copy it.
