### PR TITLE
Make defaults apply in deep

### DIFF
--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -509,7 +509,7 @@ function make_apply_defaults(&$info) {
     foreach ($defaults as $type => $default_data) {
       if (isset($info[$type])) {
         foreach ($info[$type] as $project => $data) {
-          $info[$type][$project] += $default_data;
+          $info[$type][$project] = _drush_array_overlay_recursive($default_data, $info[$type][$project]);
         }
       }
       else {


### PR DESCRIPTION
Right now the defaults are not applied in deep. If a project has a level 1 key, the will override the default without checking in deep. See #1307.