### PR TITLE
Updated documentation for drush_log.

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -1397,8 +1397,11 @@ function drush_do_command_redispatch($command, $args = array(), $remote_host = N
  * @param type
  *   The type of message to be logged. Common types are 'warning', 'error', 'success' and 'notice'.
  *   A type of 'failed' can also be supplied to flag as an 'error'.
- *   A type of 'ok' or 'completed' can also be supplied to flag as a 'success'
- *   All other types of messages will be assumed to be notices.
+ *   A type of 'ok' or 'completed' can also be supplied to flag as a 'success'.
+ *   If you want your log messages to print to screen without the user entering
+ *   a -v or --verbose flag, use type 'ok', this prints log messages out to
+ *   STDERR, which prints to screen (unless you have redirected it). All other
+ *   types of messages will be assumed to be notices.
  */
 function drush_log($message, $type = 'notice', $error = null) {
   $log =& drush_get_context('DRUSH_LOG', array());


### PR DESCRIPTION
  Provide a few more details about 'ok', so it's a more obvious alternative to
  drush_print, when developers want to print messages to screen and log.

```
modified:   drush.inc
```
