### PR TITLE
Change instructions to run unit tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@ high quality, our tests are run on every push by [Travis](https://travis-ci.org/
 Usage
 --------
 1. Review the configuration settings in tests/phpunit.xml.dist. If customization is needed, copy to phpunit.xml and edit away.
-1. Run unit tests: `unish.sh` or `cd tests && ..\vendor\phpunit`
+1. Run unit tests: `unish.sh` or `cd tests && ../vendor/bin/phpunit`
 
 Advanced usage
 ---------


### PR DESCRIPTION
I couldn't run the unit tests with the command "cd tests && ..\vendor\phpunit". Inside unish.sh the path is "vendor/bin/phpunit". So I tried that and it worked.
