### PR TITLE
Fix for #324, don't pass PHP, PHP-options for drush alias groups

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -1196,7 +1196,7 @@ function drush_preflight_command_dispatch() {
       }
     }
     $command_name = array_shift($args);
-    $multi_options = drush_get_context('cli');
+    $multi_options = drush_redispatch_get_options();
     unset($multi_options['php']);
     unset($multi_options['php-options']);
     $backend_options = array();


### PR DESCRIPTION
Fixed issues with remote drush groups with different PHP paths. See issue #324.