### PR TITLE
Add a drush-directory command

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -319,6 +319,15 @@ function core_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_NONE,
   );
 
+  $items['drush-directory'] = array(
+    'description' => 'Return the filesystem path of the currently running drush.',
+    'examples' => array(
+      'cd `drush drush-directory`' => 'Navigate into the drush directory',
+    ),
+    'aliases' => array('drush-dir'),
+    'bootstrap' => DRUSH_BOOTSTRAP_NONE,
+  );
+
   $items['batch-process'] = array(
     'description' => 'Process operations in the specified batch set',
     'hidden' => TRUE,
@@ -1234,6 +1243,19 @@ function drush_core_drupal_directory($target = 'root') {
   else {
     return drush_set_error('DRUSH_TARGET_NOT_FOUND', dt("Target '!target' not found.", array('!target' => $target)));
   }
+}
+
+/**
+ * Command callback.
+ */
+function drush_core_drush_directory() {
+  $path = realpath(__DIR__ . '/../..');
+
+  if ($path === FALSE) {
+    return drush_set_error('CORE_EXECUTE_FAILED', dt("The command !command failed.", array('!command' => 'drush-directory')));
+  }
+
+  return $path;
 }
 
 /**


### PR DESCRIPTION
Add a `drush-directory` command to retrieve the [realpath()](http://php.net/manual/en/function.realpath.php) of the currently executing version of Drush.

---

Going to use this for sourcing Drush completion without knowing Drush's path:

```
source $(drush drush-dir)/drush.complete.sh
```