### PR TITLE
Fix drush logging to be compatible with latest Drupal 8.1.x code

### DIFF
--- a/commands/core/drupal/environment.inc
+++ b/commands/core/drupal/environment.inc
@@ -8,7 +8,6 @@
  */
 
 use Drupal\Core\Site\Settings;
-use Drupal\Core\Logger\RfcLogLevel;
 
 /**
  * Get complete information for all available modules.
@@ -298,14 +297,14 @@ function drush_theme_disable($themes) {
  */
 function drush_watchdog_severity_levels() {
   return array(
-    RfcLogLevel::EMERGENCY => 'emergency',
-    RfcLogLevel::ALERT => 'alert',
-    RfcLogLevel::CRITICAL => 'critical',
-    RfcLogLevel::ERROR    => 'error',
-    RfcLogLevel::WARNING  => 'warning',
-    RfcLogLevel::NOTICE   => 'notice',
-    RfcLogLevel::INFO     => 'info',
-    RfcLogLevel::DEBUG    => 'debug',
+    LogLevel::EMERGENCY => 'emergency',
+    LogLevel::ALERT => 'alert',
+    LogLevel::CRITICAL => 'critical',
+    LogLevel::ERROR    => 'error',
+    LogLevel::WARNING  => 'warning',
+    LogLevel::NOTICE   => 'notice',
+    LogLevel::INFO     => 'info',
+    LogLevel::DEBUG    => 'debug',
   );
 }
 

--- a/lib/Drush/Log/DrushLog.php
+++ b/lib/Drush/Log/DrushLog.php
@@ -2,14 +2,13 @@
 
 namespace Drush\Log;
 
-use Drupal\Core\Logger\RfcLoggerTrait;
-use Drupal\Core\Logger\RfcLogLevel;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\LoggerTrait;
 
 class DrushLog implements LoggerInterface {
 
-  use RfcLoggerTrait;
+  use LoggerTrait;
 
   /**
    * {@inheritdoc}
@@ -21,10 +20,6 @@ class DrushLog implements LoggerInterface {
     // and they should cause Drush to exit or panic. Not sure how to handle this,
     // though.
     switch ($level) {
-      case RfcLogLevel::ALERT:
-      case RfcLogLevel::CRITICAL:
-      case RfcLogLevel::EMERGENCY:
-      case RfcLogLevel::ERROR:
       case LogLevel::ALERT:
       case LogLevel::CRITICAL:
       case LogLevel::EMERGENCY:
@@ -32,14 +27,10 @@ class DrushLog implements LoggerInterface {
         $error_type = 'error';
         break;
 
-      case RfcLogLevel::WARNING:
       case LogLevel::WARNING:
         $error_type = 'warning';
         break;
 
-      case RfcLogLevel::DEBUG:
-      case RfcLogLevel::INFO:
-      case RfcLogLevel::NOTICE:
       case LogLevel::DEBUG:
       case LogLevel::INFO:
       case LogLevel::NOTICE:


### PR DESCRIPTION
Otherwise drush gives following error when using drupal-8.1.x 

PHP Fatal error:  Trait 'Drupal\Core\Logger\RfcLoggerTrait' not found in /root/.composer/vendor/drush/drush/lib/Drush/Log/DrushLog.php on line 12
Drush command terminated abnormally due to an unrecoverable error.                                                                      [error]
Error: Trait 'Drupal\Core\Logger\RfcLoggerTrait' not found in /root/.composer/vendor/drush/drush/lib/Drush/Log/DrushLog.php, line 12
