### PR TITLE
We must use entity_load_multiple() for dependant migrations

### DIFF
--- a/lib/Drush/Migrate/MigrateManifest8.php
+++ b/lib/Drush/Migrate/MigrateManifest8.php
@@ -99,7 +99,7 @@ class MigrateManifest8 implements MigrateInterface {
     }
 
     // Warn the user if any migrations were not found.
-    $nonexistent_migrations = array_diff($this->migrationList, array_keys($migrations));
+    $nonexistent_migrations = array_diff(array_keys($migration_ids), array_keys($migrations));
     if (count($nonexistent_migrations) > 0) {
       drush_log(dt('The following migrations were not found: !migrations', array(
         '!migrations' => implode(', ', $nonexistent_migrations),


### PR DESCRIPTION
The recent refactor incorrectly switched to using entity_load() instead of entity_load_multiple(). I can't believe I overlooked this, I didn't know whether to laugh or cry when I came across it tonight.

This PR simply gathers the migrate ids up first and then loads them using entity_load_multiple(), everything else stays the same.
