### PR TITLE
Fix issue 903 Cannot access protected propert when drush generate-makefi...

### DIFF
--- a/commands/make/generate.make.inc
+++ b/commands/make/generate.make.inc
@@ -164,9 +164,9 @@ function _drush_make_generate_add_patch_files(&$project, $location) {
  * Create a project record for an extension not downloaded from drupal.org
  */
 function _drush_generate_custom_project($name, $extension, $version_options) {
-  $project['_type'] = $extension->type;
-  $project['type'] = $extension->type;
-  $info_file = $extension->filename;
+  $project['_type'] = $extension->getType();
+  $project['type'] = $extension->getType();
+  $info_file = $extension->getFilename();
   $location = DRUPAL_ROOT . '/' . dirname($info_file);
   // To start off, we will presume that our custom extension is
   // stored in a folder named after its project, and there are


### PR DESCRIPTION
Happen in Drush 7

PHP Fatal error: Cannot access protected property Drupal\Core\Extension\Extension::$filename in /home/username/.composer/vendor/drush/drush/commands/make/generate.make.inc on line 169

Solution:

Change generate.make.inc line 167 - 169

$project['_type'] = $extension->getType();
$project['type'] = $extension->getType();
$info_file = $extension->getFilename();

https://github.com/drush-ops/drush/issues/903
