### PR TITLE
Fixed Win backslashes in paths in .gitmodules.

### DIFF
--- a/commands/pm/package_handler/git_drupalorg.inc
+++ b/commands/pm/package_handler/git_drupalorg.inc
@@ -192,7 +192,7 @@ function package_handler_post_download($project, $release) {
       $command[] = drush_get_option('gitsubmoduleaddparams');
       $command[] = $project['repository'];
       // We need the submodule relative path.
-      $command[] = substr(realpath($project['full_project_path']), strlen(realpath($superproject)) + 1);
+      $command[] = strtr(substr(realpath($project['full_project_path']), strlen(realpath($superproject)) + 1), '\\', '/');
       if (!drush_shell_cd_and_exec($superproject, implode(' ', $command))) {
         return drush_set_error('DRUSH_PM_GIT_CHECKOUT_PROBLEMS', dt('Unable to add !name as a git submodule of !super.', array('!name' => $project['name'], '!super' => $superproject)));
       }


### PR DESCRIPTION
A solution to the https://github.com/drush-ops/drush/issues/1086.
