### PR TITLE
Add multiple permissions at once.

### DIFF
--- a/commands/core/role.drush.inc
+++ b/commands/core/role.drush.inc
@@ -203,8 +203,6 @@ function drush_role_perm($action, $rid, $permission = NULL) {
     }
   }
 
-  $role_perms = $role->getPerms();
-
   $result = $role->{$action}($permission);
   if ($result === FALSE) {
     return FALSE;


### PR DESCRIPTION
It takes minutes settings permissions when done step by step.

For https://github.com/build2be/drupal-rest-test I need to set 30 permissions which currently takes 5:20 mins which is due to the `drush_drupal_cache_clear_all()`. With the patch it is reduced to 1:29 mins but that's due to my bad script in mentioned project.

> 30 calls in 5:20 : ~ 11 secs per call
> 8 calls in 1:29 : ~ 11 sec per call
