### PR TITLE
SQL Drop does not escape tables names.

### DIFF
--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -225,6 +225,9 @@ class SqlBase {
 
   public function drop($tables) {
     if ($tables) {
+      foreach ($tables as &$table) {
+        $table = sprintf("`%s`", $table);
+      }
       $sql = 'DROP TABLE '. implode(', ', $tables);
       return $this->query($sql);
     }


### PR DESCRIPTION
SQL Drop does not escape tables names. The generated fails on tables name that contains minus (-) oder other special chars.