### PR TITLE
Remove duplicate `cli` alias

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -7,7 +7,7 @@ function cli_drush_command() {
   $items['core-cli'] = array(
     'description' => 'Open an interactive shell on a Drupal site.',
     'remote-tty' => TRUE,
-    'aliases' => array('cli', 'php'),
+    'aliases' => array('php'),
     'bootstrap' => DRUSH_BOOTSTRAP_MAX,
   );
   return $items;


### PR DESCRIPTION
Pull request #388 added a `core-cli` command which fires up a Boris shell. It has a `cli` alias. But `cli` is already aliased to `config-list`.

```
Slate ~/Sites/abweb.test/www> d7 | grep cli
 core-cli (cli, php)   Open an interactive shell on a Drupal site.              
 config-list (cli)     List config names by prefix.                             
 sql-cli (sqlc)        Open a SQL command-line interface using Drupal's     
```

The commit in this PR simply removes the `cli` alias from `core-cli`. `config-list` was there first, after all, and IMO the other alias of `php` is almost as memorable.
