### PR TITLE
Show hook_update_N return values.

### DIFF
--- a/commands/core/drupal/update_7.inc
+++ b/commands/core/drupal/update_7.inc
@@ -71,6 +71,13 @@ function drush_update_do_one($module, $number, $dependency_map,  &$context) {
 
       drush_log("Executing " . $function);
       $ret['results']['query'] = $function($context['sandbox']);
+
+      // If the update hook returned a status message (common in batch updates),
+      // show it to the user.
+      if ($ret['results']['query']) {
+        drush_log($ret['results']['query'], 'ok');
+      }
+
       $ret['results']['success'] = TRUE;
     }
     // @TODO We may want to do different error handling for different exception


### PR DESCRIPTION
[hook_update_N](https://api.drupal.org/api/drupal/modules!system!system.api.php/function/hook_update_N/7) allows for a translated message to be returned. Update hooks often use this to show log messages during updates with update.php. This PR logs the return to the console so there isn't a feature difference between CLI and browser updates.
