### PR TITLE
Fix migrate tests

### DIFF
--- a/lib/Drush/Migrate/MigrateManifest8.php
+++ b/lib/Drush/Migrate/MigrateManifest8.php
@@ -98,6 +98,8 @@ class MigrateManifest8 implements MigrateInterface {
         $migrations[$migration->id()] = array(
           'executable' => $executable,
           'migration' => $migration,
+          'source' => $migration->get('source'),
+          'destination' => $migration->get('destination'),
         );
       }
     }

--- a/tests/migrateManifestTest.php
+++ b/tests/migrateManifestTest.php
@@ -82,11 +82,11 @@ class migrateManifestTest extends CommandUnishTestCase {
     $this->assertArrayHasKey('d6_action_settings', $return['object']);
 
     // Check source config.
-    $source_config = $return['object']['d6_file']['migration']['source'];
+    $source_config = $return['object']['d6_file']['source'];
     $this->assertEquals('sites/assets', $source_config['conf_path']);
 
     // Check destination config.
-    $destination_config = $return['object']['d6_file']['migration']['destination'];
+    $destination_config = $return['object']['d6_file']['destination'];
     $this->assertEquals('destination/base/path', $destination_config['source_base_path']);
     $this->assertEquals('uri', $destination_config['destination_path_property']);
   }


### PR DESCRIPTION
Source and destination are no longer public since: https://www.drupal.org/node/2384529

Somewhere in Drush the return result becomes an array so I added source and destination to the return because we don't have the full migration object in the test.