### PR TITLE
[Backport] Add support for git repositories in the 'includes' directive.

### DIFF
--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -52,6 +52,19 @@ function make_parse_info_file($makefile, $parsed = TRUE, $makefile_options = arr
             make_error('BUILD_ERROR', dt("Include file missing: !include", array('!include' => $include)));
           }
         }
+        elseif (!empty($include) && is_array($include)) {
+          if ($include['download']['type'] = 'git') {
+            $tmp_dir = make_tmp();
+            make_download_git($include['makefile'], $include['download']['type'], $include['download'], $tmp_dir);
+            $makefile = $tmp_dir . '/' . $include['makefile'];
+            if (file_exists($makefile) && $file = make_parse_info_file($makefile, FALSE)) {
+              $includes[] = $file;
+            }
+            else {
+              make_error('BUILD_ERROR', dt("Include file missing: !include", array('!include' => $makefile)));
+            }
+          }
+        }        
       }
     }
     $includes[] = $data;

--- a/docs/make.txt
+++ b/docs/make.txt
@@ -277,8 +277,8 @@ projects. Additionally, they may specify a destination:
 ### Includes
 
 An array of makefiles to include. Each include may be a local relative path
-to the includer makefile directory or a direct URL to the makefile. Includes
-are appended in order with the source makefile appended last, allowing latter
+to the include makefile directory or a direct URL to the makefile, or from a git repository. 
+Includes are appended in order with the source makefile appended last, allowing latter
 makefiles to override the keys/values of former makefiles.
 
 **Example:**
@@ -286,6 +286,10 @@ makefiles to override the keys/values of former makefiles.
     includes[example] = "example.make"
     includes[example_relative] = "../example_relative/example_relative.make"
     includes[remote] = "http://www.example.com/remote.make"
+    includes[example_git][makefile] = 'example_dir/example.make'
+    includes[example_git][download][type] = "git"
+    includes[example_git][download][url] = "git@github.com:organisation/repository.git"
+    includes[example_git][download][branch] = "master"
 
 ### Defaults
 

--- a/tests/makeTest.php
+++ b/tests/makeTest.php
@@ -116,6 +116,23 @@ class makeMakefileCase extends Drush_CommandTestCase {
     $this->runMakefileTest('include');
   }
 
+  /**
+   * Test git support on includes directive.
+   */
+  function testMakeIncludesGit() {
+    $config = $this->getMakefile('includes-git');
+    $options = array();
+    $makefile = $this->makefile_path . DIRECTORY_SEPARATOR . $config['makefile'];
+    $this->drush('make', array($makefile, UNISH_SANDBOX . '/test-build'), $options);
+    
+    // Verify that core and example main module were downloaded.
+    $this->assertFileExists(UNISH_SANDBOX . '/test-build/README.txt');
+    $this->assertFileExists(UNISH_SANDBOX . '/test-build/sites/all/modules/contrib/apachesolr/README.txt');
+    
+    // Verify that module included in sub platform was downloaded.
+    $this->assertFileExists(UNISH_SANDBOX . '/test-build/sites/all/modules/contrib/jquery_update/README.txt');
+  }
+
   function testMakeRecursion() {
     $this->runMakefileTest('recursion');
   }
@@ -454,6 +471,12 @@ class makeMakefileCase extends Drush_CommandTestCase {
         'md5' => 'e2e230ec5eccaf5618050559ab11510d',
         'options'  => array(),
       ),
+      'includes-git' => array(
+        'name'     => 'Including makefiles from remote repositories',
+        'makefile' => 'includes-main.make',
+        'build'    => TRUE,
+        'options'  => array(),
+      ),      
       'recursion' => array(
         'name'     => 'Recursion',
         'makefile' => 'recursion.make',

--- a/tests/makefiles/includes-main.make
+++ b/tests/makefiles/includes-main.make
@@ -1,0 +1,14 @@
+core = 7.x
+api = 2
+
+; Main makefile containing drupal core
+includes[platform][makefile] = 'tests/makefiles/includes-platform.make'
+includes[platform][download][type] = "git"
+includes[platform][download][url] = "https://github.com/pmatias/drush.git"
+includes[platform][download][branch] = "includes-git-support"
+
+; Sub platform makefile 
+includes[subplatform][makefile] = 'tests/makefiles/includes-sub-platform.make'
+includes[subplatform][download][type] = "git"
+includes[subplatform][download][url] = "https://github.com/pmatias/drush.git"
+includes[subplatform][download][branch] = "includes-git-support"

--- a/tests/makefiles/includes-platform.make
+++ b/tests/makefiles/includes-platform.make
@@ -1,0 +1,10 @@
+api = 2
+core = 7.x
+
+; Drupal core
+projects[drupal][type] = "core"
+projects[drupal][version] = 7.34
+
+; Contrib modules
+projects[apachesolr][subdir] = "contrib"
+projects[apachesolr][version] = "1.6"

--- a/tests/makefiles/includes-sub-platform.make
+++ b/tests/makefiles/includes-sub-platform.make
@@ -1,0 +1,6 @@
+api = 2
+core = 7.x
+
+; Contrib modules
+projects[jquery_update][version] = "2.4"
+projects[jquery_update][subdir] = "contrib"


### PR DESCRIPTION
This is a backport of https://github.com/drush-ops/drush/pull/1063 (please see PR for full documentation on the matter) for the 6.x branch. 

Mentioned PR is already reviewed, tested and merged into master. It would be great if we can do the same for the 6.x branch.

Thanks!