### PR TITLE
Explain how to set up ZSH autocompletion in the docs

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -7,8 +7,8 @@ Configure
    your .bashrc (or equivalent): source /path/to/drush/examples/example.bashrc
 
 * If you didn't source it the step above, see top of
-   [drush.complete.sh](https://raw.githubusercontent.com/drush-ops/drush/master/drush.complete.sh) file for instructions adding bash completion for drush
-   command to your shell.  Once configured, completion works for site aliases,
+   [drush.complete.sh](https://raw.githubusercontent.com/drush-ops/drush/master/drush.complete.sh) file for instructions on adding completion for drush
+   commands to your shell.  Once configured, completion works for site aliases,
    command names, shell aliases, global options, and command-specific options.
 
 * Optional. If [drush.complete.sh](https://raw.githubusercontent.com/drush-ops/drush/master/drush.complete.sh) is being sourced (ideally in

--- a/drush.complete.sh
+++ b/drush.complete.sh
@@ -4,6 +4,13 @@
 # ~/.bash_completion or ~/.bash_profile files.  Alternatively, source
 # examples/example.bashrc instead, as it will automatically find and source
 # this file.
+#
+# If you're using ZSH instead of BASH, add the following to your ~/.zshrc file
+# and source it.
+#
+#   autoload bashcompinit
+#   bashcompinit
+#   source /path/to/your/drush.complete.sh
 
 # Ensure drush is available.
 which drush > /dev/null || alias drush &> /dev/null || return


### PR DESCRIPTION
It's very easy to set up shell auto-completion for ZSH as well as BASH, but this isn't documented anywhere officially.

I added the small amount of information to the documentation, which works quite well for me.  The details are originally from [Use Drush Autocomplete with Zsh](http://mark.shropshires.net/blog/use-drush-autocomplete-zsh).