### PR TITLE
Make drush use @alias work even if called from a script

### DIFF
--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -2020,7 +2020,7 @@ function drush_sitealias_get_envar_filename($filename_prefix = 'drush-drupal-sit
   }
 
   $tmp = getenv('TMPDIR') ? getenv('TMPDIR') : '/tmp/';
-  return "{$tmp}/drush-env/{$filename_prefix}" . posix_getppid();
+  return "{$tmp}/drush-env/{$filename_prefix}" . posix_getsid(posix_getppid());
 }
 
 /**


### PR DESCRIPTION
If `drush use @alias` is called from a script, then posix_getppid() will return a process id which is not the same as the process of the hosting shell and hence the stored alias won't be recognized by subsequent calls to drush which makes drush use @alias pretty useless. This only applies if drush is called through another script, which will be the case in a lot of scenarios.

To resolve this we should grab the session id of the current process which will go up the tree to the shell which is hosting any tree of scripts that are eventually calling drush.
