### PR TITLE
Exclude the 'vendor' directory from consideration

### DIFF
--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1599,7 +1599,7 @@ function _drush_add_commandfiles($searchpath, $phase = NULL, $reset = FALSE) {
  * Substrings to ignore during commandfile and site alias searching.
  */
 function drush_filename_blacklist() {
-  $blacklist = array('.', '..', 'drush_make', 'examples', 'tests', 'disabled', 'gitcache', 'cache');
+  $blacklist = array('.', '..', 'drush_make', 'examples', 'tests', 'disabled', 'gitcache', 'cache', 'vendor');
   for ($v=4; $v<=(DRUSH_MAJOR_VERSION)+3; ++$v) {
     if ($v != DRUSH_MAJOR_VERSION) {
       $blacklist[] = 'drush' . $v;


### PR DESCRIPTION
Vendor directories have a large number of files in them, and should not be searched for commandfiles.

Currently, if you want to install a global Drush extension via Composer, you do this:

`cd ~/.drush && composer require ...`.  

This puts the commandfile and all of its dependencies in the ~/.drush directory, requiring Drush to search everything there for *.drush.inc files.  This directory should be actively excluded by Drush.

Where should these commandfiles go, then?  On further reflection (after creating this PR), I decided that global Drush extensions should be installed the same way as Drush is installed globally:

`composer global require organization/project:dev-master`

This is the only reasonable solution.  It puts your global commandfiles in the same composer.json as the Global Drush.  This insures that the dependencies for Drush and all of its extensions will be evaluated together at `composer install` time.  Anything less than this can result in dependency hell.  (See [FAQ for composer_manager](https://www.drupal.org/node/2405789)).

So, the big question is, how does Drush find commandfiles if we put them in ~/.composer/vendor/organization/project?  This is no easier to search than ~/.drush/vendor, so we certainly should not simply add this location as a search path.

I see two options.

1) Somehow find and register commandfiles in the vendor directory at `composer install` time.

2) Alter ~/.composer/composer.json to include a custom installer, and redirect Drush extensions to ~/.drush/commands in its 'extras' section.

I will investigate these options, and see if I can come up with something workable.
