### PR TITLE
Keep configuration in confgis dirs during installation

### DIFF
--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -37,6 +37,7 @@ function site_install_drush_command() {
         'example-value' => 'directory_name',
       ),
       'writable' => 'Make CMI and other dirs writable by both web and CLI users. Suitable for non Prod environments.',
+      'keep-config-dirs' => 'Keep CMI directories untouched. This preserves existing configuration.'
     ),
     'examples' => array(
       'drush site-install expert --locale=uk' => '(Re)install using the expert install profile. Set default language to Ukrainian.',
@@ -212,9 +213,11 @@ function drush_core_pre_site_install($profile = NULL) {
       $directories['staging'] =  $files . '/' . $directories[2];
     }
 
-    foreach ($directories as $directory) {
-      if (file_exists($directory)) {
-        drush_delete_dir_contents($directory, TRUE);
+    if (drush_get_option('keep-config-dirs', FALSE) == FALSE) {
+      foreach ($directories as $directory) {
+        if (file_exists($directory)) {
+          drush_delete_dir_contents($directory, TRUE);
+        }
       }
     }
 

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -37,7 +37,7 @@ function site_install_drush_command() {
         'example-value' => 'directory_name',
       ),
       'writable' => 'Make CMI and other dirs writable by both web and CLI users. Suitable for non Prod environments.',
-      'keep-config-dirs' => 'Keep CMI directories untouched. This preserves existing configuration.'
+      'keep-config' => 'Keep CMI directories untouched. This preserves existing configuration.'
     ),
     'examples' => array(
       'drush site-install expert --locale=uk' => '(Re)install using the expert install profile. Set default language to Ukrainian.',
@@ -64,6 +64,7 @@ function site_install_drush_help_alter(&$command) {
     }
     else {
       unset($command['options']['writable']);
+      unset($command['options']['keep-config']);
     }
   }
 }
@@ -109,7 +110,7 @@ function drush_core_pre_site_install($profile = NULL) {
   $sitesfile = "sites/sites.php";
   $default = realpath($alias_record['root'] . '/sites/default');
   $sitesfile_write = drush_drupal_major_version() >= 8 && $conf_path != $default && !file_exists($sitesfile);
-  
+
   if (!file_exists($settingsfile)) {
     $msg[] = dt('create a @settingsfile file', array('@settingsfile' => $settingsfile));
   }
@@ -213,7 +214,7 @@ function drush_core_pre_site_install($profile = NULL) {
       $directories['staging'] =  $files . '/' . $directories[2];
     }
 
-    if (drush_get_option('keep-config-dirs', FALSE) == FALSE) {
+    if (drush_get_option('keep-config', FALSE) == FALSE) {
       foreach ($directories as $directory) {
         if (file_exists($directory)) {
           drush_delete_dir_contents($directory, TRUE);


### PR DESCRIPTION
```drush site-install``` wipes all files in config dirs during installation. Please add an option to keep these config files. Otherwise it is not possible to install Drupal from CLI with [Config Installer](http://drupal.org/project/config_installer].

Example command

```
drush si config_installer --keep-config -y config_installer_staging_configure_form.staging_directory=../config/staging config_installer_site_configure_form.account.name=foobar config_installer_site_configure_form.account.pass=foobar config_installer_site_configure_form.account.mail=foobar@example.com
```


// cc @alexpott