### PR TITLE
Respect --lock=drupal in pm-updatecode.

### DIFF
--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -1904,12 +1904,14 @@ function drush_pm_update_lock(&$projects, $projects_to_lock, $projects_to_unlock
 
   $drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT');
   foreach ($projects as $name => $project) {
-    if ($name == 'drupal') {
-      continue;
-    }
     $message = NULL;
     if (isset($project['path'])) {
-      $lockfile = $drupal_root . '/' . $project['path'] . '/.drush-lock-update';
+      if ($name == 'drupal') {
+        $lockfile = $drupal_root . '/.drush-lock-update';
+      }
+      else {
+        $lockfile = $drupal_root . '/' . $project['path'] . '/.drush-lock-update';
+      }
 
       // Remove the lock file if the --unlock option was specified
       if (((in_array($name, $projects_to_unlock)) || (in_array('all', $projects_to_unlock))) && (file_exists($lockfile))) {


### PR DESCRIPTION
For some reason, the --lock feature of pm-updatecode explicitly excludes core.  This PR enables --lock with core, which is very useful if you are in a managed hosting environment with a custom core (e.g. pressflow at Pantheon).