### PR TITLE
Add more examples of php-eval

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -209,7 +209,9 @@ function core_drush_command() {
   $items['php-eval'] = array(
     'description' => 'Evaluate arbitrary php code after bootstrapping Drupal (if available).',
     'examples' => array(
-      'drush php-eval "variable_set(\'hello\', \'world\');"' => 'Sets the hello variable using Drupal API.',
+      'drush php-eval \'variable_set("hello", "world");\'' => 'Sets the hello variable using Drupal API.',
+      'drush php-eval \'$node = node_load(1); print $node->title;\'' => 'Loads node with nid 1 and then prints its title.',
+      'drush php-eval "file_unmanaged_copy(\'$HOME/Pictures/image.jpg\', \'public://image.jpg\');"' => 'Copies a file whose path is determined by an environment\'s variable. Note the use of double quotes so the variable $HOME gets replaced by its value.',
     ),
     'arguments' => array(
       'code' => 'PHP code',


### PR DESCRIPTION
- Add an example where there are two statements separated by semicolons.
- Add an example that illustrates the subtle difference of wrapping
  statements with double quotes.
