### PR TITLE
Only install completions for the "drush" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ INSTALL - MANUAL
     1. Add an alias for drush (this method can also be handy if you want to use 2 versions of Drush, for example Drush 5 or 6 (stable) for Drupal 7 development, and Drush 7 (master) for Drupal 8 development).
      To add an alias to your Drush 7 executable, add this to you shell configuration file (see list in previous option):
          `$ alias drush-master=/path/to/drush/drush`
+     Bash completion will not be enabled for these aliases by default, a small
+     modification to the completion script is needed. Instructions can be found
+     near the bottom of [drush.complete.sh](drush.complete.sh) where the
+     completion function is registered.
 
     For options 2 and 3 above, in order to apply your changes to your current session, either log out and then log back in again, or re-load your bash configuration file, i.e.:
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ POST-INSTALL
    [drush.complete.sh](drush.complete.sh) file for instructions adding bash completion for drush
    command to your shell.  Once configured, completion works for site aliases,
    command names, shell aliases, global options, and command-specific options.
+   It is also possible to enable completion for aliases, e.g. dr='drush'.
+   Instructions are near the bottom of [drush.complete.sh](drush.complete.sh)
+   where the completion function is registered.
 
 1. Optional. If [drush.complete.sh](drush.complete.sh) is being sourced (ideally in
    bash_completion.d), you can use the supplied __drush_ps1() sh function to

--- a/drush.complete.sh
+++ b/drush.complete.sh
@@ -32,5 +32,17 @@ _drush_completion() {
   COMPREPLY=( $(drush --early=includes/complete.inc "${COMP_WORDS[@]}" < /dev/null 2> /dev/null) )
 }
 
-# Register our completion function. We include common short aliases for Drush.
-complete -o bashdefault -o default -o nospace -F _drush_completion d dr drush drush5 drush6 drush7 drush.php
+# Register our completion function. By default, Drush only installs
+# one executable, "drush", so we only register completions by that
+# name.
+#
+# If you'd like to register completions for aliases, add the alias
+# names to the end of the command below. For example, in
+# examples/example.bashrc we create an alias dr='drush'. To enable
+# bash completion for the "dr" alias, one would change the command to,
+#
+#   complete -o bashdefault ... -F _drush_completion drush dr
+#
+# Other aliases can be appended in the same manner.
+#
+complete -o bashdefault -o default -o nospace -F _drush_completion drush

--- a/examples/example.bashrc
+++ b/examples/example.bashrc
@@ -75,6 +75,11 @@
 # is used in one of the arguments.
 
 # Aliases for common drush commands that work in a global context.
+#
+# Note: by default, bash completions don't work for aliases. If you
+# would like your completions to appear for e.g. the "dr" alias below,
+# then you need to modify drush.complete.sh. Simply follow the
+# instructions near the end of that file.
 alias dr='drush'
 alias ddd='drush drupal-directory'
 alias dl='drush pm-download'


### PR DESCRIPTION
This is a potential fix for issue #915. I've tried to document the procedure everywhere that aliases/bash-completion are already mentioned in the docs.
