### PR TITLE
Port Simpletest error code patch.

### DIFF
--- a/commands/core/test.drush.inc
+++ b/commands/core/test.drush.inc
@@ -186,6 +186,31 @@ function simpletest_drush_run_test($class) {
   if ($dir = drush_get_option('xml')) {
     drush_test_xml_results($test_id, $dir, $info);
   }
+  if ($status === 'error') {
+    if (drush_drupal_major_version() >= 7) {
+      $args = array(':test_id' => $test_id);
+      $result = db_query("SELECT * FROM {simpletest} WHERE test_id = :test_id AND status IN ('exception', 'fail') ORDER BY test_class, message_id", $args);
+      foreach ($result as $record) {
+        drush_set_error('DRUSH_TEST_FAIL', dt("Test !function failed: !message in !file on line !line", array(
+          '!function' => $record->function,
+          '!message' => $record->message,
+          '!file' => $record->file,
+          '!line' => $record->line,
+        )));
+      }
+    }
+    else {
+      $result = db_query("SELECT * FROM {simpletest} WHERE test_id = %d AND status IN ('exception', 'fail') ORDER BY test_class, message_id", $test_id);
+      while ($row = db_fetch_object($result)) {
+        drush_set_error('DRUSH_TEST_FAIL', dt("Test !function failed: !message in !file on line !line", array(
+          '!function' => $row->function,
+          '!message' => $row->message,
+          '!file' => $row->file,
+          '!line' => $row->line,
+        )));
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Non-zero error codes when tests fail, based on change in https://github.com/drush-ops/drush/commit/e5655f2decb185352f00f3d553ea3198887f5840
