### PR TITLE
#1256: Split out contrib-paths from commandfile_searchpaths()

### DIFF
--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -74,6 +74,28 @@ abstract class DrupalBoot extends BaseBoot {
     );
   }
 
+  /**
+   * @return array of strings - paths to directories where contrib
+   * modules can be found
+   */
+  function contrib_modules_paths() {
+    return array(
+      conf_path() . '/modules',
+      'sites/all/modules',
+    );
+  }
+
+  /**
+   * @return array of strings - paths to directories where contrib
+   * themes can be found
+   */
+  function contrib_themes_paths() {
+    return array(
+      conf_path() . '/themes',
+      'sites/all/themes',
+    );
+  }
+
   function commandfile_searchpaths($phase, $phase_max = FALSE) {
     if (!$phase_max) {
       $phase_max = $phase;
@@ -99,13 +121,7 @@ abstract class DrupalBoot extends BaseBoot {
         // only those Drush commandfiles that are associated with
         // enabled modules.
         if ($phase_max < DRUSH_BOOTSTRAP_DRUPAL_FULL) {
-          $searchpath[] = conf_path() . '/modules';
-          // Add all module paths, even disabled modules. Prefer speed over accuracy.
-          $searchpath[] = 'sites/all/modules';
-          // In D8, we search top level directories as well.
-          if (drush_drupal_major_version() >=8) {
-            $searchpath[] = 'modules';
-          }
+          $searchpath += $this->contrib_modules_paths();
 
           // Adding commandfiles located within /profiles. Try to limit to one profile for speed. Note
           // that Drupal allows enabling modules from a non-active profile so this logic is kinda dodgy.
@@ -122,12 +138,7 @@ abstract class DrupalBoot extends BaseBoot {
         }
 
         // TODO: Treat themes like modules and stop unconditionally searching here.
-        $searchpath[] = 'sites/all/themes';
-        $searchpath[] = conf_path() . '/themes';
-        // In D8, we search top level directories as well.
-        if (drush_drupal_major_version() >=8) {
-          $searchpath[] = 'themes';
-        }
+        $searchpath += $this->contrib_themes_paths();
         break;
       case DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION:
         // Nothing to do here anymore. Left for documentation.

--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -78,23 +78,13 @@ abstract class DrupalBoot extends BaseBoot {
    * @return array of strings - paths to directories where contrib
    * modules can be found
    */
-  function contrib_modules_paths() {
-    return array(
-      conf_path() . '/modules',
-      'sites/all/modules',
-    );
-  }
+  abstract function contrib_modules_paths();
 
   /**
    * @return array of strings - paths to directories where contrib
    * themes can be found
    */
-  function contrib_themes_paths() {
-    return array(
-      conf_path() . '/themes',
-      'sites/all/themes',
-    );
-  }
+  abstract function contrib_themes_paths();
 
   function commandfile_searchpaths($phase, $phase_max = FALSE) {
     if (!$phase_max) {
@@ -121,7 +111,7 @@ abstract class DrupalBoot extends BaseBoot {
         // only those Drush commandfiles that are associated with
         // enabled modules.
         if ($phase_max < DRUSH_BOOTSTRAP_DRUPAL_FULL) {
-          $searchpath += $this->contrib_modules_paths();
+          $searchpath = array_merge($searchpath, $this->contrib_modules_paths());
 
           // Adding commandfiles located within /profiles. Try to limit to one profile for speed. Note
           // that Drupal allows enabling modules from a non-active profile so this logic is kinda dodgy.
@@ -138,7 +128,7 @@ abstract class DrupalBoot extends BaseBoot {
         }
 
         // TODO: Treat themes like modules and stop unconditionally searching here.
-        $searchpath += $this->contrib_themes_paths();
+        $searchpath = array_merge($searchpath, $this->contrib_themes_paths());
         break;
       case DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION:
         // Nothing to do here anymore. Left for documentation.

--- a/lib/Drush/Boot/DrupalBoot6.php
+++ b/lib/Drush/Boot/DrupalBoot6.php
@@ -31,6 +31,20 @@ class DrupalBoot6 extends DrupalBoot {
     }
   }
 
+  function contrib_modules_paths() {
+    return array(
+      conf_path() . '/modules',
+      'sites/all/modules',
+    );
+  }
+
+  function contrib_themes_paths() {
+    return array(
+      conf_path() . '/themes',
+      'sites/all/themes',
+    );
+  }
+
   function bootstrap_drupal_core($drupal_root) {
     define('DRUPAL_ROOT', $drupal_root);
     $core = DRUPAL_ROOT;

--- a/lib/Drush/Boot/DrupalBoot7.php
+++ b/lib/Drush/Boot/DrupalBoot7.php
@@ -28,6 +28,20 @@ class DrupalBoot7 extends DrupalBoot {
     }
   }
 
+  function contrib_modules_paths() {
+    return array(
+      conf_path() . '/modules',
+      'sites/all/modules',
+    );
+  }
+
+  function contrib_themes_paths() {
+    return array(
+      conf_path() . '/themes',
+      'sites/all/themes',
+    );
+  }
+
   function bootstrap_drupal_core($drupal_root) {
     define('DRUPAL_ROOT', $drupal_root);
     $core = DRUPAL_ROOT;

--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -31,6 +31,18 @@ class DrupalBoot8 extends DrupalBoot {
     \Drupal::getContainer()->get('logger.factory')->addLogger(new \Drush\Log\DrushLog);
   }
 
+  function contrib_modules_paths() {
+    return parent::contrib_modules_paths() + array(
+      'modules',
+    );
+  }
+
+  function contrib_themes_paths() {
+    return parent::contrib_themes_paths() + array(
+      'themes',
+    );
+  }
+
   function bootstrap_drupal_core($drupal_root) {
     $core = DRUPAL_ROOT . '/core';
 

--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -32,13 +32,21 @@ class DrupalBoot8 extends DrupalBoot {
   }
 
   function contrib_modules_paths() {
-    return parent::contrib_modules_paths() + array(
+    return array(
+      conf_path() . '/modules',
+      'sites/all/modules',
       'modules',
     );
   }
 
+  /**
+   * @return array of strings - paths to directories where contrib
+   * themes can be found
+   */
   function contrib_themes_paths() {
-    return parent::contrib_themes_paths() + array(
+    return array(
+      conf_path() . '/themes',
+      'sites/all/themes',
       'themes',
     );
   }


### PR DESCRIPTION
Defined separate methods to return the locations where modules and themes can be found.