### PR TITLE
Fix docblock for php-script command

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -989,10 +989,6 @@ function drush_core_quick_drupal_options(&$items) {
 /**
  * Command callback. Runs "naked" php scripts
  * and drush "shebang" scripts ("#!/usr/bin/env drush").
- *
- * @params
- *   Command arguments, optional. First argument is site name, remaining
- *   argument(s) are contrib modules to install.
  */
 function drush_core_php_script() {
   $found = FALSE;


### PR DESCRIPTION
It contained a `@params` section which seems to be a copy & paste mistake.
