### PR TITLE
Fix symfony/yaml requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": ">=5.3.0",
     "d11wtq/boris": "*",
-    "symfony/yaml": "2.2.1",
+    "symfony/yaml": "~2.2",
     "pear/console_table": "1.1.5"
   },
   "require-dev": {


### PR DESCRIPTION
Updated to minimum of 2.2 but not 3 and higher. Fixes #793. 
