### PR TITLE
Adds checks for class methods to drush_op()

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -676,7 +676,18 @@ function drush_op($callable) {
   foreach ($args as $arg) {
     $args_printed[] = is_scalar($arg) ? $arg : (is_array($arg) ? 'Array' : 'Object');
   }
-  $callable_string = is_array($callable) ? implode('::', $callable) : $callable;
+
+  if (!is_array($callable)) {
+    $callable_string = $callable;
+  }
+  else {
+    if (is_object($callable[0])) {
+      $callable_string = get_class($callable[0]) . '::' . $callable[1];
+    }
+    else {
+      $callable_string = implode('::', $callable);
+    }
+  }
 
   // Special checking for drush_op('system')
   if ($callable == 'system') {


### PR DESCRIPTION
first tried fixing the issue described here in https://www.drupal.org/node/2487632, but it seemed that the better place was to fix this in `drush_op()`.

the issue is when calling `drush_op()` via a D6 -> D8 migration, the migrate-manifest command is showing lots of PHP notices during console output:

```
$ drush migrate-manifest --legacy-db-url=mysql://user:@127.0.0.1/test-drupal-redesign-devdrupal migrate-manifest.yml --verbose --debug
Calling ::import() [3.37 sec, 48.87 MB]                                                                                                                                                            [debug]
Running d6_system_maintenance [3.38 sec, 48.89 MB]                                                                                                                                             [ok]
Object of class Drupal\migrate\MigrateExecutable could not be converted to string MigrateManifest8.php:122 [3.38 sec, 48.9 MB]                                                                    [notice]
Object of class Drupal\migrate\MigrateExecutable could not be converted to string drush.inc:680 [3.38 sec, 48.9 MB]                                                                               [notice]
Calling ::import() [3.38 sec, 48.9 MB]                                                                                                          
```