### PR TITLE
Convert commands to classes.

### DIFF
--- a/lib/Drush/Command/CommandInterface.php
+++ b/lib/Drush/Command/CommandInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drush\Command\CommandInterface.
+ */
+
+namespace Drush\Command;
+
+/**
+ * An interface for a Drush command class.
+ */
+interface CommandInterface {
+
+  /**
+   * Provides the command name.
+   *
+   * @return string
+   *   The command's name, e.g. "pm-download".
+   */
+  public function name();
+
+  /**
+   * Provides a list of shorter names for the command.
+   *
+   * For example, pm-download may also be called via `drush dl`. If the alias is
+   * used, Drush will substitute back in the primary command name, so
+   * pm-download will still be used to generate the command hook, etc.
+   *
+   * @return array
+   *   An indexed array of command aliases.
+   */
+  public function aliases();
+
+  public function description();
+
+  public function arguments();
+
+  public function options();
+
+  public function help();
+
+  public function preValidate();
+
+  public function validate();
+
+  public function preExecute();
+
+  public function execute();
+
+  public function postExecute();
+
+}


### PR DESCRIPTION
This is the beginning of a proof of concept for converting Drush commands to classes per https://github.com/drush-ops/drush/pull/532#issuecomment-38189227. I'm beginning by creating a `CommandInterface`, imagining that individual commands would implement it. I started by just creating a method for each of the major elements returned by `COMMANDFILE_drush_command()` and one for each of the command hooks. Does this seem like the right approach? Should I continue?
