### PR TITLE
Copy the autoloading from 7.x branch into 6.x

### DIFF
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -1012,15 +1012,16 @@ function drush_bootstrap_value($context, $value = null) {
 function drush_bootstrap_prepare() {
   define('DRUSH_BASE_PATH', dirname(dirname(__FILE__)));
 
+  // If Drush was installed with composer, load autoload.php.
   $local_vendor_path = DRUSH_BASE_PATH . '/vendor/autoload.php';
   $global_vendor_path = DRUSH_BASE_PATH . '/../../../vendor/autoload.php';
-
-  // Check for a local composer install or a global composer install. Vendor dirs are in different spots).
-  if ((!@include $local_vendor_path) && (!@include $global_vendor_path)) {
-    $msg = "Unable to load autoload.php. Drush now requires Composer in order to install its depedencies and autoload classes. Please see README.md\n";
-    fwrite(STDERR, $msg);
-    return FALSE;
+  if (file_exists($local_vendor_path)) {
+    require_once $local_vendor_path;
   }
+  elseif (file_exists($global_vendor_path)) {
+    require_once $global_vendor_path;
+  }
+
   require_once DRUSH_BASE_PATH . '/includes/environment.inc';
   require_once DRUSH_BASE_PATH . '/includes/command.inc';
   require_once DRUSH_BASE_PATH . '/includes/drush.inc';


### PR DESCRIPTION
Without this, Drush extensions can't do something like `$yaml = new Parser();`
