### PR TITLE
By mpdonadio: force result-file=FALSE for _drush_sql_get_db_table_list()...

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -805,6 +805,7 @@ function _drush_sql_get_db_table_list($db_spec, $site_record = NULL) {
   // this is called by sql-drop. Also needed during archive-restore.
   $options = array(
     'db-spec' => $db_spec,
+    'result-file' => FALSE,
   );
   $backend_options = array(
     'integrate' => FALSE,


### PR DESCRIPTION
The patch simply sets the option to force the result file off for this function so that the query can be returned from drush_invoke_process() instead of being written to a file.
