### PR TITLE
Create a log entry when a test starts.

### DIFF
--- a/commands/core/test.drush.inc
+++ b/commands/core/test.drush.inc
@@ -175,6 +175,7 @@ function drush_test_run_class($class) {
  * Run a single test and display any failure messages.
  */
 function simpletest_drush_run_test($class) {
+  drush_log(dt('Starting test @test.', array('@test' => $class)), 'ok');
   if (drush_drupal_major_version() >= 7) {
     $test_id = db_insert('simpletest_test_id')
     ->useDefaults(array('test_id'))


### PR DESCRIPTION
It would be helpful if drush logs when a new test is started. Currently the class which is tested is not mentioned, only the short name of the test, which is not unique. This is output in the summary at the end the test which is a bit counterintuitive as you will have to read the test results backwards.

In case an exception occurs during a test the name of the test that has run is not printed at all and you have to rely on the alphabetical ordering of the tests to figure out exactly which test has failed.

Current output when a test succeeds  (test class is not mentioned, only the short name which can be ambiguous as it is not unique):

```
[Sun Jun  8 22:31:48 2014] 127.0.0.1:48501 [200]: /user
[Sun Jun  8 22:31:48 2014] Watchdog: Session opened for oW2214dT. | severity: 5 | type: user | uid: 2 | 127.0.0.1 | http://127.0.0.1:8080/user |  | 
Reference test 89 passes, 0 fails, 0 exceptions, and 15 debug messages      [ok]
No leftover tables to remove.                                        [status]
No temporary directories to remove.                                  [status]
Removed 1 test result.                                               [status]
 Group  Class  Name 
```

Current output when an exception occurs in a test run (no context at all which test failed):

```
[Sun Jun  8 22:31:48 2014] 127.0.0.1:48501 [200]: /user
[Sun Jun  8 22:31:48 2014] Watchdog: Session opened for oW2214dT. | severity: 5 | type: user | uid: 2 | 127.0.0.1 | http://127.0.0.1:8080/user |  | 
Invalid entity id.                                                  [error]
```

Output with patch (unique class name is logged at the start of the test):

```
Starting test ClientReferenceTestCase.                                                                                                                  [ok]
[Sun Jun  8 22:31:48 2014] 127.0.0.1:48501 [200]: /user
[Sun Jun  8 22:31:48 2014] Watchdog: Session opened for oW2214dT. | severity: 5 | type: user | uid: 2 | 127.0.0.1 | http://127.0.0.1:8080/user |  | 
Invalid entity id.                                                  [error]
```
