### PR TITLE
Fix sql-sync not propagating command-specific options to sub-commands

### DIFF
--- a/commands/sql/sync.sql.inc
+++ b/commands/sql/sync.sql.inc
@@ -82,6 +82,15 @@ function drush_sql_sync($source, $destination) {
   $global_options = drush_redispatch_get_options() + array(
      'strict' => 0,
   );
+  // Merge command specific options for sql-sync with global options so they are applied
+  // on sub-commands such as sql-dump.
+  if (!empty($source_settings['command-specific']['sql-sync'])) {
+    $global_options = array_merge($global_options, $source_settings['command-specific']['sql-sync']);
+  }
+  // Same for source-command-specific options for sql-sync.
+  if (!empty($source_settings['source-command-specific']['sql-sync'])) {
+    $global_options = array_merge($global_options, $source_settings['source-command-specific']['sql-sync']);
+  }
 
   if (drush_get_context('DRUSH_SIMULATE')) {
     $backend_options['backend-simulate'] = TRUE;


### PR DESCRIPTION
Currently, the following example at `examples/example.aliases.drushrc.php` does not work:

``````
```
 #$aliases['live'] = array(
 #    'parent' => '@server,@dev',
 #    'uri' => 'mydrupalsite.com',
 #     'target-command-specific' => array (
 #       'sql-sync' => array (
 #         'skip-tables-list' => 'comments',
 #       ),
 #     ),
 #  );
```
``````

 The reason is that skip-tables-list is an option for sql-dump, not for sql-sync. The above would only work if the setting was set to the sql-dump command instead of the sql-sync command. However, this may be desired just for sql-sync so it is not a good solution. Besides, this must be frustrating developers which do not understand why tables are not ignored.

We should propagate sql-sync options to its sub-commands such as sql-dump or sql-sanitize. Perhaps on a follow up we could remove options which belong to sub-commads defined at sql-sync and instead use `allow-additional-options => ('sql-create', 'sql-dump', 'sql-sanitize')`.
