### PR TITLE
#800: Allow sites/[site]/drushrc.php to change the value of 'uri'.

### DIFF
--- a/includes/context.inc
+++ b/includes/context.inc
@@ -114,7 +114,7 @@ function _drush_config_file($context, $prefix = NULL, $version = '') {
       $drupal_root . '/drush/' . $config_file,
     );
 
-    if ($conf_path = drush_get_context('DRUSH_SELECTED_DRUPAL_SITE_CONF_PATH')) {
+    if ($conf_path = drush_get_context('DRUSH_SELECTED_DRUPAL_SITE_CONF_PATH', 'sites/default')) {
       $site_path = $drupal_root . '/' . $conf_path;
       $configs['site'] = $site_path . "/" . $config_file;
     }

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -261,6 +261,17 @@ function drush_preflight_site() {
     }
   }
 
+  // If someone set 'uri' in the 'site' context, then copy it
+  // to the 'process' context (to give it a higher priority
+  // than the 'cli' and 'alias' contexts) and reset our selected
+  // site and @self alias.
+  $uri = drush_get_option('uri');
+  if ($uri != drush_get_option('uri', $uri, 'site')) {
+    drush_set_option('uri', drush_get_option('uri', $uri, 'site'));
+    _drush_preflight_uri();
+    drush_sitealias_create_self_alias();
+  }
+
   _drush_preflight_global_options();
 }
 


### PR DESCRIPTION
This patch insures that our selected site is set prior to the site bootstrap phase, so that we don't have to go back and fix up anything if uri changes in the sites drush config file.