### PR TITLE
Internal calls to query() in sql commands should run even in --simulate ...

### DIFF
--- a/lib/Drush/Sql/Sqlmysql.php
+++ b/lib/Drush/Sql/Sqlmysql.php
@@ -69,12 +69,19 @@ EOT;
   }
 
   public function db_exists() {
-    return $this->query("SELECT 1;", NULL, TRUE);
+    $current = drush_get_context('DRUSH_SIMULATE');
+    drush_set_context('DRUSH_SIMULATE', FALSE);
+    $return = $this->query("SELECT 1;", NULL, TRUE);
+    drush_set_context('DRUSH_SIMULATE', $current);
+    return $return;
   }
 
   public function listTables() {
+    $current = drush_get_context('DRUSH_SIMULATE');
+    drush_set_context('DRUSH_SIMULATE', FALSE);
     $return = $this->query('SHOW TABLES;', NULL, TRUE);
     $tables = drush_shell_exec_output();
+    drush_set_context('DRUSH_SIMULATE', $current);
     return $tables;
   }
 


### PR DESCRIPTION
Currently, `sql-dump --simulate` does not work properly as table selection queries do not run (because we are in simulate mode). That can be fixed in an ugly way by this PR or perhaps we should just use drush_invoke_process() with override-simulated backend option instead. My annoyance with that approach is that you have to decide whether or not to $integrate the log for the backend call. I wish we could integrate only in the case of errors. Because usually, $integrate just adds noise.
