### PR TITLE
Make drush site-install pass langcode properly in D8

### DIFF
--- a/commands/core/drupal/site_install.inc
+++ b/commands/core/drupal/site_install.inc
@@ -18,7 +18,7 @@ function drush_core_site_install_version($profile, array $additional_form_option
   $settings = array(
     'parameters' => array(
       'profile' => $profile,
-      'locale' => drush_get_option('locale', 'en'),
+      (drush_drupal_major_version() === 7 ? 'locale' : 'langcode') => drush_get_option('locale', 'en'),
     ),
     'forms' => array(
       'install_settings_form' => array(


### PR DESCRIPTION
Drupal 8 has switched to using a 'langcode' install state parameter, instead of 'locale' which is used in Drupal 7.

This conditionally adapts the behavior in site_install.inc. I'm not sure whether a separate site_install_8.inc (or rather site_install_7.inc ?) should be created just for this purpose.

It would also be possible to allow to pass the 'langcode' option from the command line as well, instead of or in addition to the 'locale' option. Not sure about that either.
