### PR TITLE
Adding youngj/httpserver to requirements to fix broken drush run-server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "php": ">=5.3.0",
     "d11wtq/boris": "*",
     "symfony/yaml": "2.2.1",
-    "pear/console_table": "1.1.5"
+    "pear/console_table": "1.1.5",
+    "youngj/httpserver": "dev-master"
   },
   "require-dev": {
     "phpunit/phpunit": ">=3.5"


### PR DESCRIPTION
drush run-server doesn't work with the latest copy on `master` branch.

Adding `youngj/httpserver` to `require` then running composer update worked for me.

Not sure if this is the right fix, but that's what pull requests are for!
