### PR TITLE
Remove #name result of the site-alias command

### DIFF
--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -189,6 +189,8 @@ function drush_sitealias_print() {
   $site_specs = array();
   foreach ($site_list as $site => $alias_record) {
     list($alias_name, $result_record) = _drush_sitealias_prepare_record($alias_record, $site);
+    // Remove the internal #name property.
+    unset($result_record['#name']);
     $site_specs[$alias_name] = $result_record;
   }
   ksort($site_specs);


### PR DESCRIPTION
It is an internal property used by Drush and does not need to be printed out.

Currently if you do drush site-alias @self you get the following output:

```bash
$ dr site-alias @self
$aliases["self"] = array (
  'root' => '/home/juampy/projects/drupal',
  'uri' => 'http://default',
  '#name' => 'self',
);
```

`root` and `uri` are known options for Drupal users, but `#name` is not. There is no documentation about the usage of the `#name` property and my understanding by reading core and the git log is that it is used by Drush to cache site alias definitions. I have also seen that at some point in the past this property was being unset too.

In this PR I am assuming that the property is not needed by the site-alias command and simply removing it. Please let me know if I should take anything else into consideration. Let's also see if tests pass with this change.