### PR TITLE
Add make-update command

### DIFF
--- a/commands/make/generate.contents.make.inc
+++ b/commands/make/generate.contents.make.inc
@@ -82,13 +82,8 @@ function _drush_make_generate_makefile_body($projects, $output = array()) {
  */
 function make_generate_from_makefile($file, $makefile) {
   $projects = drush_get_option('DRUSH_MAKE_PROJECTS', FALSE);
-  if ($projects === FALSE || drush_get_option('lock-update', FALSE)) {
+  if ($projects === FALSE) {
     $info = make_parse_info_file($makefile);
-    if (drush_get_option('lock-update', FALSE)) {
-      foreach ($info['projects'] as $name => $project) {
-        unset($info['projects'][$name]['version']);
-      }
-    }
     $projects = make_prepare_projects(FALSE, $info);
     if (isset($projects['contrib'])) {
       $projects = array_merge($projects['core'], $projects['contrib']);

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -148,6 +148,21 @@ function make_drush_command() {
     'engines' => array('release_info'),
   );
 
+  $items['make-update'] = array(
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUSH,
+    'description' => 'Process a makefile and outputs an equivalent makefile with projects version resolved to latest available.',
+    'arguments' => array(
+      'makefile' => 'Filename of the makefile to use for this build.',
+    ),
+    'options' => array(
+      'result-file' => array(
+        'description' => 'Save to a file. If not provided, the updated makefile will be dump to stdout.',
+        'example-value' => 'updated.make',
+      ),
+    ),
+    'engines' => array('release_info', 'update_status'),
+  );
+
   // Add docs topic.
   $docs_dir = drush_get_context('DOC_PREFIX', DRUSH_BASE_PATH);
   $items['docs-make'] = array(

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -47,7 +47,6 @@ function make_drush_command() {
       'drush make --no-core --contrib-destination=. installprofile.make' => 'Build an installation profile within an existing Drupal site',
       'drush make http://example.com/example.make example' => 'Build the remote example.make makefile in the example directory.',
       'drush make example.make --no-build --lock=example.lock' => 'Write a new makefile to example.lock. All project versions will be resolved.',
-      'drush make example.make --no-build --lock-update=example.make' => 'Write a new makefile to example.make. All project versions will be updated.',
     ),
     'options' => array(
       'version' => 'Print the make API version and exit.',
@@ -88,10 +87,6 @@ function make_drush_command() {
       'lock' => array(
         'description' => 'Generate a makefile, based on the one passed in, with all versions *resolved*. Defaults to printing to the terminal, but an output file may be provided.',
         'example-value' => 'example.make.lock',
-      ),
-      'lock-update' => array(
-        'description' => 'Generate an updated makefile, based on the one passed in, with all versions *updated*. Defaults to printing to the terminal, but an output file may be provided.',
-        'example-value' => 'example.make',
       ),
       'shallow-clone' => array(
         'description' => 'For makefile entries which use git for downloading, this option will utilize shallow clones where possible (ie. by using the git-clone\'s depth=1 option). If the "working-copy" option is not desired, this option will significantly speed up makes which involve modules stored in very large git repos. In fact, if "working-copy" option is enabled, this option cannot be used.',
@@ -302,11 +297,6 @@ function drush_make($makefile = NULL, $build_path = NULL) {
   // Process --lock.
   if (drush_get_option('lock', FALSE)) {
     make_generate_from_makefile(drush_get_option('lock'), $makefile);
-  }
-
-  // Process --lock-update.
-  if (drush_get_option('lock-update', FALSE)) {
-    make_generate_from_makefile(drush_get_option('lock-update'), $makefile);
   }
 
   // Used by core-quick-drupal command.

--- a/commands/make/update.make.inc
+++ b/commands/make/update.make.inc
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @file
+ * make-update command implementation.
+ */
+
+/**
+ * Command callback for make-update.
+ */
+function drush_make_update($makefile = NULL) {
+  // Process makefile and get projects array.
+  $info = _make_parse_info_file($makefile);
+
+  make_prepare_projects(FALSE, $info);
+  $make_projects = drush_get_option('DRUSH_MAKE_PROJECTS', FALSE);
+
+  // Pick projects coming from drupal.org and adjust its structure
+  // to feed update_status engine.
+  // We provide here some heuristics to determine if a git clone comes
+  // from drupal.org and also guess its version.
+  // #TODO# move git checks to make_prepare_projects() and use it to leverage
+  // git_drupalorg engine.
+  $projects = array();
+  foreach ($make_projects as $project_name => $project) {
+    if (($project['download']['type'] == 'git') && !empty($project['download']['url'])) {
+      // TODO check that tag or branch are valid version strings (with pm_parse_version()).
+      if (!empty($project['download']['tag'])) {
+        $version = $project['download']['tag'];
+      }
+      elseif (!empty($project['download']['branch'])) {
+        $version = $project['download']['branch'] . '-dev';
+      }
+      /*
+      elseif (!empty($project['download']['refspec'])) {
+        #TODO# Parse refspec.
+      }
+      */
+      else {
+        // If no tag or branch, we can't match a d.o version.
+        continue;
+      }
+      $projects[$project_name] = $project + array(
+        'path'    => '',
+        'label'   => $project_name,
+        'version' => $version,
+      );
+    }
+    elseif ($project['download']['type'] == 'pm') {
+      $projects[$project_name] = $project + array(
+        'path'  => '',
+        'label' => $project_name,
+      );
+    }
+  }
+
+  // Check for updates.
+  $update_status = drush_get_engine('update_status');
+  $update_info = $update_status->getStatus($projects, TRUE);
+
+  $security_only = drush_get_option('security-only', FALSE);
+  foreach ($update_info as $project_name => $project_update_info) {
+    if (!$security_only || ($security_only && $project_update_info['status'] == DRUSH_UPDATESTATUS_NOT_SECURE)) {
+      $make_projects[$project_name]['download']['full_version'] = $project_update_info['recommended'];
+    }
+  }
+
+  // Inject back make projects and generate the updated makefile.
+  drush_set_option('DRUSH_MAKE_PROJECTS', $make_projects);
+  make_generate_from_makefile(drush_get_option('result-file'), $makefile);
+}
+


### PR DESCRIPTION
The purpose of this command is to improve and replace --lock-update. It uses the update_status engine to generate an updated makefile.
