### PR TITLE
Added --force option to pm-download to skip MD5 validation.

### DIFF
--- a/commands/pm/package_handler/wget.inc
+++ b/commands/pm/package_handler/wget.inc
@@ -70,12 +70,14 @@ function package_handler_download_project(&$request, $release) {
   }
 
   // Check Md5 hash.
-  if (drush_op('md5_file', $download_path) != $release['mdhash'] && !drush_get_context('DRUSH_SIMULATE')) {
-    drush_delete_dir(drush_download_file_name($download_link, TRUE));
-    return drush_set_error('DRUSH_PM_FILE_CORRUPT', dt('File !filename is corrupt (wrong md5 checksum).', array('!filename' => $filename)));
-  }
-  else {
-    drush_log(dt('Md5 checksum of !filename verified.', array('!filename' => $filename)));
+  if (!drush_get_option('force')) {
+    if (drush_op('md5_file', $download_path) != $release['mdhash'] && !drush_get_context('DRUSH_SIMULATE')) {
+      drush_delete_dir(drush_download_file_name($download_link, TRUE));
+      return drush_set_error('DRUSH_PM_FILE_CORRUPT', dt('File !filename is corrupt (wrong md5 checksum).', array('!filename' => $filename)));
+    }
+    else {
+      drush_log(dt('Md5 checksum of !filename verified.', array('!filename' => $filename)));
+    }
   }
 
   // Extract the tarball in place and return the full path to the untarred directory.

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -430,6 +430,7 @@ function pm_drush_command() {
       ),
       'skip' => 'Skip automatic downloading of libraries (c.f. devel).',
       'pipe' => 'Returns a list of the names of the extensions (modules and themes) contained in the downloaded projects.',
+      'force' => 'Skip hash validation of downloads.',
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_MAX,
     'aliases' => array('dl'),


### PR DESCRIPTION
I hate having to wait for all the MD5 hashes to be updated properly in order to download new module updates. Can we provide an option to bypass it?