### PR TITLE
Fatal error: Call to undefined method stdClass::getType() in generate.make.inc (D7)

### DIFF
--- a/commands/core/drupal/environment.inc
+++ b/commands/core/drupal/environment.inc
@@ -384,6 +384,18 @@ function _drush_extension_get_path($info) {
   return $info->getPath();
 }
 
+/**
+ * Gets the extension filename.
+ *
+ * @param $info
+ *   The extension info.
+ * @return string
+ *   The extension filename.
+ */
+function _drush_extension_get_filename($info) {
+  return $info->getFilename();
+}
+
 /*
  * Wrapper for CSRF token generation.
  */

--- a/commands/core/drupal/environment_6.inc
+++ b/commands/core/drupal/environment_6.inc
@@ -386,6 +386,18 @@ function _drush_extension_get_path($info) {
   return dirname($info->filename);
 }
 
+/**
+ * Gets the extension filename.
+ *
+ * @param $info
+ *   The extension info.
+ * @return string
+ *   The extension filename.
+ */
+function _drush_extension_get_filename($info) {
+  return $info->filename;
+}
+
 /*
  * Wrapper for CSRF token generation.
  */

--- a/commands/core/drupal/environment_7.inc
+++ b/commands/core/drupal/environment_7.inc
@@ -372,6 +372,18 @@ function _drush_extension_get_path($info) {
   return dirname($info->filename);
 }
 
+/**
+ * Gets the extension filename.
+ *
+ * @param $info
+ *   The extension info.
+ * @return string
+ *   The extension filename.
+ */
+function _drush_extension_get_filename($info) {
+  return $info->filename;
+}
+
 /*
  * Wrapper for CSRF token generation.
  */

--- a/commands/make/generate.make.inc
+++ b/commands/make/generate.make.inc
@@ -164,9 +164,8 @@ function _drush_make_generate_add_patch_files(&$project, $location) {
  * Create a project record for an extension not downloaded from drupal.org
  */
 function _drush_generate_custom_project($name, $extension, $version_options) {
-  $project['_type'] = $extension->getType();
-  $project['type'] = $extension->getType();
-  $info_file = $extension->getFilename();
+  $project['type'] = $project['_type'] = drush_extension_get_type($extension);
+  $info_file = drush_extension_get_filename($extension);
   $location = DRUPAL_ROOT . '/' . dirname($info_file);
   // To start off, we will presume that our custom extension is
   // stored in a folder named after its project, and there are

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -791,6 +791,19 @@ function drush_extension_get_path($info) {
 }
 
 /**
+ * Gets the extension filename.
+ *
+ * @param $info
+ *   The extension info.
+ * @return string
+ *   The extension filename.
+ */
+function drush_extension_get_filename($info) {
+  drush_include_engine('drupal', 'environment');
+  return _drush_extension_get_filename($info);
+}
+
+/**
  * Test compatibility of a extension with version of drupal core and php.
  *
  * @param $file Extension object as returned by system_rebuild_module_data().


### PR DESCRIPTION
When running `drush generate-makefile` on a D7 site, the command fails with a fatal error, when there are any custom projects. This is due to the changes in #904, as that was only "fixed" for D8 there.

```
PHP Fatal error:  Call to undefined method stdClass::getType() in /Users/derhasi/.composer/vendor/drush/drush/commands/make/generate.make.inc on line 167
PHP Stack trace:
PHP   1. {main}() /Users/derhasi/.composer/vendor/drush/drush/drush.php:0
PHP   2. drush_main() /Users/derhasi/.composer/vendor/drush/drush/drush.php:16
PHP   3. Drush\Boot\DrupalBoot->bootstrap_and_dispatch() /Users/derhasi/.composer/vendor/drush/drush/drush.php:76
PHP   4. drush_dispatch() /Users/derhasi/.composer/vendor/drush/drush/lib/Drush/Boot/DrupalBoot.php:46
PHP   5. call_user_func_array:{/Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:178}() /Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:178
PHP   6. drush_command() /Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:178
PHP   7. _drush_invoke_hooks() /Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:210
PHP   8. call_user_func_array:{/Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:359}() /Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:359
PHP   9. drush_make_generate() /Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:359
PHP  10. _drush_make_generate_projects() /Users/derhasi/.composer/vendor/drush/drush/commands/make/generate.make.inc:17
PHP  11. _drush_generate_custom_project() /Users/derhasi/.composer/vendor/drush/drush/commands/make/generate.make.inc:128

Fatal error: Call to undefined method stdClass::getType() in /Users/derhasi/.composer/vendor/drush/drush/commands/make/generate.make.inc on line 167

Call Stack:
    0.0008     233224   1. {main}() /Users/derhasi/.composer/vendor/drush/drush/drush.php:0
    0.0289     302952   2. drush_main() /Users/derhasi/.composer/vendor/drush/drush/drush.php:16
    0.1881    2547184   3. Drush\Boot\DrupalBoot->bootstrap_and_dispatch() /Users/derhasi/.composer/vendor/drush/drush/drush.php:76
    0.7141    7775544   4. drush_dispatch() /Users/derhasi/.composer/vendor/drush/drush/lib/Drush/Boot/DrupalBoot.php:46
    0.9635   11093104   5. call_user_func_array:{/Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:178}() /Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:178
    0.9635   11093440   6. drush_command() /Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:178
    0.9638   11094240   7. _drush_invoke_hooks() /Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:210
    0.9736   11163944   8. call_user_func_array:{/Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:359}() /Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:359
    0.9736   11164280   9. drush_make_generate() /Users/derhasi/.composer/vendor/drush/drush/includes/command.inc:359
    1.4336   12952248  10. _drush_make_generate_projects() /Users/derhasi/.composer/vendor/drush/drush/commands/make/generate.make.inc:17
   31.6883   19086648  11. _drush_generate_custom_project() /Users/derhasi/.composer/vendor/drush/drush/commands/make/generate.make.inc:128

Drush command terminated abnormally due to an unrecoverable error.                                                                                 [error]
Error: Call to undefined method stdClass::getType() in /Users/derhasi/.composer/vendor/drush/drush/commands/make/generate.make.inc, line 167
```
