### PR TITLE
Ensure that --db-su works without --db-su-pw for site-install

### DIFF
--- a/lib/Drush/Sql/Sqlmysql.php
+++ b/lib/Drush/Sql/Sqlmysql.php
@@ -11,17 +11,15 @@ class Sqlmysql extends SqlBase {
   public function creds($hide_password = TRUE) {
     if ($hide_password) {
       // EMPTY password is not the same as NO password, and is valid.
-      if (isset($this->db_spec['password'])) {
-        $contents = <<<EOT
+      $contents = <<<EOT
 #This file was written by Drush's Sqlmysql.inc.
 [client]
 user="{$this->db_spec['username']}"
 password="{$this->db_spec['password']}"
 EOT;
 
-        $file = drush_save_data_to_temp_file($contents);
-        $parameters['defaults-extra-file'] = $file;
-      }
+      $file = drush_save_data_to_temp_file($contents);
+      $parameters['defaults-extra-file'] = $file;
     }
     else {
       // User is required. Drupal calls it 'username'. MySQL calls it 'user'.


### PR DESCRIPTION
In the follow up to #365 (commit ac050dd) the defaults-extra-file is only created if a password is given. This means that --db-su=root has no effect without the (optional) argument --db-su-pw being set when running site-install. The username is simply ignored.