### PR TITLE
Warn the user if migrate-manifest did not find some (or all) of the migrations

### DIFF
--- a/commands/core/migrate.d8.drush.inc
+++ b/commands/core/migrate.d8.drush.inc
@@ -49,6 +49,16 @@ function drush_migrate_manifest($manifest) {
         drush_log("Running $migration_id", 'ok');
         $executable = new MigrateExecutable($migration, $message);
         $executable->import();
+
+        // Remove the migration from the list, so that we can track whether any
+        // migrations were not found.
+        $list = array_diff($list, array($migration_id));
+      }
+      // Warn the user if any migrations were not found.
+      if ($list) {
+        drush_log(dt('The following migrations were not found: !migrations', array(
+          '!migrations' => implode(', ', $list),
+        )), 'warning');
       }
       drush_invoke_process('@self', 'cache-rebuild', array(), array(), FALSE);
     }


### PR DESCRIPTION
In case you have incorrectly prepared your target D8 site and the migrations are not in the system `migrate-manifest` will run through without giving any feedback, even though it does not actually perform any migrations. This commit adds a warning to the output in that case.
