### PR TITLE
Fix #631 : D8 include files might have .php in future

### DIFF
--- a/commands/core/drupal/site_install.inc
+++ b/commands/core/drupal/site_install.inc
@@ -8,7 +8,11 @@ function drush_core_site_install_version($profile, array $additional_form_option
     $profile = 'standard';
   }
 
-  require_once DRUSH_DRUPAL_CORE . '/includes/install.core.inc';
+  $install_file = '/includes/install.core.inc';
+  if (file_exists(DRUSH_DRUPAL_CORE . $install_file . '.php')) {
+    $install_file .= '.php';
+  }
+  require_once DRUSH_DRUPAL_CORE . $install_file;
 
   $sql = drush_sql_get_class();
   $db_spec = $sql->db_spec();

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -953,7 +953,11 @@ function drush_pm_enable_validate() {
     }
     $modules = array_diff(array_merge($modules, $all_dependencies), drush_module_list());
     // Discard modules which doesn't meet requirements.
-    require_once DRUSH_DRUPAL_CORE . '/includes/install.inc';
+    $install_file = '/includes/install.inc';
+    if (file_exists(DRUSH_DRUPAL_CORE . $install_file . '.php')) {
+      $install_file .= '.php';
+    }
+    require_once DRUSH_DRUPAL_CORE . $install_file;
     foreach ($modules as $key => $module) {
       // Check to see if the module can be installed/enabled (hook_requirements).
       // See @system_modules_submit

--- a/includes/drupal.inc
+++ b/includes/drupal.inc
@@ -29,7 +29,11 @@ function drush_drupal_version($drupal_root = NULL) {
         // Load the autoloader so we can access the class constants.
         require_once $drupal_root .'/core/vendor/autoload.php';
         // Drush depends on bootstrap being loaded at this point;
-        require_once $drupal_root .'/core/includes/bootstrap.inc';
+        $bootstrap_file = '/core/includes/bootstrap.inc';
+        if (file_exists($drupal_root . $bootstrap_file . '.php')) {
+          $bootstrap_file .= '.php';
+        }
+        require_once $drupal_root . $bootstrap_file;
         if (defined('Drupal::VERSION')) {
           $version = Drupal::VERSION;
         }
@@ -273,4 +277,3 @@ function _drush_drupal_parse_info_file($data, $merge_item = NULL) {
 function drush_cid_install_profile() {
   return drush_get_cid('install_profile', array(), array(drush_get_context('DRUSH_SELECTED_DRUPAL_SITE_CONF_PATH')));
 }
-

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -356,6 +356,10 @@ function drush_valid_drupal_root($path) {
     // Drupal 8 root. Additional check for the presence of core/composer.json to
     // grant it is not a Drupal 7 site with a base folder named "core".
     $candidate = 'core/includes/common.inc';
+    // Drupal 8 might have .php includes in the future.
+    if (file_exists($path . '/' . $candidate . '.php')) {
+      $candidate .= '.php';
+    }
     if (file_exists($path . '/' . $candidate) && file_exists($path . '/core/misc/drupal.js') && file_exists($path . '/composer.json')) {
       return $candidate;
     }


### PR DESCRIPTION
This fixes absolutely necessary to get the testbot up and running in https://drupal.org/node/7269
which is `si` and `en` commands.

Related issue https://github.com/drush-ops/drush/issues/631