### PR TITLE
Add a hook_drush_make_post_download().

### DIFF
--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -152,6 +152,9 @@ class DrushMakeProject {
     if (make_download_factory($this->name, $this->type, $this->download, $this->download_location) === FALSE) {
       $this->downloaded = FALSE;
     }
+
+    drush_command_invoke_all('drush_make_post_download', $this);
+
     return $this->downloaded;
   }
 

--- a/docs/drush.api.php
+++ b/docs/drush.api.php
@@ -203,6 +203,21 @@ function hook_drush_command_alter(&$command) {
 }
 
 /**
+ * Take action after a project in a make file has been downloaded.
+ *
+ * Similar to hook_drush_pm_post_download() but invoked after each project in a
+ * make file has been downloaded.
+ *
+ * Notice that hook_drush_pm_post_download() is also invoked for make file
+ * projects of type 'pm' (native Drupal.org projects).
+ *
+ * @see hook_drush_pm_post_download()
+ */
+function hook_drush_make_post_download(DrushMakeProject $make_project) {
+
+}
+
+/**
  * Take action after a project has been downloaded.
  */
 function hook_drush_pm_post_download($project, $release) {


### PR DESCRIPTION
Take action after a project in a make file has been downloaded.

Similar to hook_drush_pm_post_download() but invoked after each project
in a make file has been downloaded.

Notice that hook_drush_pm_post_download() is also invoked for make file
projects of type 'pm' (native Drupal.org projects).
