### PR TITLE
Undefined functions for watchdog-show in Drupal 8

### DIFF
--- a/commands/core/watchdog.drush.inc
+++ b/commands/core/watchdog.drush.inc
@@ -282,7 +282,7 @@ function core_watchdog_format_result($result, $extended = FALSE) {
     $result->message = Unicode::truncate(strip_tags(String::decodeEntities($result->message)), $message_length, FALSE, FALSE);
   }
   else {
-    $result->message = truncate_utf9(strip_tags(decode_entities($result->message)), $message_length, FALSE, FALSE);
+    $result->message = truncate_utf8(strip_tags(decode_entities($result->message)), $message_length, FALSE, FALSE);
   }
 
   return $result;


### PR DESCRIPTION
truncate_utf8() and decode_entities() functions have become methods on the Unicode and String utilities in Drupal 8. This change loads those classes and calls the correct methods.

Patch is tested and working locally with ws and ws --tail in both 7 and 8.
