### PR TITLE
Improve readability of help output

### DIFF
--- a/commands/core/help.drush.inc
+++ b/commands/core/help.drush.inc
@@ -375,8 +375,9 @@ function drush_help_listing_print($command_categories, $format) {
     // Build rows for drush_print_table().
     $rows = array();
     foreach($commands as $cmd => $command) {
-      $name = $command['aliases'] ? $cmd . ' (' . implode(', ', $command['aliases']) . ')': $cmd;
-      $rows[$cmd] = array('name' => $name, 'description' => $command['description']);
+      $name = $cmd;
+      $alias = $command['aliases'] ? ' (' . implode(', ', $command['aliases']) . ')': '';
+      $rows[$cmd] = array('name' => $name, 'aliases' => $alias, 'description' => $command['description']);
     }
 
     // Vary the output by mode: CLI or HTML
@@ -386,7 +387,7 @@ function drush_help_listing_print($command_categories, $format) {
     }
     else {
       drush_print($info['title'] . ": (" . $key . ")");
-      drush_print_table($rows, FALSE, array('name' => 20));
+      drush_print_table($rows, FALSE, array('name' => 40, 'aliases' => 35));
     }
   }
 }

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -131,7 +131,8 @@ function drush_preflight() {
   // --reserve-margin flag can be used to declare how much
   // space to leave out.  This only affects drush functions
   // such as drush_print_table() that wrap the output.
-  $columns -= drush_get_option('reserve-margin', 0);
+  //$columns -= drush_get_option('reserve-margin', 0);
+  $columns = 300; 
   drush_set_context('DRUSH_COLUMNS', $columns);
 
   // Display is tidy now that column width has been handled.


### PR DESCRIPTION
This does a couple things I find very helpful for help output.  
1. It increases the column widths of the commands from 20 to 40.   I find 20 to be entirely unreadable when reading acquia and pantheon long commands.
2. It moves the aliases into their own column so they are easier to quickly read.  I feel readability is becoming a larger issue since now there are about 250 commands printed when you have both acquia and pantheon commands included.

Hopefully you also find this helpful.

Enjoy.

Dan
