### PR TITLE
Silence a warning when an alias record does not contian a 'root' element

### DIFF
--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -94,11 +94,7 @@ function sitealias_site_set_complete() {
  * is the site specification for the given alias.
  */
 function _drush_sitealias_alias_list() {
-  $all_aliases = drush_get_context('site-aliases');
-  foreach($all_aliases as $key => $value) {
-    $result['@' . $key] = $value;
-  }
-  return $result;
+  return drush_get_context('site-aliases');
 }
 
 /**
@@ -193,8 +189,8 @@ function drush_sitealias_print() {
 
   $site_specs = array();
   foreach ($site_list as $site => $alias_record) {
-    list($alias_name, $result_record) = _drush_sitealias_prepare_record($alias_record, $site);
-    $site_specs[$alias_name] = $result_record;
+    $result_record = _drush_sitealias_prepare_record($alias_record);
+    $site_specs[$site] = $result_record;
   }
   ksort($site_specs);
   return $site_specs;
@@ -207,7 +203,7 @@ function drush_sitealias_print() {
  * @param alias_record
  *   The name of the site alias to print
  */
-function _drush_sitealias_prepare_record($alias_record, $site_alias = '') {
+function _drush_sitealias_prepare_record($alias_record) {
   $output_db = drush_get_option('with-db');
   $output_db_url = drush_get_option('with-db-url');
   $output_optional_items = drush_get_option('with-optional');
@@ -246,16 +242,6 @@ function _drush_sitealias_prepare_record($alias_record, $site_alias = '') {
     unset($alias_record['databases']);
   }
 
-  // The alias name will be the same as the site alias name,
-  // unless the user specified some other name on the command line.
-  $alias_name = drush_get_option('alias-name');
-  if (!isset($alias_name)) {
-    $alias_name = $site_alias;
-    if (empty($alias_name) || is_numeric($alias_name)) {
-      $alias_name = drush_sitealias_uri_to_site_dir($alias_record['uri']);
-    }
-  }
-
   // We don't want certain fields to go into the output
   unset($alias_record['#group']);
   unset($alias_record['#hidden']);
@@ -269,17 +255,28 @@ function _drush_sitealias_prepare_record($alias_record, $site_alias = '') {
     }
   }
 
+  return $alias_record;
+}
+
+function _drush_sitealias_print_record($alias_record, $site_alias = '') {
+  $result_record = _drush_sitealias_prepare_record($alias_record);
+
+  // The alias name will be the same as the site alias name,
+  // unless the user specified some other name on the command line.
+  $alias_name = drush_get_option('alias-name');
+  if (!isset($alias_name)) {
+    $alias_name = $site_alias;
+    if (empty($alias_name) || is_numeric($alias_name)) {
+      $alias_name = drush_sitealias_uri_to_site_dir($result_record['uri']);
+    }
+  }
+
   // Alias names contain an '@' when referenced, but do
   // not contain an '@' when defined.
   if (substr($alias_name,0,1) == '@') {
     $alias_name = substr($alias_name,1);
   }
 
-  return array($alias_name, $alias_record);
-}
-
-function _drush_sitealias_print_record($alias_record, $site_alias = '') {
-  list($alias_name, $result_record) = _drush_sitealias_prepare_record($alias_record, $site_alias);
   $exported_alias = var_export($result_record, TRUE);
   drush_print('$aliases[\'' . $alias_name . '\'] = ' . $exported_alias . ';');
 }

--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -45,6 +45,7 @@ function sitealias_drush_command() {
     'examples' => array(
       'drush site-alias' => 'List all alias records known to drush.',
       'drush site-alias @dev' => 'Print an alias record for the alias \'dev\'.',
+      'drush @none site-alias' => 'Print only actual aliases; omit multisites from the local Drupal installation.',
     ),
     'topics' => array('docs-aliases'),
   );
@@ -93,7 +94,11 @@ function sitealias_site_set_complete() {
  * is the site specification for the given alias.
  */
 function _drush_sitealias_alias_list() {
-  return drush_get_context('site-aliases');
+  $all_aliases = drush_get_context('site-aliases');
+  foreach($all_aliases as $key => $value) {
+    $result['@' . $key] = $value;
+  }
+  return $result;
 }
 
 /**

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1184,7 +1184,9 @@ function _drush_sitealias_add_static_defaults(&$alias_record) {
       $alias_record['path-aliases'] = array();
     }
     // If there is a 'root' entry, then copy it to the '%root' path alias
-    $alias_record['path-aliases']['%root'] = $alias_record['root'];
+    if (isset($alias_record['root'])) {
+      $alias_record['path-aliases']['%root'] = $alias_record['root'];
+    }
   }
 }
 


### PR DESCRIPTION
Just putting this in the queue for Travis.

I did update .travis.yaml to get one branch tested, but then I had to put it back before merging with master. Is there a way to tell Travis to test a branch that contains a pattern, but NOT if it's on the master branch (UNLESS it IS a pull request)?  Probably not.  Just wondering if there's something we could live with that stayed in .travis.yaml all the time.