### PR TITLE
Respect enabled/disabled state of themes

### DIFF
--- a/commands/core/drupal/environment.inc
+++ b/commands/core/drupal/environment.inc
@@ -121,6 +121,14 @@ function drush_module_list() {
 }
 
 /**
+ * TODO: Returns a list of enabled themes.
+ */
+function drush_theme_list() {
+  return array();
+}
+
+
+/**
  * Installs a given list of modules.
  *
  * @see \Drupal\Core\Extension\ModuleInstallerInterface::install()

--- a/commands/core/drupal/environment_6.inc
+++ b/commands/core/drupal/environment_6.inc
@@ -108,6 +108,19 @@ function drush_module_list() {
 }
 
 /**
+ * Returns a list of enabled themes.
+ */
+function drush_theme_list() {
+  $enabled = array();
+  $rsc = drush_db_select('system', 'name', 'type=:type AND status=:status', array(':type' => 'theme', ':status' => 1));
+  while ($row = drush_db_result($rsc)) {
+    $enabled[$row] = $row;
+  }
+
+  return $enabled;
+}
+
+/**
  * Return a list of extensions from a list of named extensions.
  * Both enabled and disabled/uninstalled extensions are returned.
  */

--- a/commands/core/drupal/environment_7.inc
+++ b/commands/core/drupal/environment_7.inc
@@ -118,6 +118,19 @@ function drush_module_list() {
 }
 
 /**
+ * Returns a list of enabled themes.
+ */
+function drush_theme_list() {
+  $enabled = array();
+  $rsc = drush_db_select('system', 'name', 'type=:type AND status=:status', array(':type' => 'theme', ':status' => 1));
+  while ($row = drush_db_result($rsc)) {
+    $enabled[$row] = $row;
+  }
+
+  return $enabled;
+}
+
+/**
  * Return a list of extensions from a list of named extensions.
  * Both enabled and disabled/uninstalled extensions are returned.
  */
@@ -201,7 +214,7 @@ function drush_module_implements($hook, $sort = FALSE, $reset = FALSE) {
  */
 function drush_module_invoke($module, $hook) {
   $args = func_get_args();
-  return call_user_func_array('module_invoke', $args);  
+  return call_user_func_array('module_invoke', $args);
 }
 
 /**

--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -119,16 +119,15 @@ abstract class DrupalBoot extends BaseBoot {
           if ($cached = drush_cache_get($cid)) {
             $profile = $cached->data;
             $searchpath[] = "profiles/$profile/modules";
+            $searchpath[] = "profiles/$profile/themes";
           }
           else {
             // If install_profile is not available, scan all profiles.
             $searchpath[] = "profiles";
             $searchpath[] = "sites/all/profiles";
           }
+          $searchpath = array_merge($searchpath, $this->contrib_themes_paths());
         }
-
-        // TODO: Treat themes like modules and stop unconditionally searching here.
-        $searchpath = array_merge($searchpath, $this->contrib_themes_paths());
         break;
       case DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION:
         // Nothing to do here anymore. Left for documentation.
@@ -143,6 +142,12 @@ abstract class DrupalBoot extends BaseBoot {
         }
         foreach (array_diff(drush_module_list(), $ignored_modules) as $module) {
           $filepath = drupal_get_path('module', $module);
+          if ($filepath && $filepath != '/') {
+            $searchpath[] = $filepath;
+          }
+        }
+        foreach (array_diff(drush_theme_list(), $ignored_modules) as $module) {
+          $filepath = drupal_get_path('theme', $module);
           if ($filepath && $filepath != '/') {
             $searchpath[] = $filepath;
           }


### PR DESCRIPTION
When searching for commandfiles, respect the enabled / disabled state of themes, just like modules.

Incomplete - still needs Drupal 8 support.
