### PR TITLE
Allow contrib_destination to be managed per project.

### DIFF
--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -195,13 +195,9 @@ function make_validate_info_file($info) {
           }
           $names[] = $project;
           foreach ($project_data as $attribute => $value) {
-            // Unset disallowed attributes.
-            if (in_array($attribute, array('contrib_destination'))) {
-              unset($info['projects'][$project][$attribute]);
-            }
             // Prevent malicious attempts to access other areas of the
             // filesystem.
-            elseif (in_array($attribute, array('subdir', 'directory_name')) && !make_safe_path($value)) {
+            if (in_array($attribute, array('subdir', 'directory_name', 'contrib_destination')) && !make_safe_path($value)) {
               $args = array(
                 '!path' => $value,
                 '!attribute' => $attribute,


### PR DESCRIPTION
When defining a Make file, you can't currently control the download contrib destination per project, only globally. This means all module projects are downloaded and restricted to something like "sites/all" by default. If you are using multisite and need to download different modules to different subdirectories, then you can't currently manage that will one drush make call. Likewise, if you want to update modules in a profile, the same issue applies.

This patch amends that be enabling contrib_destination to be controlled per project. However, the project path is still deemed safe through make_safe_path().
