### PR TITLE
Prevent Drush scanning the root directory

### DIFF
--- a/lib/Drush/Boot/command.inc
+++ b/lib/Drush/Boot/command.inc
@@ -63,8 +63,9 @@ function _drush_find_commandfiles($phase, $phase_max = FALSE) {
       // we can use the Drupal API.
       $ignored_modules = drush_get_option_list('ignored-modules', array());
       foreach (array_diff(drush_module_list(), $ignored_modules) as $module) {
-        $filename = drupal_get_filename('module', $module);
-        $searchpath[] = dirname($filename);
+        if ($filename = drupal_get_filename('module', $module)) {
+          $searchpath[] = dirname($filename);
+        }
       }
       break;
   }


### PR DESCRIPTION
By accidentally adding '/' as a commandfile searchpath in
_drush_find_commandfiles() Drush ends up scanning the entire directory tree.
This can happen if drupal_get_filename() returns NULL, which can happen in
very rare circumstances, for example if a module is registered as installed in
the configuration but does not exist in the filesystem.
