### PR TITLE
Fix #589. Pass along php-options from a site alias to backend  calls.

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -417,6 +417,7 @@ function drush_verify_cli() {
  * e.g. in backend_invoke.
  */
 function drush_build_drush_command($drush_path = NULL, $php = NULL, $os = NULL, $remote_command = FALSE) {
+  $environment_variables = array();
   $os = _drush_get_os($os);
   $additional_options = '';
   if (!isset($drush_path)) {
@@ -442,18 +443,27 @@ function drush_build_drush_command($drush_path = NULL, $php = NULL, $os = NULL, 
       $additional_options .= ' --php=' . drush_escapeshellarg($php, $os);
     }
     // We will also add in the php options from --php-options
-    $php = drush_escapeshellarg($php, $os) . ' ';
+    $prefix = drush_escapeshellarg($php, $os);
     $php_options = drush_get_option('php-options','');
     if (!empty($php_options)) {
-      $php .= $php_options . ' ';
+      $prefix .= ' ' . $php_options;
       $additional_options .= ' --php-options=' . drush_escapeshellarg($php_options, $os);
     }
   }
-  elseif ($php && drush_has_bash($os)) {
-    $php = 'DRUSH_PHP=' . drush_escapeshellarg($php, $os) . ' ';
+  else {
+    // Set environment variables to propogate config to redispatched calls.
+    if (drush_has_bash($os)) {
+      if ($php) {
+        $environment_variables[] = 'DRUSH_PHP=' . drush_escapeshellarg($php, $os);
+      }
+      if ($php_options_alias = drush_get_option('php-options', NULL, 'alias')) {
+        $environment_variables[] = 'PHP_OPTIONS=' . drush_escapeshellarg($php_options_alias, $os);
+      }
+      $prefix = implode(' ', $environment_variables);
+    }
   }
 
-  return $php . drush_escapeshellarg($drush_path, $os) . $additional_options;
+  return $prefix . ' ' . drush_escapeshellarg($drush_path, $os) . $additional_options;
 }
 
 /**


### PR DESCRIPTION
Pass along php-options from a site alias to backend calls via an environment variable.

Any thoughts, @greg-1-anderson? I limited what we pass along to just site alias provided php-options.
