### PR TITLE
Fix issue where Drush assumes multi-site on D8 when installing to a symlinked docroot.

### DIFF
--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -103,7 +103,7 @@ function drush_core_pre_site_install($profile = NULL) {
   $files = !empty($GLOBALS['conf']['files_public_path']) ? $GLOBALS['conf']['files_public_path'] : "$conf_path/files";
   $settingsfile = "$conf_path/settings.php";
   $sitesfile = "sites/sites.php";
-  $default = $alias_record['root'] . '/sites/default';
+  $default = realpath($alias_record['root'] . '/sites/default');
   $sitesfile_write = drush_drupal_major_version() >= 8 && $conf_path != $default && !file_exists($sitesfile);
   
   if (!file_exists($settingsfile)) {


### PR DESCRIPTION
Changed the $default path to use `realpath()` as `drush_sitealias_local_site_path()` does.

https://github.com/drush-ops/drush/blob/master/includes/sitealias.inc#L372
