### PR TITLE
PostgreSQL not returning original query in query_format method.

### DIFF
--- a/lib/Drush/Sql/Sqlpgsql.php
+++ b/lib/Drush/Sql/Sqlpgsql.php
@@ -55,6 +55,7 @@ class Sqlpgsql extends SqlBase {
     if (strtolower($query) == 'show tables;') {
       return $this->listTables();
     }
+    return $query;
   }
 
   public function listTables() {
@@ -65,6 +66,7 @@ class Sqlpgsql extends SqlBase {
       array_shift($tables);
       return $tables;
     }
+    return array();
   }
 
   public function dumpCmd($table_selection, $file) {


### PR DESCRIPTION
The query_format method transforms $query if given $query is 'show tables;' (or with other case), but otherwise, it returns nothing. This makes listTables return an empty list of tables, and --structure-tables becames empty, so all database is dump, with all data. Also, that generated a PHP warning trying to find an element in a NULL array with in_array.
