### PR TITLE
Shorthand for download[url] in make file

### DIFF
--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -289,9 +289,11 @@ function make_validate_info_file($info) {
 
   // Convert shorthand project/library download style to array format.
   foreach (array('projects', 'libraries') as $type) {
-    foreach ($info[$type] as $name => $item) {
-      if (!empty($item['download']) && is_string($item['download'])) {
-        $info[$type][$name]['download'] = array('url' => $item['download']);
+    if (isset($info[$type]) && is_array($info[$type])) {
+      foreach ($info[$type] as $name => $item) {
+        if (!empty($item['download']) && is_string($item['download'])) {
+          $info[$type][$name]['download'] = array('url' => $item['download']);
+        }
       }
     }
   }

--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -287,6 +287,15 @@ function make_validate_info_file($info) {
     }
   }
 
+  // Convert shorthand project/library download style to array format.
+  foreach (array('projects', 'libraries') as $type) {
+    foreach ($info[$type] as $name => $item) {
+      if (!empty($item['download']) && is_string($item['download'])) {
+        $info[$type][$name]['download'] = array('url' => $item['download']);
+      }
+    }
+  }
+
   // Apply defaults after projects[] array has been expanded, but prior to
   // external validation.
   make_apply_defaults($info);

--- a/docs/make.md
+++ b/docs/make.md
@@ -274,6 +274,19 @@ Do not use both types of declarations for a single project in your makefile.
 
   `working-copy` - If true, the checked out source will be kept as a working copy rather than exported as standalone files
 
+  Shorthand for `download[url]` available for all download types:
+  
+     projects:
+       mytheme:
+         download: "git://github.com/jane_doe/mytheme.git"
+         
+  is equivalent to:
+  
+     projects:
+       mytheme:
+         download:
+           url: "git://github.com/jane_doe/mytheme.git"
+
 ### Libraries
 
 An array of non-Drupal-specific libraries to be retrieved (e.g. js, PHP or other


### PR DESCRIPTION
Implement a shorthand for the case we have only the `url` key under project/library `download`.

```yaml
projects:
  mymodule:
    download: http://example.com/modules/mymodule.git
libraries:
  thirdpartylib:
    download: http://example.com/libs/thirdpartylib.min.js
```

is equivalent to:

```yaml
projects:
  mymodule:
    download:
      url: http://example.com/modules/mymodule.git
libraries:
  thirdpartylib:
    download:
      url: http://example.com/libs/thirdpartylib.min.js
```

