### PR TITLE
Fixed drush_core_updatedb() calls drush cache-clear which is deprecated ...

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -451,7 +451,7 @@ function drush_core_updatedb() {
 
   // Clear all caches in a new process. We just performed major surgery.
   if (drush_drupal_major_version() == 8) {
-    drush_invoke_process('@self', 'cache-rebuild', array('all'));
+    drush_invoke_process('@self', 'cache-rebuild');
   }
   else {
     drush_invoke_process('@self', 'cache-clear', array('all'));


### PR DESCRIPTION
...for D8.
