### PR TITLE
#561: Allow for numeric and NULL values to be passed in.

### DIFF
--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -253,6 +253,15 @@ function drush_core_site_install($profile = NULL) {
     // Subsequent arguments are additional form values.
     foreach ($args as $arg) {
       list($key, $value) = explode('=', $arg);
+
+      // Allow for numeric and NULL values to be passed in.
+      if (is_numeric($value)) {
+        $value = intval($value);
+      }
+      elseif ($value == 'NULL') {
+        $value = NULL;
+      }
+
       $form_options[$key] = $value;
     }
   }


### PR DESCRIPTION
As per #561, Site Install $additional_form_options only accepts strings, which is an issue for checkboxes and possibly other form elements. This PR adds support for integers and NULL values.
