### PR TITLE
Use the get() and set() methods to set source and destination on a migration.

### DIFF
--- a/lib/Drush/Migrate/MigrateManifest8.php
+++ b/lib/Drush/Migrate/MigrateManifest8.php
@@ -77,15 +77,19 @@ class MigrateManifest8 implements MigrateInterface {
 
       // If we have source config, apply it to the migration.
       if (isset($migration_info['source'])) {
+        $source = $migration->get('source');
         foreach ($migration_info['source'] as $source_key => $source_value) {
-          $migration->source[$source_key] = $source_value;
+          $source[$source_key] = $source_value;
         }
+        $migration->set('source', $source);
       }
       // If we have destination config, apply it to the migration.
       if (isset($migration_info['destination'])) {
+        $destination = $migration->get('destination');
         foreach ($migration_info['destination'] as $destination_key => $destination_value) {
-          $migration->destination[$destination_key] = $destination_value;
+          $destination[$destination_key] = $destination_value;
         }
+        $migration->set('destination', $destination);
       }
 
       if (isset($migration)) {


### PR DESCRIPTION
This is necessary after changes being discussed in [#2384529: Make the class variables protected for Migration](https://www.drupal.org/node/2384529). While that issue is not committed yet, the changes in this commit will work even now, and will continue to work after the issue is committed.

Note: There might be direct getter methods but that is under discussion in that issue. However, the changes in these pull request don't rely on those methods.