### PR TITLE
Attempt to bootstrap in drush_sql_get_class()

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -612,6 +612,11 @@ function _drush_sql_get_post_sync_messages() {
  */
 function drush_sql_get_class($db_spec = NULL) {
   try {
+    drush_bootstrap_max(DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION);
+  }
+  catch (Exception $e) {
+  }
+  try {
     if ($db_spec) {
       return drush_get_class('Drush\Sql\Sql', array($db_spec), array($db_spec['driver']));
     }


### PR DESCRIPTION
I found that the `drush @example.dev sql-query` and `drush @example.dev sqlc` commands did not work with a Drupal 6 site unless this bit of code was added in. `drush @example.dev sql-conf` did work, which clued me in to this fix.
