### PR TITLE
Return support for hook_queue_info()

### DIFF
--- a/commands/core/drupal/environment_7.inc
+++ b/commands/core/drupal/environment_7.inc
@@ -272,6 +272,15 @@ function drush_queue_get_queues() {
         $queues[$name]['cron']['time'] = $queue['time'];
       }
     }
+    // Merge in queues from modules that implement hook_queue_info.
+    // Currently only defined by the queue_ui module.
+    $info_queues = module_invoke_all('queue_info');
+    foreach($info_queues as $name => $queue) {
+      $queues[$name]['worker callback'] = $queue['cron']['callback'];
+      if (isset($queue['cron']['time'])) {
+        $queues[$name]['cron']['time'] = $queue['cron']['time'];
+      }
+    }
   }
   return $queues;
 }


### PR DESCRIPTION
Drush use to support hook_queue_info() until https://github.com/drush-ops/drush/issues/232

This PR returns that support
