### PR TITLE
Fix unary operator expected error.

### DIFF
--- a/drush
+++ b/drush
@@ -126,7 +126,7 @@ fi
 
 # If on PHP 5.3, disable magic_quotes_gpc and friends
 PHP_MINOR_VERSION="`\"$php\" -r 'print PHP_MINOR_VERSION;'`"
-if [ $PHP_MINOR_VERSION -le 3 ] ; then
+if [[ $PHP_MINOR_VERSION -le 3 ]] ; then
   php_options="$php_options -d magic_quotes_gpc=Off -d magic_quotes_runtime=Off -d magic_quotes_sybase=Off"
 fi
 


### PR DESCRIPTION
I get the following error when I run Drush with xDebug enabled:

    Command stderr:
    /usr/local/drush/drush: line 129: [: -le: unary operator expected