### PR TITLE
Improve site alias resolution in bootstrap

### DIFF
--- a/drush.php
+++ b/drush.php
@@ -71,7 +71,9 @@ function drush_main() {
       }
     }
   }
-  $bootstrap->terminate();
+  if ($bootstrap) {
+    $bootstrap->terminate();
+  }
   drush_postflight();
 
   // How strict are we?  If we are very strict, turn 'ok' into 'error'

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1745,7 +1745,7 @@ function drush_enforce_requirement_core(&$command) {
  * Check if a shell alias exists for current request. If so, re-route to
  * core-execute and pass alias value along with rest of CLI arguments.
  */
-function drush_shell_alias_replace() {
+function drush_shell_alias_replace($target_site_alias) {
   $escape = TRUE;
   $args = drush_get_arguments();
   $argv = drush_get_context('argv');
@@ -1762,7 +1762,6 @@ function drush_shell_alias_replace() {
       // when the alias value is a string; if it is already broken out into an array,
       // then the values therein are used literally.
       $alias_variables = array( '{{@target}}' => '@none' );
-      $target_site_alias = drush_get_context('DRUSH_TARGET_SITE_ALIAS', FALSE);
       if ($target_site_alias) {
         $alias_variables = array( '{{@target}}' => $target_site_alias );
         $target = drush_sitealias_get_record($target_site_alias);
@@ -1799,7 +1798,12 @@ function drush_shell_alias_replace() {
     }
     drush_log(dt('Shell alias found: !key => !value', array('!key' => $first, '!value' => implode(' ', $alias_value))), 'debug');
     $pos = array_search($first, $argv);
-    array_splice($argv, $pos, 1, $alias_value);
+    $number = 1;
+    if ($target_site_alias && ($argv[$pos - 1] == $target_site_alias)) {
+      --$pos;
+      ++$number;
+    }
+    array_splice($argv, $pos, $number, $alias_value);
     if (!$escape) {
       drush_set_option('escape', FALSE);
     }

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -191,6 +191,10 @@ function drush_preflight() {
   // scopes listed above.
   _drush_find_commandfiles_drush();
 
+  // Look up the alias identifier that the user wants to use,
+  // either via an arguement or via 'site-set'.
+  $target_alias = drush_sitealias_check_arg_and_site_set();
+
   // Process the site alias that specifies which instance
   // of Drush (local or remote) this command will operate on.
   // We must do this after we load our config files (so that
@@ -198,16 +202,40 @@ function drush_preflight() {
   // Drush preflight and Drupal root bootstrap phase are
   // done, since site aliases may set option values that
   // affect these phases.
-  drush_sitealias_check_arg();
-
-  // Check to see if we 'use'd a site alias with site-set
-  drush_sitealias_check_site_env();
+  $alias_record = _drush_sitealias_set_context_by_name($target_alias);
 
   // Find the selected site based on --root, --uri or cwd
   drush_preflight_root();
 
   // Preflight the selected site, and load any configuration and commandfiles associated with it.
   drush_preflight_site();
+
+  // Check to see if anything changed during the 'site' preflight
+  // that might allow us to find our alias record now
+  if (empty($alias_record)) {
+    $alias_record = _drush_sitealias_set_context_by_name($target_alias);
+
+    // If the site alias settings changed late in the preflight,
+    // then run the preflight for the root and site contexts again.
+    if (!empty($alias_record)) {
+      $remote_host = drush_get_option('remote-host');
+      if (!isset($remote_host)) {
+        drush_preflight_root();
+        drush_preflight_site();
+      }
+    }
+  }
+
+  // Fail if we could not find the selected site alias.
+  if ($target_alias && empty($alias_record)) {
+    return drush_set_error('DRUSH_BOOTSTRAP_NO_ALIAS', dt("Could not find the alias !alias", array('!alias' => $target_alias)));
+  }
+
+  // If applicable swaps in shell alias values.
+  drush_shell_alias_replace();
+
+  // Copy global options to their respective contexts
+  _drush_preflight_global_options();
 
   // Select the bootstrap object and return it.
   return drush_select_bootstrap_class();
@@ -227,36 +255,18 @@ function drush_preflight_root() {
   // @todo This context name should not mention Drupal.
   // @todo Drupal code should use DRUSH_DRUPAL_ROOT instead of this constant.
   drush_set_context('DRUSH_SELECTED_DRUPAL_ROOT', $root);
-}
 
-function drush_preflight_site() {
   // Load the config options from Drupal's /drush and sites/all/drush directories,
   // even prior to bootstrapping the root.
   drush_load_config('drupal');
+}
 
-  // Similarly, load the Drupal site configuration options upfront.
+function drush_preflight_site() {
+  // Load the Drupal site configuration options upfront.
   drush_load_config('site');
 
   // Determine URI and set constants/contexts accordingly. Keep this after loading of drupal,site configs.
   _drush_preflight_uri();
-
-  // Create a @self site alias record.
-  drush_sitealias_create_self_alias();
-
-  // If applicable swaps in shell alias values.
-  drush_shell_alias_replace();
-
-  // If drush_load_config defined a site alias that did not
-  // exist before, then sitealias check arg might now match
-  // against one of those aliases.
-  if (drush_sitealias_check_arg() === TRUE) {
-    $remote_host = drush_get_option('remote-host');
-    if (!isset($remote_host)) {
-      // Load the config files for the "new" site.
-      drush_load_config('drupal');
-      drush_load_config('site');
-    }
-  }
 
   // If someone set 'uri' in the 'site' context, then copy it
   // to the 'process' context (to give it a higher priority
@@ -266,10 +276,10 @@ function drush_preflight_site() {
   if ($uri != drush_get_option('uri', $uri, 'site')) {
     drush_set_option('uri', drush_get_option('uri', $uri, 'site'));
     _drush_preflight_uri();
-    drush_sitealias_create_self_alias();
   }
 
-  _drush_preflight_global_options();
+  // Create a @self site alias record.
+  drush_sitealias_create_self_alias();
 }
 
 function _drush_preflight_global_options() {
@@ -390,7 +400,6 @@ function _drush_find_commandfiles_drush() {
   _drush_add_commandfiles($searchpath, 0);
 }
 
-
 /**
  * Handle any command preprocessing that may need to be done, including
  * potentially redispatching the command immediately (e.g. for remote
@@ -406,7 +415,7 @@ function drush_preflight_command_dispatch() {
   // is set; note that if a site alias is provided on the command line,
   // and the site alias references a remote server, then the --remote-host
   // option will be set when the site alias is processed.
-  // @see drush_sitealias_check_arg
+  // @see drush_sitealias_check_arg_and_site_set and _drush_sitealias_set_context_by_name
   $remote_host = drush_get_option('remote-host');
   $site_list = drush_get_option('site-list');
   // Get the command early so that we can allow commands to directly handle remote aliases if they wish

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -232,7 +232,7 @@ function drush_preflight() {
   }
 
   // If applicable swaps in shell alias values.
-  drush_shell_alias_replace();
+  drush_shell_alias_replace($target_alias);
 
   // Copy global options to their respective contexts
   _drush_preflight_global_options();

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -10,6 +10,44 @@
  */
 
 /**
+ * Check to see if the user specified an alias
+ * in an arguement, or via site-set.  If so, return
+ * the name of the alias.
+ *
+ * If the alias came from args, then remove it
+ * from args.
+ */
+function drush_sitealias_check_arg_and_site_set() {
+  $args = drush_get_arguments();
+
+  // Test to see if the first arg is a valid alias identifier.
+  // If the first arguement is a well-formed identifier, but we
+  // cannot find a record for it, then we will fail with an error.
+  if (!empty($args) && drush_sitealias_valid_alias_format($args[0])) {
+    // Pop the alias off the arguments list first thing.
+    $target_alias = array_shift($args);
+    drush_set_arguments($args);
+    // Record the user's desired target alias name
+    drush_set_context('DRUSH_TARGET_SITE_ALIAS', $target_alias);
+    return $target_alias;
+  }
+  // If the user did not specify an alias via an argument,
+  // check to see if a site env was set.  For the site env,
+  // we insist on being able to find the alias record, or
+  // we will silently ignore
+  $site_env = drush_sitealias_site_get();
+  if ($site_env) {
+    $site_alias_settings = drush_sitealias_get_record($alias);
+    if (!empty($site_alias_settings)) {
+      drush_set_context('DRUSH_TARGET_SITE_ALIAS', $site_env);
+      return $site_env;
+    }
+  }
+  // Return an empty array to indicate that no site alias was specified.
+  return FALSE;
+}
+
+/**
  * Check to see if the first command-line arg or the
  * -l option is a site alias; if it is, copy its record
  * values to the 'alias' context.
@@ -139,7 +177,6 @@ function drush_sitealias_valid_alias_format($alias) {
     ($alias{0} == '#') ||
     ($alias{0} == '@')
   );
-  return $alias{0} == '@';
 }
 
 /**
@@ -1611,17 +1648,19 @@ function _drush_sitealias_set_record_element(&$alias_record, $key, $value) {
  *   TRUE is an alias was found and processed.
  */
 function _drush_sitealias_set_context_by_name($alias, $prefix = '') {
-  $site_alias_settings = drush_sitealias_get_record($alias);
-  if (!empty($site_alias_settings)) {
-    drush_sitealias_set_alias_context($site_alias_settings, $prefix);
-    drush_sitealias_cache_alias_by_path($site_alias_settings);
-    if (empty($prefix)) {
-      // Create an alias '@self'
-      _drush_sitealias_cache_alias('@self', $site_alias_settings);
-      // change the selected site to match the new --root and --uri, if any were set
-      _drush_preflight_root_uri();
+  if ($alias) {
+    $site_alias_settings = drush_sitealias_get_record($alias);
+    if (!empty($site_alias_settings)) {
+      drush_sitealias_set_alias_context($site_alias_settings, $prefix);
+      drush_sitealias_cache_alias_by_path($site_alias_settings);
+      if (empty($prefix)) {
+        // Create an alias '@self'
+        _drush_sitealias_cache_alias('@self', $site_alias_settings);
+        // change the selected site to match the new --root and --uri, if any were set
+        _drush_preflight_root_uri();
+      }
+      return TRUE;
     }
-    return TRUE;
   }
   return FALSE;
 }


### PR DESCRIPTION
We will give a separate error for 'alias not found', and not simply say "@alias command" could not be found.

If the tests are okay here, there is one more change I am going to make in command.inc.