### PR TITLE
Do not restore owner/group of files when extracting module release tar

### DIFF
--- a/commands/make/make.download.inc
+++ b/commands/make/make.download.inc
@@ -113,7 +113,7 @@ function make_download_file_unpack($filename, $download_location, $name, $subtre
   if (drush_file_is_tarball($filename)) {
     $tmp_location = drush_tempdir();
 
-    if (!drush_tarball_extract($filename, $tmp_location)) {
+    if (!drush_tarball_extract($filename, $tmp_location, FALSE, '-o')) {
       return FALSE;
     }
 

--- a/commands/pm/package_handler/wget.inc
+++ b/commands/pm/package_handler/wget.inc
@@ -79,7 +79,7 @@ function package_handler_download_project(&$request, $release) {
   }
 
   // Extract the tarball.
-  $file_list = drush_tarball_extract($path, $request['base_project_path'], TRUE);
+  $file_list = drush_tarball_extract($path, $request['base_project_path'], TRUE, '-o');
 
   // Move untarred directory to project_dir, if distinct.
   if (($request['project_type'] == 'core') || (($request['project_type'] == 'profile') && (drush_get_option('variant', 'full') == 'full'))) {

--- a/docs/drush.api.php
+++ b/docs/drush.api.php
@@ -252,7 +252,7 @@ function drush_hook_pre_pm_enable() {
     else {
       $path .= '/' . drupal_get_path('module', 'hook') . '/MyLibraryName.tgz';
     }
-    drush_download_file($url, $path) && drush_tarball_extract($path);
+    drush_download_file($url, $path) && drush_tarball_extract($path, FALSE, FALSE, '-o');
   }
 }
 


### PR DESCRIPTION
This pull request is for master branch. When extracting tarballs as root (or equivalent) file owner and group is restored. Drush should not restore file owner for drupal.org releases as it doesn't make sense.
