### PR TITLE
Allow to pass an autoloader into drush_drupal_load_autoloader()

### DIFF
--- a/includes/drupal.inc
+++ b/includes/drupal.inc
@@ -8,8 +8,11 @@
 /**
  * Loads the Drupal autoloader and returns the instance.
  */
-function drush_drupal_load_autoloader($drupal_root) {
+function drush_drupal_load_autoloader($drupal_root, $new_autoloader = NULL) {
   static $autoloader = FALSE;
+  if (isset($new_autoloader)) {
+    $autoloader = $new_autoloader;
+  }
   if (!$autoloader) {
     $autoloader = require_once $drupal_root .'/core/vendor/autoload.php';
   }


### PR DESCRIPTION
When working with a Composer project where both Drush and Drupal are in the same autoloader including Drupal's `core/vendor/autoload.php` fails because `core/lib/Drupal.php` has already been included by Drush's autoloader at this point and Drupal's autoloader tries to include it again.

If `drush_drupal_load_autoloader()` allowed to pass in an autoloader from the outside (i.e. in a site-specific `drushrc.php`) this could be avoided.

Thus, this commit does just that. With this I am able to successfully run `drush site-install` given https://github.com/drush-ops/drush/pull/1030 and https://www.drupal.org/node/2386247 (and an adjustment to Drush the latter one requires).
