### PR TITLE
Use user.permissions service.

### DIFF
--- a/lib/Drush/Role/Role8.php
+++ b/lib/Drush/Role/Role8.php
@@ -33,13 +33,10 @@ class Role8 extends Role7 {
 
   public function getModulePerms($module) {
     drush_include_engine('drupal', 'environment');
-
-    // TODO remove next line when contrib modules abandonded hook_permission
-    $perms = drush_module_invoke($module, 'permission');
-
     /** @var \Drupal\user\PermissionHandlerInterface $permission_handler */
     $permission_handler = \Drupal::service('user.permissions');
     $permissions = $permission_handler->getPermissions();
+    $perms = array();
     if( $permission_handler->moduleProvidesPermissions($module)) {
       foreach ($permissions as $key => $permission) {
         if ($permission['provider'] == $module) {


### PR DESCRIPTION
As it's not useful to call `hook_permissions` anymore we need to use the `user.permissions services`

See CR https://www.drupal.org/node/2311427
https://www.drupal.org/node/2328411
https://www.drupal.org/node/2338475

Permission is now provided by `/core/modules/user/src/PermissionHandler.php`

Without this patch calling

``` bash
drush @drupal.d8 role-add-perm registered "delete any article content
Could not find the permission: delete any article content   [error]
```
