### PR TITLE
Fixed bug where if no-backup was TRUE, files were never deleted from projects.

### DIFF
--- a/commands/pm/version_control/backup.inc
+++ b/commands/pm/version_control/backup.inc
@@ -11,6 +11,10 @@ class drush_version_control_backup implements drush_version_control {
    */
   public function pre_update(&$project, $items_to_test = array()) {
     if (drush_get_option('no-backup', FALSE)) {
+      // Delete the project path to clean up files that should be removed
+      if (!drush_delete_dir($project['full_project_path'])) {
+        return FALSE;
+      }
       return TRUE;
     }
     if ($backup_target = $this->prepare_backup_dir()) {


### PR DESCRIPTION
There's a bug in pm-updatecode, where if the --no-backup option is present files that should be deleted in newer Drupal releases (and likely contrib releases) are never removed.

You can replicate this bug by installing Drupal 7.26, and updating it to Drupal 7.31 with the --no-backup command present and not present. Note that between Drupal 7.26 and 7.31 help.api.php was removed, which is why I'm grepping for it:

```
$ drush pm-updatecode drupal
 Name    Installed Version  Proposed version  Message
 Drupal  7.26               7.31              SECURITY UPDATE available


Update information last refreshed: Fri, 09/05/2014 - 15:54
Code updates will be made to drupal core.
WARNING:  Updating core will discard any modifications made to Drupal core files, most noteworthy among these are .htaccess and robots.txt.  If you have made any modifications to these files, please back them up before updating so that you can re-create your modifications in the updated version of the file.
Note: Updating core can potentially break your site. It is NOT recommended to update production sites without prior testing.

Do you really want to continue? (y/n): y
Project drupal was updated successfully. Installed version is now 7.31.
Backups were saved into the directory /Users/samuel.mortenson/drush-backups/drushbug/20140905225520/drupal.                                                                                                       [ok]
'all' cache was cleared.                                                                                                                                                                                          [success]

$ git status | grep deleted
#   deleted:    modules/help/help.api.php

$ git reset --hard
HEAD is now at 0aefc58 Installed Drupal 7.26

$ drush pm-updatecode drupal --no-backup=TRUE
 Name    Installed Version  Proposed version  Message
 Drupal  7.26               7.31              SECURITY UPDATE available


Update information last refreshed: Fri, 09/05/2014 - 15:54
Code updates will be made to drupal core.
WARNING:  Updating core will discard any modifications made to Drupal core files, most noteworthy among these are .htaccess and robots.txt.  If you have made any modifications to these files, please back them up before updating so that you can re-create your modifications in the updated version of the file.
Note: Updating core can potentially break your site. It is NOT recommended to update production sites without prior testing.

Do you really want to continue? (y/n): y
Project drupal was updated successfully. Installed version is now 7.31.
'all' cache was cleared.                                                                                                                                                                                          [success]

$ git status | grep deleted

$
```

It looks like drush_version_control_backup::pre_update will move (not copy) the codebase to the backup target by default, which is why help.api.php was removed when the --no-copy option was not present.

A simple fix for this would be to delete the project directory before performing updates, if the --no-backup option is present. I've created a branch that does just this, and seems to work normally. 

Note that users who expect --no-backup to never remove files are in for a nasty surprise when this bug is fixed.
