### PR TITLE
Remove code-formatting from FAQ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ pursuing one of the support options below.
 FAQ
 ------
 
-```
-  Q: What does "drush" stand for?
-  A: The Drupal Shell.
+>  Q: What does "drush" stand for?<br>
+>  A: The Drupal Shell.
+>
+>  Q: How do I pronounce Drush?<br>
+>  A: Some people pronounce the *dru* with a long 'u' like Dr*u*pal. Fidelity points
+>     go to them, but they are in the minority. Most pronounce Drush so that it
+>     rhymes with hush, rush, flush, etc. This is the preferred pronunciation.
+>
+>  Q: Does Drush have unit tests?<br>
+>  A: Drush has an excellent suite of unit tests. See 
+> [tests/README.md](https://github.com/drush-ops/drush/blob/master/tests/README.md) for more information.
 
-  Q: How do I pronounce Drush?
-  A: Some people pronounce the dru with a long u like Drupal. Fidelity points
-     go to them, but they are in the minority. Most pronounce Drush so that it
-     rhymes with hush, rush, flush, etc. This is the preferred pronunciation.
-
-  Q: Does Drush have unit tests?
-  A: Drush has an excellent suite of unit tests. See [tests/README.md](https://github.com/drush-ops/drush/blob/master/tests/README.md) for more information.
-```
 
 Credits
 -----------


### PR DESCRIPTION
The FAQ section was formatted in a fenced code block, which looked kind of funny but also made the embedded link non-functional.  I changed it to a blockquoted section and added a little styling for emphasis.