### PR TITLE
Insure that we have reached the right bootstrap level in drush_dispatch()

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -902,6 +902,9 @@ function drush_core_quick_drupal() {
   if (!drush_get_option('db-url', FALSE)) {
     drush_set_option('db-url', 'sqlite:' . $base . '/' . $name . '.sqlite');
   }
+  // We have just created a site root where one did not exist before.
+  // We therefore must manually reset DRUSH_SELECTED_DRUPAL_ROOT to
+  // our new root, and force a bootstrap to DRUSH_BOOTSTRAP_DRUPAL_ROOT.
   drush_set_context('DRUSH_SELECTED_DRUPAL_ROOT', $root);
   if (!drush_bootstrap_to_phase(DRUSH_BOOTSTRAP_DRUPAL_ROOT)) {
     return drush_set_error('QUICK_DRUPAL_ROOT_LOCATE_FAIL', 'Unable to locate Drupal root directory.');

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -150,6 +150,15 @@ function drush_dispatch($command, $arguments = array()) {
   $return = FALSE;
 
   if ($command) {
+    // Insure that we have reached the bootstrap level
+    // desired by the command.  We might not have bootstrapped
+    // far enough if a command uses drush_invoke to call
+    // a subcommand with a higher bootstrap level, for example.
+    $bootstrap_result = drush_bootstrap_to_phase($command['bootstrap']);
+    if (!$bootstrap_result) {
+      return FALSE;
+    }
+
     // Add arguments, if this has not already been done.
     // (If the command was fetched from drush_parse_command,
     // then you cannot provide arguments to drush_dispatch.)

--- a/lib/Drush/Boot/BaseBoot.php
+++ b/lib/Drush/Boot/BaseBoot.php
@@ -49,6 +49,8 @@ abstract class BaseBoot implements Boot {
         $command = drush_parse_command();
         if (is_array($command)) {
           $command += $this->command_defaults();
+          // Insure that we have bootstrapped to a high enough
+          // phase for the command prior to enforcing requirements.
           $bootstrap_result = drush_bootstrap_to_phase($command['bootstrap']);
           $this->enforce_requirement($command);
 


### PR DESCRIPTION
This is in case a command with a low bootstrap requirement invokes another command with a higher bootstrap requirement.  The only example we have of this today is drush quick-drupal, and qd must still explicitly set the selected site and call bootstrap, because it wants to bootstrap to a site that didn't even exist.

I think it's good to put this in for clarity, but at the moment it is a redundant step.  Let me know what you think.