### PR TITLE
Ensure that Drush will use backend_invoke() for vagrant & c.

### DIFF
--- a/examples/example.aliases.drushrc.php
+++ b/examples/example.aliases.drushrc.php
@@ -154,6 +154,9 @@
  *   hosting the Drupal instance. **Important Note: The remote-host option
  *   must be omitted for local sites, as this option controls whether or not
  *   rsync parameters are for local or remote machines.
+ * - '#check-local': Test to see if 'remote-host' is the local machine; if
+ *   it is, then 'remote-host' will be ignore. Useful when sharing aliases
+ *   among multiple machines.
  * - 'remote-user': The username to log in as when using ssh or rsync.
  * - 'os': The operating system of the remote server.  Valid values
  *   are 'Windows' and 'Linux'. Be sure to set this value for all remote

--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1106,7 +1106,7 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
   $ssh_options = $site_record['ssh-options'];
   $os = drush_os($site_record);
 
-  if (empty($ssh_options) && drush_is_local_host($hostname)) {
+  if (array_key_exists('#check-local', $site_record) && drush_is_local_host($hostname)) {
     $hostname = null;
   }
 

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1693,7 +1693,7 @@ function drush_sitealias_set_alias_context($site_alias_settings, $prefix = '') {
   // and 'remote-user' if 'remote-host' is actually the local machine.
   // This prevents drush from using the remote dispatch mechanism (the command
   // is just run directly on the local machine, bootstrapping to the specified alias)
-  elseif (array_key_exists('remote-host', $site_alias_settings) && !array_key_exists('ssh-options', $site_alias_settings) && drush_is_local_host($site_alias_settings['remote-host'])) {
+  elseif (array_key_exists('remote-host', $site_alias_settings) && array_key_exists('#check-local', $site_alias_settings) && drush_is_local_host($site_alias_settings['remote-host'])) {
     $skip_list[] = 'remote-host';
     $skip_list[] = 'remote-user';
   }


### PR DESCRIPTION
This PR will cal through to backend_invoke() instead of executing a command locally if ssh-options are defined.  c.f.: #545

This is just a quick implementation for testing.  We still need to decide if we should inspect the contents of ssh-options before deciding whether the command should be local or remote.

The conflicting use case is that some folks may have Drush aliases that they share between multiple machines; in this case, Drush currently takes some pains to insure that it does not use ssh to call a "remote" site if the alias to said site is being used on the server where it is running.  In other words, if 'remote-host' is set to 'foo.com', then Drush will pretend it is not set if the local machine is 'foo.com'.  This is the root cause for why Drush aliases to sites running on virtualbox / vagrant do not work right.

This PR should probably be enhanced to require that ssh-options does contain -p, but the -p parameter is not -p 22.  Is this the right test.
