### PR TITLE
Replace config() and config_get_storage_names_with_prefix() with \Drupal

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -151,7 +151,7 @@ function config_drush_command() {
  *   The config prefix to retrieve, or empty to return all.
  */
 function drush_config_list($prefix = '') {
-  $names = config_get_storage_names_with_prefix($prefix);
+  $names = \Drupal::configFactory()->listAll($prefix);
 
   if (empty($names)) {
     // Just in case there is no config.
@@ -359,7 +359,7 @@ function drush_config_edit($config_name = '') {
     }
   }
   else {
-    $config_names = config_get_storage_names_with_prefix();
+    $config_names = \Drupal::configFactory()->listAll();
     $choice = drush_choice($config_names, 'Choose a configuration.');
     if (empty($choice)) {
       return drush_user_abort();

--- a/commands/core/views.d8.drush.inc
+++ b/commands/core/views.d8.drush.inc
@@ -159,7 +159,7 @@ function drush_views_dev() {
     'ui.show.display_embed' => TRUE,
   );
 
-  $config = config('views.settings');
+  $config = \Drupal::config('views.settings');
 
   foreach ($settings as $setting => $value) {
     $config->set($setting, $value);


### PR DESCRIPTION
These functions are going to be removed - see https://drupal.org/node/2192693
