### PR TITLE
Add Composer's global bin directory to the system PATH for Mac OS

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -26,10 +26,10 @@ Composer - One Drush for all Projects
         sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc
         source $HOME/.bashrc
         
-        For Mac OS users whose $HOME/.bashrc file may be empty or non-existent.
-        touch $HOME/.bashrc
-        { echo 'export PATH="$HOME/.composer/vendor/bin:$PATH"'; cat $HOME/.bashrc; } | tee $HOME/.bashrc
-        source $HOME/.bashrc
+        For Mac OS users
+        touch $HOME/.bash_profile
+        { echo 'export PATH="$HOME/.composer/vendor/bin:$PATH"'; cat $HOME/.bash_profile; } | tee $HOME/.bash_profile
+        source $HOME/.bash_profile
 
 * To install Drush 6.x (stable):
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,6 +25,11 @@ Composer - One Drush for all Projects
 
         sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc
         source $HOME/.bashrc
+        
+        For Mac OS users whose $HOME/.bashrc file may be empty or non-existent.
+        touch $HOME/.bashrc
+        { echo 'export PATH="$HOME/.composer/vendor/bin:$PATH"'; cat $HOME/.bashrc; } | tee $HOME/.bashrc
+        source $HOME/.bashrc
 
 * To install Drush 6.x (stable):
 


### PR DESCRIPTION
Mac OS uses a BSD sed which is different from the Unix BSD. This instruction:

sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc

on the documentation page http://drush.org/en/master/install/, doesn't work for Mac OS users.

We can use sed in Mac OS this way:

sed -i '' '1i\
export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc

but this instruction still doesn't work if a user's ~/.bashrc is empty. When helping users install Drush 7, I often find their ~/.bashrc to be empty. Custom configuration is instead written to their ~/.bash_profile.

Mac OS users can still use ~/.bashrc for this. This patch makes sure the export PATH line gets written.