### PR TITLE
Don't run cache clear after remote-add/remove-perm if no permission was added/removed

### DIFF
--- a/commands/core/role.drush.inc
+++ b/commands/core/role.drush.inc
@@ -161,13 +161,21 @@ function drush_role_add_perm($rid, $permissions = NULL) {
   else {
     $perms = _convert_csv_to_array($permissions);
   }
+
+  $added_perm = false;
+
   foreach($perms as $perm) {
     $result = drush_role_perm('add', $rid, $perm);
     if ($result !== FALSE) {
+      $added_perm = true;
       drush_log(dt('Added "!perm" to "!role"', array('!perm' => $perm, '!role' => $result->name)), 'success');
     }
   }
-  drush_drupal_cache_clear_all();
+
+  if ($added_perm) {
+    drush_drupal_cache_clear_all();
+  }
+
   return $result;
 }
 
@@ -187,13 +195,21 @@ function drush_role_remove_perm($rid, $permissions = NULL) {
   else {
     $perms = _convert_csv_to_array($permissions);
   }
+
+  $removed_perm = false;
+
   foreach($perms as $perm) {
     $result = drush_role_perm('remove', $rid, $perm);
     if ($result !== FALSE) {
+      $removed_perm = true;
       drush_log(dt('Removed "!perm" from "!role"', array('!perm' => $perm, '!role' => $result->name)), 'ok');
     }
   }
-  drush_drupal_cache_clear_all();
+
+  if ($removed_perm) {
+    drush_drupal_cache_clear_all();
+  }
+  
   return $result;
 }
 

--- a/commands/core/role.drush.inc
+++ b/commands/core/role.drush.inc
@@ -162,12 +162,12 @@ function drush_role_add_perm($rid, $permissions = NULL) {
     $perms = _convert_csv_to_array($permissions);
   }
 
-  $added_perm = false;
+  $added_perm = FALSE;
 
   foreach($perms as $perm) {
     $result = drush_role_perm('add', $rid, $perm);
     if ($result !== FALSE) {
-      $added_perm = true;
+      $added_perm = TRUE;
       drush_log(dt('Added "!perm" to "!role"', array('!perm' => $perm, '!role' => $result->name)), 'success');
     }
   }
@@ -196,12 +196,12 @@ function drush_role_remove_perm($rid, $permissions = NULL) {
     $perms = _convert_csv_to_array($permissions);
   }
 
-  $removed_perm = false;
+  $removed_perm = FALSE;
 
   foreach($perms as $perm) {
     $result = drush_role_perm('remove', $rid, $perm);
     if ($result !== FALSE) {
-      $removed_perm = true;
+      $removed_perm = TRUE;
       drush_log(dt('Removed "!perm" from "!role"', array('!perm' => $perm, '!role' => $result->name)), 'ok');
     }
   }


### PR DESCRIPTION
This prevents the cache clear from running after modifying permissions if no permission was modified, since it isn't needed in that case.