### PR TITLE
Changing user password fails on Drupal 6 sites

### DIFF
--- a/lib/Drush/User/User6.php
+++ b/lib/Drush/User/User6.php
@@ -4,4 +4,18 @@ namespace Drush\User;
 
 class User6 extends User7 {
 
+  /**
+   * {@inheritdoc}
+   */
+  public function load_by_name($name) {
+    return user_load(array('name' => $name));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function load_by_mail($mail) {
+    return user_load(array('mail' => $mail));
+  }
+
 }


### PR DESCRIPTION
Running the following command fails on Drupal 6 sites:

```
$ drush upwd admin --password=test
PHP Fatal error:  Call to undefined function Drush\User\user_load_by_name()
```

The fix is pretty simple - override the load_by_name method of the Drush User object for Drupal 6.  I went ahead and overrode the user_load_by_mail function as well, since that doesn't exist in Drupal 6 either.
