### PR TITLE
Parts of Drupal still require a global user object.

### DIFF
--- a/commands/user/user.drush.inc
+++ b/commands/user/user.drush.inc
@@ -158,6 +158,7 @@ function user_drush_command() {
       'name' => 'The name of the account to cancel',
     ),
     // The `_user_cancel` method still references global $user.
+    // @todo remove once https://www.drupal.org/node/2163205 is in.
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
     'required-arguments' => TRUE,
     'examples' => array(

--- a/lib/Drush/User/User8.php
+++ b/lib/Drush/User/User8.php
@@ -40,6 +40,7 @@ class User8 extends UserVersion {
    */
   public function setCurrentUser($account) {
     // Some parts of Drupal still rely on a global user object.
+    // @todo remove once https://www.drupal.org/node/2163205 is in.
     global $user;
     $user = $account;
     \Drupal::currentUser()->setAccount($account);


### PR DESCRIPTION
- Fixes issue #957.
- Increases bootstrap level of the `user-cancel` command
