### PR TITLE
do not redispatch systematically when we're in backend mode

### DIFF
--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1688,7 +1688,7 @@ function drush_sitealias_set_alias_context($site_alias_settings, $prefix = '') {
   $skip_list = drush_get_special_keys();
   // If 'php-options' are set in the alias, then we will force drush
   // to redispatch via the remote dispatch mechanism even if the target is localhost.
-  if (array_key_exists('php-options', $site_alias_settings) || drush_get_context('DRUSH_BACKEND', FALSE)) {
+  if (array_key_exists('php-options', $site_alias_settings)) {
     if (!array_key_exists('remote-host', $site_alias_settings)) {
       $site_alias_settings['remote-host'] = 'localhost';
     }


### PR DESCRIPTION
since the fix for #555, commands are needlessly redispatched by drush when called with --backend. previous to commit 24addcdd08aa422aa00e2a11194a74c212a602ec, this didn't take effect because the DRUSH_BACKEND context wasn't initialised properly when we were loading aliases. but now that we set that context earlier, the check takes effect, and things get redispatched like crazy.

this seems to happen before Aegir/provision has time to set its own stuff properly (i am guessing: load the good stuff from the alias) so the redispatch fails to load with the proper alias. more details on that are on the aegir issue in https://drupal.org/node/2281983.

this was originally introduced in 510735acb4a5e9a40f2692dd9df881deca193871 to fix #1058874, but the commitlog makes no reference to backend at all, and merely references an obscure php-options variable. the issue mentions something about interactivity in backend mode, but that doesn't matter since it wasn't actually triggered before anyways.

we have yet to run unit tests on this, but with this patch, aegir can install again on drush master.
