### PR TITLE
Updated test-run documentation when running with apache user

### DIFF
--- a/commands/core/test.drush.inc
+++ b/commands/core/test.drush.inc
@@ -35,7 +35,7 @@ function test_drush_command() {
     ),
     'examples' => array(
       'test-run' => 'List all available classes and groups.',
-      'sudo -u apache test-run --all' => 'Run all available tests. Avoid permission related failures by running as web server user.',
+      'sudo -u apache drush test-run --all' => 'Run all available tests. Avoid permission related failures by running as web server user.',
       'test-run BootstrapPageCacheTestCase' => 'Run one test class.',
       'test-run Bootstrap' => 'Run all classes in a XML-RPC group.',
       'test-run Bootstrap,Filter' => 'Run all tests from multiple groups/classes.',


### PR DESCRIPTION
On the example of running the tests with the apache user, I've added drush to the command to be more clear on how to run the command.
