### PR TITLE
Add a pm-projectinfo (pmpi) command

### DIFF
--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -208,6 +208,24 @@ function pm_drush_command() {
     'drupal dependencies' => array($update),
     'aliases' => array('rf'),
   );
+  $items['pm-projectinfo'] = array(
+    'description' => 'Show a report of available  projects and their modules.',
+    'arguments' => array(
+      'projects' => 'Optional. A list of installed projects to show.',
+    ),
+    'options' => array(
+      'drush' => 'Optional. Only incude projects that have one or more Drush commands.',
+    ),
+    'outputformat' => array(
+      'default' => 'key-value-list',
+      'pipe-format' => 'list',
+      'field-labels' => array('label' => 'Name', 'type' => 'Type', 'version' => 'Version', 'status' => 'Status', 'extensions' => 'Extensions', 'drush' => 'Drush Commands'),
+      'fields-default' => array('label', 'version', 'extensions', 'drush' ),
+      'fields-pipe' => array('label'),
+      'output-data-type' => 'format-table',
+    ),
+    'aliases' => array('pmpi'),
+  );
   $items['pm-updatestatus'] = array(
     'description' => 'Show a report of available minor updates to Drupal core and contrib projects.',
     'drupal dependencies' => array($update),
@@ -401,6 +419,13 @@ function pm_pm_releasenotes_complete() {
  * Command argument complete callback.
  */
 function pm_pm_releases_complete() {
+  return pm_complete_projects();
+}
+
+/**
+ * Command argument complete callback.
+ */
+function pm_pm_projectinfo_complete() {
   return pm_complete_projects();
 }
 
@@ -813,6 +838,63 @@ function drush_pm_list() {
   }
   // In Drush-5, we used to return $extension_info here.
   return $result;
+}
+
+
+/**
+ * Command argument complete callback.
+ */
+function drush_pm_projectinfo() {
+  // Get specific requests.
+  $requests = pm_parse_arguments(func_get_args(), FALSE);
+
+  // Get installed extensions and projects.
+  $extensions = drush_get_extensions();
+  $projects = drush_get_projects($extensions);
+
+  // If user did not specify any projects, return them all
+  if (empty($requests)) {
+    $result = $projects;
+  }
+  else {
+    foreach ($requests as $name) {
+      if (array_key_exists($name, $projects)) {
+        $result[$name] = $projects[$name];
+      }
+    }
+  }
+
+  // Find the Drush commands that belong with each project.
+  foreach ($result as $name => $project) {
+    $drush_commands = pm_drush_commands_in_project($project);
+    if (!empty($drush_commands)) {
+      $result[$name]['drush'] = $drush_commands;
+    }
+  }
+
+  // If user specified --drush, remove projects with no drush extensions
+  if (drush_get_option('drush')) {
+    foreach ($result as $name => $project) {
+      if (!array_key_exists('drush', $project)) {
+        unset($result[$name]);
+      }
+    }
+  }
+
+  return $result;
+}
+
+function pm_drush_commands_in_project($project) {
+  $drush_commands = array();
+  if (array_key_exists('path', $project)) {
+    $commands = drush_get_commands();
+    foreach ($commands as $commandname => $command) {
+      if (!array_key_exists("is_alias", $command) && ($command['path'] == $project['path'])) {
+        $drush_commands[] = $commandname;
+      }
+    }
+  }
+  return $drush_commands;
 }
 
 /**


### PR DESCRIPTION
pm-projectinfo displays information on the projects available on the current Drupal site, including the list of extensions they contain (the reverse mapping of pm-info) and the Drush commands they define, if any.  If no projects are names, all are displayed.  With the --drush option specified, only projects that define Drush commands are listed.

Only projects that are part of a Drupal site are considered by this command.  Standalone Drush extensions are not visible.

This command came up as part of a discussion with Tim in Wellington.  He needed to be able to map from a project name (already downloaded) to the modules it contains.  While it seems that his actual use case might be better served by an improved pm-updatecode command (that respects module dependencies during partial upgrades -- maybe condtionally?), it does all the same seem to be really useful to have the inverse function for pm-info available.