### PR TITLE
Revert "Fix unary operator expected error."

### DIFF
--- a/drush
+++ b/drush
@@ -126,7 +126,7 @@ fi
 
 # If on PHP 5.3, disable magic_quotes_gpc and friends
 PHP_MINOR_VERSION="`\"$php\" -r 'print PHP_MINOR_VERSION;'`"
-if [[ $PHP_MINOR_VERSION -le 3 ]] ; then
+if [ $PHP_MINOR_VERSION -le 3 ] ; then
   php_options="$php_options -d magic_quotes_gpc=Off -d magic_quotes_runtime=Off -d magic_quotes_sybase=Off"
 fi
 


### PR DESCRIPTION
Reverts drush-ops/drush#1115

This commit works fine on my local machine, but the Travis build breaks.  I'm not sure why this is; perhaps Travis is not set up to use bash?

I'm going to revert this to see if we can get the tests to go green again.  I'm not opposed to putting it back in later, but it would be good to know what limitations this might introduce.  Does anyone have any idea why the [[ ]] form is required with xDebug?  I don't think I had this problem, but I haven't installed xDebug on my new laptop yet, so I'll have to return here later to try it out.

This is also my first go at using the "revert" button on GitHub -- let's see how it works out when I click "create pull request".