### PR TITLE
Follow-up to #530: Fix broken multi-user support in `site-set` command.

### DIFF
--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -354,13 +354,17 @@ function drush_sitealias_site_set($site = '@none') {
         @unlink($last_site_filename);
         @rename($filename, $last_site_filename);
       }
+      $success_message = dt("Site set to !site", array('!site' => $site));
       if ($site == '@none') {
-        drush_delete_dir($filename);
+        if (drush_delete_dir($filename)) {
+          drush_print($success_message);
+        }
       }
-      else {
-        file_put_contents($filename, $site);
+      elseif (drush_mkdir(dirname($filename), TRUE)) {
+        if (file_put_contents($filename, $site)) {
+          drush_print($success_message);
+        }
       }
-      drush_print(dt("Site set to !site", array('!site' => $site)));
     }
     else {
       drush_set_error('DRUPAL_SITE_NOT_FOUND', dt("Could not find a site definition for !site.", array('!site' => $site)));

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -2060,22 +2060,18 @@ function drush_sitealias_site_get() {
  * Returns the filename for the file that stores the DRUPAL_SITE variable.
  *
  * @param string $filename_prefix
- *   An arbitrary string to prefix the filename with. Defaults to
- *   "drush-drupal-site-".
+ *   An arbitrary string to prefix the filename with.
  *
  * @return string|false
  *   Returns the full path to temp file if possible, or FALSE if not.
  */
 function drush_sitealias_get_envar_filename($filename_prefix = 'drush-drupal-site-') {
-  $tmp = getenv('TMPDIR') ? getenv('TMPDIR') : '/tmp/';
-
-  if (function_exists('posix_getppid') && is_dir($tmp) && is_writable($tmp)) {
-    $dir = $tmp . '/drush-env';
-    if (drush_mkdir($dir, TRUE)) {
-      return $dir . '/' . $filename_prefix . posix_getppid();
-    }
+  if (!function_exists('posix_getppid')) {
+    return FALSE;
   }
-  return FALSE;
+
+  $tmp = getenv('TMPDIR') ? getenv('TMPDIR') : '/tmp/';
+  return "{$tmp}/drush-env/{$filename_prefix}" . posix_getppid();
 }
 
 /**


### PR DESCRIPTION
This should fix the regression introduced in #530. There doesn't seem to be any reason to execute a `mkdir` every time want the temp file name, so I moved that to the only place that's actually using that information to actually _write_ to the file. This also fixes a bug I discovered where `site-set @none` was emitting a success message even if it failed. (Notes in the diff.)
