### PR TITLE
Fix #825. Argument passing to module_invoke_all().

### DIFF
--- a/commands/core/drupal/environment_6.inc
+++ b/commands/core/drupal/environment_6.inc
@@ -178,9 +178,9 @@ function drush_module_implements($hook, $sort = FALSE, $reset = FALSE) {
 }
 
 /**
-  * Invokes a hook in a particular module.
-  *
-  */
+ * Invokes a hook in a particular module.
+ *
+ */
 function drush_module_invoke($module, $hook) {
   $args = func_get_args();
   if (count($args) > 2) {
@@ -193,9 +193,9 @@ function drush_module_invoke($module, $hook) {
 }
 
 /**
-  * Invokes a hook in all enabled modules that implement it.
-  *
-  */
+ * Invokes a hook in all enabled modules that implement it.
+ *
+ */
 function drush_module_invoke_all($hook) {
   $args = func_get_args();
   if (count($args) > 1) {

--- a/commands/core/drupal/environment_6.inc
+++ b/commands/core/drupal/environment_6.inc
@@ -182,7 +182,14 @@ function drush_module_implements($hook, $sort = FALSE, $reset = FALSE) {
   *
   */
 function drush_module_invoke($module, $hook) {
-  return module_invoke($module, $hook);
+  $args = func_get_args();
+  if (count($args) > 2) {
+    $args = array_slice($args, 2);
+    return module_invoke($module, $hook, $args);
+  }
+  else {
+    return module_invoke($module, $hook);
+  }
 }
 
 /**

--- a/commands/core/drupal/environment_6.inc
+++ b/commands/core/drupal/environment_6.inc
@@ -189,8 +189,8 @@ function drush_module_invoke($module, $hook) {
   * Invokes a hook in all enabled modules that implement it.
   *
   */
-function drush_module_invoke_all($hook) {
-  return module_invoke_all($hook);
+function drush_module_invoke_all($hook, $args) {
+  return module_invoke_all($hook, $args);
 }
 
 /**

--- a/commands/core/drupal/environment_6.inc
+++ b/commands/core/drupal/environment_6.inc
@@ -189,8 +189,15 @@ function drush_module_invoke($module, $hook) {
   * Invokes a hook in all enabled modules that implement it.
   *
   */
-function drush_module_invoke_all($hook, $args) {
-  return module_invoke_all($hook, $args);
+function drush_module_invoke_all($hook) {
+  $args = func_get_args();
+  if (count($args) > 1) {
+    unset($args[0]);
+    return module_invoke_all($hook, $args);
+  }
+  else {
+    return module_invoke_all($hook);
+  }    
 }
 
 /**

--- a/commands/core/drupal/environment_6.inc
+++ b/commands/core/drupal/environment_6.inc
@@ -183,13 +183,7 @@ function drush_module_implements($hook, $sort = FALSE, $reset = FALSE) {
  */
 function drush_module_invoke($module, $hook) {
   $args = func_get_args();
-  if (count($args) > 2) {
-    $args = array_slice($args, 2);
-    return module_invoke($module, $hook, $args);
-  }
-  else {
-    return module_invoke($module, $hook);
-  }
+  return call_user_func_array('module_invoke', $args);
 }
 
 /**
@@ -198,13 +192,7 @@ function drush_module_invoke($module, $hook) {
  */
 function drush_module_invoke_all($hook) {
   $args = func_get_args();
-  if (count($args) > 1) {
-    unset($args[0]);
-    return module_invoke_all($hook, $args);
-  }
-  else {
-    return module_invoke_all($hook);
-  }    
+  return call_user_func_array('module_invoke_all', $args);
 }
 
 /**

--- a/commands/core/drupal/environment_7.inc
+++ b/commands/core/drupal/environment_7.inc
@@ -200,7 +200,14 @@ function drush_module_implements($hook, $sort = FALSE, $reset = FALSE) {
   *
   */
 function drush_module_invoke($module, $hook) {
-  return module_invoke($module, $hook);
+  $args = func_get_args();
+  if (count($args) > 2) {
+    $args = array_slice($args, 2);
+    return module_invoke($module, $hook, $args);
+  }
+  else {
+    return module_invoke($module, $hook);
+  }
 }
 
 /**

--- a/commands/core/drupal/environment_7.inc
+++ b/commands/core/drupal/environment_7.inc
@@ -207,10 +207,16 @@ function drush_module_invoke($module, $hook) {
   * Invokes a hook in all enabled modules that implement it.
   *
   */
-function drush_module_invoke_all($hook, $args) {
-  return module_invoke_all($hook, $args);
+function drush_module_invoke_all($hook) {
+  $args = func_get_args();
+  if (count($args) > 1) {
+    unset($args[0]);
+    return module_invoke_all($hook, $args);
+  }
+  else {
+    return module_invoke_all($hook);
+  }    
 }
-
 
 /**
  * Get complete information for all available themes.

--- a/commands/core/drupal/environment_7.inc
+++ b/commands/core/drupal/environment_7.inc
@@ -207,8 +207,8 @@ function drush_module_invoke($module, $hook) {
   * Invokes a hook in all enabled modules that implement it.
   *
   */
-function drush_module_invoke_all($hook) {
-  return module_invoke_all($hook);
+function drush_module_invoke_all($hook, $args) {
+  return module_invoke_all($hook, $args);
 }
 
 

--- a/commands/core/drupal/environment_7.inc
+++ b/commands/core/drupal/environment_7.inc
@@ -196,9 +196,9 @@ function drush_module_implements($hook, $sort = FALSE, $reset = FALSE) {
 }
 
 /**
-  * Invokes a hook in a particular module.
-  *
-  */
+ * Invokes a hook in a particular module.
+ *
+ */
 function drush_module_invoke($module, $hook) {
   $args = func_get_args();
   if (count($args) > 2) {
@@ -211,9 +211,9 @@ function drush_module_invoke($module, $hook) {
 }
 
 /**
-  * Invokes a hook in all enabled modules that implement it.
-  *
-  */
+ * Invokes a hook in all enabled modules that implement it.
+ *
+ */
 function drush_module_invoke_all($hook) {
   $args = func_get_args();
   if (count($args) > 1) {

--- a/commands/core/drupal/environment_7.inc
+++ b/commands/core/drupal/environment_7.inc
@@ -201,13 +201,7 @@ function drush_module_implements($hook, $sort = FALSE, $reset = FALSE) {
  */
 function drush_module_invoke($module, $hook) {
   $args = func_get_args();
-  if (count($args) > 2) {
-    $args = array_slice($args, 2);
-    return module_invoke($module, $hook, $args);
-  }
-  else {
-    return module_invoke($module, $hook);
-  }
+  return call_user_func_array('module_invoke', $args);  
 }
 
 /**
@@ -216,13 +210,7 @@ function drush_module_invoke($module, $hook) {
  */
 function drush_module_invoke_all($hook) {
   $args = func_get_args();
-  if (count($args) > 1) {
-    unset($args[0]);
-    return module_invoke_all($hook, $args);
-  }
-  else {
-    return module_invoke_all($hook);
-  }    
+  return call_user_func_array('module_invoke_all', $args);
 }
 
 /**


### PR DESCRIPTION
There are warnings generated (and missing information) when running 'drush core-requirements' on an installed d6 or d7 site due to the fact that arguments are not passed to module_invoke_all() from drush_module_invoke_all().