### PR TITLE
The --local flag disables too much

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -321,7 +321,7 @@ function drush_get_global_options($brief = FALSE) {
     $options['drush-coverage']      = array('hidden' => TRUE, 'never-post' => TRUE, 'propagate-cli-value' => TRUE, 'description' => 'File to save code coverage data into.');
     $options['redirect-port']       = array('hidden' => TRUE, 'never-propagate' => TRUE, 'description' => 'Used by the user-login command to specify the redirect port on the local machine; it therefore would not do to pass this to the remote machines.');
     $options['cache-clear']         = array('propagate' => TRUE, 'description' => 'Allow cache-clear operations / skip all cache-clear options. Caller is responsible for guaranteeing that the cache does not need to be invalidated, or to call cache-clear later.', 'example-value' => '0', );
-    $options['local']               = array('propagate' => TRUE, 'description' => 'Don\'t look in global locations for commandfiles, config, and site aliases');
+    $options['site-local']          = array('propagate' => TRUE, 'description' => 'Don\'t look in global locations for commandfiles.');
 
     $command = array(
         'options' => $options,

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -321,7 +321,7 @@ function drush_get_global_options($brief = FALSE) {
     $options['drush-coverage']      = array('hidden' => TRUE, 'never-post' => TRUE, 'propagate-cli-value' => TRUE, 'description' => 'File to save code coverage data into.');
     $options['redirect-port']       = array('hidden' => TRUE, 'never-propagate' => TRUE, 'description' => 'Used by the user-login command to specify the redirect port on the local machine; it therefore would not do to pass this to the remote machines.');
     $options['cache-clear']         = array('propagate' => TRUE, 'description' => 'Allow cache-clear operations / skip all cache-clear options. Caller is responsible for guaranteeing that the cache does not need to be invalidated, or to call cache-clear later.', 'example-value' => '0', );
-    $options['site-local']          = array('propagate' => TRUE, 'description' => 'Don\'t look in global locations for commandfiles.');
+    $options['site-local']          = array('propagate' => TRUE, 'description' => 'Only consider configuration and command files stored locally with the seleced Drupal site; don\'t look in global locations.');
 
     $command = array(
         'options' => $options,

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -167,22 +167,19 @@ function drush_preflight() {
   _drush_preflight_base_environment();
 
   // Setup global alias_paths[] in context system.
-  if (!drush_get_option('local')) {
-    _drush_preflight_alias_path();
-  }
-  if (!drush_get_option('local')) {
-    // Load a drushrc.php file in the drush.php's directory.
-    drush_load_config('drush');
+  _drush_preflight_alias_path();
 
-    // Load a drushrc.php file in the $ETC_PREFIX/etc/drush directory.
-    drush_load_config('system');
+  // Load a drushrc.php file in the drush.php's directory.
+  drush_load_config('drush');
 
-    // Load a drushrc.php file at ~/.drushrc.php.
-    drush_load_config('user');
+  // Load a drushrc.php file in the $ETC_PREFIX/etc/drush directory.
+  drush_load_config('system');
 
-    // Load a drushrc.php file in the ~/.drush directory.
-    drush_load_config('home.drush');
-  }
+  // Load a drushrc.php file at ~/.drushrc.php.
+  drush_load_config('user');
+
+  // Load a drushrc.php file in the ~/.drush directory.
+  drush_load_config('home.drush');
 
   // Load a custom config specified with the --config option.
   drush_load_config('custom');
@@ -386,7 +383,7 @@ function _drush_find_commandfiles_drush() {
     }
   }
 
-  if (!drush_get_option('local')) {
+  if (!drush_get_option('site-local')) {
     // System commands, residing in $SHARE_PREFIX/share/drush/commands
     $share_path = drush_get_context('DRUSH_SITE_WIDE_COMMANDFILES');
     if (is_dir($share_path)) {
@@ -462,7 +459,7 @@ function drush_preflight_command_dispatch() {
   $command_name = array_shift($args);
   $root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
   $local_drush = drush_get_option('drush-script');
-  $is_local = drush_get_option('local');
+  $is_local = drush_get_option('site-local');
   $values = NULL;
   if (!empty($root) && !empty($local_drush) && empty($is_local)) {
     if (!drush_is_absolute_path($local_drush)) {
@@ -476,7 +473,7 @@ function drush_preflight_command_dispatch() {
       $uri = drush_get_context('DRUSH_SELECTED_URI');
       $aditional_options = array(
         'root' => $root,
-        'local' => TRUE,
+        'site-local' => TRUE,
       );
       if (!empty($uri)) {
         $aditional_options['uri'] = $uri;

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -33,6 +33,10 @@ function drush_preflight_prepare() {
     return FALSE;
   }
 
+  // Set SITE_LOCAL_DRUSH to TRUE iff this is a site-local Drush
+  // that shares an autoload.php file with a Drupal site.
+  define('SITE_LOCAL_DRUSH', ($vendor_path == $global_vendor_path));
+
   $classloader = require $vendor_path;
 
   require_once DRUSH_BASE_PATH . '/includes/bootstrap.inc';
@@ -166,20 +170,22 @@ function drush_preflight() {
   // Set up base environment for system-wide file locations.
   _drush_preflight_base_environment();
 
-  // Setup global alias_paths[] in context system.
-  _drush_preflight_alias_path();
+  if (!drush_get_option('site-local')) {
+    // Setup global alias_paths[] in context system.
+    _drush_preflight_alias_path();
 
-  // Load a drushrc.php file in the drush.php's directory.
-  drush_load_config('drush');
+    // Load a drushrc.php file in the drush.php's directory.
+    drush_load_config('drush');
 
-  // Load a drushrc.php file in the $ETC_PREFIX/etc/drush directory.
-  drush_load_config('system');
+    // Load a drushrc.php file in the $ETC_PREFIX/etc/drush directory.
+    drush_load_config('system');
 
-  // Load a drushrc.php file at ~/.drushrc.php.
-  drush_load_config('user');
+    // Load a drushrc.php file at ~/.drushrc.php.
+    drush_load_config('user');
 
-  // Load a drushrc.php file in the ~/.drush directory.
-  drush_load_config('home.drush');
+    // Load a drushrc.php file in the ~/.drush directory.
+    drush_load_config('home.drush');
+  }
 
   // Load a custom config specified with the --config option.
   drush_load_config('custom');
@@ -383,7 +389,8 @@ function _drush_find_commandfiles_drush() {
     }
   }
 
-  if (!drush_get_option('site-local')) {
+  // In site-local Drush mode, we ignore global commandfiles.
+  if (!SITE_LOCAL_DRUSH && !drush_get_option('site-local')) {
     // System commands, residing in $SHARE_PREFIX/share/drush/commands
     $share_path = drush_get_context('DRUSH_SITE_WIDE_COMMANDFILES');
     if (is_dir($share_path)) {


### PR DESCRIPTION
The --local flag has a couple of problems.

1) It disables too much.

It is necessary to disable the global locations for Drush commandfiles when using a site-local Drush; however, it is often harmful, and never (rarely?) helpful to disable a user's global configuration or alias files.  Even if the site-local Drush provides standard configuration and aliases for the team, it is too restrictive to prevent individual engineers from using their personal customizations in the team environment.  There was some talk about having special "local" global configuration, where engineers could put in the customizations that they think are "safe" for use in teams.  However, in absence of any compelling examples of why custom shell aliases, command-specific-options and so on would be harmful in team settings, I think it is simpler and better to allow the configuration options to merge together, as the currently do, and disable only global commandfiles.

2) It conflicts with existing options.

The 'drupal-directory' (dd) and 'site-aliases' (sa) commands previously defined --local options, to filter out paths and sites that are defined only on remote systems.  With the global --local option in place, the alias records used with, for example, sa --local are not read, rendering that feature unusable.

This PR renames the global --local option to --site-local, and removes the conditionals that disable global aliases and configuration when in site-local mode.  It shouldn't matter if this option's name is a little longer, as it should rarely be typed by hand -- usually it is included in an alias (e.g. a site-local 'dr' bash alias), or included automatically by Drush when doing a site-local redispatch (when `$options['drush-script']` set in a site-local drushrc.php configuration file).
