### PR TITLE
(Drush 6) Allow overwriting an existing site when --no-core is specified.

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -525,7 +525,7 @@ function make_build_path($build_path) {
   else {
     return drush_user_abort(dt('Build aborted.'));
   }
-  if ($build_path != '.' && file_exists($build_path)) {
+  if ($build_path != '.' && file_exists($build_path) && !drush_get_option('no-core', FALSE)) {
     return drush_set_error('MAKE_PATH_EXISTS', dt('Base path %path already exists.', array('%path' => $build_path)));
   }
   $saved_path = $build_path;
@@ -538,7 +538,7 @@ function make_build_path($build_path) {
 function make_move_build($build_path) {
   $tmp_path = make_tmp();
   $ret = TRUE;
-  if ($build_path == '.') {
+  if ($build_path == '.' || (drush_get_option('no-core', FALSE) && file_exists($build_path))) {
     $info = drush_scan_directory($tmp_path . DIRECTORY_SEPARATOR . '__build__', '/./', array('.', '..'), 0, FALSE, 'filename', 0, TRUE);
     foreach ($info as $file) {
       $destination = $build_path . DIRECTORY_SEPARATOR . $file->basename;


### PR DESCRIPTION
This fixes the bug reported in [this Drupal.org issue](https://www.drupal.org/node/1673676). When specifying --no-core, you should be able to overwrite an existing site directory.

I've also created this pull request for Drush 7 [here](https://github.com/drush-ops/drush/pull/920).
