### PR TITLE
Added user-edit command and db-drop-existing-tables to site-install - Drush6

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -273,6 +273,7 @@ function core_drush_command() {
         'description' => 'Password for the "db-su" account. Optional.',
         'example-value' => 'pass',
       ),
+      'db-drop-existing-tables' => 'Defaults to TRUE. Remove all tables in the target database before creating Drupal tables.',
       'account-name' => 'uid1 name. Defaults to admin',
       'account-pass' => 'uid1 pass. Defaults to a randomly generated password. If desired, set a fixed password in drushrc.php.',
       'account-mail' => 'uid1 email. Defaults to admin@example.com',

--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -273,7 +273,10 @@ function core_drush_command() {
         'description' => 'Password for the "db-su" account. Optional.',
         'example-value' => 'pass',
       ),
-      'db-drop-existing-tables' => 'Defaults to TRUE. Remove all tables in the target database before creating Drupal tables.',
+      'db-drop-existing-tables' => array(
+        'description' => 'Remove all tables in the target database before creating Drupal tables. Defaults to TRUE.',
+        'example-value' => '0'
+      ),
       'account-name' => 'uid1 name. Defaults to admin',
       'account-pass' => 'uid1 pass. Defaults to a randomly generated password. If desired, set a fixed password in drushrc.php.',
       'account-mail' => 'uid1 email. Defaults to admin@example.com',

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -25,23 +25,30 @@ function drush_core_pre_site_install($profile = NULL) {
   }
   $default_sites_subdir = drush_get_context('DRUSH_DRUPAL_SITE', 'default');
   $sites_subdir = drush_get_option('sites-subdir', $default_sites_subdir);
-
   $conf_path = "sites/$sites_subdir";
+  
   $files = "$conf_path/files";
-  $settingsfile = "$conf_path/settings.php";
-  $sitesfile = "sites/sites.php";
-  $sitesfile_write = drush_drupal_major_version() >= 8 && !file_exists($sitesfile) && $sites_subdir != 'default';
   if (!file_exists($files)) {
     $msg[] = dt('create a @files directory', array('@files' => $files));
   }
+  
+  $settingsfile = "$conf_path/settings.php";
   if (!file_exists($settingsfile)) {
     $msg[] = dt('create a @settingsfile file', array('@settingsfile' => $settingsfile));
   }
+  
+  $sitesfile = "sites/sites.php";
+  $sitesfile_write = drush_drupal_major_version() >= 8 && !file_exists($sitesfile) && $sites_subdir != 'default';
   if ($sitesfile_write) {
     $msg[] = dt('create a @sitesfile file', array('@sitesfile' => $sitesfile));
   }
-  if (drush_sql_db_exists($db_spec)) {
-    $msg[] = dt("DROP all tables in your '@db' database.", array('@db' => $db_spec['database']));
+  
+  $db_already_exists = drush_sql_db_exists($db_spec);
+  if ($db_already_exists) {
+    $db_drop_existing_tables = drush_get_option('db-drop-existing-tables', TRUE);
+    if ($db_drop_existing_tables) {
+      $msg[] = dt("DROP all tables in your '@db' database.", array('@db' => $db_spec['database']));
+    }
   }
   else {
     $msg[] = dt("CREATE  the '@db' database.", array('@db' => $db_spec['database']));
@@ -113,8 +120,13 @@ function drush_core_pre_site_install($profile = NULL) {
   }
 
   // Empty or create the DB as needed.
-  drush_sql_empty_db($db_spec);
-
+  if ($db_already_exists && $db_drop_existing_tables) {
+    drush_sql_empty_db($db_spec);
+  }
+  else {
+    drush_sql_create($db_spec, FALSE);
+  }
+  
   if (drush_drupal_major_version() >= 8) {
     // Empty out any existing config directories.
     $directories = array();

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -44,13 +44,11 @@ function drush_core_pre_site_install($profile = NULL) {
   }
   
   $db_already_exists = drush_sql_db_exists($db_spec);
-  if ($db_already_exists) {
-    $db_drop_existing_tables = drush_get_option('db-drop-existing-tables', TRUE);
-    if ($db_drop_existing_tables) {
-      $msg[] = dt("DROP all tables in your '@db' database.", array('@db' => $db_spec['database']));
-    }
+  $db_drop_existing_tables = drush_get_option('db-drop-existing-tables', TRUE);
+  if ($db_already_exists && $db_drop_existing_tables) {
+    $msg[] = dt("DROP all tables in your '@db' database.", array('@db' => $db_spec['database']));
   }
-  else {
+  elseif (!$db_already_exists) {
     $msg[] = dt("CREATE  the '@db' database.", array('@db' => $db_spec['database']));
   }
 
@@ -123,7 +121,7 @@ function drush_core_pre_site_install($profile = NULL) {
   if ($db_already_exists && $db_drop_existing_tables) {
     drush_sql_empty_db($db_spec);
   }
-  else {
+  elseif (!$db_already_exists) {
     drush_sql_create($db_spec, FALSE);
   }
   

--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -344,12 +344,17 @@ function drush_sql_connect() {
 
 /**
  * Command callback. Create a database.
+ * 
+ * @param type $db_spec
+ * @param bool $requires_user_confirmation
  */
-function drush_sql_create() {
-  $db_spec = _drush_sql_get_db_spec();
-
+function drush_sql_create($db_spec = NULL, $requires_user_confirmation = TRUE) {
+  if (is_null($db_spec)) {
+    $db_spec = _drush_sql_get_db_spec();
+  }
+  
   // Prompt for confirmation.
-  if (!drush_get_context('DRUSH_SIMULATE')) {
+  if ($requires_user_confirmation && !drush_get_context('DRUSH_SIMULATE')) {
     $txt_destination = (isset($db_spec['remote-host']) ? $db_spec['remote-host'] . '/' : '') . $db_spec['database'];
     drush_print(dt("Creating database !target. Any possible existing database will be dropped!", array('!target' => $txt_destination)));
 

--- a/commands/user/user.drush.inc
+++ b/commands/user/user.drush.inc
@@ -179,6 +179,19 @@ function user_drush_command() {
         'Set the password for the username someuser. @see xkcd.com/936',
     ),
   );
+  $items['user-edit'] = array(
+    'description' => 'Edit the user account with the specified name.',
+    'aliases' => array('uedt'),
+    'arguments' => array(
+      'name' => 'The name of the account to modify.'
+    ),
+    'required-arguments' => TRUE,
+    'options' => array(),
+    'examples' => array(
+      'drush user-edit someuser --mail="user@example.org" --pass="new-password" --someotherfield="new value")' =>
+        'Sets the mail, pass and someotherfield values for the username someuser.',
+    ),
+  );
   $items['user-login'] = array(
     'description' => 'Display a one time login link for the given user account (defaults to uid 1).',
     'aliases' => array('uli'),
@@ -417,6 +430,48 @@ function drush_user_password($name) {
   }
   else {
     drush_set_error("The user account with the name " . $name . " could not be loaded.");
+  }
+}
+
+/**
+ * Edits the account with the given username
+ */
+function drush_user_edit($name) {
+  // Load the user first:
+  if (drush_drupal_major_version() >= 7) {
+    $user = user_load_by_name($name);
+  }
+  else {
+    $user = user_load(array('name' => $name));
+  }
+  
+  // Set error and return on failure:
+  if ($user === FALSE) {
+    drush_set_error("The user account with the name " . $name . " could not be loaded.");
+    return;
+  }
+ 
+  // Skip on simulation:
+  if (drush_get_context('DRUSH_SIMULATE')) {
+    return;
+  }
+  
+  // Otherwise update user:
+  // cli: Passed as --option=value to the command line (see: drush_context_names())
+  $fields_to_update = drush_get_context('cli');
+
+  if (drush_drupal_major_version() >= 8) {
+    foreach ($fields_to_update as $key => $value) {
+      $user->{$key} = $value;
+    }
+    $user_object = $user->save();
+  }
+  else {
+    $user_object = user_save($user, $fields_to_update);
+  }
+
+  if ($user_object === FALSE) {
+    drush_set_error("Could not update the user account with the name " . $name . "!");
   }
 }
 

--- a/commands/user/user.drush.inc
+++ b/commands/user/user.drush.inc
@@ -179,19 +179,6 @@ function user_drush_command() {
         'Set the password for the username someuser. @see xkcd.com/936',
     ),
   );
-  $items['user-edit'] = array(
-    'description' => 'Edit the user account with the specified name.',
-    'aliases' => array('uedt'),
-    'arguments' => array(
-      'name' => 'The name of the account to modify.'
-    ),
-    'required-arguments' => TRUE,
-    'options' => array(),
-    'examples' => array(
-      'drush user-edit someuser --mail="user@example.org" --pass="new-password" --someotherfield="new value")' =>
-        'Sets the mail, pass and someotherfield values for the username someuser.',
-    ),
-  );
   $items['user-login'] = array(
     'description' => 'Display a one time login link for the given user account (defaults to uid 1).',
     'aliases' => array('uli'),
@@ -430,48 +417,6 @@ function drush_user_password($name) {
   }
   else {
     drush_set_error("The user account with the name " . $name . " could not be loaded.");
-  }
-}
-
-/**
- * Edits the account with the given username
- */
-function drush_user_edit($name) {
-  // Load the user first:
-  if (drush_drupal_major_version() >= 7) {
-    $user = user_load_by_name($name);
-  }
-  else {
-    $user = user_load(array('name' => $name));
-  }
-  
-  // Set error and return on failure:
-  if ($user === FALSE) {
-    drush_set_error("The user account with the name " . $name . " could not be loaded.");
-    return;
-  }
- 
-  // Skip on simulation:
-  if (drush_get_context('DRUSH_SIMULATE')) {
-    return;
-  }
-  
-  // Otherwise update user:
-  // cli: Passed as --option=value to the command line (see: drush_context_names())
-  $fields_to_update = drush_get_context('cli');
-
-  if (drush_drupal_major_version() >= 8) {
-    foreach ($fields_to_update as $key => $value) {
-      $user->{$key} = $value;
-    }
-    $user_object = $user->save();
-  }
-  else {
-    $user_object = user_save($user, $fields_to_update);
-  }
-
-  if ($user_object === FALSE) {
-    drush_set_error("Could not update the user account with the name " . $name . "!");
   }
 }
 


### PR DESCRIPTION
Added a new option called "dp-drop-existing-tables" to the site-install
command. This option denotes whether the existing database should be
cleared before installing the Drupal tables.