### PR TITLE
Use pcntl_exec to use process replacement when redispatching

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -688,6 +688,12 @@ function _drush_backend_adjust_options($site_record, $command, $command_options,
  *            dispatched using the alias name on the command line, instead of
  *            the options from the alias being added to the command line
  *            automatically.
+ *          'process-replacement'
+ *            Optional. Defauts to FALSE. Only usable locally.
+ *            If set, then backend invoke with use execve to do a full process
+ *            replacement, overlaying the new process on top of the current
+ *            process, terminating it. In this mode, the call to backend
+ *            invoke will never return.
  * @param common_options
  *    Optional. Merged in with the options for each invocation.
  * @param backend_options
@@ -814,6 +820,59 @@ function drush_backend_invoke_concurrent($invocations, $common_options = array()
     }
   }
 
+  if (!empty($backend_options['process-replacement'])) {
+    // Execute the first command (there should only be one).  We will never return from pcntl_exec()
+    // (unless we get a 'command not found', or similar.)
+    $item = array_shift($invocation_options);
+    $site_record = $item['site-record'];
+    $site_record_to_dispatch = $item['site-record-to-dispatch'];
+    $command = $item['command'];
+    $args = $item['args'];
+    $post_options = $item['post-options'];
+    $commandline_options = $item['commandline-options'];
+    $drush_global_options = $item['drush-global-options'];
+    $os = drush_os($site_record);
+    // If the caller did not pass in a specific path to drush, then we will
+    // use a default value.  For commands that are being executed on the same
+    // machine, we will use DRUSH_COMMAND, which is the path to the drush.php
+    // that is running right now.  For remote commands, we will run a wrapper
+    // script instead of drush.php -- drush.bat on Windows, or drush on Linux.
+    $drush_path = $site_record['path-aliases']['%drush-script'];
+    $env_vars = $site_record['#env-vars'];
+
+    $command_args = array();
+    foreach ($drush_global_options as $key => $value) {
+      if ($key[0] != '#') {
+        $option = "--$key";
+        if ($value !== TRUE) {
+          $option .= '=' . drush_escapeshellarg($value);
+        }
+        $command_args[] = $option;
+      }
+    }
+    $command_args[] = $command;
+    foreach ($commandline_options as $key => $value) {
+      if ($key[0] != '#') {
+        $option = "--$key";
+        if ($value !== TRUE) {
+          $option .= '=' . drush_escapeshellarg($value);
+        }
+        $command_args[] = $option;
+      }
+    }
+    $command_args = array_merge($command_args, $args);
+    // variables_order settings in php.ini may cause $_ENV to be empty; in this case,
+    // getenv() will still work.  Fetch a minimum environment (the PATH)
+    // with getenv(), and fill in the rest of the environment if it is available.
+    $env_vars['PATH'] = getenv('PATH');
+    $env_vars += $_ENV;
+    drush_log(dt('Backend invoke (process replacement): !cmd', array('!cmd' => $drush_path . ' ' . implode(' ', $command_args))), 'command');
+
+    // Unless there is an error launching Drush, pcntl_exec will not return.
+    $result = pcntl_exec($drush_path, $command_args, $env_vars);
+    exit($result);
+  }
+
   // Now take our prepared options and generate the command strings
   $cmds = array();
   foreach ($invocation_options as $site => $item) {
@@ -903,7 +962,7 @@ function _drush_backend_classify_options($site_record, $command_options, &$backe
     $additional_global_options = $backend_options['additional-global-options'];
     $command_options += $additional_global_options;
   }
-  $method_post = ((!array_key_exists('method', $backend_options)) || ($backend_options['method'] == 'POST'));
+  $method_post = (!array_key_exists('process-replacement', $backend_options)) && ((!array_key_exists('method', $backend_options)) || ($backend_options['method'] == 'POST'));
   $post_options = array();
   $commandline_options = array();
   $drush_global_options = array();

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -1187,7 +1187,6 @@ function drush_do_command_redispatch($command, $args = array(), $remote_host = N
   elseif (drush_get_option('interactive')) {
     $backend_options['interactive'] = TRUE;
   }
-
   // Run the command in a new process.
   drush_log(dt('Begin redispatch via drush_invoke_process().'));
   $values = drush_invoke_process('@self', $command_name, $args, $command_options, $backend_options);

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -474,14 +474,15 @@ function drush_preflight_command_dispatch() {
     // same drush that is currently running, redispatch to it.
     if (file_exists($local_drush) && ($this_drush != $local_drush)) {
       $uri = drush_get_context('DRUSH_SELECTED_URI');
-      $aditional_options = array(
+      $additional_options = array(
         'root' => $root,
         'local' => TRUE,
       );
       if (!empty($uri)) {
-        $aditional_options['uri'] = $uri;
+        $additional_options['uri'] = $uri;
       }
-      $values = drush_do_command_redispatch(is_array($command) ? $command : $command_name, $args, NULL, NULL, $local_drush, TRUE, $aditional_options);
+      $additional_options['#process-replacement'] = TRUE;
+      $values = drush_do_command_redispatch(is_array($command) ? $command : $command_name, $args, NULL, NULL, $local_drush, TRUE, $additional_options);
     }
   }
   // If the command sets the 'handle-remote-commands' flag, then we will short-circuit


### PR DESCRIPTION
If you are not selecting your site-local Drush via your PATH environment variable (c.f. #1343), then you can cause Drush to redispatch to the site-local Drush by setting an option in __ROOT__/drush/drushrc.php:

```$options['drush-script'] = __DIR__ . "/../core/vendor/drush/drush/drush";```

This much already works.  (n.b. this file is included before Drupal is bootstrapped, so DRUPAL_ROOT is not available here.)

When operating in this mode, this PR alters the Drush redispatch to use pcntl_exec to do the redispatch.  This means that the initial 'launcher' Drush process dies, and is replaced by the process running the site-local Drush, removing the need for backend invoke to shuffle stdin and stdout (and avoiding stderr being redirected to stdout).