### PR TITLE
Provide hook to alter order of hook invocations.

### DIFF
--- a/docs/drush.api.php
+++ b/docs/drush.api.php
@@ -416,8 +416,8 @@ function hook_drush_invoke_alter($modules, $hook) {
  * @see hook_drush_invoke_alter().
  * @see _drush_invoke_hooks().
  */
-function hook_drush_callback_list_alter($callback_list, $var_hook, $command, $args)) {
- if ($var_hook == 'post_make') {
+function hook_drush_callback_list_alter(&$callback_list, $var_hook, $command, $args)) {
+  if ($var_hook == 'post_make') {
     // Find the index of our callback, and pull it out of the list.
     $index = array_search('drush_MY_MODULE_post_make', array_keys($callback_list));
     $callback = array_splice($callback_list, $index, 1);

--- a/docs/drush.api.php
+++ b/docs/drush.api.php
@@ -386,13 +386,12 @@ function hook_drush_engine_ENGINE_TYPE() {
  * Alter the order that hooks are invoked.
  *
  * When implementing a given hook we may need to ensure it is invoked before
- * or after another implementation of the same hook. For example, let's say
- * you want to implement a hook that would be called after drush_make. You'd
- * write a drush_MY_MODULE_post_make() function. But if you need your hook to
- * be called before drush_make_post_make(), you can ensure this by implemen-
- * ting MY_MODULE_drush_invoke_alter().
+ * or after another implementation of the same hook. This only applies to hooks
+ * that use drush_command_invoke_all() or drush_command_invoke_all_ref(). This
+ * does not apply to drush-made hook (e.g. drush_hook_pre_COMMAND()).
  *
- * @see drush_command_invoke_all_ref()
+ * @see hook_drush_callback_list_alter().
+ * @see drush_command_invoke_all_ref().
  */
 function hook_drush_invoke_alter($modules, $hook) {
   if ($hook == 'some_hook') {
@@ -400,6 +399,32 @@ function hook_drush_invoke_alter($modules, $hook) {
     $module = array_pop($modules);
     // Ensure it'll be called first for 'some_hook'.
     array_unshift($modules, $module);
+  }
+}
+
+/**
+ * Alter the order that hooks are invoked.
+ *
+ * When implementing a given drush-made hook (e.g. drush_hook_pre_COMMAND()),
+ * we may need to ensure it is invoked before or after another implementation
+ * of the same hook. For example, let's say you want to implement a hook that
+ * would be called after drush_make. You'd write a drush_MY_MODULE_post_make()
+ * function. Since the order is alphabetical, your command will run after
+ * drush_make_post_make(). But if you need your hook to be called before, you
+ * can ensure this by implementing MY_MODULE_drush_callback_list_alter().
+ *
+ * @see hook_drush_invoke_alter().
+ * @see _drush_invoke_hooks().
+ */
+function hook_drush_callback_list_alter($callback_list, $var_hook, $command, $args)) {
+ if ($var_hook == 'post_make') {
+    // Find the index of our callback, and pull it out of the list.
+    $index = array_search('drush_MY_MODULE_post_make', array_keys($callback_list));
+    $callback = array_splice($callback_list, $index, 1);
+    // Find where to insert our callback, and add it back to the list.
+    $target = array_search('drush_make_post_make', array_keys($callback_list));
+    $tail = array_splice($callback_list, $target + 1);
+    $callback_list += $callback + $tail;
   }
 }
 

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -321,65 +321,58 @@ function _drush_invoke_hooks($command, $args) {
   // Iterate through the different hook variations
   $variations = array($hook . "_pre_validate", $hook . "_validate", "pre_$hook", $hook, "post_$hook");
   foreach ($variations as $var_hook) {
-    // Get the list of command files.
-    // We re-fetch the list every time through
-    // the loop in case one of the hook function
-    // does something that will add additional
-    // commandfiles to the list (i.e. bootstrapping
-    // to a higher phase will do this).
-    $list = drush_commandfile_list();
-
-    // Make a list of function callbacks to call.  If
-    // there is a 'primary function' mentioned, make sure
-    // that it appears first in the list, but only if
-    // we are running the main hook ("$hook").  After that,
-    // make sure that any callback associated with this commandfile
-    // executes before any other hooks defined in any other
-    // commandfiles.
+    // Compile a list of function callbacks to call.
     $callback_list = array();
-    if (($var_hook == $hook) && ($command['primary function'])) {
-      $callback_list[$command['primary function']] = $list[$command['commandfile']];
+    if ($hook == $var_hook) {
+      // If this is the primary function, there's no need to look for other
+      // hook implementations.
+      $commandfiles = drush_commandfile_list();
+      $primary_func = _drush_get_primary_function($command, $var_hook);
+      $callback_list[$primary_func] = $commandfiles[$command['commandfile']];
     }
     else {
-      $primary_func = ($command['commandfile'] . "_" == substr($var_hook . "_",0,strlen($command['commandfile']) + 1)) ? sprintf("drush_%s", $var_hook) : sprintf("drush_%s_%s", $command['commandfile'], $var_hook);
-      $callback_list[$primary_func] = $list[$command['commandfile']];
+      // Get the list of commandfiles that implement this hook.
+      // We re-fetch the list every time through the loop in case one of the
+      // hook functions does something that will add additional commandfiles
+      // to the list (i.e. bootstrapping to a higher phase).
+      $list = array_flip(drush_command_implements($var_hook));
+      foreach ($list as $commandfile => $filename) {
+        $func = sprintf("drush_%s_%s", $commandfile, $var_hook);
+        $callback_list[$func] = $filename;
+      }
     }
-    // We've got the callback for the primary function in the
-    // callback list; now add all of the other callback functions.
-    unset($list[$command['commandfile']]);
-    foreach ($list as $commandfile => $filename) {
-      $func = sprintf("drush_%s_%s", $commandfile, $var_hook);
-      $callback_list[$func] = $filename;
+    if (drush_get_option('show-invoke')) {
+      $commandfiles = drush_commandfile_list();
+      foreach ($commandfiles as $commandfile => $filename) {
+        $all_available_hooks[] = sprintf("drush_%s_%s", $commandfile, $var_hook);
+      }
     }
+    // Allow modules to control the order of the callback list.
+    drush_command_invoke_all_ref('drush_callback_list_alter', $callback_list, $var_hook, $command, $args);
     // Run all of the functions available for this variation
     $accumulated_result = NULL;
     foreach ($callback_list as $func => $filename) {
-      if (function_exists($func)) {
-        $all_available_hooks[] = $func . ' [* Defined in ' . $filename . ']';
-        $available_rollbacks[] = $func . '_rollback';
-        $completed[] = $func;
-        drush_log(dt("Calling hook !hook", array('!hook' => $func)), 'debug');
-        $result = call_user_func_array($func, $args);
-        drush_log(dt("Returned from hook !hook", array('!hook' => $func)), 'debug');
-        // If there is an error, break out of the foreach
-        // $variations and foreach $callback_list
-        if (drush_get_error() || ($result === FALSE)) {
-          $rollback = TRUE;
-          break 2;
-        }
-        // If result values are arrays, then combine them all together.
-        // Later results overwrite earlier results.
-        if (isset($result) && is_array($accumulated_result) && is_array($result)) {
-          $accumulated_result = array_merge($accumulated_result, $result);
-        }
-        else {
-          $accumulated_result = $result;
-        }
-        _drush_log_drupal_messages();
+      $all_available_hooks[] = $func . ' [* Defined in ' . $filename . ']';
+      $available_rollbacks[] = $func . '_rollback';
+      $completed[] = $func;
+      drush_log(dt("Calling hook !hook", array('!hook' => $func)), 'debug');
+      $result = call_user_func_array($func, $args);
+      drush_log(dt("Returned from hook !hook", array('!hook' => $func)), 'debug');
+      // If there is an error, break out of the foreach
+      // $variations and foreach $callback_list
+      if (drush_get_error() || ($result === FALSE)) {
+        $rollback = TRUE;
+        break 2;
+      }
+      // If result values are arrays, then combine them all together.
+      // Later results overwrite earlier results.
+      if (isset($result) && is_array($accumulated_result) && is_array($result)) {
+        $accumulated_result = array_merge($accumulated_result, $result);
       }
       else {
-        $all_available_hooks[] = $func;
+        $accumulated_result = $result;
       }
+      _drush_log_drupal_messages();
     }
     // Process the result value from the 'main' callback hook only.
     if ($var_hook == $hook) {
@@ -435,6 +428,28 @@ function _drush_invoke_hooks($command, $args) {
 
   if (isset($return)) {
     return $return;
+  }
+}
+
+/**
+ * If we are running the main hook ("$hook"), and a 'primary function' is
+ * mentioned, return it. Otherwise, return the callback associated with this
+ * commandfile.
+ */
+function _drush_get_primary_function($command, $var_hook) {
+  if ($command['primary function']) {
+    return $command['primary function'];
+  }
+  else {
+    $cmd_file = $command['commandfile'];
+    // When the command name starts with the same sequence of characters as
+    // the command file, then drop the repeated sequence.
+    if ($cmd_file . '_' == substr($var_hook . '_', 0, strlen($cmd_file) + 1)) {
+      return sprintf("drush_%s", $var_hook);
+    }
+    else {
+      return sprintf("drush_%s_%s", $cmd_file, $var_hook);
+    }
   }
 }
 
@@ -1255,10 +1270,6 @@ function drush_command_invoke_all_ref($hook, &$reference_parameter) {
   $args[0] = &$reference_parameter;
   $return = array();
   $modules = drush_command_implements($hook);
-  if ($hook != 'drush_invoke_alter') {
-    // Allow modules to control the order of hook invocations
-    drush_command_invoke_all_ref('drush_invoke_alter', $modules, $hook);
-  }
   foreach ($modules as $module) {
     $function = $module .'_'. $hook;
     $result = call_user_func_array($function, $args);
@@ -1286,9 +1297,14 @@ function drush_command_implements($hook) {
   $list = drush_commandfile_list();
   foreach ($list as $commandfile => $file) {
     if (drush_command_hook($commandfile, $hook)) {
-      $implementations[$hook][] = $commandfile;
+      $implementations[$hook][$file] = $commandfile;
     }
   }
+  if ($hook != 'drush_command_implements_alter') {
+    // Allow modules to control the order of hook invocations
+    drush_command_invoke_all_ref('drush_command_implements_alter', $implementations, $hook);
+  }
+
   return (array)$implementations[$hook];
 }
 

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -321,34 +321,42 @@ function _drush_invoke_hooks($command, $args) {
   // Iterate through the different hook variations
   $variations = array($hook . "_pre_validate", $hook . "_validate", "pre_$hook", $hook, "post_$hook");
   foreach ($variations as $var_hook) {
+    // Get the list of commandfiles that implement this hook.
+    // We re-fetch the list every time through the loop in case one of the
+    // hook functions does something that will add additional commandfiles
+    // to the list (i.e. bootstrapping to a higher phase).
+    $commandfiles = drush_commandfile_list();
     // Compile a list of function callbacks to call.
     $callback_list = array();
     if ($hook == $var_hook) {
       // If this is the primary function, there's no need to look for other
       // hook implementations.
-      $commandfiles = drush_commandfile_list();
       $primary_func = _drush_get_primary_function($command, $var_hook);
       $callback_list[$primary_func] = $commandfiles[$command['commandfile']];
     }
     else {
-      // Get the list of commandfiles that implement this hook.
-      // We re-fetch the list every time through the loop in case one of the
-      // hook functions does something that will add additional commandfiles
-      // to the list (i.e. bootstrapping to a higher phase).
-      $list = array_flip(drush_command_implements($var_hook));
-      foreach ($list as $commandfile => $filename) {
-        $func = sprintf("drush_%s_%s", $commandfile, $var_hook);
-        $callback_list[$func] = $filename;
+      foreach ($commandfiles as $commandfile => $filename) {
+        // Strip the duplicate prefix
+        if (substr($var_hook, 0, strlen($commandfile)) == $commandfile) {
+          $func = sprintf("drush_%s", $var_hook);
+        }
+        else {
+          $func = sprintf("drush_%s_%s", $commandfile, $var_hook);
+        }
+        if (function_exists($func)) {
+          $callback_list[$func] = $filename;
+        }
       }
     }
     if (drush_get_option('show-invoke')) {
-      $commandfiles = drush_commandfile_list();
       foreach ($commandfiles as $commandfile => $filename) {
         $all_available_hooks[] = sprintf("drush_%s_%s", $commandfile, $var_hook);
       }
     }
+
     // Allow modules to control the order of the callback list.
     drush_command_invoke_all_ref('drush_callback_list_alter', $callback_list, $var_hook, $command, $args);
+
     // Run all of the functions available for this variation
     $accumulated_result = NULL;
     foreach ($callback_list as $func => $filename) {
@@ -356,7 +364,9 @@ function _drush_invoke_hooks($command, $args) {
       $available_rollbacks[] = $func . '_rollback';
       $completed[] = $func;
       drush_log(dt("Calling hook !hook", array('!hook' => $func)), 'debug');
-      $result = call_user_func_array($func, $args);
+      if (function_exists($func)) {
+        $result = call_user_func_array($func, $args);
+      }
       drush_log(dt("Returned from hook !hook", array('!hook' => $func)), 'debug');
       // If there is an error, break out of the foreach
       // $variations and foreach $callback_list


### PR DESCRIPTION
Eventually I'll get this right...

This is a follow-up to [Provide weight-like mechanism to ensure order of hook calls](https://drupal.org/node/2031383). It provides a similar hook for native drush hooks in _drush_invoke_hooks().

It replaces https://github.com/drush-ops/drush/pull/461, which failed testing due to commit conflicts. This time I squashed everything into one commit. Fingers crossed.
