### PR TITLE
Fix compatibility w Panels/Panelizer directories

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -337,6 +337,13 @@ function drush_valid_drupal_root($path) {
     if (file_exists($path . '/' . $candidate) && file_exists($path . '/core/misc/drupal.js') && file_exists($path . '/composer.json')) {
       return $candidate;
     }
+    // Panels and Panelizer throw off Drush, because they too contain a file at
+    // "includes/common.inc".
+    foreach (array('panels.module', 'panelizer.module') as $candidate) {
+      if (file_exists($path . '/' . $candidate)) {
+        return FALSE;
+      }
+    }
     // Drupal 7 root. Additional check for the absence of core/composer.json to
     // grant $path is not core/ of a Drupal 8 root.
     $candidate = 'includes/common.inc';


### PR DESCRIPTION
When running Drush commands from within either the Panels or Panelizer directories, Drush mistakenly thinks it has found a Drupal install because both modules contain a file at "includes/common.inc". This adds a simple check to see if either "panels.module" or "panelizer.module" exist, if they do then it fails, allowing drush_locate_root() to continue recursing higher up the directory tree until it finds the correct Drupal root.
