### PR TITLE
#927: don't pass php and php-options along to remote calls

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -1171,6 +1171,8 @@ function drush_preflight_command_dispatch() {
     }
     $command_name = array_shift($args);
     $multi_options = drush_get_context('cli');
+    unset($multi_options['php']);
+    unset($multi_options['php-options']);
     $backend_options = array();
     if (drush_get_option('pipe') || drush_get_option('interactive')) {
       $backend_options['interactive'] = TRUE;


### PR DESCRIPTION
When using alias lists, we need to unset 'php' and 'php-options' from the cli context.
