### PR TITLE
Allow engines to live in lib/

### DIFF
--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -152,7 +152,7 @@ function drush_cache_command_clear($type = NULL) {
  *   A specific bin to fetch from. If not specified, the default bin is used.
  */
 function drush_cache_command_get($cid = NULL, $bin = NULL) {
-  drush_include_engine('drupal', 'cache', drush_drupal_major_version());
+  drush_include_engine('drupal', 'cache');
   $result = drush_op('_drush_cache_command_get', $cid, $bin);
 
   if (empty($result)) {
@@ -184,7 +184,7 @@ function drush_cache_command_set($cid = NULL, $data = '', $bin = NULL, $expire =
     return;
   }
 
-  drush_include_engine('drupal', 'cache', drush_drupal_major_version());
+  drush_include_engine('drupal', 'cache');
   return drush_op('_drush_cache_command_set', $cid, $data, $bin, $expire, $tags);
 }
 
@@ -223,7 +223,7 @@ function drush_cache_set_prepare_data($data) {
  * All types of caches available for clearing. Contrib commands can alter in their own.
  */
 function drush_cache_clear_types($include_bootstrapped_types = FALSE) {
-  drush_include_engine('drupal', 'cache', drush_drupal_major_version());
+  drush_include_engine('drupal', 'cache');
   $types = _drush_cache_clear_types($include_bootstrapped_types);
 
   // Include the appropriate environment engine, so callbacks can use core
@@ -270,7 +270,7 @@ function drush_cache_rebuild() {
   drush_cache_clear_drush();
 
   // Clears the render cache.
-  drush_include_engine('drupal', 'cache', drush_drupal_major_version());
+  drush_include_engine('drupal', 'cache');
   drush_cache_clear_render();
 }
 

--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -444,7 +444,7 @@ function drush_core_updatedb() {
     return TRUE;
   }
 
-  drush_include_engine('drupal', 'update', drush_drupal_major_version());
+  drush_include_engine('drupal', 'update');
   if (update_main() === FALSE) {
     return FALSE;
   }
@@ -466,7 +466,7 @@ function drush_core_updatedb() {
 function drush_core_updatedb_status() {
   require_once DRUSH_DRUPAL_CORE . '/includes/install.inc';
   drupal_load_updates();
-  drush_include_engine('drupal', 'update', drush_drupal_major_version());
+  drush_include_engine('drupal', 'update');
   list($pending, $start) = updatedb_status();
   if (empty($pending)) {
     drush_log(dt("No database updates required"), 'ok');
@@ -756,7 +756,7 @@ function drush_core_requirements() {
   );
 
   drupal_load_updates();
-  
+
   drush_include_engine('drupal', 'environment');
   $requirements = drush_module_invoke_all('requirements', 'runtime');
   // If a module uses "$requirements[] = " instead of
@@ -1123,7 +1123,7 @@ function drush_core_batch_process($id) {
  * upgrades.
  */
 function drush_core_updatedb_batch_process($id) {
-  drush_include_engine('drupal', 'update', drush_drupal_major_version());
+  drush_include_engine('drupal', 'update');
   require_once DRUSH_DRUPAL_CORE . '/includes/install.inc';
   // require_once DRUSH_DRUPAL_CORE . '/includes/update.inc';
   drupal_load_updates();

--- a/commands/core/image.drush.inc
+++ b/commands/core/image.drush.inc
@@ -64,19 +64,19 @@ function image_drush_help_alter(&$command) {
  */
 function image_image_flush_complete() {
   drush_bootstrap(DRUSH_BOOTSTRAP_DRUPAL_FULL);
-  drush_include_engine('drupal', 'image', drush_drupal_major_version());
+  drush_include_engine('drupal', 'image');
   return array('values' => array_keys(drush_image_styles()));
 }
 
 function drush_image_flush_pre_validate($style_name = NULL) {
-  drush_include_engine('drupal', 'image', drush_drupal_major_version());
+  drush_include_engine('drupal', 'image');
   if (!empty($style_name) && !$style = drush_image_style_load($style_name)) {
     return drush_set_error(dt('Image style !style not recognized.', array('!style' => $style_name)));
   }
 }
 
 function drush_image_flush($style_name = NULL) {
-  drush_include_engine('drupal', 'image', drush_drupal_major_version());
+  drush_include_engine('drupal', 'image');
   if (drush_get_option('all')) {
     $style_name = 'all';
   }
@@ -103,7 +103,7 @@ function drush_image_flush($style_name = NULL) {
 }
 
 function drush_image_derive_validate($style_name, $source) {
-  drush_include_engine('drupal', 'image', drush_drupal_major_version());
+  drush_include_engine('drupal', 'image');
   if (!$style = drush_image_style_load($style_name)) {
     return drush_set_error(dt('Image style !style not recognized.', array('!style' => $style_name)));
   }
@@ -123,6 +123,6 @@ function drush_image_derive_validate($style_name, $source) {
  *   The path to a source image, relative to Drupal root.
  */
 function drush_image_derive($style_name, $source) {
-  drush_include_engine('drupal', 'image', drush_drupal_major_version());
+  drush_include_engine('drupal', 'image');
   return _drush_image_derive($style_name, $source);
 }

--- a/commands/core/outputformat.drush.inc
+++ b/commands/core/outputformat.drush.inc
@@ -130,7 +130,7 @@ function outputformat_drush_engine_outputformat() {
     'hidden' => TRUE,
   );
   $engines['key-value-list'] = array(
-    'engine-class' => 'list',
+    'implemented-by' => 'list',
     'list-item-type' => 'key-value',
     'description' => 'A list of formatted lists of key-value pairs.',
     'list-field-selection-control' => 1,
@@ -175,7 +175,7 @@ function outputformat_drush_engine_outputformat() {
   );
   $engines['config'] = array(
     'machine-parsable' => TRUE,
-    'engine-class' => 'list',
+    'implemented-by' => 'list',
     'list-item-type' => 'var_export',
     'description' => "A configuration file in executable php format. The variable name is \"config\", and the variable keys are taken from the output data array's keys.",
     'metadata' => array(
@@ -195,7 +195,7 @@ function outputformat_drush_engine_outputformat() {
   );
   $engines['nested-csv'] = array(
     'machine-parsable' => TRUE,
-    'engine-class' => 'list',
+    'implemented-by' => 'list',
     'list-separator' => ',',
     'list-item-type' => 'csv-or-string',
     'hidden' => TRUE,
@@ -206,7 +206,7 @@ function outputformat_drush_engine_outputformat() {
   );
   $engines['csv'] = array(
     'machine-parsable' => TRUE,
-    'engine-class' => 'list',
+    'implemented-by' => 'list',
     'list-item-type' => 'nested-csv',
     'labeled-list' => TRUE,
     'description' => 'A list of values, one per row, each of which is a comma-separated list of values.',
@@ -226,7 +226,7 @@ function outputformat_drush_engine_outputformat() {
     'description' => 'A list of php exports, labeled with a name.',
     'engine-capabilities' => array('format-table'),
     'verbose-only' => TRUE,
-    'engine-class' => 'list',
+    'implemented-by' => 'list',
     'list-item-type' => 'var_export',
     'metadata' => array(
       'label-template' => '!label: !value',
@@ -353,7 +353,7 @@ class drush_outputformat {
     $this->engine_config = $config;
   }
   function format_error($message) {
-    return drush_set_error('DRUSH_FORMAT_ERROR', dt("The output data could not be processed by the selected format '!type'.  !message", array('!type' => $this->selected_engine, '!message' => $message)));
+    return drush_set_error('DRUSH_FORMAT_ERROR', dt("The output data could not be processed by the selected format '!type'.  !message", array('!type' => $this->engine, '!message' => $message)));
   }
   function formatter_type() {
     return $this->engine;
@@ -416,9 +416,9 @@ class drush_outputformat {
         }
       }
     }
-    if (isset($metadata[$this->selected_engine . '-metadata'])) {
-      $engine_specific_metadata = $metadata[$this->selected_engine . '-metadata'];
-      unset($metadata[$this->selected_engine . '-metadata']);
+    if (isset($metadata[$this->engine . '-metadata'])) {
+      $engine_specific_metadata = $metadata[$this->engine . '-metadata'];
+      unset($metadata[$this->engine . '-metadata']);
       $metadata = array_merge($metadata, $engine_specific_metadata);
     }
     if ((drush_get_context('DRUSH_PIPE')) && (isset($metadata['pipe-metadata']))) {

--- a/commands/core/outputformat/list.inc
+++ b/commands/core/outputformat/list.inc
@@ -46,7 +46,7 @@ class drush_outputformat_list extends drush_outputformat {
       }
     }
     $sub_formatter = isset($list_metadata['list-item-type']) ? $list_metadata['list-item-type'] : 'string';
-    $this->sub_engine = drush_load_engine('outputformat', $sub_formatter, NULL, NULL, $this->engine_config);
+    $this->sub_engine = drush_load_engine('outputformat', $sub_formatter, $this->engine_config);
     if (!is_object($this->sub_engine)) {
       return drush_set_error('DRUSH_INVALID_SUBFORMATTER', dt("The list output formatter could not load its subformatter: !sub", array('!sub' => $sub_formatter)));
     }

--- a/commands/core/outputformat/variables.inc
+++ b/commands/core/outputformat/variables.inc
@@ -28,7 +28,7 @@
 class drush_outputformat_variables extends drush_outputformat {
   function validate() {
     $metadata = $this->engine_config;
-    $this->sub_engine = drush_load_engine('outputformat', 'var_export', NULL, NULL, $metadata);
+    $this->sub_engine = drush_load_engine('outputformat', 'var_export', $metadata);
     if (!is_object($this->sub_engine)) {
       return FALSE;
     }

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -265,6 +265,6 @@ function drush_core_site_install($profile = NULL) {
       $form_options[$key] = $value;
     }
   }
-  drush_include_engine('drupal', 'site_install', drush_drupal_major_version());
+  drush_include_engine('drupal', 'site_install');
   drush_core_site_install_version($profile, $form_options);
 }

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -4,6 +4,8 @@
  * Drush Make commands.
  */
 
+use \Drush\UpdateService\ReleaseInfo;
+
 /**
  * Default localization server for downloading translations.
  */
@@ -319,7 +321,7 @@ function make_prepare_projects($recursion, $info, $contrib_destination = '', $bu
       'build_path'          => $build_path,
       'contrib_destination' => $contrib_destination,
       'version'             => '',
-      'location'            => drush_get_option('make-update-default-url', RELEASE_INFO_DEFAULT_URL),
+      'location'            => drush_get_option('make-update-default-url', ReleaseInfo::DEFAULT_URL),
       'subdir'              => '',
       'directory_name'      => '',
       'make_directory'      => $make_dir,
@@ -330,7 +332,7 @@ function make_prepare_projects($recursion, $info, $contrib_destination = '', $bu
     if (isset($project['download']) && !isset($project['download']['type'])) {
       $project['download']['type'] = 'git';
     }
-    if (!isset($project['l10n_url']) && ($project['location'] == RELEASE_INFO_DEFAULT_URL)) {
+    if (!isset($project['l10n_url']) && ($project['location'] == ReleaseInfo::DEFAULT_URL)) {
       $project['l10n_url'] = MAKE_DEFAULT_L10N_SERVER;
     }
 
@@ -340,7 +342,7 @@ function make_prepare_projects($recursion, $info, $contrib_destination = '', $bu
     // keys.
     $request = make_prepare_request($project);
 
-    if ($project['location'] != RELEASE_INFO_DEFAULT_URL && !isset($project['type'])) {
+    if ($project['location'] != ReleaseInfo::DEFAULT_URL && !isset($project['type'])) {
       // Set the cache option based on our '--no-cache' option.
       $cache_before = drush_get_option('cache');
       if (!drush_get_option('no-cache', FALSE)) {

--- a/commands/pm/download.pm.inc
+++ b/commands/pm/download.pm.inc
@@ -5,6 +5,8 @@
  * pm-download command implementation.
  */
 
+use \Drush\UpdateService\ReleaseInfo;
+
 /**
  * Implements drush_hook_COMMAND_validate().
  */
@@ -87,7 +89,7 @@ function drush_pm_download() {
   }
 
   // Pick cli options.
-  $source = drush_get_option('source', RELEASE_INFO_DEFAULT_URL);
+  $source = drush_get_option('source', ReleaseInfo::DEFAULT_URL);
   $restrict_to = drush_get_option('dev', '');
   $select = drush_get_option('select', 'auto');
   $all = drush_get_option('all', FALSE);

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -1060,7 +1060,7 @@ function drush_pm_enable() {
  */
 function drush_pm_disable() {
   $args = pm_parse_arguments(func_get_args());
-  drush_include_engine('drupal', 'pm', drush_drupal_major_version());
+  drush_include_engine('drupal', 'pm');
   _drush_pm_disable($args);
 }
 
@@ -1098,7 +1098,7 @@ function _drush_pm_expand_extensions(&$extensions, $extension_info = array()) {
  */
 function drush_pm_uninstall() {
   $args = pm_parse_arguments(func_get_args());
-  drush_include_engine('drupal', 'pm', drush_drupal_major_version());
+  drush_include_engine('drupal', 'pm');
   _drush_pm_uninstall($args);
 }
 
@@ -1545,6 +1545,7 @@ function pm_drush_engine_release_info() {
           'all' => 'Shows all available releases instead of a short list of recent releases.',
         ),
       ),
+      'class' => 'Drush\UpdateService\ReleaseInfo',
     ),
   );
 }

--- a/docs/drush.api.php
+++ b/docs/drush.api.php
@@ -350,9 +350,11 @@ function hook_drush_engine_type_info() {
  * Inform drush about one or more engines implementing a given engine type.
  *
  *   - description: The engine implementation's description.
- *   - engine-class:  The class that contains the engine implementation.
+ *   - implemented-by: The engine that actually implements this engine.
+ *       This is useful to allow the implementation of similar engines
+ *       in the reference one.
  *       Defaults to the engine type key (e.g. 'ice-cream').
- *   - verbose-only:  The engine implementation will only appear in help
+ *   - verbose-only: The engine implementation will only appear in help
  *       output in --verbose mode.
  *
  * This hook allow to declare implementations for an engine type.
@@ -367,6 +369,10 @@ function hook_drush_engine_ENGINE_TYPE() {
       'options' => array(
         'flavour' => 'Choose your favorite flavour',
       ),
+    ),
+    'frozen-yogurt' => array(
+      'description' => 'Frozen dairy dessert made with yogurt instead of milk and cream.',
+      'implemented-by' => 'ice-cream',
     ),
   );
 }

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -71,7 +71,7 @@ function drush_backend_batch_process($command = 'batch-process', $args = array()
   // Command line options to pass to the command.
   $options['u'] = drush_user_get_class()->getCurrentUserAsSingle()->id();
 
-  drush_include_engine('drupal', 'batch', drush_drupal_major_version());
+  drush_include_engine('drupal', 'batch');
   _drush_backend_batch_process($command, $args, $options);
 }
 
@@ -86,6 +86,6 @@ function drush_backend_batch_process($command = 'batch-process', $args = array()
  */
 function drush_batch_command($id) {
   include_once(DRUSH_DRUPAL_CORE . '/includes/batch.inc');
-  drush_include_engine('drupal', 'batch', drush_drupal_major_version());
+  drush_include_engine('drupal', 'batch');
   _drush_batch_command($id);
 }

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -471,7 +471,7 @@ function drush_handle_command_output($command, $structured_output) {
       if ($formatter === TRUE) {
         return drush_set_error(dt('No outputformat class defined for !format', array('!format' => $format)));
       }
-      if ((!empty($command['engines']['outputformat'])) && (!in_array($formatter->selected_engine, $command['engines']['outputformat']['usable']))) {
+      if ((!empty($command['engines']['outputformat'])) && (!in_array($formatter->engine, $command['engines']['outputformat']['usable']))) {
         return $formatter->format_error(dt("The command '!command' does not produce output in a structure usable by this output format.", array('!command' => $command['command'])));
       }
       // Add any user-specified options to the metadata passed to the formatter.

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -61,19 +61,21 @@ define('DRUSH_CACHE_LIFETIME_DEFAULT', 86400);
  *   TRUE if the file was found and included.
  */
 function drush_include($path, $name, $version = NULL, $extension = 'inc') {
+  $name = str_replace('-', '_', $name);
   $version = ($version) ? $version : drush_drupal_major_version();
-  $file = sprintf("%s/%s_%s.%s", $path, str_replace('-', '_', $name), $version, $extension);
+
+  $file = sprintf("%s/%s_%s.%s", $path, $name, $version, $extension);
   if (file_exists($file)) {
-    //drush_log(dt('Including version specific file : @file', array('@file' => $file)));
     include_once($file);
     return TRUE;
   }
-  $file = sprintf("%s/%s.%s", $path, str_replace('-', '_', $name), $extension);
+  $file = sprintf("%s/%s.%s", $path, $name, $extension);
   if (file_exists($file)) {
-    //drush_log(dt('Including non-version specific file : @file', array('@file' => $file)));
     include_once($file);
     return TRUE;
   }
+
+  return drush_set_error('DRUSH_INCLUDE_NO_PATH', dt('Unable to include file !name!version!extension or !name!extension from !path.', array('!name' => $name, '!version' => $version, '!extension' => $extension)));
 }
 
 /**
@@ -97,15 +99,15 @@ function drush_get_class($class_name, $constructor_args = array(), $variations =
   if (empty($variations)) {
     $variations[] = drush_drupal_major_version();
   }
-  for ($i=count($variations); $i > 0; $i--) {
+  for ($i=count($variations); $i >= 0; $i--) {
     $variant_class_name = $class_name . implode('', array_slice($variations, 0, $i));
     if (class_exists($variant_class_name)) {
       $reflectionClass = new ReflectionClass($variant_class_name);
       return $reflectionClass->newInstanceArgs($constructor_args);
     }
   }
-  // Something bad happenned. Exception?
-  // drush_set_error('DRUSH_GET_CLASS_ERROR', dt('Unable to load class - %s', $class_name));
+  // Something bad happenned. TODO Exception?
+  return drush_set_error('DRUSH_GET_CLASS_ERROR', dt('Unable to load class !class', array('!class' => $class_name)));
 }
 
 /**

--- a/includes/engines.inc
+++ b/includes/engines.inc
@@ -70,21 +70,39 @@ function drush_get_engines($engine_type) {
     if (drush_command_hook($commandfile, $hook)) {
       $function = $commandfile . '_' . $hook;
       $result = $function();
-      foreach ($result as $key => $engine) {
-        // Add some defaults
+      foreach ($result as $engine_name => $engine) {
+        // Add some defaults.
         $engine += array(
           'commandfile' => $commandfile,
-          // Engines by default live in a subdirectory of the commandfile that
-          // declared them, named as per the type of engine they are.
-          'path' => sprintf("%s/%s", dirname($path), $engine_type),
           'options' => array(),
           'sub-options' => array(),
           'drupal dependencies' => array(),
         );
-        $engines['engines'][$key] = $engine;
+
+        // Legacy engines live in a subdirectory
+        // of the commandfile that declared them.
+        $engine_path = sprintf("%s/%s", dirname($path), $engine_type);
+        if (file_exists($engine_path)) {
+          $engine['path'] = $engine_path;
+        }
+        // Build engine class name, in case the engine doesn't provide it.
+        // The class name is based on the engine type and name, converted
+        // from snake_case to CamelCase.
+        // For example for type 'package_handler' and engine 'git_drupalorg'
+        // the class is \Drush\PackageHandler\GitDrupalorg
+        elseif (!isset($engine['class'])) {
+          $parts = array();
+          $parts[] = '\Drush';
+          $parts[] = str_replace(' ', '', ucwords(strtr($engine_type, '_', ' ')));
+          $parts[] = str_replace(' ', '', ucwords(strtr($engine_name, '_', ' ')));
+          $engine['class'] = implode('\\', $parts);
+        }
+
+        $engines['engines'][$engine_name] = $engine;
       }
     }
   }
+
   return $engines;
 }
 
@@ -148,17 +166,16 @@ function drush_load_command_engine($command, $engine_type, $metadata = array()) 
 
   $config = drush_get_command_engine_config($command, $engine_type, $metadata);
   $engine_info = drush_get_engines($engine_type);
-  $selected_engine = drush_get_user_selected_engine($config, $engine_info);
+  $engine = drush_select_engine($config, $engine_info);
   $version = drush_drupal_major_version();
 
-  $context = $engine_type . '_engine_' . $selected_engine . '_' . $version;
+  $context = $engine_type . '_engine_' . $engine . '_' . $version;
   $instance = drush_get_context($context, FALSE);
   if ($instance != FALSE) {
     drush_set_engine($engine_type, $instance);
   }
   else {
-    $instance = drush_load_engine($engine_type, $selected_engine, NULL, NULL, $config);
-      $command['bootstrap_errors']["FOO"] = "BAR";
+    $instance = drush_load_engine($engine_type, $engine, $config);
     if ($instance == FALSE) {
       return FALSE;
     }
@@ -246,7 +263,7 @@ function drush_merge_engine_data(&$command) {
       $combine_help_data = array();
 
       // Process engines in order. First the default engine, the rest alphabetically.
-      $default = drush_find_engine_to_use($config, $engine_info);
+      $default = drush_select_engine($config, $engine_info);
       $engines = array_keys($engine_info['engines']);
       asort($engines);
       array_unshift($engines, $default);
@@ -367,69 +384,73 @@ function drush_engine_topic_command($engine) {
 }
 
 /**
- * Obtains the engine to use.
+ * Selects an engine between the available ones.
  *
  * Precedence:
  *
+ *  - preferred engine, if available.
  *  - user supplied engine via cli.
- *  - default engine configured for the command.
- *  - the first engine of all available.
+ *  - default engine from engine type / command declaration.
+ *  - the first engine available.
  *
- *  @see drush_find_engine_to_use().
+ * @param array $config
+ *   Engine type configuration. My be overridden in command declaration.
+ * @param array $engine_info
+ *   Engine type declaration.
+ * @param string $default
+ *   Preferred engine.
  *
- *  #TODO# clarify naming of functions and entrance point.
+ * @return string
+ *   Selected engine.
  */
-function drush_get_user_selected_engine(&$config, $engine_info) {
+function drush_select_engine($config, $engine_info, $preferred = NULL) {
   $engines = array_keys($engine_info['engines']);
-  $default = isset($config['default']) ? $config['default'] : current($engines);
-  if (!empty($config['option'])) {
-    $selected_engine = drush_get_option($config['option'], $default);
-  }
-  // Otherwise the default engine is the only option.
-  else {
-    $selected_engine = $default;
-  }
-  return $selected_engine;
-}
 
-/**
- * Returns a valid engine to use.
- *
- * If no preference is passed in $selected_engine, it will pick the
- * 'default' engine provided within the command config.
- *
- * $config is altered to add the engine info to $config['engine-info'].
- *
- *  @see drush_get_user_selected_engine().
- *
- *  #TODO# clarify naming of functions and entrance point.
- */
-function drush_find_engine_to_use(&$config, $engine_info, $selected_engine = NULL) {
-  if (!isset($selected_engine)) {
-    $selected_engine = $config['default'];
+  if (in_array($preferred, $engines)) {
+    return $preferred;
   }
-  if (array_key_exists($selected_engine, $engine_info['engines'])) {
-    $config['engine-info'] = $engine_info['engines'][$selected_engine];
+
+  if (!empty($config['option'])) {
+    $engine = drush_get_option($config['option'], FALSE);
+    if ($engine && in_array($engine, $engines)) {
+      return $engine;
+    }
   }
-  return $selected_engine;
+
+  if (isset($config['default']) && in_array($config['default'], $engines)) {
+    return $config['default'];
+  }
+
+  return current($engines);
 }
 
 /**
  * Loads and validate an engine of the given type.
+ *
+ * @param string $type
+ *   Engine type.
+ * @param string $engine
+ *   Engine name.
+ * @param array $config
+ *   Engine configuration. Tipically it comes from a command declaration.
+ *
+ * @return
+ *   TRUE or instanced object of available class on success. FALSE on fail.
  */
-function drush_load_engine($type, $engine, $version = NULL, $path = NULL, $engine_config = NULL) {
+function drush_load_engine($type, $engine, $config = array()) {
   $engine_info = drush_get_engines($type);
-  $selected_engine = drush_find_engine_to_use($engine_config, $engine_info, $engine);
-  if (!array_key_exists($selected_engine, $engine_info['engines'])) {
-    return drush_set_error('DRUSH_UNKNOWN_ENGINE_TYPE', dt('Unknown !engine_type engine !engine', array('!engine' => $selected_engine, '!engine_type' => $type)));
-  }
+  $engine = drush_select_engine($config, $engine_info, $engine);
+  $config['engine-info'] = $engine_info['engines'][$engine];
+
   // Check engine dependency on drupal modules before include.
-  foreach ($engine_config['engine-info']['drupal dependencies'] as $dependency) {
+  $dependencies = $config['engine-info']['drupal dependencies'];
+  foreach ($dependencies as $dependency) {
     if (!drush_module_exists($dependency)) {
-      return drush_set_error('DRUSH_ENGINE_DEPENDENCY_ERROR', dt('!engine_type: !engine engine needs the following modules installed/enabled to run: !dependencies.', array('!engine_type' => $type, '!engine' => $selected_engine, '!dependencies' => implode(', ', $engine_config['engine-info']['drupal dependencies']))));
+      return drush_set_error('DRUSH_ENGINE_DEPENDENCY_ERROR', dt('!engine_type: !engine engine needs the following modules installed/enabled to run: !dependencies.', array('!engine_type' => $type, '!engine' => $engine, '!dependencies' => implode(', ', $dependencies))));
     }
   }
-  $result = drush_include_engine($type, $selected_engine, $version, $path, $engine_config);
+
+  $result = drush_include_engine($type, $engine, $config);
   if (is_object($result)) {
     $valid = method_exists($result, 'validate') ? $result->validate() : TRUE;
     if ($valid) {
@@ -455,55 +476,46 @@ function drush_load_engine($type, $engine, $version = NULL, $path = NULL, $engin
  * If a class named in the form drush_$type_$engine exists, it will return an
  * instance of the class.
  *
- * If you don't need to present any user options for selecting the engine
- * (which is common if the selection is implied by the running environment)
- * and you don't need to allow other modules to define their own engines you can
- * simply pass the $path to the directory where the engines are, and the
- * appropriate one will be included.
- *
- * Unlike drush_include this function will set errors if the requested engine
- * cannot be found.
- *
- * @param $type
+ * @param string $type
  *   The type of engine.
- * @param $engine
- *   The key for the engine to be included.
- * @param $version
- *   The version of the engine to be included - defaults to the current Drupal
- *   core major version.
- * @param $path
- *   A path to include from, if the engine has no corresponding
- *   hook_drush_engine_$type item path.
+ * @param string $engine
+ *   The name for the engine to include.
+ * @param array $config
+ *   Parameters for the engine class constructor.
  *
  * @return
  *   TRUE or instanced object of available class on success. FALSE on fail.
  */
-function drush_include_engine($type, $selected_engine, $version = NULL, $path = NULL, $engine_config = NULL) {
+function drush_include_engine($type, $engine, $config = NULL) {
   $engine_info = drush_get_engines($type);
-  $engine = isset($engine_info['engines'][$selected_engine]['engine-class']) ? $engine_info['engines'][$selected_engine]['engine-class'] : $selected_engine;
-  if (!$path && isset($engine_info['engines'][$engine])) {
+
+  // Pick the engine name that actually implements the requested engine.
+  $engine = isset($engine_info['engines'][$engine]['implemented-by']) ? $engine_info['engines'][$engine]['implemented-by'] : $engine;
+
+  // Legacy engines live in a subdirectory of the commandfile
+  // that declares them. We need to explicitly include the file.
+  if (isset($engine_info['engines'][$engine]['path'])) {
     $path = $engine_info['engines'][$engine]['path'];
-  }
-  if (!$path) {
-    return drush_set_error('DRUSH_ENGINE_INCLUDE_NO_PATH', dt('No path was set for including the !type engine !engine.', array('!type' => $type, '!engine' => $engine)));
-  }
-  if (drush_include($path, $engine, $version)) {
+    if (!drush_include($path, $engine)) {
+      return drush_set_error('DRUSH_ENGINE_INCLUDE_FAILED', dt('Unable to include the !type engine !engine from !path.' , array('!path' => $path, '!type' => $type, '!engine' => $engine)));
+    }
+    // Legacy engines may be implemented in a magic class name.
     $class = 'drush_' . $type . '_' . str_replace('-', '_', $engine);
     if (class_exists($class)) {
-      $instance = new $class($engine_config);
+      $instance = new $class($config);
       $instance->engine_type = $type;
       $instance->engine = $engine;
-      $instance->selected_engine = $selected_engine;
       return $instance;
     }
+
     return TRUE;
   }
-  return drush_set_error('DRUSH_ENGINE_INCLUDE_FAILED', dt('Unable to include the !type engine !engine from !path.' , array('!path' => $path, '!type' => $type, '!engine' => $engine)));
+
+  return drush_get_class($engine_info['engines'][$engine]['class'], array($type, $engine, $config));
 }
 
 /**
- * Return the engine of the specified type that was loaded
- * by the Drush command.
+ * Return the engine of the specified type that was loaded by the Drush command.
  */
 function drush_get_engine($type) {
   return drush_get_context($type . '_engine', FALSE);

--- a/lib/Drush/UpdateService/ReleaseInfo.php
+++ b/lib/Drush/UpdateService/ReleaseInfo.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * @file
+ * Drush release info engine for update.drupal.org and compatible services.
+ *
+ * This engine does connect directly to the update service. It doesn't depend
+ * on a bootstrapped site.
+ */
+
+namespace Drush\UpdateService;
+
+/**
+ * Release info engine class.
+ */
+class ReleaseInfo {
+  const DEFAULT_URL = 'https://updates.drupal.org/release-history';
+
+  private $cache;
+  private $engine_config;
+
+  /**
+   * Constructor.
+   */
+  public function __construct($type, $engine, $config) {
+    $this->engine_type = $type;
+    $this->engine = $engine;
+
+    if (is_null($config)) {
+      $config = array();
+    }
+    $config += array(
+      'cache-duration' => drush_get_option('cache-duration-releasexml', 24*3600),
+    );
+    $this->engine_config = $config;
+    $this->cache = array();
+  }
+
+  /**
+   * Returns configured cache duration.
+   *
+   * Used by 'drush' update_info engine.
+   */
+  public function getCacheDuration() {
+    return $this->engine_config['cache-duration'];
+  }
+
+  /**
+   * Returns a project's release info from the update service.
+   *
+   * @param array $request
+   *   A request array.
+   *
+   * @param bool $refresh
+   *   Whether to discard cached object.
+   *
+   * @return \Drush\UpdateService\Project
+   */
+  public function get($request, $refresh = FALSE) {
+    if ($refresh || !isset($this->cache[$request['name']])) {
+      $project_release_info = Project::getInstance($request, $this->getCacheDuration());
+      $this->cache[$request['name']] = $project_release_info;
+    }
+    return $this->cache[$request['name']];
+  }
+
+  /**
+   * Delete cached update service file of a project.
+   *
+   * @param array $request
+   *   A request array.
+   */
+  public function clearCached(array $request) {
+    if (isset($this->cache[$request['name']])) {
+      unset($this->cache[$request['name']]);
+    }
+    $url = Project::buildFetchUrl($request);
+    $cache_file = drush_download_file_name($url);
+    if (file_exists($cache_file)) {
+      unlink($cache_file);
+    }
+  }
+
+  /**
+   * Select the most appropriate release for a project, based on a strategy.
+   *
+   * @param Array &$request
+   *   A request array.
+   *   The array will be expanded with the project type.
+   * @param String $restrict_to
+   *   One of:
+   *     'dev': Forces choosing a -dev release.
+   *     'version': Forces choosing a point release.
+   *     '': No restriction.
+   *   Default is ''.
+   * @param String $select
+   *   Strategy for selecting a release, should be one of:
+   *    - auto: Try to select the latest release, if none found allow the user
+   *            to choose.
+   *    - always: Force the user to choose a release.
+   *    - never: Try to select the latest release, if none found then fail.
+   *    - ignore: Ignore and return NULL.
+   *   If no supported release is found, allow to ask the user to choose one.
+   * @param Boolean $all
+   *   In case $select = TRUE this indicates that all available releases will be
+   *  offered the user to choose.
+   *
+   * @return array
+   *  The selected release.
+   */
+  public function selectReleaseBasedOnStrategy($request, $restrict_to = '', $select = 'never', $all = FALSE, $version = NULL) {
+    if (!in_array($select, array('auto', 'never', 'always', 'ignore'))) {
+      return drush_set_error('DRUSH_PM_UNKNOWN_SELECT_STRATEGY', dt("Error: select strategy must be one of: auto, never, always, ignore", array()));
+    }
+
+    $project_release_info = $this->get($request);
+    if (!$project_release_info) {
+      return FALSE;
+    }
+
+    if ($select != 'always') {
+      if ($restrict_to == 'dev') {
+        $release = $project_release_info->getDevRelease();
+        if ($release === FALSE) {
+          return drush_set_error('DRUSH_PM_NO_DEV_RELEASE', dt('There is no development release for project !project.', array('!project' => $request['name'])));
+        }
+      }
+      if (empty($release)) {
+        $release = $project_release_info->getSpecificRelease($request['version']);
+        if ($release === FALSE) {
+          return drush_set_error('DRUSH_PM_COULD_NOT_FIND_VERSION', dt("Could not locate !project version !version.", array(
+            '!project' => $request['name'],
+            '!version' => $request['version'],
+          )));
+        }
+      }
+      // If there was no specific release requested, try to identify the most appropriate release.
+      if (empty($release)) {
+        $release = $project_release_info->getRecommendedOrSupportedRelease();
+      }
+      if ($release) {
+        return $release;
+      }
+      else {
+        $message = dt('There are no stable releases for project !project.', array('!project' => $request['name']));
+        if ($select == 'never') {
+          return drush_set_error('DRUSH_PM_NO_STABLE_RELEASE', $message);
+        }
+        drush_log($message, 'warning');
+        if ($select == 'ignore') {
+          return NULL;
+        }
+      }
+    }
+
+    // At this point the only chance is to ask the user to choose a release.
+    if ($restrict_to == 'dev') {
+      $filter = 'dev';
+    }
+    elseif ($all) {
+      $filter = 'all';
+    }
+    else {
+      $filter = '';
+    }
+    $releases = $project_release_info->filterReleases($filter, $version);
+
+    $options = array();
+    foreach($releases as $release) {
+      $options[$release['version']] = array($release['version'], '-', gmdate('Y-M-d', $release['date']), '-', implode(', ', $release['release_status']));
+    }
+    $choice = drush_choice($options, dt('Choose one of the available releases for !project:', array('!project' => $request['name'])));
+    if (!$choice) {
+      return drush_user_abort();
+    }
+
+    return $releases[$choice];
+  }
+
+  /**
+   * Check if a project is available in the update service.
+   *
+   * Optionally check for consistency by comparing given project type and
+   * the type obtained from the update service.
+   *
+   * @param array $request
+   *   A request array.
+   * @param string $type
+   *   Optional. If provided, will do a consistent check of the project type.
+   *
+   * @return boolean
+   *   True if the project exists and type matches.
+   */
+  public function checkProject($request, $type = NULL) {
+    $project_release_info = $this->get($request);
+    if (!$project_release_info) {
+      return FALSE;
+    }
+    if ($type) {
+      if ($project_release_info->getType() != $type) {
+        return FALSE;
+      }
+    }
+
+    return TRUE;
+  }
+}

--- a/tests/pmRequestUnitTest.php
+++ b/tests/pmRequestUnitTest.php
@@ -162,7 +162,6 @@ class pmRequestUnitCase extends UnitUnishTestCase {
 
     $request = 'field-conditional-state-7.x-1.2';
     $request = pm_parse_request($request);
-    print_r($request);
     $this->assertEquals('field-conditional-state', $request['name']);
     $this->assertEquals('7.x-1.2', $request['version']);
   }

--- a/tests/releaseInfoTest.php
+++ b/tests/releaseInfoTest.php
@@ -25,7 +25,7 @@ class releaseInfoCase extends UnitUnishTestCase {
 
     // Use a local, static XML file because live files change over time.
     $xml = simplexml_load_file(dirname(__FILE__). '/devel.xml');
-    $project_release_info = new \UpdateServiceProject($xml);
+    $project_release_info = new \Drush\UpdateService\Project($xml);
 
     // Pick specific release.
     $release = $project_release_info->getSpecificRelease('6.x-1.18');


### PR DESCRIPTION
Now release_info engine is implemented in lib/Drush/UpdateService/ReleaseInfo.php. Other engines are considered legacy (while living in a command subfolder).

Also cleaned up and reduced some unneeded complexity.

API Changes:

``` diff
-function drush_get_user_selected_engine(&$config, $engine_info)
-function drush_find_engine_to_use(&$config, $engine_info, $selected_engine = NULL)
+function drush_select_engine($config, $engine_info, $preferred = NULL);

-function drush_load_engine($type, $engine, $version = NULL, $path = NULL, $engine_config = NULL)
+function drush_load_engine($type, $engine, $config = NULL)

-function drush_include_engine($type, $selected_engine, $version = NULL, $path = NULL, $engine_config = NULL)
+function drush_include_engine($type, $engine, $config = NULL)
```
