### PR TITLE
sql-create does not grant access to the right user when db-su is used

### DIFF
--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -249,10 +249,11 @@ class SqlBase {
    *   in a Windows shell. Set TRUE if the CREATE is not running on the bash command line.
    */
   public function createdb($quoted = FALSE) {
-    // Adjust connection to allow for superuser creds if provided.
     $dbname = $this->db_spec['database'];
+    $sql = $this->createdb_sql($dbname);
+    // Adjust connection to allow for superuser creds if provided.
     $this->su();
-    return $this->query($this->createdb_sql($dbname));
+    return $this->query($sql);
   }
 
   /**


### PR DESCRIPTION
SQL create (and by extension site-install) has recently started creating databases and granting access to the wrong user if a db-su has been set up.  The problem is that the database username and password are set to the su credentials before forming the createdb query.  This PR fixes the problem by switching the ordering of generating the query and setting the su credentials.  
