### PR TITLE
Issue #1249: Test for YAML first to avoid segfault.

### DIFF
--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -608,13 +608,27 @@ function _get_working_copy_option($download) {
  */
 function _make_determine_format($data) {
   // Test YAML first to avoid segmentation faults from preg_match in INI parser.
-  if ($parsed = ParserYaml::parse($data)) {
-    $parsed['format'] = 'yaml';
-    return $parsed;
+  $yaml_parse_exception = FALSE;
+  try {
+    if ($parsed = ParserYaml::parse($data)) {
+      $parsed['format'] = 'yaml';
+      return $parsed;
+    }
   }
-  elseif ($parsed = ParserIni::parse($data)) {
+  catch (\Symfony\Component\Yaml\Exception\ParseException $e) {
+    // Note that an exception was thrown, and display after .ini parsing.
+    $yaml_parse_exception = $e;
+  }
+
+  // Try INI format.
+  if ($parsed = ParserIni::parse($data)) {
     $parsed['format'] = 'ini';
     return $parsed;
   }
+
+  if ($yaml_parse_exception) {
+    throw $e;
+  }
+
   return drush_set_error('MAKE_STDIN_ERROR', dt('Unknown make file format'));
 }

--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -609,12 +609,12 @@ function _get_working_copy_option($download) {
 function _make_determine_format($data) {
   // Most .make files will have a `core` attribute. Use this to determine
   // the format.
-  if (preg_match('/^\s*core:/', $data)) {
+  if (preg_match('/^\s*core:/m', $data)) {
     $parsed = ParserYaml::parse($data);
     $parsed['format'] = 'yaml';
     return $parsed;
   }
-  elseif (preg_match('/^\s*core\s*=/', $data)) {
+  elseif (preg_match('/^\s*core\s*=/m', $data)) {
     $parsed = ParserIni::parse($data);
     $parsed['format'] = 'ini';
     return $parsed;

--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -607,7 +607,22 @@ function _get_working_copy_option($download) {
  *   Returns parsed data if it matches any known format.
  */
 function _make_determine_format($data) {
-  // Test YAML first to avoid segmentation faults from preg_match in INI parser.
+  // Most .make files will have a `core` attribute. Use this to determine
+  // the format.
+  if (preg_match('/^\s*core:/', $data)) {
+    $parsed = ParserYaml::parse($data);
+    $parsed['format'] = 'yaml';
+    return $parsed;
+  }
+  elseif (preg_match('/^\s*core\s*=/', $data)) {
+    $parsed = ParserIni::parse($data);
+    $parsed['format'] = 'ini';
+    return $parsed;
+  }
+
+  // If the .make file did not have a core attribute, it is being included
+  // by another .make file. Test YAML first to avoid segmentation faults from
+  // preg_match in INI parser.
   $yaml_parse_exception = FALSE;
   try {
     if ($parsed = ParserYaml::parse($data)) {

--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -607,13 +607,13 @@ function _get_working_copy_option($download) {
  *   Returns parsed data if it matches any known format.
  */
 function _make_determine_format($data) {
-  // Test INI first.
-  if ($parsed = ParserIni::parse($data)) {
-    $parsed['format'] = 'ini';
+  // Test YAML first to avoid segmentation faults from preg_match in INI parser.
+  if ($parsed = ParserYaml::parse($data)) {
+    $parsed['format'] = 'yaml';
     return $parsed;
   }
-  elseif ($parsed = ParserYaml::parse($data)) {
-    $parsed['format'] = 'yaml';
+  elseif ($parsed = ParserIni::parse($data)) {
+    $parsed['format'] = 'ini';
     return $parsed;
   }
   return drush_set_error('MAKE_STDIN_ERROR', dt('Unknown make file format'));

--- a/tests/makeTest.php
+++ b/tests/makeTest.php
@@ -753,4 +753,24 @@ class makeMakefileCase extends CommandUnishTestCase {
   function testMakeUseDistributionAsCore() {
     $this->runMakefileTest('use-distribution-as-core');
   }
+
+  /**
+   * Test that files without a core attribute are correctly identified.
+   */
+  public function testNoCoreMakefileParsing() {
+    require __DIR__ . '/../commands/make/make.utilities.inc';
+
+    // INI.
+    $data = file_get_contents(__DIR__ . '/makefiles/no-core.make');
+    $parsed = _make_determine_format($data);
+    $this->assertEquals('ini', $parsed['format']);
+    $this->assertEquals(42, $parsed['projects']['foo']['version']);
+
+    // YAML.
+    $data = file_get_contents(__DIR__ . '/makefiles/no-core.make.yml');
+    $parsed = _make_determine_format($data);
+    $this->assertEquals('yaml', $parsed['format']);
+    $this->assertEquals(42, $parsed['projects']['foo']['version']);
+  }
+
 }

--- a/tests/makefiles/no-core.make
+++ b/tests/makefiles/no-core.make
@@ -1,0 +1,3 @@
+; A file that does not include the `core` attribute (as is possible for included .make files).
+; ============================================================================================
+projects[foo][version] = 42

--- a/tests/makefiles/no-core.make.yml
+++ b/tests/makefiles/no-core.make.yml
@@ -1,0 +1,5 @@
+# A file that does not include the `core` attribute (as is possible for included .make files).
+# ============================================================================================
+projects:
+  foo:
+    version: 42


### PR DESCRIPTION
- On large files, preg_match_all can segfault. To avoid this, test for
  YAML first.