### PR TITLE
Update Sqlpgsql.php for Windows

### DIFF
--- a/lib/Drush/Sql/Sqlpgsql.php
+++ b/lib/Drush/Sql/Sqlpgsql.php
@@ -25,9 +25,14 @@ class Sqlpgsql extends SqlBase {
 
   public function command() {
     $environment = "";
+    
+    if (drush_is_windows()) {
+      $environment = "SET ";
+    }
+    
     $pw_file = $this->password_file();
     if (isset($pw_file)) {
-      $environment = "PGPASSFILE={$pw_file} ";
+      $environment .= "PGPASSFILE={$pw_file} ";
     }
     return "{$environment}psql -q";
   }


### PR DESCRIPTION
Under a windows environment with a Postgres database, the variable "PGPASSFILE=..." will be interpreted as a command (not found of course, as it's not a valid command).
The result is it asks for password (but silently with the -q parameter), so the drush command is blocked and the password can't be input by the prompt.

In order to set the variable properly, I added a "SET" command if it's under windows platform.
I don't know if it's the best way to handle environment issue here, but it seems to work.
