### PR TITLE
Issue-254: db prefix can be a string or an array

### DIFF
--- a/commands/sql/sync.sql.inc
+++ b/commands/sql/sync.sql.inc
@@ -73,8 +73,13 @@ function drush_sql_sync_init($source = NULL, $destination = NULL) {
 function sql_drush_sql_sync_sanitize($site) {
   $site_settings = drush_sitealias_get_record($site);
   $databases = sitealias_get_databases_from_record($site_settings);
-  $prefix = $databases['default']['default']['prefix'];
-  $prefix = isset($databases['default']['default']['prefix']) ? $databases['default']['default']['prefix'] : '';
+  $database_prefix = isset($databases['default']['default']['prefix']) ? $databases['default']['default']['prefix'] : '';
+  if (is_array($database_prefix)) {
+    $prefixes = $database_prefix + array('default' => '');
+  }
+  else {
+    $prefixes = array('default' => $database_prefix);
+  }
   $user_table_updates = array();
   $message_list = array();
 
@@ -127,11 +132,13 @@ function sql_drush_sql_sync_sanitize($site) {
   }
 
   if (!empty($user_table_updates)) {
+    $prefix = isset($prefixes['user']) ? $prefixes['user'] : $prefixes['default'];
     $sanitize_query = "UPDATE {$prefix}users SET " . implode(', ', $user_table_updates) . " WHERE uid > 0;";
     drush_sql_register_post_sync_op('user-email', dt('Reset !message in user table', array('!message' => implode(' and ', $message_list))), $sanitize_query);
   }
 
   // Seems quite portable (SQLite?) - http://en.wikipedia.org/wiki/Truncate_(SQL)
+  $prefix = isset($prefixes['sessions']) ? $prefixes['sessions'] : $prefixes['default'];
   $sql_sessions = "TRUNCATE TABLE {$prefix}sessions;";
   drush_sql_register_post_sync_op('sessions', dt('Truncate Drupal\'s sessions table'), $sql_sessions);
 }


### PR DESCRIPTION
sql-sync fails because the prefix can be an array. This PR handles whether the prefix is a string or an array. See https://api.drupal.org/api/drupal/includes%21database%21database.inc/function/DatabaseConnection%3A%3AsetPrefix/7