### PR TITLE
SQL queries are not shown using --simulate

### DIFF
--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -180,7 +180,7 @@ class SqlBase {
     // In --simulate mode, drush_shell_exec() will show the call to mysql or psql,
     // but the sql query itself is stored in a temp file and not displayed.
     // We will therefore show the query explicitly in the interest of debugging.
-    if (drush_get_context('DRUSH_SIMULATE') && empty($input_file)) {
+    if (drush_get_context('DRUSH_SIMULATE')) {
       drush_log('sql-query: ' . $query, 'status');
     }
 


### PR DESCRIPTION
SQL queries are no longer displayed when you use the --simulate flag.  $input_file is now always used in the query method, so the query is never shown.  This makes it hard to debug other issues.  
