### PR TITLE
SQL-Sync doesn't work with aliases

### DIFF
--- a/commands/sql/sync.sql.inc
+++ b/commands/sql/sync.sql.inc
@@ -116,10 +116,12 @@ function drush_sql_sync($source, $destination) {
     }
 
     // Try run to rsync locally so that aliases always resolve. https://github.com/drush-ops/drush/issues/668
-    if (empty($source['remote-host'])) {
+    $source_settings = drush_sitealias_get_record($source);
+    $destination_settings = drush_sitealias_get_record($destination);
+    if (empty($source_settings['remote-host'])) {
       $runner = $source;
     }
-    elseif (empty($destination['remote-host'])) {
+    elseif (empty($destination_settings['remote-host'])) {
       $runner = $destination;
     }
     else {


### PR DESCRIPTION
Function drush_sql_sync get as arguments just aliases: @local and etc. In the new version https://github.com/drush-ops/drush/commit/23c461f225a3aa674f2ac2844e853addf362011f was added code which set $runner based on alias. But $source and $destination it's always just string and as result commands always runs on the source server.

I added code which gets alias settings for source and destination instead of comparing with alias name.
