### PR TITLE
Fix drush test-run command for drupal 8

### DIFF
--- a/commands/core/test.drush.inc
+++ b/commands/core/test.drush.inc
@@ -198,10 +198,24 @@ function simpletest_drush_run_test($class) {
     $test->run();
   }
 
-  $info = $test->getInfo();
+  if (drush_drupal_major_version() >= 8) {
+    $info = \Drupal\simpletest\TestDiscovery::getTestInfo(new \ReflectionClass($test));
+  } else {
+    $info = $test->getInfo();
+  }
   $status = ((isset($test->results['#fail']) && $test->results['#fail'] > 0)
           || (isset($test->results['#exception']) && $test->results['#exception'] > 0) ? 'error' : 'ok');
-  drush_log($info['name'] . ' ' . _simpletest_format_summary_line($test->results), $status);
+  if (drush_drupal_major_version() >= 8) {
+    $results = array(
+      'pass' => $test->results['#pass'],
+      'fail' => $test->results['#fail'],
+      'exception' => $test->results['#exception'],
+      'debug' => $test->results['#debug']
+    );
+  } else {
+    $results = $test->results;
+  }
+  drush_log($info['name'] . ' ' . _simpletest_format_summary_line($results), $status);
 
   $test_suites = drush_test_get_results($test_id, $info);
   if ($dir = drush_get_option('xml')) {


### PR DESCRIPTION
- Uses the TestDiscovery class for Drupal 8 and higher instead of the removed getInfo() method.
- Altered the variables passed into _simpletest_format_summary_line() to work for Drupal 8
