### PR TITLE
Backport drush_autoload() from master branch.

### DIFF
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -1155,3 +1155,26 @@ function drush_shutdown() {
 function drush_return_status() {
   exit((drush_get_error()) ? DRUSH_FRAMEWORK_ERROR : DRUSH_SUCCESS);
 }
+
+/**
+ * Used by a Drush extension to request that its Composer autoload
+ * files be loaded by Drush, if they have not already been.
+ *
+ * Usage:
+ *
+ * function mycommandfile_drush_init() {
+ *   drush_autoload(__FILE__)
+ * }
+ *
+ */
+function drush_autoload($commandfile) {
+  $dir = dirname($commandfile);
+  $candidates = array("vendor/autoload.php", "../../../vendor/autoload.php");
+
+  foreach ($candidates as $candidate) {
+      $autoload = $dir . '/' . $candidate;
+      if (file_exists($autoload)) {
+        include $autoload;
+      }
+  }
+}


### PR DESCRIPTION
We should recommend that Drush extensions that have composer.json files should call drush_autoload in their hook_init. This will allow us the flexibility to support extensions in the vendor directory, once we have an efficient mechanism for doing that, while still allowing folks to write extensions that can still go in the usual places.

Today, extension writers have to put their own logic for finding and including their autoload file, which is not optimal. We already have drush_autoload() in Drush 7; it would be low-impact to have it in Drush 6 as well, which will help folks who want to be compatible with the recommended Drush 7 mechanism without becoming incompatible with Drush 6.