### PR TITLE
Fix #1054 by more selectively pruning empty project array items.

### DIFF
--- a/commands/make/generate.contents.make.inc
+++ b/commands/make/generate.contents.make.inc
@@ -130,7 +130,7 @@ function make_generate_from_makefile($file, $makefile) {
       unset($projects[$name]['name']);
     }
     if ($project['type'] == 'module' && !isset($info[$name]['type'])) {
-      unset($projects[$name]['type']);
+      unset($projects[$name]['type']);  // Module is the default
     }
     if (!(isset($project['download']['type'])) || ($project['download']['type'] == 'pm')) {
       unset($projects[$name]['download']); // PM is the default
@@ -140,7 +140,7 @@ function make_generate_from_makefile($file, $makefile) {
       unset($projects[$name][$key]);
     }
     // Remove empty entries (e.g. 'directory_name')
-    $projects[$name] = array_filter($projects[$name]);
+    $projects[$name] = _make_generate_array_filter($projects[$name]);
   }
 
   $libraries = drush_get_option('DRUSH_MAKE_LIBRARIES', FALSE);
@@ -160,6 +160,22 @@ function make_generate_from_makefile($file, $makefile) {
   // Write or print our makefile.
   $file = $file !== TRUE ? $file : NULL;
   make_generate_print($contents, $file);
+}
+
+/**
+ * Helper function to recursively remove empty values from an array (but not
+ * '0'!).
+ */
+function _make_generate_array_filter($haystack) {
+  foreach ($haystack as $key => $value) {
+    if (is_array($value)) {
+      $haystack[$key] = _make_generate_array_filter($haystack[$key]);
+    }
+    if (empty($value) && $value !== '0') {
+      unset($haystack[$key]);
+    }
+  }
+  return $haystack;
 }
 
 /**


### PR DESCRIPTION
This fixes issue #1054. I basically just added a recursive array_filter() re-implementation that allows '0' values to remain.