### PR TITLE
Fix "drush: 129: [: -le: unexpected operator" errors when Xdebug is enabled

### DIFF
--- a/drush
+++ b/drush
@@ -125,7 +125,9 @@ if [ -n "$PHP_OPTIONS" ] ; then
 fi
 
 # If on PHP 5.3, disable magic_quotes_gpc and friends
-PHP_MINOR_VERSION="`\"$php\" -r 'print PHP_MINOR_VERSION;'`"
+# If Xdebug is enabled it interferes with the following command, so disable it
+# for the version check (but not for the actual call to drush.php).
+PHP_MINOR_VERSION="`\"$php\" -d xdebug.remote_enable=Off -r 'print PHP_MINOR_VERSION;'`"
 if [ $PHP_MINOR_VERSION -le 3 ] ; then
   php_options="$php_options -d magic_quotes_gpc=Off -d magic_quotes_runtime=Off -d magic_quotes_sybase=Off"
 fi


### PR DESCRIPTION
I don't exactly know why, but Xdebug messes up the `php -r` call in the Drush sh script. This commit simply disables Xdebug for the version check, where it should be unnecessary anyways. This avoids the nasty errors/failures.