### PR TITLE
Convert most of exec.inc to use Symfony Process component.

### DIFF
--- a/commands/core/archive.drush.inc
+++ b/commands/core/archive.drush.inc
@@ -267,13 +267,13 @@ function drush_archive_dump($sites_subdirs = '@self') {
   file_put_contents("{$tmp}/MANIFEST.ini", $contents);
 
   // Add manifest to archive.
-  drush_shell_cd_and_exec($tmp, "$tar --dereference -rf %s %s", $destination, 'MANIFEST.ini');
+  drush_run(array("$tar", "--dereference", "-rf", $destination, 'MANIFEST.ini'), $tmp);
 
   // Ensure that default/default.settings.php is in the archive. This is needed
   // by site-install when restoring a site without any DB.
   // NOTE: Windows tar file replace operation is broken so we have to check if file already exists.
   // Otherwise it will corrupt the archive.
-  $res = drush_shell_cd_and_exec($workdir, "$tar -tf %s %s", $destination, $docroot . '/sites/default/default.settings.php');
+  $res = drush_run(array("$tar", "-tf", $destination, $docroot . '/sites/default/default.settings.php'), $workdir);
   $output = drush_shell_exec_output();
   if (!$res || !isset($output[0]) || empty($output[0])) {
     drush_shell_cd_and_exec($workdir, "$tar --dereference -vrf %s %s", $destination, $docroot . '/sites/default/default.settings.php');
@@ -285,7 +285,7 @@ function drush_archive_dump($sites_subdirs = '@self') {
   }
 
   // Compress the archive
-  drush_shell_exec("gzip --no-name -f %s", $destination);
+  drush_run(array("gzip", "--no-name", "-f", $destination));
 
   // gzip appends .gz unless the name already ends in .gz, .tgz, or .taz.
   if ("{$destination}.gz" != $final_destination) {

--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -383,7 +383,7 @@ function drush_config_export($destination = NULL) {
   $branch = FALSE;
   if ($remote) {
     // Get the branch that we're on at the moment
-    $result = drush_shell_cd_and_exec($destination_dir, 'git rev-parse --abbrev-ref HEAD');
+    $result = drush_run('git rev-parse --abbrev-ref HEAD', $destination_dir);
     if (!$result) {
       return drush_set_error('DRUSH_CONFIG_EXPORT_NO_GIT', dt("The drush config-export command requires that the selected configuration directory !dir be under git revision control when using --commit or --push options.", array('!dir' => $destination_dir)));
     }
@@ -496,7 +496,7 @@ function _drush_config_export($destination, $destination_dir, $branch) {
   if ($commit || $remote) {
     // There must be changed files at the destination dir; if there are not, then
     // we will skip the commit-and-push step
-    $result = drush_shell_cd_and_exec($destination_dir, 'git status --porcelain .');
+    $result = drush_run('git status --porcelain .', $destination_dir);
     if (!$result) {
       return drush_set_error('DRUSH_CONFIG_EXPORT_FAILURE', dt("`git status` failed."));
     }
@@ -507,7 +507,7 @@ function _drush_config_export($destination, $destination_dir, $branch) {
         return drush_set_error('DRUSH_CONFIG_EXPORT_FAILURE', dt("`git add -A` failed."));
       }
       $comment_file = drush_save_data_to_temp_file($comment);
-      $result = drush_shell_cd_and_exec($destination_dir, 'git commit --file=%s', $comment_file);
+      $result = drush_run(array('git', 'commit', "--file=$comment_file"), $destination_dir);
       if (!$result) {
         return drush_set_error('DRUSH_CONFIG_EXPORT_FAILURE', dt("`git commit` failed.  Output:\n\n!output", array('!output' => implode("\n", drush_shell_exec_output()))));
       }
@@ -628,7 +628,7 @@ function drush_config_import($source = NULL) {
     $destination_dir = drush_tempdir();
     drush_invoke_process('@self', 'config-export', array(), array('destination' => $destination_dir));
     // @todo Can DiffFormatter produce a CLI pretty diff?
-    drush_shell_exec('diff -x %s -u %s %s', '*.git', $destination_dir, $source_dir);
+    drush_run(array('diff', '-x', '*.git', '-u', $destination_dir, $source_dir));
     $output = drush_shell_exec_output();
     drush_print(implode("\n", $output));
   }
@@ -728,7 +728,7 @@ function drush_config_edit($config_name = '') {
     $existing = new FileStorage(drush_tempdir());
     $existing->write($config_name, $contents);
     // @todo Can DiffFormatter produce a CLI pretty diff?
-    drush_shell_exec('diff -u %s %s', $existing->getFilePath($config_name), $temp_storage->getFilePath($config_name));
+    drush_run(array('diff', '-u', $existing->getFilePath($config_name), $temp_storage->getFilePath($config_name)));
     $output = drush_shell_exec_output();
     drush_print(implode("\n", $output));
 

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "php": ">=5.4.5",
     "psr/log": "~1.0",
     "psy/psysh": "~0.6",
+    "symfony/process": "^2.4.5",
     "symfony/yaml": "2.7.*",
     "symfony/var-dumper": "^2.6.3",
     "pear/console_table": "~1.2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "160e694a860dd8b012104bae69cd2d75",
-    "content-hash": "345215a79dc35e20c5858b0a05b0aba6",
+    "hash": "3ccfd44c0f366bd24bfc9852b7015362",
+    "content-hash": "cc8209c673538976e26c01d893566972",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -395,6 +395,55 @@
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
             "time": "2015-11-18 09:54:26"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.7.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "f6290983c8725d0afa29bdc3e5295879de3e58f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f6290983c8725d0afa29bdc3e5295879de3e58f5",
+                "reference": "f6290983c8725d0afa29bdc3e5295879de3e58f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-11-19 16:11:24"
         },
         {
             "name": "symfony/var-dumper",
@@ -1407,55 +1456,6 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2015-06-21 13:59:46"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v2.7.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "f6290983c8725d0afa29bdc3e5295879de3e58f5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f6290983c8725d0afa29bdc3e5295879de3e58f5",
-                "reference": "f6290983c8725d0afa29bdc3e5295879de3e58f5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Process Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-11-19 16:11:24"
         }
     ],
     "aliases": [],

--- a/includes/exec.inc
+++ b/includes/exec.inc
@@ -1,5 +1,8 @@
 <?php
 
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
 /**
  * @file
  *   Functions for executing system commands. (e.g. exec(), system(), ...).
@@ -19,6 +22,10 @@ use Drush\Log\LogLevel;
  * (e.g. unlink() and other file system functions) so that can be suppressed
  * if the simulation mode is enabled.
  *
+ * DEPRECATED.  Instead, use a functon that handles escaping the command
+ * arguments and options.  Use only when none of the arguments or options
+ * contain file paths.
+ *
  * @param $exec
  *   The shell command to execute.  Parameters should already be escaped.
  * @return
@@ -35,7 +42,8 @@ function drush_op_system($exec) {
   }
 
   // Throw away output.  Use drush_shell_exec() to capture output.
-  system($exec, $result_code);
+  $process = new Process($exec, NULL, NULL, NULL, 0);
+  $result_code = $process->run();
 
   return $result_code;
 }
@@ -70,6 +78,8 @@ function drush_shell_cd_and_exec($effective_wd, $cmd) {
  * Output is stored and can be retrieved using drush_shell_exec_output().
  * If in simulation mode, no action is taken.
  *
+ * Use drush_run() instead where possible.
+ *
  * @param $cmd
  *   The command to execute. May include placeholders used for sprintf.
  * @param ...
@@ -102,28 +112,18 @@ function drush_get_editor() {
  * @see drush_shell_exec.
  */
 function drush_shell_exec_interactive($cmd) {
-  return _drush_shell_exec(func_get_args(), TRUE);
+  $command = _drush_build_shell_command(func_get_args());
+
+  if (drush_get_context('DRUSH_VERBOSE') || drush_get_context('DRUSH_SIMULATE')) {
+    drush_print('Executing: ' . $command, 0, STDERR);
+  }
+  if (!drush_get_context('DRUSH_SIMULATE')) {
+    $result = drush_shell_proc_open($command);
+    return ($result == 0) ? TRUE : FALSE;
+  }
 }
 
-/**
- * Internal function: executes a shell command on the
- * local machine.  This function should not be used
- * in instances where ssh is utilized to execute a
- * command remotely; otherwise, remote operations would
- * fail if executed from a Windows machine to a remote
- * Linux server.
- *
- * @param $args
- *   The command and its arguments.
- * @param $interactive
- *   Whether to run in
- *
- * @return
- *   TRUE on success, FALSE on failure
- *
- * @see drush_shell_exec.
- */
-function _drush_shell_exec($args, $interactive = FALSE) {
+function _drush_build_shell_command($args) {
   // Do not change the command itself, just the parameters.
   for ($x = 1; $x < count($args); $x++) {
     $args[$x] = drush_escapeshellarg($args[$x]);
@@ -140,27 +140,100 @@ function _drush_shell_exec($args, $interactive = FALSE) {
     $command = call_user_func_array('sprintf', $args);
   }
 
+  return $command;
+}
+
+/**
+ * Internal function: executes a shell command on the
+ * local machine.  This function should not be used
+ * in instances where ssh is utilized to execute a
+ * command remotely; otherwise, remote operations would
+ * fail if executed from a Windows machine to a remote
+ * Linux server.
+ *
+ * @param $args
+ *   The command and its arguments.
+ *
+ * @return
+ *   TRUE on success, FALSE on failure
+ *
+ * @see drush_shell_exec.
+ */
+function _drush_shell_exec($args) {
+  $command = _drush_build_shell_command($args);
+  $process = new Process($command);
+  return drush_run_process($process);
+}
+
+/**
+ * Run a command using the Symfony process component.
+ *
+ * @param $args
+ *   string - the command to run, and its arguments (if no escaping is needed)
+ *   array - the command to run and its arguments
+ *      $args[0] - the command to execute
+ *      $args[1] - the first commandline argument
+ *      etc.
+ */
+function drush_run($args, $path = NULL) {
+  if (is_string($args)) {
+    $process = new Process($command);
+    if ($path) {
+      $process->setWorkingDirectory($path);
+    }
+  }
+  else {
+    $process = _drush_build_process($args, $path);
+  }
+  return drush_run_process($process);
+}
+
+/**
+ * Run a command using the Symfony process component.
+ *
+ * @param $args
+ *   $args[0] - the command to execute
+ *   $args[1] - the first commandline argument
+ *   etc.
+ */
+function _drush_build_process(array $args, $path = NULL) {
+  // The first argument is the command; the rest
+  // are the command arguments.
+  $commandPrefix = array_shift($args);
+
+  // Use a Symfony ProcessBuilder to create a Process.
+  $builder = new ProcessBuilder();
+  $builder
+    ->setWorkingDirectory($path)
+    ->setPrefix($commandPrefix)
+    ->setArguments($args);
+  return $builder->getProcess();
+}
+
+/**
+ * Given a Symfony process component, run it the Drush way.
+ *
+ * @param $process
+ *   Symfony Process component to run.
+ */
+function drush_run_process(Process $process) {
   if (drush_get_context('DRUSH_VERBOSE') || drush_get_context('DRUSH_SIMULATE')) {
+    $command = $process->getCommandLine();
     drush_print('Executing: ' . $command, 0, STDERR);
   }
   if (!drush_get_context('DRUSH_SIMULATE')) {
-    if ($interactive) {
-      $result = drush_shell_proc_open($command);
-      return ($result == 0) ? TRUE : FALSE;
-    }
-    else {
-      exec($command . ' 2>&1', $output, $result);
-      _drush_shell_exec_output_set($output);
+    $result = $process->run();
+    $output = explode("\n", trim($process->getOutput()));
+    _drush_shell_exec_output_set($output);
 
-      if (drush_get_context('DRUSH_DEBUG')) {
-        foreach ($output as $line) {
-          drush_print($line, 2);
-        }
+    if (drush_get_context('DRUSH_DEBUG')) {
+      foreach ($output as $line) {
+        drush_print($line, 2);
       }
-
-      // Exit code 0 means success.
-      return ($result == 0);
     }
+
+    // Exit code 0 means success.
+    return ($result == 0);
   }
   else {
     return TRUE;
@@ -242,6 +315,7 @@ function drush_shell_proc_open($cmd) {
     drush_print("Calling proc_open($cmd);", 0, STDERR);
   }
   if (!drush_get_context('DRUSH_SIMULATE')) {
+    // TODO: Use 'new Process($cmd, NULL, NULL, NULL, 0)'
     $process = proc_open($cmd, array(0 => STDIN, 1 => STDOUT, 2 => STDERR), $pipes);
     $proc_status = proc_get_status($process);
     $exit_code = proc_close($process);

--- a/lib/Drush/Process/ProcessBuilder.php
+++ b/lib/Drush/Process/ProcessBuilder.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drush\Process;
+
+class ProcessBuilder extends Symfony\Component\Process\ProcessBuilder {
+
+  private $simulated = FALSE;
+
+  public function __construct(array $arguments = array())
+  {
+    parent::__construct($arguments);
+
+    $this->simulated = (getenv("DRUSH_SIMULATED") != NULL);
+  }
+
+  /**
+   * Sets 'simulated' mode.
+   *
+   * Common use case: setSimultate(FALSE) when building a
+   * command that does not change any state.
+   *
+   * @param boolean     $simulate  Whether or not to set simulated mode.
+   *
+   * @return ProcessBuilder
+   */
+  public function setSimulated($simulate)
+  {
+    $this->simulated = $simulate;
+
+    return $this;
+  }
+
+  /**
+   * Get 'simulated' mode.
+   *
+   * @return boolean
+   */
+  public function getSimulated()
+  {
+    return $this->simulated;
+  }
+
+  /**
+   * Creates a Process instance and returns it.
+   *
+   * @return Process
+   *
+   * @throws LogicException In case no arguments have been provided
+   */
+  public function getProcess()
+  {
+    if ($this->simulated) {
+      return new SimulatedProcess($this->getCommandLine());
+    }
+    else {
+      return parent::getProcess();
+    }
+  }
+}

--- a/lib/Drush/Process/SimulatedProcess.php
+++ b/lib/Drush/Process/SimulatedProcess.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Drush\Process;
+
+/**
+ * Behaves like a Process, but does not actually run anything.
+ *
+ * @api
+ */
+class SimulatedProcess extends Symfony\Component\Process\Process
+{
+
+    /**
+     * Constructor.
+     *
+     * @param string             $commandline The command line that would run were this not a simulated Process
+     *
+     * @api
+     */
+    public function __construct($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
+    {
+        parent::__construct($commandline, $cwd, $env, $stdin, $timeout, $options);
+    }
+
+    /**
+     * Simulate starting the process.
+     */
+    public function start($callback = null)
+    {
+        // TODO: how should we output the debug message?
+        // Do we care to display any of the other arguments?
+        print("Executing " . $this->getCommandLine() . "\n");
+    }
+
+    public function restart($callback = null)
+    {
+        return $this;
+    }
+
+    /**
+     * Simulated wait == no wait.
+     */
+    public function wait($callback = null)
+    {
+        return 0;
+    }
+
+    /**
+     * No pid, always return null
+     */
+    public function getPid()
+    {
+        return null;
+    }
+
+    /**
+     * Simulated signal.
+     */
+    public function signal($signal)
+    {
+        return $this;
+    }
+
+    /**
+     * Simulated commands never produce output.
+     */
+    public function getOutput()
+    {
+        return '';
+    }
+
+    public function getIncrementalOutput()
+    {
+        return '';
+    }
+
+    public function clearOutput()
+    {
+        return $this;
+    }
+
+    public function getErrorOutput()
+    {
+        return '';
+    }
+
+    public function getIncrementalErrorOutput()
+    {
+        return '';
+    }
+
+    public function clearErrorOutput()
+    {
+        return $this;
+    }
+
+    public function getExitCode()
+    {
+        return 0;
+    }
+
+    public function hasBeenSignaled()
+    {
+        return FALSE;
+    }
+
+    public function getTermSignal()
+    {
+        return 0;
+    }
+
+    public function hasBeenStopped()
+    {
+        return FALSE;
+    }
+
+    public function getStopSignal()
+    {
+        return 0;
+    }
+
+    public function isRunning()
+    {
+        return FALSE;
+    }
+
+    public function isStarted()
+    {
+        return FALSE;
+    }
+
+    public function isTerminated()
+    {
+        $this->updateStatus(false);
+
+        return TRUE;
+    }
+
+    public function getStatus()
+    {
+        return STATUS_TERMINATED;
+    }
+
+    public function stop($timeout = 10, $signal = null)
+    {
+        return 0;
+    }
+
+    public function checkTimeout()
+    {
+    }
+}

--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -143,7 +143,7 @@ class SqlBase {
   public function query($query, $input_file = NULL, $result_file = '') {
     $input_file_original = $input_file;
     if ($input_file && drush_file_is_tarball($input_file)) {
-      if (drush_shell_exec('gunzip %s', $input_file)) {
+      if (drush_run(array('gunzip', $input_file))) {
         $input_file = trim($input_file, '.gz');
       }
       else {


### PR DESCRIPTION
Here is a start at using Process instead of exec() and friends. There isn't much to gain here yet. I'm actually most interested in @greg-1-anderson taking a look at backend.inc and seeing how much we can simplify _drush_backend_proc_open() and related code by using Process. I'm fine with losing some functionality there if it improves maintainability.
