### PR TITLE
Enable PHP 5.6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
   - 5.3
 #  - 5.4 Bugs in this version should be caught by 5.3 or 5.5
   - 5.5
+  - 5.6
 env:
 #D7
   - UNISH_NO_TIMEOUTS=y UNISH_DRUPAL_MAJOR_VERSION=7 UNISH_DB_URL=mysql://root:@127.0.0.1 PHPUNIT_ARGS=--group=make


### PR DESCRIPTION
I'm struggling with PHP 5.6 testing for Rules ( https://github.com/fago/rules/pull/107 ) and it always fails when executing drush to install Drupal. I wonder if Drush itself passes testing on 5.6.
