### PR TITLE
Send command's retun value further up the system

### DIFF
--- a/includes/command.inc
+++ b/includes/command.inc
@@ -220,6 +220,8 @@ function drush_command() {
       _drush_log_drupal_messages();
     }
   }
+
+  return $result;
 }
 
 /**


### PR DESCRIPTION
Drush expects commands to be able to return exit values which drush can return when exiting. We are not returning exit value from drush_command() and we should probably do that.
