### PR TITLE
Attempt to fix D6 to D7 upgrades, see https://www.drupal.org/node/238266...

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -336,7 +336,7 @@ function core_drush_command() {
       'batch-id' => 'The batch id that will be processed',
     ),
     'required-arguments' => TRUE,
-    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL, // https://github.com/drush-ops/drush/issues/961
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION, // https://github.com/drush-ops/drush/issues/961
   );
   $items['core-global-options'] = array(
     'description' => 'All global options',
@@ -1137,9 +1137,6 @@ function drush_core_batch_process($id) {
  */
 function drush_core_updatedb_batch_process($id) {
   drush_include_engine('drupal', 'update');
-  require_once DRUSH_DRUPAL_CORE . '/includes/install.inc';
-  // require_once DRUSH_DRUPAL_CORE . '/includes/update.inc';
-  drupal_load_updates();
   _update_batch_command($id);
 }
 


### PR DESCRIPTION
After #691 was fixed we still had a problem running the Aegir test suite on drush master. 

On D.o: https://www.drupal.org/node/2382663

Summary: 
When upgrading a site from D6 to D7 we get the " Base table or view not found: ... 'blocked_ips'" error.

I've git bisected this to one commit in drush: b45184a02b914a8a1055d37733d5f4fad2373d29 

After much debugging I came to this change that lets out tests pass again.