### PR TITLE
Allow projects of type `drupalorg` to be moved into .drush.

### DIFF
--- a/commands/pm/download.pm.inc
+++ b/commands/pm/download.pm.inc
@@ -273,7 +273,7 @@ function pm_drush_pm_download_destination_alter(&$request, $release) {
   // A module is a pure drush command if it has no .module and contain
   // .drush.inc files.  Skip this test for drush itself, though; we do
   // not want to download drush to the ~/.drush folder.
-  if (($request['project_type'] == 'module') && ($request['name'] != 'drush')) {
+  if (in_array($request['project_type'], array('module', 'utility')) && ($request['name'] != 'drush')) {
     $drush_command_files = drush_scan_directory($request['full_project_path'], '/.*\.drush.inc/');
     if (!empty($drush_command_files)) {
       $module_files = drush_scan_directory($request['full_project_path'], '/.*\.module/');

--- a/lib/Drush/UpdateService/Project.php
+++ b/lib/Drush/UpdateService/Project.php
@@ -126,6 +126,7 @@ class Project {
       'theme' => 'project_theme',
       'theme engine' => 'project_theme_engine',
       'translation' => 'project_translation',
+      'utility' => 'project_drupalorg',
     );
     $type = $project_info['type'];
     // Probably unused but kept for possible legacy compat.


### PR DESCRIPTION
There are apparently projects of type `project_drupalorg`, that are essentially drush commands. Currently `drush dl drupalorg_drush` doesn't place the project in the `.drush` directory. See [this issue](https://www.drupal.org/node/1432296#comment-9323857) for context.
