### PR TITLE
Rename the --local flag of drupal-directory and site-alias to --local-only

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -306,7 +306,7 @@ function core_drush_command() {
     ),
     'options' => array(
       'component' => "The portion of the evaluated path to return.  Defaults to 'path'; 'name' returns the site alias of the target.",
-      'local' => "Reject any target that specifies a remote site.",
+      'local-only' => "Reject any target that specifies a remote site.",
     ),
     'examples' => array(
       'cd `drush dd devel`' => 'Navigate into the devel module directory',
@@ -1225,7 +1225,7 @@ function _drush_core_directory($target = 'root', $component = 'path', $local_onl
  * Command callback.
  */
 function drush_core_drupal_directory($target = 'root') {
-  $path = _drush_core_directory($target, drush_get_option('component', 'path'), drush_get_option('local', FALSE));
+  $path = _drush_core_directory($target, drush_get_option('component', 'path'), drush_get_option('local-only', FALSE));
 
   // If _drush_core_directory is working right, it will turn
   // %blah into the path to the item referred to by the key 'blah'.

--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -28,7 +28,7 @@ function sitealias_drush_command() {
       'no-db' => 'Do not include the database record in the full alias record (default).',
       'with-optional' => 'Include optional default items.',
       'alias-name' => 'For a single alias, set the name to use in the output.',
-      'local' => 'Only display sites that are available on the local system (remote-site not set, and Drupal root exists).',
+      'local-only' => 'Only display sites that are available on the local system (remote-site not set, and Drupal root exists).',
       'show-hidden' => 'Include hidden internal elements in site alias output',
     ),
     'outputformat' => array(
@@ -161,7 +161,7 @@ function _drush_sitealias_user_specified_list() {
   }
 
   // Filter for only local sites if specified.
-  if (drush_get_option('local', FALSE)) {
+  if (drush_get_option('local-only', FALSE)) {
     foreach ($site_list as $site_name => $one_site) {
       if ( (array_key_exists('remote-site', $one_site)) ||
            (!array_key_exists('root', $one_site)) ||

--- a/examples/example.bashrc
+++ b/examples/example.bashrc
@@ -24,7 +24,7 @@
 #       dl               - drush pm-download
 #       ev               - drush php-eval
 #       sa               - drush site-alias
-#       sa               - drush site-alias --local (show local site aliases)
+#       sa               - drush site-alias --local-only (show local site aliases)
 #       st               - drush core-status
 #       use              - drush site-set
 #
@@ -80,7 +80,7 @@ alias ddd='drush drupal-directory'
 alias dl='drush pm-download'
 alias ev='drush php-eval'
 alias sa='drush site-alias'
-alias lsa='drush site-alias --local'
+alias lsa='drush site-alias --local-only'
 alias st='drush core-status'
 alias use='drush site-set'
 
@@ -126,7 +126,7 @@ if [ -h "$d" ] ; then
     d="$d2"
   else
     d="$(dirname $d)/$d2"
-  fi 
+  fi
 fi
 
 # Get the directory that drush is stored in.
@@ -155,13 +155,19 @@ function cddl() {
     builtin cd
   elif [ "${s:0:1}" == "@" ] || [ "${s:0:1}" == "%" ]
   then
-    d="$(drush drupal-directory $1 --local 2>/dev/null)"
+    d="$(drush drupal-directory $1 --local-only 2>/dev/null)"
     if [ $? == 0 ]
     then
       echo "cd $d";
       builtin cd "$d";
     else
-      echo "Cannot cd to remote site $s"
+      t="$(drush site-alias $1 >/dev/null 2>/dev/null)"
+      if [ $? == 0 ]
+      then
+        echo "Cannot cd to remote site $s"
+      else
+        echo "Cannot cd to $s"
+      fi
     fi
   else
     builtin cd "$s";
@@ -259,7 +265,7 @@ function cpd() {
   for a in "$@" ; do
     if [ ${a:0:1} == "@" ] || [ ${a:0:1} == "%" ]
     then
-      p[${#p[@]}]="$(drush drupal-directory $a --local 2>/dev/null)"
+      p[${#p[@]}]="$(drush drupal-directory $a --local-only 2>/dev/null)"
     elif [ -n "$a" ]
     then
       p[${#p[@]}]="$a"


### PR DESCRIPTION
Avoid conflict with the new --local global option.  See related issue #1340.