### PR TITLE
Fix role-add-perm.

### DIFF
--- a/classes/DrushRole.php
+++ b/classes/DrushRole.php
@@ -160,7 +160,7 @@ class DrushRole6 extends DrushRole {
 
   function updatePerms() {
     $new_perms = implode(", ", $this->perms);
-    drush_op('db_query', "UPDATE {permission} SET perm = '%s' FROM {role} WHERE role.rid = permission.rid AND role.rid= '%d'", $new_perms, $this->rid);
+    drush_op('db_query', "UPDATE {permission} SET perm = '%s' WHERE rid = %d", $new_perms, $this->rid);
   }
 }
 


### PR DESCRIPTION
DrushRole6::updatePerms() uses some invalid SQL that breaks things.

Confirmed this is fixed in master already.
