### PR TITLE
Enables caching for libraries.

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -186,8 +186,6 @@ function make_make_complete() {
  * Drush callback; make based on the makefile.
  */
 function drush_make($makefile = NULL, $build_path = NULL) {
-  $release_info = drush_get_engine('release_info');
-
   // Set the cache option based on our '--no-cache' option.
   _make_enable_cache();
 


### PR DESCRIPTION
- Resolves #824.

This is a start, however, I am inclined at this point to simply enable caching at the very beginning of the process, rather than the current attempt to enable and disable as the process progresses.
