### PR TITLE
Add a hook_drush_sitealias_alter, with documentation.

### DIFF
--- a/examples/example.aliases.drushrc.php
+++ b/examples/example.aliases.drushrc.php
@@ -201,11 +201,7 @@
  *   standard port, alternative identity file, or alternative
  *   authentication method, ssh-options can contain a string of extra
  *   options that are used with the ssh command, eg "-p 100"
- * - 'parent': The name of a parent alias (e.g. '@server') to use as a basis
- *   for this alias.  Any value of the parent will appear in the child
- *   unless overridden by an item with the same name in the child.
- *   Multiple inheritance is possible; name multiple parents in the
- *   'parent' item separated by commas (e.g. '@server,@devsite').
+ * - 'parent': Deprecated.  See "altering aliases", below.
  * - 'db-url': The Drupal 6 database connection string from settings.php.
  *   For remote databases accessed via an ssh tunnel, set the port
  *   number to the tunneled port as it is accessed on the local machine.
@@ -295,6 +291,30 @@
  * ),
  * @endcode
  *
+ * Altering aliases:
+ *
+ * Alias records are written in php, so you may use php code to alter
+ * alias records if you wish.  For example:
+ *
+ * @code
+ * $common_live = array(
+ *   'remote-host' => 'myserver.isp.com',
+ *   'remote-user' => 'www-admin',
+ * );
+ *
+ * $aliases['live'] = array(
+ *   'uri' => 'mysite.com',
+ *   'root' => '/path.to/root',
+ * ) + $common_live;
+ * @endcode
+ *
+ * If you wish, you might want to put $common_live in a separate file,
+ * and include it at the top of each alias file that uses it.
+ *
+ * You may also use a policy file to alter aliases in code as they are
+ * loaded by Drush.  See policy_drush_sitealias_alter in
+ * `drush topic docs-policy` for details.
+ *
  * Some examples appear below.  Remove the leading hash signs to enable.
  */
 
@@ -354,11 +374,6 @@
 #    'os' => 'Linux',
 #  );
 #$aliases['live'] = array(
-#    'parent' => '@server,@dev',
 #    'uri' => 'mydrupalsite.com',
-#     'target-command-specific' => array (
-#       'sql-sync' => array (
-#         'skip-tables-list' => 'comments',
-#       ),
-#     ),
-#  );
+#    'root' => $aliases['dev']['root'],
+#  ) + $aliases['server'];

--- a/examples/policy.drush.inc
+++ b/examples/policy.drush.inc
@@ -29,6 +29,34 @@ function drush_policy_sql_sync_validate($source = NULL, $destination = NULL) {
 }
 
 /**
+ * Implements hook_drush_sitealias_alter
+ *
+ * Alter alias record data in code.
+ */
+function policy_drush_sitealias_alter(&$alias_record) {
+  // A duplicate of the old implementation of the 'parent' element.
+  // Keep this if you want to keep using 'parent', but do not want
+  // to be nagged (or worse, break when it is removed).
+  if (isset($alias_record['parent'])) {
+    // Fetch and merge in each parent
+    foreach (explode(',', $alias_record['parent']) as $parent) {
+      $parent_record = drush_sitealias_get_record($parent);
+      unset($parent_record['#name']);
+      unset($parent_record['#file']);
+      unset($parent_record['#hidden']);
+      $array_based_keys = array_merge(drush_get_special_keys(), array('path-aliases'));
+      foreach ($array_based_keys as $array_based_key) {
+        if (isset($alias_record[$array_based_key]) && isset($parent_record[$array_based_key])) {
+          $alias_record[$array_based_key] = array_merge($parent_record[$array_based_key], $alias_record[$array_based_key]);
+        }
+      }
+      $alias_record = array_merge($parent_record, $alias_record);
+    }
+    unset($alias_record['parent']);
+  }
+}
+
+/**
  * Implements hook_drush_help_alter().
  *
  * When a hook extends a command with additional options, it must

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -775,7 +775,9 @@ function _drush_sitealias_add_inherited_values(&$aliases) {
 }
 
 function _drush_sitealias_add_inherited_values_to_record(&$alias_value) {
+  drush_command_invoke_all_ref('drush_sitealias_alter', $alias_value);
   if (isset($alias_value['parent'])) {
+    drush_log(dt("Using deprecated 'parent' element '!parent' in '!name'.", array('!parent' => $alias_value['parent'], '!name' => $alias_value['#name'])), 'warning');
     // Fetch and merge in each parent
     foreach (explode(',', $alias_value['parent']) as $parent) {
       $parent_record = drush_sitealias_get_record($parent);
@@ -790,8 +792,8 @@ function _drush_sitealias_add_inherited_values_to_record(&$alias_value) {
       }
       $alias_value = array_merge($parent_record, $alias_value);
     }
-    unset($alias_value['parent']);
   }
+  unset($alias_value['parent']);
 }
 
 /**


### PR DESCRIPTION
Deprecate 'parent' element in site aliases, for eventual removal (probably in Drush 8).