### PR TITLE
Refuse re-install to a different install profile due to Drupal bug

### DIFF
--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -155,7 +155,20 @@ function drush_core_pre_site_install($profile = NULL) {
     drush_log(dt('Sites directory @subdir already exists - proceeding.', array('@subdir' => $conf_path)));
   }
 
-  if (!drush_file_not_empty($settingsfile)) {
+  // If there is an existing settings.php file, and if it records the installation profile used,
+  // then update it to insure that it matches the installation profile currently being installed.
+  // See https://github.com/drush-ops/drush/issues/1344
+  if (drush_file_not_empty($settingsfile)) {
+    $selected_profile = $profile ?: "standard";
+    // If the settings.php file exists, we need to make sure that the $settings['install_profile'] line is
+    // removed, if it exists.
+    $settings_contents = file_get_contents($settingsfile);
+    $settings_contents = preg_replace('/(\$settings\[.install_profile.\] = ).*/m', '\1 ' . "'$selected_profile';", $settings_contents);
+    @chmod(dirname($settingsfile), 0777);
+    @chmod($settingsfile, 0777);
+    file_put_contents($settingsfile, $settings_contents);
+  }
+  else {
     if (!drush_op('copy', 'sites/default/default.settings.php', $settingsfile) && !drush_get_context('DRUSH_SIMULATE')) {
       return drush_set_error(dt('Failed to copy sites/default/default.settings.php to @settingsfile', array('@settingsfile' => $settingsfile)));
     }


### PR DESCRIPTION
If settings.php contains a cached value holding the installation profile, and drush site-install is ran again to install a different profile, then we must update the settings value, or the install will fail.

Anyone have any objection to Drush performing this service to insure that the install goes okay?  Should we write-protect settings.php again afterward modifying it?
