### PR TITLE
Ensure path returned by drush_server_home() does not have trailing slashes

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -647,7 +647,7 @@ function drush_is_local_host($host) {
  * Return the user's home directory.
  */
 function drush_server_home() {
-  // Cannot use $_SERVER superglobal since that's empty during Drush_UnitTestCase
+  // Cannot use $_SERVER superglobal since that's empty during UnitUnishTestCase
   // getenv('HOME') isn't set on Windows and generates a Notice.
   $home = getenv('HOME');
   if (!empty($home)) {


### PR DESCRIPTION
Fixes #848.
