### PR TITLE
Automatically detect a distribution installation profile when installing Drupal 8

### DIFF
--- a/commands/core/drupal/site_install.inc
+++ b/commands/core/drupal/site_install.inc
@@ -4,11 +4,25 @@
  * Install Drupal 8+
  */
 function drush_core_site_install_version($profile, array $additional_form_options = array()) {
-  if (!isset($profile)) {
-    $profile = 'standard';
-  }
-
   require_once DRUSH_DRUPAL_CORE . '/includes/install.core.inc';
+  $class_loader = drush_drupal_load_autoloader(DRUPAL_ROOT);
+
+  if (!isset($profile)) {
+    // If there is an installation profile that acts as a distribution, use that
+    // one.
+    $install_state = array('interactive' => FALSE) + install_state_defaults();
+    try {
+      install_begin_request($class_loader, $install_state);
+      $profile = _install_select_profile($install_state);
+    }
+    catch (\Exception $e) {
+      // This is only a best effort to provide a better default, no harm done
+      // if it fails.
+    }
+    if (!isset($profile) || !$profile) {
+      $profile = 'standard';
+    }
+  }
 
   $sql = drush_sql_get_class();
   $db_spec = $sql->db_spec();
@@ -61,7 +75,6 @@ function drush_core_site_install_version($profile, array $additional_form_option
     $msg .= ' Consider using the --notify global option.';
   }
   drush_log(dt($msg), 'ok');
-  $class_loader = drush_drupal_load_autoloader(DRUPAL_ROOT);
   drush_op('install_drupal', $class_loader, $settings);
   drush_log(dt('Installation complete.  User name: @name  User password: @pass', array('@name' => $account_name, '@pass' => $account_pass)), 'ok');
 }

--- a/commands/core/drupal/site_install.inc
+++ b/commands/core/drupal/site_install.inc
@@ -19,7 +19,7 @@ function drush_core_site_install_version($profile, array $additional_form_option
       // This is only a best effort to provide a better default, no harm done
       // if it fails.
     }
-    if (!isset($profile) || !$profile) {
+    if (empty($profile)) {
       $profile = 'standard';
     }
   }

--- a/commands/core/drupal/site_install_7.inc
+++ b/commands/core/drupal/site_install_7.inc
@@ -4,11 +4,27 @@
  * Install Drupal 7
  */
 function drush_core_site_install_version($profile, array $additional_form_options = array()) {
-  if (!isset($profile)) {
-    $profile = 'standard';
-  }
-
   require_once DRUSH_DRUPAL_CORE . '/includes/install.core.inc';
+
+  if (!isset($profile)) {
+    require_once DRUSH_DRUPAL_CORE . '/includes/file.inc';
+    require_once DRUSH_DRUPAL_CORE . '/includes/install.inc';
+    require_once DRUSH_DRUPAL_CORE . '/includes/common.inc';
+    require_once DRUSH_DRUPAL_CORE . '/includes/module.inc';
+
+    // If there is an installation profile that is marked as exclusive, use that
+    // one.
+    try {
+      $profile = _install_select_profile(install_find_profiles());
+    }
+    catch (\Exception $e) {
+      // This is only a best effort to provide a better default, no harm done
+      // if it fails.
+    }
+    if (empty($profile)) {
+      $profile = 'standard';
+    }
+  }
 
   $sql = drush_sql_get_class();
   $db_spec = $sql->db_spec();

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -4,7 +4,7 @@ function site_install_drush_command() {
   $items['site-install'] = array(
     'description' => 'Install Drupal along with modules/themes/configuration using the specified install profile.',
     'arguments' => array(
-      'profile' => 'the install profile you wish to run. defaults to \'default\' in D6, \'standard\' in D7+',
+      'profile' => 'the install profile you wish to run. defaults to \'default\' in D6, \'standard\' in D7+, unless an install profile is marked as exclusive (or as a distribution in D8+ terminology) in which case that is used',
       'key=value...' => 'any additional settings you wish to pass to the profile. Fully supported on D7+, partially supported on D6 (single step configure forms only). The key is in the form [form name].[parameter name] on D7 or just [parameter name] on D6.',
     ),
     'options' => array(

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -4,8 +4,24 @@ function site_install_drush_command() {
   $items['site-install'] = array(
     'description' => 'Install Drupal along with modules/themes/configuration using the specified install profile.',
     'arguments' => array(
-      'profile' => 'the install profile you wish to run. defaults to \'default\' in D6, \'standard\' in D7+, unless an install profile is marked as exclusive (or as a distribution in D8+ terminology) in which case that is used',
-      'key=value...' => 'any additional settings you wish to pass to the profile. Fully supported on D7+, partially supported on D6 (single step configure forms only). The key is in the form [form name].[parameter name] on D7 or just [parameter name] on D6.',
+      // In Drupal 7 installation profiles can be marked as exclusive by placing
+      // a
+      // @code
+      //   exclusive: true
+      // @endcode
+      // line in the profile's info file.
+      // See https://www.drupal.org/node/1022020 for more information.
+      //
+      // In Drupal 8 you can turn your installation profile into a distribution
+      // by providing a
+      // @code
+      //   distribution:
+      //   name: 'Distribution name'
+      // @endcode
+      // block in the profile's info YAML file.
+      // See https://www.drupal.org/node/2210443 for more information.
+      'profile' => 'The install profile you wish to run. Defaults to \'default\' in D6, \'standard\' in D7+, unless an install profile is marked as exclusive (or as a distribution in D8+ terminology) in which case that is used.',
+      'key=value...' => 'Any additional settings you wish to pass to the profile. Fully supported on D7+, partially supported on D6 (single step configure forms only). The key is in the form [form name].[parameter name] on D7 or just [parameter name] on D6.',
     ),
     'options' => array(
       'db-url' => array(

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -16,7 +16,7 @@ function site_install_drush_command() {
       // by providing a
       // @code
       //   distribution:
-      //   name: 'Distribution name'
+      //     name: 'Distribution name'
       // @endcode
       // block in the profile's info YAML file.
       // See https://www.drupal.org/node/2210443 for more information.


### PR DESCRIPTION
Instead of always falling back to `standard` this allows lazy people to just type `drush si` and Drush will install
a distribution installation profile if there is one. This makes `drush si` consistent with the behavior of `install.php`