### PR TITLE
Move uri cache from runserver to qd

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -936,8 +936,13 @@ function drush_core_quick_drupal() {
      return drush_set_error('QUICK_DRUPAL_PROJECT_ENABLE_FAIL', 'Project enable failed.');
     }
   }
+  $server = drush_get_option('server', '/');
+  if ($server) {
+    $server_uri = runserver_uri($server);
+    _drush_core_qd_cache_uri($server_uri);
+  }
   if (!drush_get_option('no-server', FALSE)) {
-    if ($server = drush_get_option('server', '/')) {
+    if ($server) {
       // Current CLI user is also the web server user, which is for development
       // only. Hence we can safely make the site directory writable. This makes
       // it easier to delete and edit settings.php.
@@ -947,6 +952,40 @@ function drush_core_quick_drupal() {
   }
   else {
     drush_print(dt('Login URL: ') . drush_invoke('user-login'));
+  }
+}
+
+// Write a drushrc.php to cache the server information for future Drush calls
+function _drush_core_qd_cache_uri($uri) {
+  $server = $uri['host'];
+  if (!empty($uri["port"])) {
+    $server .= ':' . $uri["port"];
+  }
+  $dir = DRUPAL_ROOT . '/drush';
+  $target_file = $dir . '/drushrc.php';
+  drush_log(dt("Caching 'uri' !uri in !target", array('!uri' => $server, '!target' => $target_file)), 'ok');
+  $create_file = TRUE;
+  if (file_exists($target_file)) {
+    // Don't bother to ask with --use-existing; just
+    // continue.
+    if (drush_get_option('use-existing', FALSE)) {
+      $create_file = FALSE;
+    }
+    else {
+      $create_file = drush_confirm(dt('!target already exists. Overwrite?', array('!target' => $target_file)));
+    }
+  }
+  $content = <<<EOT
+<?php
+
+// Inserted by `drush quick-drupal`.  This allows `drush user-login`
+// and similar commands to work seemlessly.  Remove if using
+// Drupal multisite feature.
+\$options['uri'] = "$server";
+EOT;
+  if ($create_file) {
+    drush_mkdir($dir);
+    file_put_contents($target_file, $content);
   }
 }
 

--- a/commands/runserver/runserver.drush.inc
+++ b/commands/runserver/runserver.drush.inc
@@ -62,35 +62,18 @@ function drush_core_runserver($uri = NULL) {
   global $user, $base_url;
 
   // Determine active configuration.
-  $drush_default = array(
-    'host' => '127.0.0.1',
-    'port' => '8888',
-    'path' => '',
-  );
-  $user_default = runserver_parse_uri(drush_get_option('default-server', '127.0.0.1:8888'));
-  $uri = runserver_parse_uri($uri);
+  $uri = runserver_uri($uri);
   if (!$uri) {
-    return $uri;
+    return FALSE;
   }
-  // Populate defaults.
-  $uri = $uri + $user_default + $drush_default;
-  if (ltrim($uri['path'], '/') == '-') {
-    // Allow a path of a single hyphen to clear a default path.
-    $uri['path'] = '';
-  }
+
   // Remove any leading slashes from the path, since that is what url() expects.
   $path = ltrim($uri['path'], '/');
 
-  // Determine and set the new URI.
-  $hostname = $addr = $uri['host'];
-  if (drush_get_option('dns', FALSE)) {
-    if (ip2long($hostname)) {
-      $hostname = gethostbyaddr($hostname);
-    }
-    else {
-      $addr = gethostbyname($hostname);
-    }
-  }
+  // $uri['addr'] is a special field set by runserver_uri()
+  $hostname = $uri['host'];
+  $addr = $uri['addr'];
+
   drush_set_context('DRUSH_URI', 'http://' . $hostname . ':' . $uri['port']);
 
   // We pass in the currently logged in user (if set via the --user option),
@@ -158,6 +141,39 @@ function drush_core_runserver($uri = NULL) {
 }
 
 /**
+ * Determine the URI to use for this server.
+ */
+function runserver_uri($uri) {
+  $drush_default = array(
+    'host' => '127.0.0.1',
+    'port' => '8888',
+    'path' => '',
+  );
+  $user_default = runserver_parse_uri(drush_get_option('default-server', ''));
+  $site_default = runserver_parse_uri(drush_get_option('uri', ''));
+  $uri = runserver_parse_uri($uri);
+  if ($uri) {
+    // Populate defaults.
+    $uri = $uri + $user_default + $site_default + $drush_default;
+    if (ltrim($uri['path'], '/') == '-') {
+      // Allow a path of a single hyphen to clear a default path.
+      $uri['path'] = '';
+    }
+    // Determine and set the new URI.
+    $uri['addr'] = $uri['host'];
+    if (drush_get_option('dns', FALSE)) {
+      if (ip2long($uri['host'])) {
+        $uri['host'] = gethostbyaddr($uri['host']);
+      }
+      else {
+        $uri['addr'] = gethostbyname($uri['host']);
+      }
+    }
+  }
+  return $uri;
+}
+
+/**
  * Parse a URI or partial URI (including just a port, host IP or path).
  *
  * @param string $uri
@@ -167,6 +183,9 @@ function drush_core_runserver($uri = NULL) {
  *   URI array as returned by parse_url.
  */
 function runserver_parse_uri($uri) {
+  if (empty($uri)) {
+    return array();
+  }
   if ($uri[0] == ':') {
     // ':port/path' shorthand, insert a placeholder hostname to allow parsing.
     $uri = 'placeholder-hostname' . $uri;

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -858,11 +858,22 @@ function drush_sitealias_convert_db_spec_to_db_url($db_spec) {
     }
     $result .= "@";
   }
-  $result .= urlencode($db_spec["host"]);
-  if (isset($db_spec["port"])) {
-    $result .= ":" . urlencode($db_spec["port"]);
+  // Host is required, unless this is an sqlite db.
+  if (isset($db_spec["host"]))
+  {
+    $result .= urlencode($db_spec["host"]);
+    if (isset($db_spec["port"])) {
+      $result .= ":" . urlencode($db_spec["port"]);
+    }
+    $result .= '/' . urlencode($db_spec["database"]);
   }
-  $result .= "/" . urlencode($db_spec["database"]);
+  else {
+    // URL-encode the database, but convert slashes
+    // back to their original form for readability.
+    // This portion is the "path" of the URL, so it may
+    // contain slashes.  This is important for sqlite.
+    $result .= str_replace("%2F", "/", urlencode(ltrim($db_spec["database"], '/')));
+  }
   return $result;
 }
 
@@ -1567,11 +1578,12 @@ function drush_sitealias_uri_to_site_dir($uri, $site_root = NULL) {
  */
 function drush_convert_db_from_db_url($db_url) {
   if (is_array($db_url)) {
-    $url = parse_url($db_url['default']);
+    $db_url_default = $db_url['default'];
   }
   else {
-    $url = parse_url($db_url);
+    $db_url_default = $db_url;
   }
+  $url = parse_url($db_url_default);
   // If parse_url failed, return an empty array
   if (!is_array($url)) {
     return array();
@@ -1587,15 +1599,30 @@ function drush_convert_db_from_db_url($db_url) {
     'database' => NULL,
   );
   $url = (object)array_map('urldecode', $url);
+  $host = $url->host;
+  $database = substr($url->path, 1);
+  if ($url->scheme == 'sqlite') {
+    $host = '';
+    // The sqlite path with start with a / if there
+    // is both a host and a path component; sqlite
+    // databases without an abosolute path will have only
+    // a host component.
+    if (isset($url->path)) {
+      $database = '/' . $url->host  . $url->path;
+    }
+    else {
+      $database = $url->host;
+    }
+  }
   return array(
     'driver' => $url->scheme == 'mysqli' ? 'mysql' : $url->scheme,
     'username' => $url->user,
     'password' => $url->pass,
     'port' => $url->port,
-    'host' => $url->scheme == 'sqlite' ? '' : $url->host,
+    'host' => $host,
     // Remove leading / character from database names, unless we're installing
     // to SQLite (which won't have a slash there unless it's part of a path).
-    'database' => $url->scheme == 'sqlite'  ? $url->host  . $url->path : substr($url->path, 1),
+    'database' => $database,
   );
 }
 


### PR DESCRIPTION
This is a continuation of #1177, with the creation of the drushrc.php file moved from the runserver command to the quick-drupal command.

It is very useful to record the port used when running qd, as it helps subsequent commands to be correctly targeted, should they need to use the 'uri' for any reason.

I would like to see this in the 7.0-rc1 release, if possible.