### PR TITLE
Fixes #1265:  Define an exit status code for user aborts.

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -675,15 +675,15 @@ function drush_core_config($filter = NULL) {
   $exec = drush_get_editor();
   if (count($all) == 1) {
     $filepath = current($all);
-    return drush_shell_exec_interactive($exec, $filepath, $filepath);
   }
   else {
     $choice = drush_choice($all, 'Enter a number to choose which file to edit.', '!key');
-    if ($choice !== FALSE) {
-      $filepath = $all[$choice];
-      drush_shell_exec_interactive($exec, $filepath, $filepath);
+    if (!$choice) {
+      return drush_user_abort();
     }
+    $filepath = $all[$choice];
   }
+  return drush_shell_exec_interactive($exec, $filepath, $filepath);
 }
 
 /**

--- a/commands/core/field.drush.inc
+++ b/commands/core/field.drush.inc
@@ -230,6 +230,9 @@ function drush_field_delete($field_name) {
     if (count($all_bundles) > 1) {
       $options = array_merge(array('all' => dt('All bundles')), array_combine($all_bundles, $all_bundles));
       $bundle = drush_choice($options, dt("Choose a particular bundle or 'All bundles'"));
+      if (!$bundle) {
+        return drush_user_abort();
+      }
       $confirm = FALSE;
     }
     else {

--- a/commands/core/role.drush.inc
+++ b/commands/core/role.drush.inc
@@ -209,7 +209,7 @@ function drush_role_remove_perm($rid, $permissions = NULL) {
   if ($removed_perm) {
     drush_drupal_cache_clear_all();
   }
-  
+
   return $result;
 }
 
@@ -243,7 +243,7 @@ function drush_role_perm($action, $rid, $permission = NULL) {
     }
     $choice = drush_choice($module_perms, "Enter a number to choose which permission to $action.");
     if ($choice === FALSE) {
-      return FALSE;
+      return drush_user_abort();
     }
     $permission = $module_perms[$choice];
   }

--- a/commands/core/topic.drush.inc
+++ b/commands/core/topic.drush.inc
@@ -71,7 +71,7 @@ function drush_topic_core_topic($topic_name = NULL) {
     }
     natcasesort($choices);
     if (!$topic_name = drush_choice($choices, dt('Choose a topic'), '!value (!key)', array(5))) {
-      return;
+      return drush_user_abort();
     }
   }
   else {

--- a/commands/core/topic.drush.inc
+++ b/commands/core/topic.drush.inc
@@ -74,7 +74,9 @@ function drush_topic_core_topic($topic_name = NULL) {
       return;
     }
   }
-  $topic_name = array_pop(array_keys($topics));
+  else {
+    $topic_name = array_pop(array_keys($topics));
+  }
   return drush_dispatch($commands[$topic_name]);
 }
 

--- a/commands/core/variable.drush.inc
+++ b/commands/core/variable.drush.inc
@@ -218,12 +218,13 @@ function drush_variable_set() {
   }
   else {
     $choice = drush_choice($options, 'Enter a number to choose which variable to set.');
-    if ($choice !== FALSE) {
-      $choice = $options[$choice];
-      $choice = str_replace(' ' . dt('(new variable)'), '', $choice);
-      drush_op('variable_set', $choice, $value);
-      drush_log(dt('!name was set to !value', array('!name' => $choice, '!value' => $display)), 'success');
+    if ($choice === FALSE) {
+      return drush_user_abort();
     }
+    $choice = $options[$choice];
+    $choice = str_replace(' ' . dt('(new variable)'), '', $choice);
+    drush_op('variable_set', $choice, $value);
+    drush_log(dt('!name was set to !value', array('!name' => $choice, '!value' => $display)), 'success');
   }
 }
 

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -16,6 +16,11 @@
 define('DRUSH_SUCCESS', 0);
 /** The command could not be completed because the framework has specified errors that have occured. */
 define('DRUSH_FRAMEWORK_ERROR', 1);
+/** The command was aborted because the user chose to cancel it at some prompt.
+This exit code is arbitrarily the same as EX_TEMPFAIL in sysexits.h, although
+note that shell error codes are distinct from C exit codes, so this alignment
+not meaningful. */
+define('DRUSH_EXITCODE_USER_ABORT', 75);
 /** The command that was executed resulted in an application error,
 The most commom causes for this is invalid PHP or a broken SSH
 pipe when using drush_backend_invoke in a distributed manner. */
@@ -496,7 +501,6 @@ function drush_choice($options, $prompt = 'Enter a number.', $label = '!value', 
   if (drush_get_context('DRUSH_AFFIRMATIVE')  && (count($options) == 1)) {
     return $selection_list[1];
   }
-  drush_print(dt('Cancelled'));
   return FALSE;
 }
 
@@ -1614,7 +1618,8 @@ function drush_clear_error() {
  */
 function drush_user_abort($msg = NULL) {
   drush_set_context('DRUSH_USER_ABORT', TRUE);
-  drush_log($msg ? $msg : dt('Aborting.'), 'cancel');
+  drush_set_context('DRUSH_EXIT_CODE', DRUSH_EXITCODE_USER_ABORT);
+  drush_log($msg ? $msg : dt('Cancelled.'), 'cancel');
   return FALSE;
 }
 

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -661,5 +661,11 @@ function drush_coverage_shutdown() {
 }
 
 function drush_return_status() {
-  exit((drush_get_error()) ? DRUSH_FRAMEWORK_ERROR : DRUSH_SUCCESS);
+  // If a specific exit code was set, then use it.
+  $exit_code = drush_get_context('DRUSH_EXIT_CODE');
+  if (empty($exit_code)) {
+    $exit_code = (drush_get_error()) ? DRUSH_FRAMEWORK_ERROR : DRUSH_SUCCESS;
+  }
+
+  exit($exit_code);
 }

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -37,7 +37,7 @@ function drush_sitealias_check_arg_and_site_set() {
   // we will silently ignore
   $site_env = drush_sitealias_site_get();
   if ($site_env) {
-    $site_alias_settings = drush_sitealias_get_record($alias);
+    $site_alias_settings = drush_sitealias_get_record($site_env);
     if (!empty($site_alias_settings)) {
       drush_set_context('DRUSH_TARGET_SITE_ALIAS', $site_env);
       return $site_env;

--- a/tests/Unish/CommandUnishTestCase.php
+++ b/tests/Unish/CommandUnishTestCase.php
@@ -10,6 +10,7 @@ abstract class CommandUnishTestCase extends UnishTestCase {
   // Unix exit codes.
   const EXIT_SUCCESS  = 0;
   const EXIT_ERROR = 1;
+  const UNISH_EXITCODE_USER_ABORT = 75; // Same as DRUSH_EXITCODE_USER_ABORT
 
   /**
    * Code coverage data collected during a single test.

--- a/tests/pmDownloadTest.php
+++ b/tests/pmDownloadTest.php
@@ -73,7 +73,7 @@ class pmDownloadCase extends CommandUnishTestCase {
       'choice' => 0, // Cancel.
     );
     // --select. Specify 6.x since that has so many releases.
-    $this->drush('pm-download', array('devel-6.x'), $options);
+    $this->drush('pm-download', array('devel-6.x'), $options, NULL, NULL, CommandUnishTestCase::UNISH_EXITCODE_USER_ABORT);
     $items = $this->getOutputAsList();
     $output = $this->getOutput();
      // 6 items are: Select message + Cancel + 3 versions.
@@ -81,7 +81,7 @@ class pmDownloadCase extends CommandUnishTestCase {
     $this->assertContains('6.x-1.x-dev', $output, 'Dev release was shown by --select.');
 
     // --select --dev. Specify 6.x since that has so many releases.
-    $this->drush('pm-download', array('devel-6.x'), $options + array('dev' => NULL));
+    $this->drush('pm-download', array('devel-6.x'), $options + array('dev' => NULL), NULL, NULL, CommandUnishTestCase::UNISH_EXITCODE_USER_ABORT);
     $items = $this->getOutputAsList();
     $output = $this->getOutput();
     // 12 items are: Select message + Cancel + 1 option.
@@ -89,7 +89,7 @@ class pmDownloadCase extends CommandUnishTestCase {
     $this->assertContains('6.x-1.x-dev', $output, 'Assure that --dev lists the only dev release.');
 
     // --select --all. Specify 5.x since this is frozen.
-    $this->drush('pm-download', array('devel-5.x'), $options + array('all' => NULL));
+    $this->drush('pm-download', array('devel-5.x'), $options + array('all' => NULL), NULL, NULL, CommandUnishTestCase::UNISH_EXITCODE_USER_ABORT);
     $items = $this->getOutputAsList();
     $output = $this->getOutput();
     // 12 items are: Select message + Cancel + 9 options.


### PR DESCRIPTION
Here's a proposed patch that defines an exit code (75) that Drush returns if the user cancels.  Also defines a mechanism for Drush to set other exit codes, if desired.  (Currently, only "0" or "1" is ever returned.)
