### PR TITLE
Remove DRUPAL_BOOTSTRAP_PAGE_CACHE from Drupal 8 bootstrap

### DIFF
--- a/lib/Drush/Boot/bootstrap.inc
+++ b/lib/Drush/Boot/bootstrap.inc
@@ -811,11 +811,6 @@ function drupal8_bootstrap($phase = NULL) {
 
         case DRUPAL_BOOTSTRAP_KERNEL:
           $kernel->boot();
-          break;
-
-        case DRUPAL_BOOTSTRAP_PAGE_CACHE:
-          $kernel->handlePageCache($request);
-          break;
 
         case DRUPAL_BOOTSTRAP_CODE:
         case DRUPAL_BOOTSTRAP_FULL:


### PR DESCRIPTION
https://www.drupal.org/node/2348679 has landed. DRUPAL_BOOTSTRAP_PAGE_CACHE no longer exists.