### PR TITLE
[Windows] Using git command argument instead of GIT_DIR environment variable

### DIFF
--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -262,10 +262,10 @@ class DrushMakeProject {
         // http://drupal.org/node/1054616
         $patch_levels = array('-p1', '-p0');
         foreach ($patch_levels as $patch_level) {
-          $checked = drush_shell_exec('cd %s && GIT_DIR=. git apply --check %s %s --verbose', $project_directory, $patch_level, $filename);
+          $checked = drush_shell_exec('cd %s && git --git-dir=. apply --check %s %s --verbose', $project_directory, $patch_level, $filename);
           if ($checked) {
             // Apply the first successful style.
-            $patched = drush_shell_exec('cd %s && GIT_DIR=. git apply %s %s --verbose', $project_directory, $patch_level, $filename);
+            $patched = drush_shell_exec('cd %s && git --git-dir=. apply %s %s --verbose', $project_directory, $patch_level, $filename);
             break;
           }
         }


### PR DESCRIPTION
Setting GIT_DIR in Windows must be done through "set" command. Instead of doing this, I switched from environment variable to the command parameter.

Output for a failing run on Windows:

    Executing: cd D:/tmp/drupal-exec11-tmp/make_tmp_1431341027_555087e3bb150/__build__/sites/all/modules/contrib/conditional_fields && GIT_DIR=. git apply --check -p1 D:/tmp/drupal-exec11-tmp/make_tmp_1431341027_555087e3bb150/IEF_compatibility-2193025-14.patch --verbose
  'GIT_DIR' is not recognized as an internal or external command,
  operable program or batch file.

The attached commit is tested on Windows and should also work for Linux users as the fix rely on git commands and not the environment. Should also be tested on Linux.

An **alternative Windows only solution** that might work (not tested):

    'cd %s && set GIT_DIR=. && git apply --check %s %s --verbose'