### PR TITLE
fix install core with further drivers

### DIFF
--- a/commands/core/drupal/site_install.inc
+++ b/commands/core/drupal/site_install.inc
@@ -25,6 +25,7 @@ function drush_core_site_install_version($profile, array $additional_form_option
         'driver' => $db_spec['driver'],
         $db_spec['driver'] => $db_spec,
         'op' => dt('Save and continue'),
+        '_triggering_element_name' => 'op',
       ),
       'install_configure_form' => array(
         'site_name' => drush_get_option('site-name', 'Site-Install'),


### PR DESCRIPTION
With Drupal 7, when you have further SGBD drivers (mysql, postgreSQL, SQLite) and settings.php doesn't contains yet any database settings (so step is not skipped), in install_settings_form, all SGDB have some fields required, so including SGBD you won't use.

Install settings form play with limit validation error to prevent having some other SGBD fields required than the driver you choose.
But with drush, as install step is not interactive, the triggering form submit element is not set and so limit validation errors not applied.
As a result, you got some errors with the "drush si" command ("dababase name and user fields are required") for other SGDB you didn't use and the installation is interrupt.

This patch fix this issue just by providing the form element which is suppose to be triggered.
Limit validation errors is so applied and other SGBD required fields are ignored.

It should be nice if this patch could be back-ported for the 6.x branch too.
Note that Drupal 8 is not tested.

Thanks for the review.
