### PR TITLE
#32 fixing drush submodule leaves two clones

### DIFF
--- a/commands/pm/download.pm.inc
+++ b/commands/pm/download.pm.inc
@@ -321,9 +321,8 @@ function _pm_download_destination_lookup($type, $drupal_root, $sitepath, $create
  */
 function _pm_download_destination($type) {
   $drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT');
-
-  $site_root = drush_get_context('DRUSH_DRUPAL_SITE_ROOT', FALSE);
-  $full_site_root = $drupal_root .'/'. $site_root;
+  $site_root = drush_get_context('DRUSH_DRUPAL_SITE_ROOT');
+  $full_site_root = empty($drupal_root) ? '' : $drupal_root .'/'. $site_root;
   $sitewide = $drupal_root . '/' . drush_drupal_sitewide_directory();
 
   $in_site_directory = FALSE;


### PR DESCRIPTION
This fixes #32 which was introduced at 9c9eb542a6b3bd5230e064790bf3b95efef0a808
