### PR TITLE
Don't mix basic types

### DIFF
--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -374,12 +374,11 @@ function _drush_find_commandfiles_drush() {
   $searchpath[] = realpath(dirname(__FILE__) . '/../commands/');
 
   // User commands, specified by 'include' option
-  if ($include = drush_get_context('DRUSH_INCLUDE', FALSE)) {
-    foreach ($include as $path) {
-      if (is_dir($path)) {
-        drush_log('Include ' . $path, 'notice');
-        $searchpath[] = $path;
-      }
+  $include = drush_get_context('DRUSH_INCLUDE', array());
+  foreach ($include as $path) {
+    if (is_dir($path)) {
+      drush_log('Include ' . $path, 'notice');
+      $searchpath[] = $path;
     }
   }
 


### PR DESCRIPTION
This sometimes poisons the context cache which can then cause type
errors later at places like drush_set_config_special_contexts() when
trying to merge options.