### PR TITLE
Merge pull request #890 from drush-ops/library-caching

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -166,6 +166,9 @@ function make_make_complete() {
  * Drush callback; make based on the makefile.
  */
 function drush_make($makefile = NULL, $build_path = NULL) {
+  // Set the cache option based on our '--no-cache' option.
+  _make_enable_cache();
+
   // If --version option is supplied, print it and bail.
   if (drush_get_option('version', FALSE)) {
     drush_print(dt('Drush make API version !version', array('!version' => MAKE_API)));
@@ -317,14 +320,7 @@ function make_projects($recursion, $contrib_destination, $info, $build_path, $ma
     $request = make_prepare_request($project);
 
     if ($project['location'] != RELEASE_INFO_DEFAULT_URL && !isset($project['type'])) {
-      // Set the cache option based on our '--no-cache' option.
-      $cache_before = drush_get_option('cache');
-      if (!drush_get_option('no-cache', FALSE)) {
-        drush_set_option('cache', TRUE);
-      }
       $project_type = release_info_check_project($request, 'core');
-      // Restore the previous '--cache' option value.
-      drush_set_option('cache', $cache_before);
       $project['download_type'] = ($project_type ? 'core' : 'contrib');
     }
     elseif (!empty($project['type'])) {
@@ -361,17 +357,10 @@ function make_projects($recursion, $contrib_destination, $info, $build_path, $ma
         // TODO: refactor to enforce 'make' to internally work with release_info
         // keys.
         $request = make_prepare_request($project, $type);
-        // Set the cache option based on our '--no-cache' option.
-        $cache_before = drush_get_option('cache');
-        if (!drush_get_option('no-cache', FALSE)) {
-          drush_set_option('cache', TRUE);
-        }
         $release = release_info_fetch($request, '', 'ignore');
         if ($release === FALSE) {
           return FALSE;
         }
-        // Restore the previous '--cache' option value.
-        drush_set_option('cache', $cache_before);
         if (!isset($project['type'])) {
           // Translate release_info key for project_type to drush make.
           $project['type'] = $request['project_type'];
@@ -404,14 +393,7 @@ function make_projects($recursion, $contrib_destination, $info, $build_path, $ma
       else {
         make_error('PROJECT-TYPE', dt('Non-existent project type %type on project %project.', array('%type' => $project['type'], '%project' => $project['name'])));
       }
-      // Set the cache option based on our '--no-cache' option.
-      $cache_before = drush_get_option('cache');
-      if (!drush_get_option('no-cache', FALSE)) {
-        drush_set_option('cache', TRUE);
-      }
       $project->make();
-      // Restore the previous '--cache' option value.
-      drush_set_option('cache', $cache_before);
     }
   }
 
@@ -614,4 +596,18 @@ function make_project_needs_release_info($project) {
     // Only fetch release info if the project type is unknown OR if
     // download attributes are unspecified.
     && (!isset($project['type']) || !isset($project['download']));
+}
+
+/**
+ * Enables caching if not explicitly disabled.
+ *
+ * @return bool
+ *   The previous value of the 'cache' option.
+ */
+function _make_enable_cache() {
+  $cache_before = drush_get_option('cache');
+  if (!drush_get_option('no-cache', FALSE)) {
+    drush_set_option('cache', TRUE);
+  }
+  return $cache_before;
 }


### PR DESCRIPTION
Enables caching for libraries.

Backport of #824 for `6.x`.
