### PR TITLE
Use Symfony var-dumper component as Boris variable inspector

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -18,7 +18,8 @@ function cli_drush_command() {
  */
 function drush_cli_core_cli() {
   $boris = new \Boris\Boris(drush_sitealias_bootstrapped_site_name() . '> ');
-  $boris->setInspector(new \Boris\ColoredInspector());
+  // Use the Symfony var-dumper to inspect variables.
+  $boris->setInspector(new \Drush\Boris\VarDumperInspector());
 
   // Boris will never return control to us, but our shutdown
   // handler will still run after the user presses ^D.  Mark

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "php": ">=5.3.0",
     "d11wtq/boris": "*",
     "symfony/yaml": "~2.2",
+    "symfony/var-dumper": "2.6.3",
     "pear/console_table": "~1.2.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,9 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "601c32e0991410574ce55674a27da19c",
+    "hash": "13d22dd9dcd6a92cbb29e64dd4614fe4",
     "packages": [
         {
             "name": "d11wtq/boris",
@@ -93,6 +94,59 @@
                 "console"
             ],
             "time": "2014-10-27 10:04:49"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v2.6.3",
+            "target-dir": "Symfony/Component/VarDumper",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "36af986811340fd4c1bc39cf848da388bbdd8473"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/36af986811340fd4c1bc39cf848da388bbdd8473",
+                "reference": "36af986811340fd4c1bc39cf848da388bbdd8473",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-symfony_debug": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-0": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "http://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2015-01-01 13:28:01"
         },
         {
             "name": "symfony/yaml",
@@ -889,17 +943,12 @@
             "time": "2014-05-22 13:46:01"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
+    "prefer-stable": true,
     "platform": {
         "php": ">=5.3.0"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/lib/Drush/Boris/VarDumperInspector.php
+++ b/lib/Drush/Boris/VarDumperInspector.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drush\Boris;
+
+use Symfony\Component\VarDumper\VarDumper;
+
+/**
+ * Boris inspector class for the Symfony var dumper.
+ */
+class VarDumperInspector {
+
+  public function inspect($variable) {
+    return VarDumper::dump($variable);
+  }
+}

--- a/lib/Drush/Boris/VarDumperInspector.php
+++ b/lib/Drush/Boris/VarDumperInspector.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * Contains \Drush\Boris\VarDumperInspector.
+ */
+
 namespace Drush\Boris;
 
 use Symfony\Component\VarDumper\VarDumper;


### PR DESCRIPTION
The drush php command currently uses Boris, and the standard `ColoredInspector` to show variables.

The Symfony var-dumper component has much more going for it. It shows much more information about objects, like property visibility, array counts... The `ColoredInspector` does not show any protected properties (which is most properties in D8 now) or floats for example. See the screenshots below:

### Now:

#### Array
![drush_____sites_d8_core_ _php_ _264x50](https://cloud.githubusercontent.com/assets/1053891/5774281/03e82f70-9d64-11e4-9ad1-e668e1d6c32a.png)

#### Action config entity
![drush_____sites_d8_core_ _php_ _264x50](https://cloud.githubusercontent.com/assets/1053891/5774313/6c87def4-9d64-11e4-9362-a88f343c21fd.png)


### With PR:

#### Array
![__forks_drush_drush_____sites_d8_core_ _php_ _264x50_and_testing_text_format___hrweb](https://cloud.githubusercontent.com/assets/1053891/5774273/f65df81c-9d63-11e4-819f-1a2010566a87.png)

#### Action config entity
![__forks_drush_drush_____sites_d8_core_ _php_ _264x50](https://cloud.githubusercontent.com/assets/1053891/5774322/79f69d00-9d64-11e4-8094-43939bf21962.png)

