### PR TITLE
Strategies for managing your site-local Drush

### DIFF
--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -398,8 +398,7 @@ function drush_sitealias_site_set($site = '@none') {
       // exists, in $HOME/.drush/use/__PPID__/bin and
       // $HOME/.drush/use/bin, or remove both of those
       // if there is no site-local Drush.
-      $use_dir = drush_server_home() . '/.drush/use';
-      $terminal_specific_link = drush_sitealias_create_site_specific_symlinks($use_dir, $site);
+      $terminal_specific_link = drush_sitealias_create_site_specific_symlinks($site);
       if ($terminal_specific_link === FALSE) {
         return FALSE;
       }
@@ -427,41 +426,44 @@ function drush_sitealias_site_set($site = '@none') {
  *   path to the terminal-specific symlink created, or an empty
  *   string if a symlink is instead removed.
  */
-function drush_sitealias_create_site_specific_symlinks($use_dir, $site) {
-  drush_mkdir($use_dir);
-  $terminal_specific_link = $use_dir . '/' . posix_getppid() . '/bin';
-  $global_link = $use_dir . '/bin';
+function drush_sitealias_create_site_specific_symlinks($site, $use_dir = FALSE) {
+  // Get the path to the link files.
+  $terminal_specific_link = drush_get_terminal_specific_use_link_path($use_dir);
+  $global_link = drush_get_global_use_link_path($use_dir);
 
   $alias_record = drush_sitealias_get_record($site);
   $root = sitealias_find_local_drupal_root(array($alias_record));
-  $site_local_drush_dir = FALSE;
+  $site_local_drush_target = FALSE;
   if (!empty($root)) {
-    $search_locations = array('.', 'core', '..');
-    foreach (array('vendor/bin', 'vendor/drush/drush') as $bin_dir) {
-      foreach ($search_locations as $loc) {
-        $drush_test = "$root/$loc/$bin_dir";
-        if (!$site_local_drush_dir && file_exists($drush_test . '/drush')) {
-          $site_local_drush_dir = $drush_test;
-          break 2;
-        }
-      }
-    }
+    $site_local_drush_target = find_wrapper_or_launcher($root);
   }
-  if ($site_local_drush_dir) {
+  if ($site_local_drush_target) {
     drush_mkdir(dirname($terminal_specific_link));
-    if (!@symlink($site_local_drush_dir, $terminal_specific_link)) {
+    if (!@symlink($site_local_drush_target, $terminal_specific_link)) {
       return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not create symlink at !link", array('!link' => $terminal_specific_link)));
     }
-    if (!@symlink($site_local_drush_dir, $global_link)) {
+    drush_mkdir(dirname($global_link));
+    if (!@symlink($site_local_drush_target, $global_link)) {
       return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not create symlink at !link", array('!link' => $global_link)));
     }
 
     return $terminal_specific_link;
   }
   else {
+    // If there is no site-specific Drush script associated
+    // with this alias, then remove the terminal-specific and
+    // global "use" symlinks.
     if (is_file($terminal_specific_link)) {
       if (!@unlink($terminal_specific_link)) {
         return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not remove symlink at !link", array('!link' => $terminal_specific_link)));
+      }
+      // If there is a terminal-specific link (it will be at
+      // the same path as the global link if not), then also
+      // remove the PPID directory, and the 'bin' directory
+      // inside it.
+      if ($terminal_specific_link != $global_link) {
+        @rmdir(dirname($terminal_specific_link));
+        @rmdir(dirname(dirname($terminal_specific_link)));
       }
     }
     if (is_file($global_link)) {

--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -64,6 +64,9 @@ function sitealias_drush_command() {
       'drush site-set -' => 'Go back to the previously-set site (like `cd -`).',
       'drush site-set' => 'Without an argument, any existing site becomes unset.',
     ),
+    'options' => array(
+      'path' => 'Print out a modified PATH that places the site-local Drush at the head if it exists in the used site.',
+    ),
   );
   return $items;
 }
@@ -380,12 +383,37 @@ function drush_sitealias_site_set($site = '@none') {
       $success_message = dt("Site set to !site", array('!site' => $site));
       if ($site == '@none') {
         if (drush_delete_dir($filename)) {
-          drush_print($success_message);
+          drush_log($success_message, 'ok');
         }
       }
       elseif (drush_mkdir(dirname($filename), TRUE)) {
         if (file_put_contents($filename, $site)) {
-          drush_print($success_message);
+          drush_log($success_message, 'ok');
+        }
+      }
+      // See if user requested PATH adjustment
+      if (drush_get_option('path')) {
+        $alias_record = drush_sitealias_get_record($site);
+        $root = sitealias_find_local_drupal_root(array($alias_record));
+        $new_path = array();
+        if (!empty($root)) {
+          $search_locations = array('.', 'core', '..');
+          foreach ($search_locations as $loc) {
+            $drush_test = "$root/$loc/vendor/drush/drush";
+            if (is_file($drush_test . '/drush')) {
+              $new_path[] = $drush_test;
+            }
+          }
+        }
+        $path = getenv("PATH");
+        foreach (explode(':', $path) as $path_item) {
+          if (strstr($path_item, "/vendor/drush/drush") === FALSE) {
+            $new_path[] = $path_item;
+          }
+        }
+        $set_path = implode(':', $new_path);
+        if (trim($set_path) != trim($path)) {
+          drush_print($set_path);
         }
       }
     }

--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -391,34 +391,71 @@ function drush_sitealias_site_set($site = '@none') {
           drush_log($success_message, 'ok');
         }
       }
+      // Create a symlink to the site-local Drush, if it
+      // exists, in $HOME/.drush/use/__PPID__/bin and
+      // $HOME/.drush/use/bin, or remove both of those
+      // if there is no site-local Drush.
+      $use_dir = drush_server_home() . '/.drush/use';
+      $terminal_specific_link = drush_sitealias_create_site_specific_symlinks($use_dir, $site);
+
       // See if user requested PATH adjustment
       if (drush_get_option('path')) {
-        $alias_record = drush_sitealias_get_record($site);
-        $root = sitealias_find_local_drupal_root(array($alias_record));
-        $new_path = array();
-        if (!empty($root)) {
-          $search_locations = array('.', 'core', '..');
-          foreach ($search_locations as $loc) {
-            $drush_test = "$root/$loc/vendor/drush/drush";
-            if (is_file($drush_test . '/drush')) {
-              $new_path[] = $drush_test;
-            }
-          }
-        }
-        $path = getenv("PATH");
-        foreach (explode(':', $path) as $path_item) {
-          if (strstr($path_item, "/vendor/drush/drush") === FALSE) {
-            $new_path[] = $path_item;
-          }
-        }
-        $set_path = implode(':', $new_path);
-        if (trim($set_path) != trim($path)) {
-          drush_print($set_path);
-        }
+        drush_sitealias_manage_path($use_dir, $terminal_specific_link);
       }
     }
     else {
       return drush_set_error('DRUPAL_SITE_NOT_FOUND', dt("Could not find a site definition for !site.", array('!site' => $site)));
     }
+  }
+}
+
+function drush_sitealias_create_site_specific_symlinks($use_dir, $site) {
+  drush_mkdir($use_dir);
+  $terminal_specific_link = $use_dir . '/' . posix_getppid() . '/bin';
+  $global_link = $use_dir . '/bin';
+
+  $alias_record = drush_sitealias_get_record($site);
+  $root = sitealias_find_local_drupal_root(array($alias_record));
+  $site_local_drush_dir = FALSE;
+  if (!empty($root)) {
+    $search_locations = array('.', 'core', '..');
+    foreach (array('vendor/bin', 'vendor/drush/drush') as $bin_dir) {
+      foreach ($search_locations as $loc) {
+        $drush_test = "$root/$loc/$bin_dir";
+        if (!$site_local_drush_dir && file_exists($drush_test . '/drush')) {
+          $site_local_drush_dir = $drush_test;
+        }
+      }
+    }
+  }
+  if ($site_local_drush_dir) {
+    drush_mkdir(dirname($terminal_specific_link));
+    @symlink($site_local_drush_dir, $terminal_specific_link);
+    @symlink($site_local_drush_dir, $global_link);
+
+    return $terminal_specific_link;
+  }
+  else {
+    @unlink($terminal_specific_link);
+    @unlink($global_link);
+
+    return FALSE;
+  }
+}
+
+function drush_sitealias_manage_path($use_dir, $terminal_specific_link = FALSE) {
+  $new_path = array();
+  if ($terminal_specific_link) {
+    $new_path[] = $terminal_specific_link;
+  }
+  $path = getenv("PATH");
+  foreach (explode(':', $path) as $path_item) {
+    if (strstr($path_item, $use_dir) === FALSE) {
+      $new_path[] = $path_item;
+    }
+  }
+  $set_path = implode(':', $new_path);
+  if (trim($set_path) != trim($path)) {
+    drush_print($set_path);
   }
 }

--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -67,6 +67,9 @@ function sitealias_drush_command() {
     'options' => array(
       'path' => 'Print out a modified PATH that places the site-local Drush at the head if it exists in the used site.',
     ),
+    'outputformat' => array(
+      'default' => 'string',
+    ),
   );
   return $items;
 }
@@ -397,10 +400,13 @@ function drush_sitealias_site_set($site = '@none') {
       // if there is no site-local Drush.
       $use_dir = drush_server_home() . '/.drush/use';
       $terminal_specific_link = drush_sitealias_create_site_specific_symlinks($use_dir, $site);
+      if ($terminal_specific_link === FALSE) {
+        return FALSE;
+      }
 
       // See if user requested PATH adjustment
       if (drush_get_option('path')) {
-        drush_sitealias_manage_path($use_dir, $terminal_specific_link);
+        return drush_sitealias_manage_path($use_dir, $terminal_specific_link);
       }
     }
     else {
@@ -409,6 +415,18 @@ function drush_sitealias_site_set($site = '@none') {
   }
 }
 
+/**
+ * Create symlinks to 'use' / 'site-set' the specified $site.  Both
+ * a "terminal-specific" (based on PPID) and "global" link are written.
+ *
+ * @param $use_dir
+ *   location to write symlinks.
+ * @param $site
+ *   alias name or site specification for the site to use
+ * @return
+ *   path to the terminal-specific symlink created, or an empty
+ *   string if a symlink is instead removed.
+ */
 function drush_sitealias_create_site_specific_symlinks($use_dir, $site) {
   drush_mkdir($use_dir);
   $terminal_specific_link = $use_dir . '/' . posix_getppid() . '/bin';
@@ -424,25 +442,49 @@ function drush_sitealias_create_site_specific_symlinks($use_dir, $site) {
         $drush_test = "$root/$loc/$bin_dir";
         if (!$site_local_drush_dir && file_exists($drush_test . '/drush')) {
           $site_local_drush_dir = $drush_test;
+          break 2;
         }
       }
     }
   }
   if ($site_local_drush_dir) {
     drush_mkdir(dirname($terminal_specific_link));
-    @symlink($site_local_drush_dir, $terminal_specific_link);
-    @symlink($site_local_drush_dir, $global_link);
+    if (!@symlink($site_local_drush_dir, $terminal_specific_link)) {
+      return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not create symlink at !link", array('!link' => $terminal_specific_link)));
+    }
+    if (!@symlink($site_local_drush_dir, $global_link)) {
+      return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not create symlink at !link", array('!link' => $global_link)));
+    }
 
     return $terminal_specific_link;
   }
   else {
-    @unlink($terminal_specific_link);
-    @unlink($global_link);
+    if (!@unlink($terminal_specific_link)) {
+      return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not remove symlink at !link", array('!link' => $terminal_specific_link)));
+    }
+    if (!@unlink($global_link)) {
+      return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not remove symlink at !link", array('!link' => $global_link)));
+    }
 
-    return FALSE;
+    return '';
   }
 }
 
+/**
+ * Given the path to a new symlink to the site-local
+ * Drush that the user just 'use'd, adjust the PATH
+ * to include the site-local Drush directory at its head.
+ * Also remove any existing PATH components inside the
+ * specified $use_dir.
+ *
+ * @param $use_dir
+ *   path to the directory where site-local Drush symlinks are created.
+ * @param $teminal_specific_link
+ *   path to the symlink created for the currently-use'd site, or
+ *   FALSE / empty for 'use @none'
+ * @return
+ *   a new $PATH, adjusted for the provided teminal-specific symlink
+ */
 function drush_sitealias_manage_path($use_dir, $terminal_specific_link = FALSE) {
   $new_path = array();
   if ($terminal_specific_link) {
@@ -456,6 +498,6 @@ function drush_sitealias_manage_path($use_dir, $terminal_specific_link = FALSE) 
   }
   $set_path = implode(':', $new_path);
   if (trim($set_path) != trim($path)) {
-    drush_print($set_path);
+    return $set_path;
   }
 }

--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -459,11 +459,15 @@ function drush_sitealias_create_site_specific_symlinks($use_dir, $site) {
     return $terminal_specific_link;
   }
   else {
-    if (!@unlink($terminal_specific_link)) {
-      return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not remove symlink at !link", array('!link' => $terminal_specific_link)));
+    if (is_file($terminal_specific_link)) {
+      if (!@unlink($terminal_specific_link)) {
+        return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not remove symlink at !link", array('!link' => $terminal_specific_link)));
+      }
     }
-    if (!@unlink($global_link)) {
-      return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not remove symlink at !link", array('!link' => $global_link)));
+    if (is_file($global_link)) {
+      if (!@unlink($global_link)) {
+        return drush_set_error('DRUSH_SYMLINK_ERROR', dt("Could not remove symlink at !link", array('!link' => $global_link)));
+      }
     }
 
     return '';

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   },
   "bin": [
     "drush",
+    "drush.launcher",
     "drush.php",
     "drush.bat",
     "drush.complete.sh"

--- a/drush
+++ b/drush
@@ -2,17 +2,17 @@
 
 #
 # This is the Drush "finder" script, which is one part of the
-# Drush dispatching strategy.  This is the script that
+# Drush dispatching chain.  This is the script that
 # should appear in your global $PATH, or, if using composer
 # (as usually the case), will be found in your vendor/bin directory.
 #
 #
-# NEVER copy this script to your Drupal root. Use examples/drush instead.
+# - Never copy this script to your site root. Use examples/drush instead.
 #
-# NEVER copy this script to a directory other than its install directory.
+# - Never copy this script to a directory other than its install directory.
 # Symlink to it instead.
 #
-# NEVER rename this script to "drush.launcher".  Why would you do that?
+# - Never rename this script to "drush.launcher".  Why would you do that?
 #
 #
 # OVERVIEW OF DRUSH FINDER / WRAPPER / LAUNCHER SCRIPTS
@@ -58,18 +58,19 @@
 #
 # DRUSH WRAPPER
 #
-# - The "drush" script that the user copies to their Drupal __ROOT__
-# - Its goal is to allow the user to add config locations when --local is in use
+# - The "drush" script that the user copies to their site __ROOT__
+# - Its goal is to allow the user to add options when --local is in use
 #
-# The "drush wrapper" is found in examples/drush, and may optionally
-# be copied to __ROOT__/drush by the user.  It will call the "drush launcher"
+# The drush "wrapper" is found in examples/drush, and may optionally
+# be copied to __ROOT__/drush by the user.  It may be named either
+# "drush" or "drush.wrapper".  It will call the "drush launcher"
 # for the same site that it is located in.  It adds the --local flag; the
 # user is encouraged to add other options to the "drush wrapper", e.g. to set
 # the location where aliases and global commandfiles can be found.
-# We must always call the "drush wrapper" if it exists, since it
-# can be customized.  However, if the user does not want to customize
-# the site-local Drush's early options (site-alias locations, etc.),
-# then the wrapper does not need to be used.
+# The drush "finder" script always calls the "drush wrapper" if it exists;
+# however, if the user does not want to customize the site-local Drush's
+# early options (site-alias locations, etc.), then the wrapper does not
+# need to be used.
 #
 #
 # DRUSH LAUNCHER
@@ -122,7 +123,7 @@ FOUND_SCRIPT=
 SITE_USE_DIR="$HOME/.drush/use/$$/bin"
 
 # We will look for a "drush wrapper" script that might
-# be stored in the root of a Drupal site.  If there is
+# be stored in the root of a site site.  If there is
 # no wrapper script, then we will look for the
 # drush.launcher script in vendor/bin.  We try just a
 # few of the most common locations; if the user relocates
@@ -137,12 +138,12 @@ SITE_USE_DIR="$HOME/.drush/use/$$/bin"
 # "drush.launcher" at the root, or "drush" in a vendor directory.
 # We also allow users to rename their drush wrapper to
 # 'drush.wrapper' to avoid conflicting with a directory named
-# 'drush' at the Drupal root.
+# 'drush' at the site root.
 DRUSH_LOCATIONS="drush vendor/bin/drush ../vendor/bin/drush sites/all/vendor/bin/drush"
 
 # Here is the function that checks each location and
 # returns the drush wrapper or drush launcher, if found.
-function find_wrapper_or_launcher {
+find_wrapper_or_launcher() {
   LOCATON="$1"
   for d in $DRUSH_LOCATIONS
   do
@@ -191,7 +192,7 @@ for option in "$@" ; do
         NONE=true
         ;;
       --root=*)
-        ROOT="${option:7}"
+        ROOT="`echo $option | cut -c 8-`"
         ;;
       -r)
         VAR=ROOT
@@ -235,14 +236,14 @@ fi
 #
 #   drush --root=/path
 #
-# If the Drupal root is specified via a commandline option, then we
+# If the site root is specified via a commandline option, then we
 # should always use the Drush stored at this root, if there is one.
 # We will first check for a "wrapper" script at the root, and then
 # we will look for a "launcher" script in vendor/bin.
 #
 if [ -z "$FOUND_SCRIPT" ]
 then
-  FOUND_SCRIPT="$(find_wrapper_or_launcher "$ROOT")"
+  FOUND_SCRIPT="`find_wrapper_or_launcher "$ROOT"`"
   if [ -n "$FOUND_SCRIPT" ]
   then
     cd "$ROOT"
@@ -273,7 +274,7 @@ if [ -z "$FOUND_SCRIPT" ]
 then
   if [ -f ".drush-use" ]
   then
-    FOUND_SCRIPT="$(cat .drush-use)"
+    FOUND_SCRIPT="`cat .drush-use`"
   fi
 fi
 
@@ -286,17 +287,16 @@ fi
 #
 if [ -z "$FOUND_SCRIPT" ]
 then
-  c="$(pwd)"
+  c="`pwd`"
   while [ -n "$c" ] && [ "$c" != "/" ]
   do
-    echo $c
-    FOUND_SCRIPT="$(find_wrapper_or_launcher "$c")"
+    FOUND_SCRIPT="`find_wrapper_or_launcher "$c"`"
     if [ -n "$FOUND_SCRIPT" ]
     then
       cd "$c"
       break
     fi
-    c="$(dirname $c)"
+    c="`dirname $c`"
   done
 fi
 
@@ -319,15 +319,15 @@ then
   # there is a "drush.launcher" script in the same directory,
   # then we will skip the "drush" script and use the drush launcher
   # instead.  This is because drush "wrapper" scripts should
-  # only ever exist at the ROOT OF A DRUPAL SITE, and there should
-  # NEVER be a drush "launcher" at the root of a Drupal site.
+  # only ever exist at the root of a site, and there should
+  # never be a drush "launcher" at the root of a site.
   # Therefore, if we find a "drush.launcher" next to a script
   # called "drush", we have probably found a Drush install directory,
-  # not a Drupal root.  Adjust appropriately.  Note that this
+  # not a site root.  Adjust appropriately.  Note that this
   # also catches the case where a drush "finder" script finds itself.
-  if [ -f "$(dirname "$FOUND_SCRIPT")/drush.launcher" ]
+  if [ -f "`dirname "$FOUND_SCRIPT"`/drush.launcher" ]
   then
-    FOUND_SCRIPT="$(dirname "$FOUND_SCRIPT")/drush.launcher"
+    FOUND_SCRIPT="`dirname "$FOUND_SCRIPT"`/drush.launcher"
   fi
 fi
 

--- a/drush
+++ b/drush
@@ -1,131 +1,350 @@
-#!/usr/bin/env sh
+#!/bin/sh
+
 #
-# This script is a simple wrapper that will run Drush with the most appropriate
-# php executable it can find.
+# This is the Drush "finder" script, which is one part of the
+# Drush dispatching strategy.  This is the script that
+# should appear in your global $PATH, or, if using composer
+# (as usually the case), will be found in your vendor/bin directory.
 #
-# Solaris users: Add /usr/xpg4/bin to the head of your PATH
 #
+# NEVER copy this script to your Drupal root. Use examples/drush instead.
+#
+# NEVER copy this script to a directory other than its install directory.
+# Symlink to it instead.
+#
+# NEVER rename this script to "drush.launcher".  Why would you do that?
+#
+#
+# OVERVIEW OF DRUSH FINDER / WRAPPER / LAUNCHER SCRIPTS
+#
+# When the user types "drush", up to three scripts might be
+# involved in the initial launch:
+#
+#   "drush finder" -> "drush wrapper" -> "drush launcher".
+#
+# Breif description of each:
+#
+#  - Drush finder:   Finds the right Drush script and calls it.
+#  - Drush wrapper:  Contains user customizations to options.
+#  - Drush launcher: Excutes drush.php.
+#
+# A full explanation of each script follows.
+#
+#
+# DRUSH FINDER
+#
+# - The "drush" script on the user's global $PATH
+# - It's goal is to find the correct site-local Drush to run.
+#
+# The Drush finder will locate the correct site-local Drush to use
+# by examining:
+#
+#   a) The --root option
+#   b) The site set via `drush site set` in the current terminal
+#   c) The cwd
+#
+# If no site-local Drush is found, then the global Drush will be
+# used.  The Drush finder assumes that the global Drush is the
+# "Drush launcher" found in the same directory as the Drush finder itself.
+#
+# If a site-local Drush is found, then the Drush finder will call
+# either the "Drush wrapper", if it exists, or the "Drush launcher" if
+# there is no wrapper script.  If the "Drush launcher" is called, then
+# the Drush Finder will add the --local flag.  If the --local flag was
+# already passed in when the Drush Finder is called, then it will always
+# call the "Drush launcher", even if there is a Drush Wrapper, to prevent
+# possible infinite loops.
+#
+#
+# DRUSH WRAPPER
+#
+# - The "drush" script that the user copies to their Drupal __ROOT__
+# - Its goal is to allow the user to add config locations when --local is in use
+#
+# The "drush wrapper" is found in examples/drush, and may optionally
+# be copied to __ROOT__/drush by the user.  It will call the "drush launcher"
+# for the same site that it is located in.  It adds the --local flag; the
+# user is encouraged to add other options to the "drush wrapper", e.g. to set
+# the location where aliases and global commandfiles can be found.
+# We must always call the "drush wrapper" if it exists, since it
+# can be customized.  However, if the user does not want to customize
+# the site-local Drush's early options (site-alias locations, etc.),
+# then the wrapper does not need to be used.
+#
+#
+# DRUSH LAUNCHER
+#
+# - The "drush.launcher" script in vendor/bin
+# - The script formerly called "drush"
+#
+# The "drush launcher" is the traditional script that identifies PHP and
+# sets up to call drush.php.  It is called by the "drush wrapper", or
+# directly by the "drush launcher" if there is no "drush wrapper" in use.
+#
+#
+# LOCATIONS FOR THESE SCRIPTS
+#
+#   "drush finder"  :   __ROOT__/vendor/bin/drush           (composer install)
+#                       __DRUSH__/drush                     (source)
+#
+#   "drush wrapper" :   __ROOT__/drush                      (copied by user)
+#                       __DRUSH__/examples/drush            (source)
+#
+#   "drush laucher" :   __ROOT__/vendor/bin/drush.launcher  (composer install)
+#                       __DRUSH__/drush.launcher            (source)
+#
+#
+# BACKEND CALL DISPATCHING
+#
+# Backend calls are typically set up to call the "drush" script in the $PATH,
+# or perhaps some might call __ROOT__/vendor/bin/drush directly, by way
+# of the "drush-script" element in a site alias.  In either event, this is
+# the "drush finder" script.
+#
+# The backend call will always set --root.  The "drush finder" script
+# always favors the site-local Drush stored with the site indicated by the
+# --root option, if it exists.  If there is no site-local Drush, then the
+# "drush finder" will behave as usual (i.e., it will end up calling the
+# "drush launcher" located next to it).
+#
+# This should always get you the correct "Drush" for local and remote calls.
+# Note that it is also okay for aliases to specify a path directly to
+# drush.launcher, in instances where it is known that a recent version of
+# Drush is installed on the remote end.
+#
+
 
 # Get the absolute path of this executable
 SELF_DIRNAME="`dirname -- "$0"`"
 SELF_PATH="`cd -P -- "$SELF_DIRNAME" && pwd -P`/`basename -- "$0"`"
 
-# Decide if we are running a Unix shell on Windows
-if `which uname > /dev/null 2>&1`; then
-  case "`uname -a`" in
-    CYGWIN*)
-      CYGWIN=1 ;;
-    MINGW*)
-      MINGW=1 ;;
-  esac
+FOUND_SCRIPT=
+SITE_USE_DIR="$HOME/.drush/use/$$/bin"
+
+# We will look for a "drush wrapper" script that might
+# be stored in the root of a Drupal site.  If there is
+# no wrapper script, then we will look for the
+# drush.launcher script in vendor/bin.  We try just a
+# few of the most common locations; if the user relocates
+# their vendor directory anywhere else, then they must
+# use a wrapper script to locate it.  See the comment in
+# 'examples/drush' for details.
+#
+# We are somewhat "loose" about whether we are looking
+# for "drush" or "drush.launcher", because in old versions
+# of Drush, the "drush launcher" was named "drush".
+# Otherwise, there wouldn't be any point in looking for
+# "drush.launcher" at the root, or "drush" in a vendor directory.
+# We also allow users to rename their drush wrapper to
+# 'drush.wrapper' to avoid conflicting with a directory named
+# 'drush' at the Drupal root.
+DRUSH_LOCATIONS="drush vendor/bin/drush ../vendor/bin/drush sites/all/vendor/bin/drush"
+
+# Here is the function that checks each location and
+# returns the drush wrapper or drush launcher, if found.
+function find_wrapper_or_launcher {
+  LOCATON="$1"
+  for d in $DRUSH_LOCATIONS
+  do
+    if [ -f "$LOCATON/$d.launcher" ]
+    then
+      echo "$LOCATON/$d.launcher"
+      break;
+    fi
+    if [ -f "$LOCATON/$d.wrapper" ]
+    then
+      echo "$LOCATON/$d.wrapper"
+      break;
+    fi
+    if [ -f "$LOCATON/$d" ]
+    then
+      echo "$LOCATON/$d"
+      break;
+    fi
+  done
+}
+
+#
+# We need to do at least a partial parsing of the options,
+# so that we can find --root / -r and --local
+#
+VERBOSE=false
+LOCAL=false
+NONE=false
+ROOT=
+VAR=
+
+for option in "$@" ; do
+  # If a variable to set was indicated on the
+  # previous iteration, then set the value of
+  # the named variable (e.g. "ROOT") to "$option".
+  if [ -n "$VAR" ]
+  then
+    eval $VAR="$option"
+    VAR=
+  else
+    case "$option" in
+      --local)
+        LOCAL=true
+        ;;
+      @none)
+        NONE=true
+        ;;
+      --root=*)
+        ROOT="${option:7}"
+        ;;
+      -r)
+        VAR=ROOT
+        ;;
+      --verbose|-v)
+        VERBOSE=true
+        ;;
+    esac
+  fi
+done
+
+#
+# First check:
+#
+#   drush --local ...
+#   drush @none ...
+#
+# If either the --local option, or the @none alias is used, then
+# we must skip the Drush wrapper, and call the Drush launcher directly.
+#
+# In this instance, we are assuming that the 'drush' that is being
+# called is:
+#
+#  a) The global 'drush', or
+#  b) A site-local 'drush' in a vendor/bin directory.
+#
+# In either event, the appropriate 'drush.launcher' should be right next
+# to this script (stored in the same directory).
+if $NONE || $LOCAL ; then
+  if [ -f "$SELF_DIRNAME/drush.launcher" ]
+  then
+    FOUND_SCRIPT="$SELF_DIRNAME/drush.launcher"
+  else
+    echo "Could not find drush.launcher in $SELF_DIRNAME. Check your installation." >&2
+    exit 1
+  fi
 fi
 
-# Resolve symlinks - this is the equivalent of "readlink -f", but also works with non-standard OS X readlink.
-while [ -h "$SELF_PATH" ]; do
-    # 1) cd to directory of the symlink
+#
+# Second check:
+#
+#   drush --root=/path
+#
+# If the Drupal root is specified via a commandline option, then we
+# should always use the Drush stored at this root, if there is one.
+# We will first check for a "wrapper" script at the root, and then
+# we will look for a "launcher" script in vendor/bin.
+#
+if [ -z "$FOUND_SCRIPT" ]
+then
+  FOUND_SCRIPT="$(find_wrapper_or_launcher "$ROOT")"
+  if [ -n "$FOUND_SCRIPT" ]
+  then
+    cd "$ROOT"
+  fi
+fi
+
+#
+# Third check:
+#
+# If there is a "drush" symlink in the "use dir",
+# then we will use the Drush indicated by this file.
+#
+if [ -z "$FOUND_SCRIPT" ]
+then
+  if [ -f "$SITE_USE_DIR/drush" ]
+  then
+    FOUND_SCRIPT="$SITE_USE_DIR/drush"
+  fi
+fi
+
+#
+# Fourth check:
+#
+# If there is a .drush-use file, then its contents will
+# contain the path to the Drush to use.
+#
+if [ -z "$FOUND_SCRIPT" ]
+then
+  if [ -f ".drush-use" ]
+  then
+    FOUND_SCRIPT="$(cat .drush-use)"
+  fi
+fi
+
+#
+# Fifth check:
+#
+# Look for a 'drush' wrapper or launcher at the cwd,
+# and in each of the directories above the cwd.  If
+# we find one, use it.
+#
+if [ -z "$FOUND_SCRIPT" ]
+then
+  c="$(pwd)"
+  while [ -n "$c" ] && [ "$c" != "/" ]
+  do
+    echo $c
+    FOUND_SCRIPT="$(find_wrapper_or_launcher "$c")"
+    if [ -n "$FOUND_SCRIPT" ]
+    then
+      cd "$c"
+      break
+    fi
+    c="$(dirname $c)"
+  done
+fi
+
+if [ -n "$FOUND_SCRIPT" ]
+then
+  # Resolve symlinks - this is the equivalent of "readlink -f", but also works with non-standard OS X readlink.
+  while [ -h "$FOUND_SCRIPT" ]; do
+    # 1) cd to directory of the symlink (in case the symlink is relative)
     # 2) cd to the directory of where the symlink points
     # 3) Get the pwd
     # 4) Append the basename
-    DIR="`dirname -- "$SELF_PATH"`"
-    SYM="`readlink "$SELF_PATH"`"
+    DIR="`dirname -- "$FOUND_SCRIPT"`"
+    SYM="`readlink "$FOUND_SCRIPT"`"
     SYM_DIRNAME="`dirname -- "$SYM"`"
-    SELF_PATH="`cd "$DIR" && cd "$SYM_DIRNAME" && pwd`/`basename -- "$SYM"`"
-done
+    FOUND_SCRIPT="`cd "$DIR" && cd "$SYM_DIRNAME" && pwd`/`basename -- "$SYM"`"
+  done
 
-# If not exported, try to determine and export the number of columns.
-# We do not want to run `tput cols` if $TERM is empty, "unknown", or "dumb", because
-# if we do, tput will output an undesirable error message to stderr.  If
-# we redirect stderr in any way, e.g. `tput cols 2>/dev/null`, then the
-# error message is suppressed, but tput cols becomes confused about the
-# terminal and prints out the default value (80).
-if [ -z $COLUMNS ] && [ -n "$TERM" ] && [ "$TERM" != dumb ] && [ "$TERM" != unknown ] && [ -n "`which tput`" ] ; then
-  # Note to cygwin/mingw/msys users: install the ncurses package to get tput command.
-  # Note to mingw/msys users: there is no precompiled ncurses package.
-  if COLUMNS="`tput cols`"; then
-    export COLUMNS
+  # Guard against errors:  if we have found a "drush" script
+  # (that is, theoretically a drush wrapper script), and
+  # there is a "drush.launcher" script in the same directory,
+  # then we will skip the "drush" script and use the drush launcher
+  # instead.  This is because drush "wrapper" scripts should
+  # only ever exist at the ROOT OF A DRUPAL SITE, and there should
+  # NEVER be a drush "launcher" at the root of a Drupal site.
+  # Therefore, if we find a "drush.launcher" next to a script
+  # called "drush", we have probably found a Drush install directory,
+  # not a Drupal root.  Adjust appropriately.  Note that this
+  # also catches the case where a drush "finder" script finds itself.
+  if [ -f "$(dirname "$FOUND_SCRIPT")/drush.launcher" ]
+  then
+    FOUND_SCRIPT="$(dirname "$FOUND_SCRIPT")/drush.launcher"
   fi
 fi
 
-if [ -n "$DRUSH_PHP" ] ; then
-  # Use the DRUSH_PHP environment variable if it is available.
-  php="$DRUSH_PHP"
-else
-  # On MSYSGIT, we need to use "php", not the full path to php
-  if [ -n "$MINGW" ] ; then
-    php="php"
-  else
-    # Default to using the php that we find on the PATH.
-    # We check for a command line (cli) version of php, and if found use that.
-    # Note that we need the full path to php here for Dreamhost, which behaves oddly.  See http://drupal.org/node/662926
-    php="`which php-cli 2>/dev/null`"
-
-    if [ ! -x "$php" ]; then
-      php="`which php 2>/dev/null`"
-    fi
-
-    if [ ! -x "$php" ]; then
-      echo "ERROR: can't find php."; exit 1
-    fi
-  fi
+# Didn't find any site-local Drush, or @use'd Drush?
+# In that case, there should always be a drush.launcher in
+# the same directory this script is stored in; use that.
+if [ -z "$FOUND_SCRIPT" ]
+then
+  FOUND_SCRIPT="$SELF_DIRNAME/drush.launcher"
 fi
 
-# Build the path to drush.php.
-SCRIPT_PATH="`dirname "$SELF_PATH"`/drush.php"
-if [ -n "$CYGWIN" ] ; then
-  # try to determine if we are running cygwin port php or Windows native php:
-  if [ -n "`"$php" -i | grep -E '^System => Windows'`" ]; then
-    SCRIPT_PATH="`cygpath -w -a -- "$SCRIPT_PATH"`"
-  else
-    SCRIPT_PATH="`cygpath -u -a -- "$SCRIPT_PATH"`"
-  fi
+# Emit a message in verbose mode advertising the location of the
+# script we found.
+if $VERBOSE
+then
+  echo "Using the Drush script found at $FOUND_SCRIPT" >&2
 fi
 
-# Check to see if the user has provided a php.ini file or drush.ini file in any conf dir
-# Last found wins, so search in reverse priority order
-for conf_dir in "`dirname "$SELF_PATH"`" /etc/drush "$HOME/.drush" ; do
-  if [ ! -d "$conf_dir" ] ; then
-    continue
-  fi
-  # Handle paths that don't start with a drive letter on MinGW shell. Equivalent to cygpath on Cygwin.
-  if [ -n "$MINGW" ] ; then
-    conf_dir=`sh -c "cd \"$conf_dir\"; pwd -W"`
-  fi
-  if [ -f "$conf_dir/php.ini" ] ; then
-    drush_php_ini="$conf_dir/php.ini"
-  fi
-  if [ -f "$conf_dir/drush.ini" ] ; then
-    drush_php_override="$conf_dir/drush.ini"
-  fi
-done
-# If the PHP_INI environment variable is specified, then tell
-# php to use the php.ini file that it specifies.
-if [ -n "$PHP_INI" ] ; then
-  drush_php_ini="$PHP_INI"
-fi
-# If the DRUSH_INI environment variable is specified, then
-# extract all ini variable assignments from it and convert
-# them into php '-d' options. These will override similarly-named
-# options in the php.ini file
-if [ -n "$DRUSH_INI" ] ; then
-  drush_php_override="$DRUSH_INI"
-fi
-
-# Add in the php file location and/or the php override variables as appropriate
-if [ -n "$drush_php_ini" ] ; then
-  php_options="--php-ini $drush_php_ini"
-fi
-if [ -n "$drush_php_override" ] ; then
-  php_options=`grep '^[a-z_A-Z0-9.]\+ *=' $drush_php_override | sed -e 's|\([^ =]*\) *= *\(.*\)|\1="\2"|' -e 's| ||g' -e 's|^|-d |' | tr '\n\r' '  '`
-fi
-# If the PHP_OPTIONS environment variable is specified, then
-# its contents will be passed to php on the command line as
-# additional options to use.
-if [ -n "$PHP_OPTIONS" ] ; then
-  php_options="$php_options $PHP_OPTIONS"
-fi
-
-# Pass in the path to php so that drush knows which one to use if it
-# re-launches itself to run subcommands.  We will also pass in the php options.
-# Important note: Any options added here must be removed  when Drush processes
-# a #! (shebang) script.  @see drush_adjust_args_if_shebang_script()
-exec "$php" $php_options "$SCRIPT_PATH" --php="$php" --php-options="$php_options" "$@"
+# Launch the script that we found.
+"$FOUND_SCRIPT" "$@"

--- a/drush
+++ b/drush
@@ -1,350 +1,320 @@
-#!/bin/sh
+#!/usr/bin/env php
+<?php
 
-#
-# This is the Drush "finder" script, which is one part of the
-# Drush dispatching chain.  This is the script that
-# should appear in your global $PATH, or, if using composer
-# (as usually the case), will be found in your vendor/bin directory.
-#
-#
-# - Never copy this script to your site root. Use examples/drush instead.
-#
-# - Never copy this script to a directory other than its install directory.
-# Symlink to it instead.
-#
-# - Never rename this script to "drush.launcher".  Why would you do that?
-#
-#
-# OVERVIEW OF DRUSH FINDER / WRAPPER / LAUNCHER SCRIPTS
-#
-# When the user types "drush", up to three scripts might be
-# involved in the initial launch:
-#
-#   "drush finder" -> "drush wrapper" -> "drush launcher".
-#
-# Breif description of each:
-#
-#  - Drush finder:   Finds the right Drush script and calls it.
-#  - Drush wrapper:  Contains user customizations to options.
-#  - Drush launcher: Excutes drush.php.
-#
-# A full explanation of each script follows.
-#
-#
-# DRUSH FINDER
-#
-# - The "drush" script on the user's global $PATH
-# - It's goal is to find the correct site-local Drush to run.
-#
-# The Drush finder will locate the correct site-local Drush to use
-# by examining:
-#
-#   a) The --root option
-#   b) The site set via `drush site set` in the current terminal
-#   c) The cwd
-#
-# If no site-local Drush is found, then the global Drush will be
-# used.  The Drush finder assumes that the global Drush is the
-# "Drush launcher" found in the same directory as the Drush finder itself.
-#
-# If a site-local Drush is found, then the Drush finder will call
-# either the "Drush wrapper", if it exists, or the "Drush launcher" if
-# there is no wrapper script.  If the "Drush launcher" is called, then
-# the Drush Finder will add the --local flag.  If the --local flag was
-# already passed in when the Drush Finder is called, then it will always
-# call the "Drush launcher", even if there is a Drush Wrapper, to prevent
-# possible infinite loops.
-#
-#
-# DRUSH WRAPPER
-#
-# - The "drush" script that the user copies to their site __ROOT__
-# - Its goal is to allow the user to add options when --local is in use
-#
-# The drush "wrapper" is found in examples/drush, and may optionally
-# be copied to __ROOT__/drush by the user.  It may be named either
-# "drush" or "drush.wrapper".  It will call the "drush launcher"
-# for the same site that it is located in.  It adds the --local flag; the
-# user is encouraged to add other options to the "drush wrapper", e.g. to set
-# the location where aliases and global commandfiles can be found.
-# The drush "finder" script always calls the "drush wrapper" if it exists;
-# however, if the user does not want to customize the site-local Drush's
-# early options (site-alias locations, etc.), then the wrapper does not
-# need to be used.
-#
-#
-# DRUSH LAUNCHER
-#
-# - The "drush.launcher" script in vendor/bin
-# - The script formerly called "drush"
-#
-# The "drush launcher" is the traditional script that identifies PHP and
-# sets up to call drush.php.  It is called by the "drush wrapper", or
-# directly by the "drush launcher" if there is no "drush wrapper" in use.
-#
-#
-# LOCATIONS FOR THESE SCRIPTS
-#
-#   "drush finder"  :   __ROOT__/vendor/bin/drush           (composer install)
-#                       __DRUSH__/drush                     (source)
-#
-#   "drush wrapper" :   __ROOT__/drush                      (copied by user)
-#                       __DRUSH__/examples/drush            (source)
-#
-#   "drush laucher" :   __ROOT__/vendor/bin/drush.launcher  (composer install)
-#                       __DRUSH__/drush.launcher            (source)
-#
-#
-# BACKEND CALL DISPATCHING
-#
-# Backend calls are typically set up to call the "drush" script in the $PATH,
-# or perhaps some might call __ROOT__/vendor/bin/drush directly, by way
-# of the "drush-script" element in a site alias.  In either event, this is
-# the "drush finder" script.
-#
-# The backend call will always set --root.  The "drush finder" script
-# always favors the site-local Drush stored with the site indicated by the
-# --root option, if it exists.  If there is no site-local Drush, then the
-# "drush finder" will behave as usual (i.e., it will end up calling the
-# "drush launcher" located next to it).
-#
-# This should always get you the correct "Drush" for local and remote calls.
-# Note that it is also okay for aliases to specify a path directly to
-# drush.launcher, in instances where it is known that a recent version of
-# Drush is installed on the remote end.
-#
+/**
+ * This is the Drush "finder" script, which is one part of the
+ * Drush dispatching chain.  This is the script that
+ * should appear in your global $PATH, or, if using composer
+ * (as usually the case), will be found in your vendor/bin directory.
+ *
+ *
+ * - Never copy this script to your site root. Use examples/drush instead.
+ *
+ * - Never copy this script to a directory other than its install directory.
+ * Symlink to it instead.
+ *
+ * - Never rename this script to "drush.launcher".  Why would you do that?
+ * This is the Drush "finder" script. You can rename it to "drush.finder"
+ * if you wish.
+ *
+ *
+ * OVERVIEW OF DRUSH FINDER / WRAPPER / LAUNCHER SCRIPTS
+ *
+ * When the user types "drush", up to three scripts might be
+ * involved in the initial launch:
+ *
+ *   "drush finder" -> "drush wrapper" -> "drush launcher".
+ *
+ * Breif description of each:
+ *
+ *  - Drush finder:   Finds the right Drush script and calls it.
+ *  - Drush wrapper:  Contains user customizations to options.
+ *  - Drush launcher: Excutes drush.php.
+ *
+ * A full explanation of each script follows.
+ *
+ *
+ * DRUSH FINDER
+ *
+ * - The "drush" script on the user's global $PATH
+ * - It's goal is to find the correct site-local Drush to run.
+ *
+ * The Drush finder will locate the correct site-local Drush to use
+ * by examining:
+ *
+ *   a) The --root option
+ *   b) The site set via `drush site set` in the current terminal
+ *   c) The cwd
+ *
+ * If no site-local Drush is found, then the global Drush will be
+ * used.  The Drush finder assumes that the global Drush is the
+ * "Drush launcher" found in the same directory as the Drush finder itself.
+ *
+ * If a site-local Drush is found, then the Drush finder will call
+ * either the "Drush wrapper", if it exists, or the "Drush launcher" if
+ * there is no wrapper script.  If the "Drush launcher" is called, then
+ * the Drush Finder will add the --local flag.  If the --local flag was
+ * already passed in when the Drush Finder is called, then it will always
+ * call the "Drush launcher", even if there is a Drush Wrapper, to prevent
+ * possible infinite loops.
+ *
+ *
+ * DRUSH WRAPPER
+ *
+ * - The "drush" script that the user copies to their site __ROOT__
+ * - Its goal is to allow the user to add options when --local is in use
+ *
+ * The drush "wrapper" is found in examples/drush, and may optionally
+ * be copied to __ROOT__/drush by the user.  It may be named either
+ * "drush" or "drush.wrapper".  It will call the "drush launcher"
+ * for the same site that it is located in.  It adds the --local flag; the
+ * user is encouraged to add other options to the "drush wrapper", e.g. to set
+ * the location where aliases and global commandfiles can be found.
+ * The drush "finder" script always calls the "drush wrapper" if it exists;
+ * however, if the user does not want to customize the eary options of
+ * the site-local Drush (site-alias locations, etc.), then the wrapper does not
+ * need to be used.
+ *
+ *
+ * DRUSH LAUNCHER
+ *
+ * - The "drush.launcher" script in vendor/bin
+ * - The script formerly called "drush"
+ *
+ * The "drush launcher" is the traditional script that identifies PHP and
+ * sets up to call drush.php.  It is called by the "drush wrapper", or
+ * directly by the "drush launcher" if there is no "drush wrapper" in use.
+ *
+ *
+ * LOCATIONS FOR THESE SCRIPTS
+ *
+ *   "drush finder"  :   __ROOT__/vendor/bin/drush           (composer install)
+ *                       __DRUSH__/drush                     (source)
+ *
+ *   "drush wrapper" :   __ROOT__/drush                      (copied by user)
+ *                       __DRUSH__/examples/drush            (source)
+ *
+ *   "drush laucher" :   __ROOT__/vendor/bin/drush.launcher  (composer install)
+ *                       __DRUSH__/drush.launcher            (source)
+ *
+ *
+ * BACKEND CALL DISPATCHING
+ *
+ * Backend calls are typically set up to call the "drush" script in the $PATH,
+ * or perhaps some might call __ROOT__/vendor/bin/drush directly, by way
+ * of the "drush-script" element in a site alias.  In either event, this is
+ * the "drush finder" script.
+ *
+ * The backend call will always set --root.  The "drush finder" script
+ * always favors the site-local Drush stored with the site indicated by the
+ * --root option, if it exists.  If there is no site-local Drush, then the
+ * "drush finder" will behave as usual (i.e., it will end up calling the
+ * "drush launcher" located next to it).
+ *
+ * This should always get you the correct "Drush" for local and remote calls.
+ * Note that it is also okay for aliases to specify a path directly to
+ * drush.launcher, in instances where it is known that a recent version of
+ * Drush is installed on the remote end.
+ */
 
+include __DIR__ . '/includes/startup.inc';
 
-# Get the absolute path of this executable
-SELF_DIRNAME="`dirname -- "$0"`"
-SELF_PATH="`cd -P -- "$SELF_DIRNAME" && pwd -P`/`basename -- "$0"`"
+$found_script = "";
+$home = getenv("HOME");
+$use_dir = "$home/.drush/use";
 
-FOUND_SCRIPT=
-SITE_USE_DIR="$HOME/.drush/use/$$/bin"
-
-# We will look for a "drush wrapper" script that might
-# be stored in the root of a site site.  If there is
-# no wrapper script, then we will look for the
-# drush.launcher script in vendor/bin.  We try just a
-# few of the most common locations; if the user relocates
-# their vendor directory anywhere else, then they must
-# use a wrapper script to locate it.  See the comment in
-# 'examples/drush' for details.
-#
-# We are somewhat "loose" about whether we are looking
-# for "drush" or "drush.launcher", because in old versions
-# of Drush, the "drush launcher" was named "drush".
-# Otherwise, there wouldn't be any point in looking for
-# "drush.launcher" at the root, or "drush" in a vendor directory.
-# We also allow users to rename their drush wrapper to
-# 'drush.wrapper' to avoid conflicting with a directory named
-# 'drush' at the site root.
-DRUSH_LOCATIONS="drush vendor/bin/drush ../vendor/bin/drush sites/all/vendor/bin/drush"
-
-# Here is the function that checks each location and
-# returns the drush wrapper or drush launcher, if found.
-find_wrapper_or_launcher() {
-  LOCATON="$1"
-  for d in $DRUSH_LOCATIONS
-  do
-    if [ -f "$LOCATON/$d.launcher" ]
-    then
-      echo "$LOCATON/$d.launcher"
-      break;
-    fi
-    if [ -f "$LOCATON/$d.wrapper" ]
-    then
-      echo "$LOCATON/$d.wrapper"
-      break;
-    fi
-    if [ -f "$LOCATON/$d" ]
-    then
-      echo "$LOCATON/$d"
-      break;
-    fi
-  done
+// Drush site-set will always write both the terminal-specific
+// and global links.  We should always use the terminal-specific
+// link if posix_getppid() is available; otherwise, we will use
+// the global location.
+$site_use_link = "$use_dir/bin/drush";
+if (function_exists('posix_getppid')) {
+  $site_use_link = $use_dir . '/' . posix_getppid() . '/bin/drush';
 }
 
-#
-# We need to do at least a partial parsing of the options,
-# so that we can find --root / -r and --local
-#
-VERBOSE=false
-LOCAL=false
-NONE=false
-ROOT=
-VAR=
+//
+// We need to do at least a partial parsing of the options,
+// so that we can find --root / -r and --local
+//
+$VERBOSE=FALSE;
+$LOCAL=FALSE;
+$NONE=FALSE;
+$ROOT=FALSE;
+$VAR=FALSE;
 
-for option in "$@" ; do
-  # If a variable to set was indicated on the
-  # previous iteration, then set the value of
-  # the named variable (e.g. "ROOT") to "$option".
-  if [ -n "$VAR" ]
-  then
-    eval $VAR="$option"
-    VAR=
-  else
-    case "$option" in
-      --local)
-        LOCAL=true
-        ;;
-      @none)
-        NONE=true
-        ;;
-      --root=*)
-        ROOT="`echo $option | cut -c 8-`"
-        ;;
-      -r)
-        VAR=ROOT
-        ;;
-      --verbose|-v)
-        VERBOSE=true
-        ;;
-    esac
-  fi
-done
+foreach ($argv as $option) {
+  // If a variable to set was indicated on the
+  // previous iteration, then set the value of
+  // the named variable (e.g. "ROOT") to "$option".
+  if ($VAR) {
+    $$VAR = "$option";
+    $VAR = FALSE;
+  }
+  else {
+    switch ($option) {
+      case "--local":
+        $LOCAL = TRUE;
+        break;
 
-#
-# First check:
-#
-#   drush --local ...
-#   drush @none ...
-#
-# If either the --local option, or the @none alias is used, then
-# we must skip the Drush wrapper, and call the Drush launcher directly.
-#
-# In this instance, we are assuming that the 'drush' that is being
-# called is:
-#
-#  a) The global 'drush', or
-#  b) A site-local 'drush' in a vendor/bin directory.
-#
-# In either event, the appropriate 'drush.launcher' should be right next
-# to this script (stored in the same directory).
-if $NONE || $LOCAL ; then
-  if [ -f "$SELF_DIRNAME/drush.launcher" ]
-  then
-    FOUND_SCRIPT="$SELF_DIRNAME/drush.launcher"
-  else
-    echo "Could not find drush.launcher in $SELF_DIRNAME. Check your installation." >&2
-    exit 1
-  fi
-fi
+      case "@none":
+        $NONE = TRUE;
+        break;
 
-#
-# Second check:
-#
-#   drush --root=/path
-#
-# If the site root is specified via a commandline option, then we
-# should always use the Drush stored at this root, if there is one.
-# We will first check for a "wrapper" script at the root, and then
-# we will look for a "launcher" script in vendor/bin.
-#
-if [ -z "$FOUND_SCRIPT" ]
-then
-  FOUND_SCRIPT="`find_wrapper_or_launcher "$ROOT"`"
-  if [ -n "$FOUND_SCRIPT" ]
-  then
-    cd "$ROOT"
-  fi
-fi
+      case "-r":
+        $VAR = "ROOT";
+        break;
 
-#
-# Third check:
-#
-# If there is a "drush" symlink in the "use dir",
-# then we will use the Drush indicated by this file.
-#
-if [ -z "$FOUND_SCRIPT" ]
-then
-  if [ -f "$SITE_USE_DIR/drush" ]
-  then
-    FOUND_SCRIPT="$SITE_USE_DIR/drush"
-  fi
-fi
+      case "--verbose":
+      case "-v":
+        $VERBOSE = TRUE;
+        break;
+    }
+    if (substr($option, 0, 7) == "--root=") {
+      $ROOT = substr($option, 7);
+    }
+  }
+}
 
-#
-# Fourth check:
-#
-# If there is a .drush-use file, then its contents will
-# contain the path to the Drush to use.
-#
-if [ -z "$FOUND_SCRIPT" ]
-then
-  if [ -f ".drush-use" ]
-  then
-    FOUND_SCRIPT="`cat .drush-use`"
-  fi
-fi
+//
+// First check:
+//
+//   drush --local ...
+//   drush @none ...
+//
+// If either the --local option, or the @none alias is used, then
+// we must skip the Drush wrapper, and call the Drush launcher directly.
+//
+// In this instance, we are assuming that the 'drush' that is being
+// called is:
+//
+//  a) The global 'drush', or
+//  b) A site-local 'drush' in a vendor/bin directory.
+//
+// In either event, the appropriate 'drush.launcher' should be right next
+// to this script (stored in the same directory).
+if ($NONE || $LOCAL) {
+  if (is_file(__DIR__ . "/drush.launcher")) {
+    $found_script = __DIR__ . "/drush.launcher";
+  }
+  else {
+    fwrite(STDERR, "Could not find drush.launcher in " . __DIR__ . ". Check your installation.\n");
+    exit(1);
+  }
+}
 
-#
-# Fifth check:
-#
-# Look for a 'drush' wrapper or launcher at the cwd,
-# and in each of the directories above the cwd.  If
-# we find one, use it.
-#
-if [ -z "$FOUND_SCRIPT" ]
-then
-  c="`pwd`"
-  while [ -n "$c" ] && [ "$c" != "/" ]
-  do
-    FOUND_SCRIPT="`find_wrapper_or_launcher "$c"`"
-    if [ -n "$FOUND_SCRIPT" ]
-    then
-      cd "$c"
-      break
-    fi
-    c="`dirname $c`"
-  done
-fi
+//
+// Second check:
+//
+//   drush --root=/path
+//
+// If the site root is specified via a commandline option, then we
+// should always use the Drush stored at this root, if there is one.
+// We will first check for a "wrapper" script at the root, and then
+// we will look for a "launcher" script in vendor/bin.
+//
+if (empty($found_script)) {
+  $found_script = find_wrapper_or_launcher($ROOT);
+  if (!empty("$found_script")) {
+    chdir("$ROOT");
+  }
+}
 
-if [ -n "$FOUND_SCRIPT" ]
-then
-  # Resolve symlinks - this is the equivalent of "readlink -f", but also works with non-standard OS X readlink.
-  while [ -h "$FOUND_SCRIPT" ]; do
-    # 1) cd to directory of the symlink (in case the symlink is relative)
-    # 2) cd to the directory of where the symlink points
-    # 3) Get the pwd
-    # 4) Append the basename
-    DIR="`dirname -- "$FOUND_SCRIPT"`"
-    SYM="`readlink "$FOUND_SCRIPT"`"
-    SYM_DIRNAME="`dirname -- "$SYM"`"
-    FOUND_SCRIPT="`cd "$DIR" && cd "$SYM_DIRNAME" && pwd`/`basename -- "$SYM"`"
-  done
+//
+// Third check:
+//
+// If there is a "drush" symlink in the "use dir",
+// then we will use the Drush indicated by this file.
+//
+if (empty($found_script)) {
+  if (is_file("$site_use_link")) {
+    $found_script = "$site_use_link";
+  }
+}
 
-  # Guard against errors:  if we have found a "drush" script
-  # (that is, theoretically a drush wrapper script), and
-  # there is a "drush.launcher" script in the same directory,
-  # then we will skip the "drush" script and use the drush launcher
-  # instead.  This is because drush "wrapper" scripts should
-  # only ever exist at the root of a site, and there should
-  # never be a drush "launcher" at the root of a site.
-  # Therefore, if we find a "drush.launcher" next to a script
-  # called "drush", we have probably found a Drush install directory,
-  # not a site root.  Adjust appropriately.  Note that this
-  # also catches the case where a drush "finder" script finds itself.
-  if [ -f "`dirname "$FOUND_SCRIPT"`/drush.launcher" ]
-  then
-    FOUND_SCRIPT="`dirname "$FOUND_SCRIPT"`/drush.launcher"
-  fi
-fi
+//
+// Fourth check:
+//
+// If there is a .drush-use file, then its contents will
+// contain the path to the Drush to use.
+//
+if (empty($found_script)) {
+  if (is_file(".drush-use")) {
+    $found_script = file_get_contents(".drush-use");
+  }
+}
 
-# Didn't find any site-local Drush, or @use'd Drush?
-# In that case, there should always be a drush.launcher in
-# the same directory this script is stored in; use that.
-if [ -z "$FOUND_SCRIPT" ]
-then
-  FOUND_SCRIPT="$SELF_DIRNAME/drush.launcher"
-fi
+//
+// Fifth check:
+//
+// Look for a 'drush' wrapper or launcher at the cwd,
+// and in each of the directories above the cwd.  If
+// we find one, use it.
+//
+if (empty($found_script)) {
+  $c = getcwd();
+  while (!empty($c) && ($c != "/")) {
+    $found_script = find_wrapper_or_launcher($c);
+    if ($found_script) {
+      chdir($c);
+      break;
+    }
+    $c = dirname($c);
+  }
+}
 
-# Emit a message in verbose mode advertising the location of the
-# script we found.
-if $VERBOSE
-then
-  echo "Using the Drush script found at $FOUND_SCRIPT" >&2
-fi
+if (!empty("$found_script")) {
+  $found_script = realpath($found_script);
 
-# Launch the script that we found.
-"$FOUND_SCRIPT" "$@"
+  // Guard against errors:  if we have found a "drush" script
+  // (that is, theoretically a drush wrapper script), and
+  // there is a "drush.launcher" script in the same directory,
+  // then we will skip the "drush" script and use the drush launcher
+  // instead.  This is because drush "wrapper" scripts should
+  // only ever exist at the root of a site, and there should
+  // never be a drush "launcher" at the root of a site.
+  // Therefore, if we find a "drush.launcher" next to a script
+  // called "drush", we have probably found a Drush install directory,
+  // not a site root.  Adjust appropriately.  Note that this
+  // also catches the case where a drush "finder" script finds itself.
+  if (is_file(dirname($found_script) . "/drush.launcher")) {
+    $found_script = dirname($found_script) . "/drush.launcher";
+  }
+}
+
+// Didn't find any site-local Drush, or @use'd Drush?
+// In that case, there should always be a drush.launcher in
+// the same directory this script is stored in; use that.
+if (empty($found_script)) {
+  $found_script = __DIR__ . "/drush.launcher";
+}
+
+// Emit a message in verbose mode advertising the location of the
+// script we found.
+if ($VERBOSE) {
+  fwrite(STDERR, "Using the Drush script found at $found_script\n");
+}
+
+// Get the arguments for the command.  Shift off argv[0],
+// which contains the name of this script.
+$arguments = $argv;
+array_shift($arguments);
+
+// Prepare the environment for pnctl_exec.
+$env = $_ENV;
+
+// If PHP is not configured correctly, $_ENV will be
+// empty.  Drush counts on the fact that environment
+// variables will always be passed through, so we
+// need to repair this situation.
+if (empty($env)) {
+  exec('printenv', $env_items);
+  foreach ($env_items as $item) {
+    list($key, $value) = explode('=', $item, 2);
+    $env[$key] = $value;
+  }
+}
+
+// Launch the new script in the same process.
+// If the launch succeeds, then it will not return.
+pcntl_exec($found_script, $arguments, $env);
+exit(1);

--- a/drush.launcher
+++ b/drush.launcher
@@ -1,0 +1,132 @@
+#!/usr/bin/env sh
+#
+# This script is a simple launcher that will run Drush with the most appropriate
+# php executable it can find.  In most cases, the 'drush' script should be
+# called first; it will in turn launch this script.
+#
+# Solaris users: Add /usr/xpg4/bin to the head of your PATH
+#
+
+# Get the absolute path of this executable
+SELF_DIRNAME="`dirname -- "$0"`"
+SELF_PATH="`cd -P -- "$SELF_DIRNAME" && pwd -P`/`basename -- "$0"`"
+
+# Decide if we are running a Unix shell on Windows
+if `which uname > /dev/null 2>&1`; then
+  case "`uname -a`" in
+    CYGWIN*)
+      CYGWIN=1 ;;
+    MINGW*)
+      MINGW=1 ;;
+  esac
+fi
+
+# Resolve symlinks - this is the equivalent of "readlink -f", but also works with non-standard OS X readlink.
+while [ -h "$SELF_PATH" ]; do
+    # 1) cd to directory of the symlink
+    # 2) cd to the directory of where the symlink points
+    # 3) Get the pwd
+    # 4) Append the basename
+    DIR="`dirname -- "$SELF_PATH"`"
+    SYM="`readlink "$SELF_PATH"`"
+    SYM_DIRNAME="`dirname -- "$SYM"`"
+    SELF_PATH="`cd "$DIR" && cd "$SYM_DIRNAME" && pwd`/`basename -- "$SYM"`"
+done
+
+# If not exported, try to determine and export the number of columns.
+# We do not want to run `tput cols` if $TERM is empty, "unknown", or "dumb", because
+# if we do, tput will output an undesirable error message to stderr.  If
+# we redirect stderr in any way, e.g. `tput cols 2>/dev/null`, then the
+# error message is suppressed, but tput cols becomes confused about the
+# terminal and prints out the default value (80).
+if [ -z $COLUMNS ] && [ -n "$TERM" ] && [ "$TERM" != dumb ] && [ "$TERM" != unknown ] && [ -n "`which tput`" ] ; then
+  # Note to cygwin/mingw/msys users: install the ncurses package to get tput command.
+  # Note to mingw/msys users: there is no precompiled ncurses package.
+  if COLUMNS="`tput cols`"; then
+    export COLUMNS
+  fi
+fi
+
+if [ -n "$DRUSH_PHP" ] ; then
+  # Use the DRUSH_PHP environment variable if it is available.
+  php="$DRUSH_PHP"
+else
+  # On MSYSGIT, we need to use "php", not the full path to php
+  if [ -n "$MINGW" ] ; then
+    php="php"
+  else
+    # Default to using the php that we find on the PATH.
+    # We check for a command line (cli) version of php, and if found use that.
+    # Note that we need the full path to php here for Dreamhost, which behaves oddly.  See http://drupal.org/node/662926
+    php="`which php-cli 2>/dev/null`"
+
+    if [ ! -x "$php" ]; then
+      php="`which php 2>/dev/null`"
+    fi
+
+    if [ ! -x "$php" ]; then
+      echo "ERROR: can't find php."; exit 1
+    fi
+  fi
+fi
+
+# Build the path to drush.php.
+SCRIPT_PATH="`dirname "$SELF_PATH"`/drush.php"
+if [ -n "$CYGWIN" ] ; then
+  # try to determine if we are running cygwin port php or Windows native php:
+  if [ -n "`"$php" -i | grep -E '^System => Windows'`" ]; then
+    SCRIPT_PATH="`cygpath -w -a -- "$SCRIPT_PATH"`"
+  else
+    SCRIPT_PATH="`cygpath -u -a -- "$SCRIPT_PATH"`"
+  fi
+fi
+
+# Check to see if the user has provided a php.ini file or drush.ini file in any conf dir
+# Last found wins, so search in reverse priority order
+for conf_dir in "`dirname "$SELF_PATH"`" /etc/drush "$HOME/.drush" ; do
+  if [ ! -d "$conf_dir" ] ; then
+    continue
+  fi
+  # Handle paths that don't start with a drive letter on MinGW shell. Equivalent to cygpath on Cygwin.
+  if [ -n "$MINGW" ] ; then
+    conf_dir=`sh -c "cd \"$conf_dir\"; pwd -W"`
+  fi
+  if [ -f "$conf_dir/php.ini" ] ; then
+    drush_php_ini="$conf_dir/php.ini"
+  fi
+  if [ -f "$conf_dir/drush.ini" ] ; then
+    drush_php_override="$conf_dir/drush.ini"
+  fi
+done
+# If the PHP_INI environment variable is specified, then tell
+# php to use the php.ini file that it specifies.
+if [ -n "$PHP_INI" ] ; then
+  drush_php_ini="$PHP_INI"
+fi
+# If the DRUSH_INI environment variable is specified, then
+# extract all ini variable assignments from it and convert
+# them into php '-d' options. These will override similarly-named
+# options in the php.ini file
+if [ -n "$DRUSH_INI" ] ; then
+  drush_php_override="$DRUSH_INI"
+fi
+
+# Add in the php file location and/or the php override variables as appropriate
+if [ -n "$drush_php_ini" ] ; then
+  php_options="--php-ini $drush_php_ini"
+fi
+if [ -n "$drush_php_override" ] ; then
+  php_options=`grep '^[a-z_A-Z0-9.]\+ *=' $drush_php_override | sed -e 's|\([^ =]*\) *= *\(.*\)|\1="\2"|' -e 's| ||g' -e 's|^|-d |' | tr '\n\r' '  '`
+fi
+# If the PHP_OPTIONS environment variable is specified, then
+# its contents will be passed to php on the command line as
+# additional options to use.
+if [ -n "$PHP_OPTIONS" ] ; then
+  php_options="$php_options $PHP_OPTIONS"
+fi
+
+# Pass in the path to php so that drush knows which one to use if it
+# re-launches itself to run subcommands.  We will also pass in the php options.
+# Important note: Any options added here must be removed  when Drush processes
+# a #! (shebang) script.  @see drush_adjust_args_if_shebang_script()
+exec "$php" $php_options "$SCRIPT_PATH" --php="$php" --php-options="$php_options" "$@"

--- a/examples/drush
+++ b/examples/drush
@@ -26,5 +26,5 @@
 # IMPORTANT:  Modify the path below if your 'vendor' directory has been
 # relocated to another location in your composer.json file.
 #
-cd "$(dirname $0)"
+cd "`dirname $0`"
 vendor/bin/drush.launcher --local $@

--- a/examples/drush
+++ b/examples/drush
@@ -1,13 +1,30 @@
 #!/usr/bin/env sh
 #
-# A wrapper script which launches the Drush that is in your project's /vendor directory.
-# Copy it to the root of your project (or wherever you store handy scripts) and edit as desired.
+# DRUSH WRAPPER
 #
-# Below are options which you might want to add. More info at `drush topic core-global-options`:
+# A wrapper script which launches the Drush that is in your project's /vendor
+# directory.  Copy it to the root of your project (or wherever you store handy
+# scripts) and edit as desired.  If you already have a folder named 'drush',
+# then you may rename this script to 'drush.wrapper' (or, move your 'drush'
+# script to __ROOT__/sites/all/drush).
 #
-# --local Only discover commandfiles/site aliases/config that are inside your project dir.
-# --alias-path A list of directories where Drush will search for site alias files.
-# --config A list of paths to config files
-# --include A list of directories to search for commandfiles.
+# Below are options which you might want to add. More info at
+# `drush topic core-global-options`:
 #
-vendor/bin/drush --local $@
+# --local       Only discover commandfiles/site aliases/config that are
+#               inside your project dir.
+# --alias-path  A list of directories where Drush will search for site
+#               alias files.
+# --config      A list of paths to config files
+# --include     A list of directories to search for commandfiles.
+#
+# Note that it is recommended to always use --local when using a drush
+# wrapper script.
+#
+# See __DRUSH__/bin/drush for an explanation of the different 'drush' scripts.
+#
+# IMPORTANT:  Modify the path below if your 'vendor' directory has been
+# relocated to another location in your composer.json file.
+#
+cd "$(dirname $0)"
+vendor/bin/drush.launcher --local $@

--- a/examples/example.bashrc
+++ b/examples/example.bashrc
@@ -82,7 +82,6 @@ alias ev='drush php-eval'
 alias sa='drush site-alias'
 alias lsa='drush site-alias --local-only'
 alias st='drush core-status'
-alias use='drush site-set'
 
 # Aliases for drush commands that work on the current drupal site
 alias cc='drush cache-clear'
@@ -135,6 +134,16 @@ d="$(dirname "$d")"
 if [ -f "$d/drush.complete.sh" ] ; then
   . "$d/drush.complete.sh"
 fi
+
+# 'use @site' will run 'drush site-set' and then set your path
+# such that the site-local Drush appears first.
+function use() {
+  p=$(drush site-set "$1" --path --strict=0)
+  if [ -n "$p" ] && [ "$p" != "${p/:/}" ]
+  then
+    export PATH="$p"
+  fi
+}
 
 # We extend the cd command to allow convenient
 # shorthand notations, such as:

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -642,27 +642,6 @@ function drush_is_local_host($host) {
 }
 
 /**
- * Return the user's home directory.
- */
-function drush_server_home() {
-  // Cannot use $_SERVER superglobal since that's empty during UnitUnishTestCase
-  // getenv('HOME') isn't set on Windows and generates a Notice.
-  $home = getenv('HOME');
-  if (!empty($home)) {
-    // home should never end with a trailing slash.
-    $home = rtrim($home, '/');
-  }
-  elseif (!empty($_SERVER['HOMEDRIVE']) && !empty($_SERVER['HOMEPATH'])) {
-    // home on windows
-    $home = $_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'];
-    // If HOMEPATH is a root directory the path can end with a slash. Make sure
-    // that doesn't happen.
-    $home = rtrim($home, '\\/');
-  }
-  return empty($home) ? NULL : $home;
-}
-
-/**
  * Return the name of the user running drush.
  */
 function drush_get_username() {

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -35,6 +35,7 @@ function drush_preflight_prepare() {
 
   $classloader = require $vendor_path;
 
+  require_once DRUSH_BASE_PATH . '/includes/startup.inc';
   require_once DRUSH_BASE_PATH . '/includes/bootstrap.inc';
   require_once DRUSH_BASE_PATH . '/includes/environment.inc';
   require_once DRUSH_BASE_PATH . '/includes/command.inc';

--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -5,8 +5,10 @@
  *   Functions used when Drush is starting up.
  *
  * This file is included and used early in the Drush
- * startup process, before any other Drush APIs are
- * available.
+ * startup process, before any other Drush code is
+ * loaded.  Therefore, the code in this file only uses
+ * standard PHP library functions, and the other functions
+ * also defined directly in this file.
  */
 
 
@@ -47,4 +49,70 @@ function find_wrapper_or_launcher($location) {
     }
   }
   return "";
+}
+
+/**
+ * Return the user's home directory.
+ */
+function drush_server_home() {
+  // Cannot use $_SERVER superglobal since that's empty during UnitUnishTestCase
+  // getenv('HOME') isn't set on Windows and generates a Notice.
+  $home = getenv('HOME');
+  if (!empty($home)) {
+    // home should never end with a trailing slash.
+    $home = rtrim($home, '/');
+  }
+  elseif (!empty($_SERVER['HOMEDRIVE']) && !empty($_SERVER['HOMEPATH'])) {
+    // home on windows
+    $home = $_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'];
+    // If HOMEPATH is a root directory the path can end with a slash. Make sure
+    // that doesn't happen.
+    $home = rtrim($home, '\\/');
+  }
+  return empty($home) ? NULL : $home;
+}
+
+/**
+ * Get the path to the directory that holds the
+ * information about the sites 'used' via site-set.
+ */
+function drush_get_use_dir() {
+  return drush_server_home() . "/.drush/use";
+}
+
+/**
+ * Return the path where the terminal-specific symlink
+ * for the site-specific Drush script will be created.  This
+ * is typically $HOME/.drush/use/PPID/bin/drush.
+ *
+ * Note that this requires the posix_getppid() function in
+ * order to work correctly.  On systems missing this function,
+ * the global symlink path will be returned instead.
+ */
+function drush_get_terminal_specific_use_link_path($use_dir = FALSE) {
+  if (!$use_dir) {
+    $use_dir = drush_get_use_dir();
+  }
+  // Drush site-set will always write both the terminal-specific
+  // and global links.  We should always use the terminal-specific
+  // link if posix_getppid() is available; otherwise, we will use
+  // the global location.
+  if (function_exists('posix_getppid')) {
+    return $use_dir . '/' . posix_getppid() . '/bin/drush';
+  }
+  else {
+    return drush_get_global_use_link_path($use_dir);
+  }
+}
+
+/**
+ * Return the path where the global symlink for the
+ * site-specific Drush script will be created.  This
+ * is typically $HOME/.drush/use/bin/drush.
+ */
+function drush_get_global_use_link_path($use_dir = FALSE) {
+  if (!$use_dir) {
+    $use_dir = drush_get_use_dir();
+  }
+  return "$use_dir/bin/drush";
 }

--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @file
+ *   Functions used when Drush is starting up.
+ *
+ * This file is included and used early in the Drush
+ * startup process, before any other Drush APIs are
+ * available.
+ */
+
+
+/**
+ * Checks the provided location and return the appropriate
+ * drush wrapper or drush launcher script, if found.
+ */
+function find_wrapper_or_launcher($location) {
+  // We will look for a "drush wrapper" script that might
+  // be stored in the root of a site site.  If there is
+  // no wrapper script, then we will look for the
+  // drush.launcher script in vendor/bin.  We try just a
+  // few of the most common locations; if the user relocates
+  // their vendor directory anywhere else, then they must
+  // use a wrapper script to locate it.  See the comment in
+  // 'examples/drush' for details.
+  //
+  // We are somewhat "loose" about whether we are looking
+  // for "drush" or "drush.launcher", because in old versions
+  // of Drush, the "drush launcher" was named "drush".
+  // Otherwise, there wouldn't be any point in looking for
+  // "drush.launcher" at the root, or "drush" in a vendor directory.
+  // We also allow users to rename their drush wrapper to
+  // 'drush.wrapper' to avoid conflicting with a directory named
+  // 'drush' at the site root.
+  $drush_locations = array(
+    "drush",
+    "vendor/bin/drush",
+    "../vendor/bin/drush",
+    "sites/all/vendor/bin/drush",
+  );
+
+  foreach ($drush_locations as $d) {
+    foreach (array('.launcher', '.wrapper', '') as $suffix) {
+      if (is_file("$location/$d$suffix")) {
+        return "$location/$d$suffix";
+      }
+    }
+  }
+  return "";
+}

--- a/tests/siteSetTest.php
+++ b/tests/siteSetTest.php
@@ -17,7 +17,7 @@ class siteSetCommandCase extends CommandUnishTestCase {
 
     $this->drush('ev', array("drush_invoke('site-set', '$alias'); print drush_sitealias_site_get();"));
     $output = $this->getOutput();
-    $this->assertEquals("Site set to $alias\n$alias", $output);
+    $this->assertEquals("$alias", $output);
 
     $this->drush('site-set', array());
     $output = $this->getOutput();
@@ -25,15 +25,24 @@ class siteSetCommandCase extends CommandUnishTestCase {
 
     $this->drush('site-set', array($alias));
     $expected = 'Site set to ' . $alias;
-    $output = $this->getOutput();
+    $output = $this->getErrorOutput();
+    $output = trim(rtrim($output, "[ok]"));
     $this->assertEquals($expected, $output);
 
+    $this->drush('site-set', array());
+    $output = $this->getErrorOutput();
+    $output = trim(rtrim($output, "[ok]"));
+    $this->assertEquals('Site set to @none', $output);
+
     $this->drush('ev', array("drush_invoke('site-set', '@none'); drush_invoke('site-set', '$alias'); drush_invoke('site-set', '@none'); drush_invoke('site-set', '-'); print drush_sitealias_site_get();"));
+    $stderr = $this->getErrorOutputAsList();
+    $stderr = array_map(function ($line) { return trim(rtrim($line, "[ok]")); }, $stderr);
+    $stderr = implode("\n", $stderr);
     $output = $this->getOutput();
+    $this->assertEquals($alias, $output);
     $this->assertEquals("Site set to @none
 Site set to $alias
 Site set to @none
-Site set to $alias
-$alias", $output);
+Site set to $alias", $stderr);
   }
 }


### PR DESCRIPTION
If you 'use' a Drupal site with a site-local Drush, your PATH will be adjusted such that the site-local Drush appears first.  'use @none' or using a site with no site-local Drush will reset your PATH back to the way it was.