### PR TITLE
Fix 'array_merge(): Argument #1 is not an array context.inc:261'

### DIFF
--- a/includes/context.inc
+++ b/includes/context.inc
@@ -259,7 +259,7 @@ function drush_set_config_special_contexts(&$options) {
             }
           }
           else {
-            $cache = array_unique(array_merge($cache, $value));
+            $cache = array_unique(array_merge((array)$cache, (array)$value));
           }
           // Once we have moved the option to its special context, we
           // can remove it from its option context -- unless 'propagate-cli-value'


### PR DESCRIPTION
I found that if you specify an 'include' option in a drush alias, the following warnings are returned during a drush rsync:

````
array_merge(): Argument #1 is not an array context.inc:261                                                   [warning]
array_unique() expects parameter 1 to be array, null given context.inc:261                                   [warning]
````

This is a result of $cache being set to bool(false) as a result of a call a little farther up to drush_get_context(DRUSH_INCLUDE). According to http://php.net/manual/en/function.array-merge.php, the recommended method of ensuring both arguments to array_merge() are arrays is to do a typecast, which is what this patch does.