### PR TITLE
Fix "Undefined index: time in environment_*.inc"

### DIFF
--- a/commands/core/drupal/environment_6.inc
+++ b/commands/core/drupal/environment_6.inc
@@ -289,12 +289,10 @@ function drush_queue_get_queues() {
     $queues = module_invoke_all('cron_queue_info');
     drupal_alter('cron_queue_info', $queues);
     foreach($queues as $name => $queue) {
-      $queues[$name] = array(
-        'worker callback' => $queue['worker callback'],
-        'cron' => array(
-          'time' => $queue['time'],
-        ),
-      );
+      $queues[$name]['worker callback'] = $queue['worker callback'];
+      if (isset($queue['time'])) {
+        $queues[$name]['cron']['time'] = $queue['time'];
+      }
     }
   }
   return $queues;

--- a/commands/core/drupal/environment_7.inc
+++ b/commands/core/drupal/environment_7.inc
@@ -267,12 +267,10 @@ function drush_queue_get_queues() {
     $queues = module_invoke_all('cron_queue_info');
     drupal_alter('cron_queue_info', $queues);
     foreach($queues as $name => $queue) {
-      $queues[$name] = array(
-        'worker callback' => $queue['worker callback'],
-        'cron' => array(
-          'time' => $queue['time'],
-        ),
-      );
+      $queues[$name]['worker callback'] = $queue['worker callback'];
+      if (isset($queue['time'])) {
+        $queues[$name]['cron']['time'] = $queue['time'];
+      }
     }
   }
   return $queues;


### PR DESCRIPTION
[`hook_cron_queue_info()`](https://api.drupal.org/api/drupal/modules!system!system.api.php/function/hook_cron_queue_info/7) declares that the `time` array element is optional, but `drush_queue_get_queues()` assumes that it's defined and therefore causes a PHP notice if it's not:

> Undefined index: time environment_7.inc:273 [notice]

This eliminates the assumption and eliminates the notice. (`drush_queue_run()` already adds the default value afterward.)
