### PR TITLE
#64:  Use a per-user tmp directory with the 'use' command.

### DIFF
--- a/drush.complete.sh
+++ b/drush.complete.sh
@@ -16,7 +16,7 @@
 which drush > /dev/null || alias drush &> /dev/null || return
 
 __drush_ps1() {
-  f="${TMPDIR:-/tmp/}/drush-env/drush-drupal-site-$$"
+  f="${TMPDIR:-/tmp/}/drush-${USER}-env/drush-drupal-site-$$"
   if [ -f $f ]
   then
     __DRUPAL_SITE=$(cat "$f")

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -2065,8 +2065,12 @@ function drush_sitealias_get_envar_filename($filename_prefix = 'drush-drupal-sit
     return FALSE;
   }
 
+  // Unfortunately, we cannot use drush_directory_cache() here, as
+  // we need to use a path that can be very predictably reproduced
+  // in __drush_ps1.  See
   $tmp = getenv('TMPDIR') ? getenv('TMPDIR') : '/tmp/';
-  return "{$tmp}/drush-env/{$filename_prefix}" . posix_getppid();
+  $user = drush_get_username();
+  return "{$tmp}/drush-{$user}-env/{$filename_prefix}" . posix_getppid();
 }
 
 /**


### PR DESCRIPTION
This PR changes the directory that the 'use' environment is stored in to be a per-user filename, so that multiple users on the same machine can use the 'use' command.