### PR TITLE
Fix PHP warning due to a wrong argument given to drush_print_table

### DIFF
--- a/commands/core/docs.drush.inc
+++ b/commands/core/docs.drush.inc
@@ -251,7 +251,8 @@ EOD;
 
   $tmpfile = drush_tempnam('drush-errorcodes.');
   file_put_contents($tmpfile, $header);
-  drush_print_table($data, FALSE, array(0 => 35), $tmpfile);
+  $handle = fopen($tmpfile, 'r');
+  drush_print_table($data, FALSE, array(0 => 35), $handle);
   drush_print_file($tmpfile);
 }
 


### PR DESCRIPTION
A file name is being given as a `$handle` to [drush_print_table()](https://github.com/drush-ops/drush/blob/master/includes/output.inc#L209-L212) instead of a file handler, thus
provoking the following warning after runing drush topic docs-errorcodes:

```
fwrite() expects parameter 1 to be resource, string given output.inc:35
```
