### PR TITLE
Fixed 1924420: finished callback exisiting check handling

### DIFF
--- a/commands/core/drupal/batch.inc
+++ b/commands/core/drupal/batch.inc
@@ -222,7 +222,7 @@ function _drush_batch_finished() {
       if (isset($batch_set['file']) && is_file($batch_set['file'])) {
         include_once DRUPAL_ROOT . '/' . $batch_set['file'];
       }
-      if (function_exists($batch_set['finished'])) {
+      if (is_callable($batch_set['finished'])) {
         $queue = _batch_queue($batch_set);
         $operations = $queue->getAllItems();
         $elapsed = $batch_set['elapsed'] / 1000;


### PR DESCRIPTION
While fixing the `drush sapi-i` (https://www.drupal.org/node/2230949) command, I noticed that the `batch.inc` file in D8 was slightly altered. The finished callback doesn't use the function `function_exists`, but uses `is_callable` instead. This way namespaced methods can be passed in a decent way (cf original issue on d.o https://www.drupal.org/node/1924420).

Since this change is not very intrusive and should not break things for D6 and D7, I immediately created this PR.