### PR TITLE
drush ssh, use a login shell by default

### DIFF
--- a/commands/core/ssh.drush.inc
+++ b/commands/core/ssh.drush.inc
@@ -70,7 +70,7 @@ function drush_ssh_site_ssh($command = NULL) {
   $interactive = FALSE;
   $cd = drush_get_option('cd', TRUE);
   if (empty($command)) {
-    $command = 'bash';
+    $command = 'bash -l';
     $interactive = TRUE;
   }
   $cmd = drush_shell_proc_build($site, $command, $cd, $interactive);


### PR DESCRIPTION
See: https://github.com/drush-ops/drush/issues/558
