### PR TITLE
Allow drush make to run composer install, for better integration of exis...

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -79,6 +79,10 @@ function make_drush_command() {
         'description' => 'Restrict the make to this comma-separated list of libraries. To specify all libraries, pass *.',
         'example-value' => 'tinymce',
       ),
+      'composer' => array(
+        'description' => 'Run "composer install" on the specified composer file before processing makefile.',
+        'example-value' => 'composer.json',
+      ),
       'allow-override' => array(
         'description' => 'Restrict the make options to a comma-separated list. Defaults to unrestricted.',
       ),
@@ -224,7 +228,49 @@ function drush_make($makefile = NULL, $build_path = NULL) {
 
   $info = make_parse_info_file($makefile);
 
+  // Find the build path
+  if (!drush_get_option('no-build', FALSE) || drush_get_option('composer', FALSE)) {
+    $build_path = make_build_path($build_path);
+  }
+
+  // Compose.
+  $composed = FALSE;
+  if ($composer_file = drush_get_option('composer', FALSE)) {
+    if (!drush_is_absolute_path($composer_file)) {
+      if (drush_is_absolute_path($makefile)) {
+        $source_dir = dirname($makefile);
+      }
+      else {
+        $source_dir = drush_cwd();
+      }
+      $composer_file = $source_dir . '/' . $composer_file;
+    }
+    // Copy the composer.json file to the build path.
+    // This file must be named 'composer.json' when
+    // passed to composer, but we allow other names
+    // for the source file.
+    drush_mkdir($build_path);
+    copy($composer_file, $build_path . '/composer.json');
+
+    $options = array('--working-dir="%s"');
+
+    // TODO:  we could specify --no-plugins and --no-scripts if run
+    // in a high-security mode.  However, currently, --no-plugins would
+    // break some Drupal installs.  Check to see if this works with split-core.
+    $run_securely = FALSE;
+    if ($run_securely) {
+      $options[] = '--no-plugins';
+      $options[] = '--no-scripts';
+    }
+    if (drush_get_context('DRUSH_AFFIRMATIVE')) {
+      $options[] = '--no-interaction';
+    }
+    $command = 'composer install ' . implode(' ', $options);
+    drush_shell_exec_interactive($command, $build_path);
+    $composed = TRUE;
+  }
   // Build.
+  $built = FALSE;
   if (!drush_get_option('no-build', FALSE)) {
     drush_log(dt('Beginning to build !makefile.', array('!makefile' => $makefile)), 'ok');
 
@@ -233,7 +279,6 @@ function drush_make($makefile = NULL, $build_path = NULL) {
     $sitewide = drush_drupal_sitewide_directory($core_version);
     $contrib_destination = drush_get_option('contrib-destination', $sitewide);
 
-    $build_path = make_build_path($build_path);
     $make_dir = realpath(dirname($makefile));
 
     $success = make_projects(FALSE, $contrib_destination, $info, $build_path, $make_dir);
@@ -252,17 +297,21 @@ function drush_make($makefile = NULL, $build_path = NULL) {
           drush_log(dt('Build hash: %md5', array('%md5' => $md5)), 'ok');
         }
       }
-      // Only take final build steps if not in testing mode.
-      if (!drush_get_option('test')) {
-        if (drush_get_option('tar')) {
-          make_tar($build_path);
-        }
-        else {
-          make_move_build($build_path);
-        }
-      }
-      make_clean_tmp();
+      $built = TRUE;
     }
+  }
+
+  if ($built || $composed) {
+    // Only take final build steps if not in testing mode.
+    if (!drush_get_option('test')) {
+      if (drush_get_option('tar')) {
+        make_tar($build_path);
+      }
+      elseif ($built) {
+        make_move_build($build_path);
+      }
+    }
+    make_clean_tmp();
   }
 
   // Process --lock.
@@ -615,7 +664,7 @@ function make_build_path($build_path) {
 function make_move_build($build_path) {
   $tmp_path = make_tmp();
   $ret = TRUE;
-  if ($build_path == '.' || (drush_get_option('no-core', FALSE) && file_exists($build_path))) {
+  if ($build_path == '.' || ((drush_get_option('no-core', FALSE) || drush_get_option('composer', FALSE)) && file_exists($build_path))) {
     $info = drush_scan_directory($tmp_path . DIRECTORY_SEPARATOR . '__build__', '/./', array('.', '..'), 0, FALSE, 'filename', 0, TRUE);
     foreach ($info as $file) {
       $destination = $build_path . DIRECTORY_SEPARATOR . $file->basename;

--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -38,6 +38,18 @@ function _make_parse_info_file($makefile) {
   // $info['format'] will specify the determined format.
   $info = _make_determine_format($data);
 
+  // If this is a composer file, then point to it
+  // via the 'composer' option so that we will run
+  // 'composer install' on it later. 
+  //
+  // n.b. --allow-overrides=compsoer or --allow-overides=all
+  // must be set for this to work.
+  if ($info['format'] == 'composer') {
+    $info['options']['composer'] = $makefile;
+    // There is no makefile here, so we will also set the 'no-build' option.
+    drush_set_option('no-build', TRUE);
+  }
+
   // Set any allowed options.
   if (!empty($info['options'])) {
     foreach ($info['options'] as $key => $value) {
@@ -166,6 +178,11 @@ function make_validate_info_file($info) {
   // Assume no errors to start.
   $errors = FALSE;
 
+  // Don't validate $info if it is a proxy for
+  // a composer.json file.
+  if ($info['format'] == 'composer') {
+    return $info;
+  }
   if (empty($info['core'])) {
     make_error('BUILD_ERROR', dt("The 'core' attribute is required"));
     $errors = TRUE;
@@ -571,6 +588,15 @@ function _make_determine_format($data) {
   if ($parsed = ParserIni::parse($data)) {
     $parsed['format'] = 'ini';
     return $parsed;
+  }
+  elseif ($json = (array)json_decode($data)) {
+    // The composer.json file must have 'name' and 'require' sections
+    // for us to consider it valid and usable.
+    if (array_key_exists('name', $json) && array_key_exists('require', $json)) {
+      $parsed = $json;
+      $parsed['format'] = 'composer';
+      return $parsed;
+    }
   }
   elseif ($parsed = ParserYaml::parse($data)) {
     $parsed['format'] = 'yaml';


### PR DESCRIPTION
This PR is a proof-of-concept. It has been lightly tested, but needs some work.

These are just some ideas.  We are in a situation where it is becoming really useful to use Composer wherever dependency management is needed (i.e., modules that need to require external php libraries from github / packagist); however, Drush make is firmly ingrained in the infrastructure of a lot of workflows, so it makes sense to provide a transition plan to help composer adoption.

The basic feature in this patch is that users can reference a composer file to use in their makefile via a make option override.  This feature is enabled by default, but may be turned off via --allow-overrides.  Those who are already using --allow-overrides (e.g. drupal.org) will find composer install turned off by default.

The benefit of just this much of the code is not huge; it saves folks from having to type `composer install` after `drush make`.  This is a minor service, but it ties in with other integrations.

We also allow `drush make composer.json` -- that is, if the user substitutes a composer.json file for their makefile, then make will just build it.  The advantage here is that it makes it easier to enable Composer use with existing tools that are already integrated with make.  For example, `drush qd --makefile=composer.json`.  We could also just enhance `drush qd`; the question is, how many other tools or services could we integrate with if we did it this way?

While we are here, we should also consider what the right way to manage other assets, such as Javascript libraries is.  Make handles this; it seems that Composer does not (packagist being for php code).  [Bower](http://bower.io/) is commonly used for this outside of Drupal, but does not presently seem to be commonly used with Drupal.  Perhaps the best interim solution would be make + composer?  This PR does not address js files.

Something else to consider is the current Drupal user who is managing sites with Drush make.  What happens when an existing module adds a dependency from packagist, and includes a new composer.json at the root of the project?  drush make could warn about this situation.  It might even be possible to move the module from the makefile to the project's composer.json; however, in instances like this, it's probably better to just move all of the modules to composer.json, and leave the makefile for managing just the non-module assets (js libraries, et. al.).  In any event, this PR does not attempt to handle this.