### PR TITLE
Fixes #1241: Make Drush better at finding site aliases in the sites folder

### DIFF
--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -408,6 +408,14 @@ function drush_sitealias_alias_path($alias_path_context = NULL) {
   if (!empty($drupal_root)) {
     $site_paths[] = $drupal_root . '/drush';
     $site_paths[] = $drupal_root . '/sites/all/drush';
+    $uri = drush_get_context('DRUSH_SELECTED_URI');
+    if (empty($uri)) {
+      $uri = 'default';
+    }
+    $site_dir = drush_sitealias_uri_to_site_dir($uri, $drupal_root);
+    if ($site_dir) {
+      $site_paths[] = "$drupal_root/sites/$site_dir";
+    }
   }
   $alias_path = (array) drush_get_context('ALIAS_PATH', array());
   return array_unique(array_merge($context_path, $alias_path, $site_paths));


### PR DESCRIPTION
Drush had trouble finding aliases in the 'sites' folder early in the bootstrap.

This is a simple bugfix, that brings the behavior of `drush @foo command` in line with the documentation, and `drush sa @foo`, for aliases defined in ROOT/sites/default/aliases.drushrc.php.

I'll merge this if the tests come up clean.