### PR TITLE
Respect working-copy setting in download array

### DIFF
--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -185,7 +185,7 @@ class DrushMakeProject {
       $this->processGitInfoFiles();
     }
     // Clean-up .git directories.
-    if (!drush_get_option('working-copy') && (empty($this->options['working-copy']) ||  !_make_is_override_allowed('working-copy'))) {
+    if (!_get_working_copy_option($this->download)) {
       $this->removeGitDirectory();
     }
     if (!$this->recurse($this->download_location)) {


### PR DESCRIPTION
There have been a number of changes to the implementation of the "working-copy" setting in the download options for a project/library/etc over the last year, but it appears the code in make.project.inc has not kept up with the logic in make.download.inc. In the latter file there is a helper function utilized to identify whether we should keep the working copy. The line changed in this pull request is basically doing the same thing but ignoring the setting which is accessible, in this context, at $this->download.

This is my first contribution to drush so hopefully I've got this all right. Tested (just manually, not with a unit test) on this end, with both project and library git clones. Thanks!
