### PR TITLE
drush_is_local_host() doesn't seem to get run for shell alias commands that start with !

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -1258,7 +1258,7 @@ function drush_core_execute() {
  * Helper function for drush_core_execute: run one shell command
  */
 function _drush_core_execute_cmd($site, $cmd) {
-  if (!empty($site['remote-host'])) {
+  if (!empty($site['remote-host']) && !drush_is_local_host($site['remote-host'])) {
     // Remote, so execute an ssh command with a bash fragment at the end.
     $exec = drush_shell_proc_build($site, $cmd, TRUE);
     return (drush_shell_proc_open($exec) == 0);


### PR DESCRIPTION
I have the following in my sites/all/drush/drushrc.php:

``` php
$root = str_replace('/drush', '', dirname(__FILE__));
$options['shell-aliases']['build-theme'] = '!cd ' . $root . '/themes/custom/mytheme && npm install && bundle install && grunt --env=production';
```

And my Drush alias is defined as the following:

``` php
$aliases['not-really-remote'] = array(
  'root' => '/var/www/local.mysite.com/',
  'uri' => 'local.mysite.com',
  'remote-host' => 'Corsair250D', // This matches my current *local* computer's host name.
);
```

When I run drush @not-really-remote build-theme I get a SSH prompt, which is very unexpected:

```
davereid@Corsair250D$ drush @not-really-remote build-theme
The authenticity of host 'corsair250d (127.0.1.1)' can't be established.
ECDSA key fingerprint is 0a:e9:83:1c:59:0e:e1:b9:a1:2d:43:e8:83:77:e9:6f.
Are you sure you want to continue connecting (yes/no)?
```
