### PR TITLE
Automatically set 'dispatch-using-alias' when a remote site alias does not define 'root' or 'uri'

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -601,13 +601,14 @@ function _drush_backend_adjust_options($site_record, $command, $command_options,
   if ((array_key_exists('integrate', $backend_options)) && ($backend_options['integrate'] === FALSE) && (!array_key_exists('output', $backend_options))) {
     $backend_options['output'] = FALSE;
   }
+  $has_site_specification = array_key_exists('root', $site_record) || array_key_exists('uri', $site_record);
   $result = $backend_options + array(
      'method' => 'GET',
      'output' => TRUE,
      'log' => TRUE,
      'integrate' => TRUE,
      'backend' => TRUE,
-     'dispatch-using-alias' => FALSE,
+     'dispatch-using-alias' => !$has_site_specification,
   );
   // Convert '#integrate' et. al. into backend options
   foreach ($command_options as $key => $value) {


### PR DESCRIPTION
This requires an alias of the same name be defined on the remote host; the benefit is that the root and uri for the site can be maintained on the remote server.

This came up when I was talking with Aegir users in Auckland at Sparks Interactive.  They are having problems with the site root of his remote sites moving, as Aegir is wont to do during upgrades--this breaks local site aliases.  We briefly discussed pulling the site root from the remote site, so that it was available for use by the dev machine, but it is much tidier to just do as shown in this PR, and remove any knowledge of the site root from the dev machine.  The limitation here is that you must have an alias of the same name defined on the remote machine, but overall, it seems like a big win to me.  The change is minor, since 'dispatch-using-alias' is already readily available in code (via backend options); this makes it also available in configuration.

If you agree, then I'll write up some documentation for it in the example site alias file & merge.
