### PR TITLE
Fix backend output to console

### DIFF
--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -213,7 +213,6 @@ function _drush_preflight_global_options() {
   drush_set_context('DRUSH_VERBOSE',     drush_get_option(array('verbose', 'debug'), FALSE));
   drush_set_context('DRUSH_DEBUG', drush_get_option('debug'));
   drush_set_context('DRUSH_SIMULATE',    drush_get_option('simulate', FALSE));
-  drush_set_context('DRUSH_BACKEND', drush_get_option('backend'));
 
   // Backend implies affirmative unless negative is explicitly specified
   drush_set_context('DRUSH_NEGATIVE',    drush_get_option('no', FALSE));

--- a/lib/Drush/Boot/bootstrap.inc
+++ b/lib/Drush/Boot/bootstrap.inc
@@ -383,7 +383,11 @@ function drush_bootstrap_error($code, $message = null) {
 }
 
 function _drush_bootstrap_output_prepare() {
-  $backend = drush_get_context('DRUSH_BACKEND');
+  // Note that as soon as we set the DRUSH_BACKEND context, we change
+  // the behavior of drush_log().  It is therefore important that we
+  // should not set this context until immediately before we call ob_start
+  // (i.e., in this function).
+  $backend = drush_set_context('DRUSH_BACKEND', drush_get_option('backend'));
   $quiet = drush_get_context('DRUSH_QUIET');
 
   if ($backend) {


### PR DESCRIPTION
Back out 24addcdd; it is important that we set DRUSH_BACKEND in concert with the call to ob_start.
