### PR TITLE
983: Fix for makefiles using querystrings

### DIFF
--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -26,11 +26,8 @@ function make_parse_info_file($makefile, $parsed = TRUE, $makefile_options = arr
   elseif (ParserYaml::supportedFile($makefile)) {
     $info = ParserYaml::parse($data);
   }
-  elseif ($makefile === '-') {
-    $info = _make_determine_format($data);
-  }
   else {
-    return drush_set_error('MAKE_INVALID_FORMAT', dt('Invalid file format: !makefile', array('!makefile' => $makefile)));
+    $info = _make_determine_format($data);
   }
 
   // $makefile_options are from projects[projectname][options][...] = value in


### PR DESCRIPTION
Fix for #983, removed the error completely as if the filetype is unknown it will error inside of the _make_determine_format() function.
