### PR TITLE
Fixed bug where downloaded Drupal archive was never deleted.

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -736,7 +736,7 @@ function drush_download_file($url, $destination = FALSE, $cache_duration = 0) {
     return copy($url, $destination) ? $destination : FALSE;
   }
 
-  if ($cache_duration !== 0 && $cache_file = drush_download_file_name($url)) {
+  if (drush_get_option('cache') && $cache_duration !== 0 && $cache_file = drush_download_file_name($url)) {
     // Check for cached, unexpired file.
     if (file_exists($cache_file) && filectime($cache_file) > ($_SERVER['REQUEST_TIME']-$cache_duration)) {
       drush_log(dt('!name retrieved from cache.', array('!name' => $cache_file)));


### PR DESCRIPTION
Created in reference to Issue #1022, this PR fixes a bug where the Drupal archive is never marked as a temporary file, and therefore never deleted. If you look at the Drush 6 version of drush_download_file a drush_get_option('cache') check is made, so I'm not sure why Drush 7 removed it in the first place. 

Git reveals:

```
290e0dd9 includes/drush.inc (Jonathan Araña Cruz 2014-11-17 08:23:07 +0000  739)   if ($cache_duration !== 0 && $cache_file = drush_download_file_name($url)) {
```

```
commit 290e0dd94b02584c92611d500ce38578bc26e028
Author: Jonathan Araña Cruz <jonhattan@faita.net>
Date:   Mon Nov 17 08:23:07 2014 +0000

    Cache release xml by default.

```

So I'm not sure if this PR will affect @jonhattan's previous commit. A better solution is welcome.
