### PR TITLE
Only do MySQL GRANT statement if called with db-su

### DIFF
--- a/lib/Drush/Sql/Sqlmysql.php
+++ b/lib/Drush/Sql/Sqlmysql.php
@@ -62,9 +62,12 @@ EOT;
     }
     $sql[] = sprintf('DROP DATABASE IF EXISTS %s;', $dbname);
     $sql[] = sprintf('CREATE DATABASE %s /*!40100 DEFAULT CHARACTER SET utf8 */;', $dbname);
-    $sql[] = sprintf('GRANT ALL PRIVILEGES ON %s.* TO \'%s\'@\'%s\'', $dbname, $this->db_spec['username'], $this->db_spec['host']);
-    $sql[] = sprintf("IDENTIFIED BY '%s';", $this->db_spec['password']);
-    $sql[] = 'FLUSH PRIVILEGES;';
+    $db_superuser = drush_get_option('db-su');
+    if (isset($db_superuser)) {
+      $sql[] = sprintf('GRANT ALL PRIVILEGES ON %s.* TO \'%s\'@\'%s\'', $dbname, $this->db_spec['username'], $this->db_spec['host']);
+      $sql[] = sprintf("IDENTIFIED BY '%s';", $this->db_spec['password']);
+      $sql[] = 'FLUSH PRIVILEGES;';
+    }
     return implode(' ', $sql);
   }
 


### PR DESCRIPTION
This is a patch for an old Drupal.org issue: https://www.drupal.org/node/1116566

For MySQL, when creating a database, drush always runs a GRANT statement. But if drush is called without 'db-su', the database user most likely won't have access to run the GRANT statement, and for drush 6 (and I believe 5 as well), this outputs an error which, while harmless, makes people think that the DB sync may have failed. For example:

```
$ drush sql-sync @test.one @test.two --create-db

You will destroy data in drupal2 and replace with data from drupal1.

You might want to make a backup first, using the sql-dump command.

Do you really want to continue? (y/n): y
ERROR 1044 (42000) at line 1: Access denied for user 'drupal2_rw'@'localhost' to database 'drupal2'
```

Drush 7.x actually hides this error message although it still attempts to perform the GRANT.

In either case, the GRANT is not needed every time a database is dropped and created, since MySQL stores user information separately from the database.  So my patch makes it so that the GRANT is only called when 'db-su' in used -- implying that the DB is being created for the first time and therefore the Drupal site's MySQL user needs to be created with the GRANT statement.

I've tested this, and it works fine without db-su, and in the case that db-su is used, I can confirm that the GRANT is run and the user is created successfully.

I have a separate patch for 6.x, I'll open a second PR for that.
