### PR TITLE
fix for use under cygwin's php

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -140,7 +140,9 @@ function drush_cwd() {
  */
 function _drush_convert_path($path) {
   $path = str_replace('\\','/', $path);
-  $path = preg_replace('/^\/cygdrive\/([A-Za-z])(.*)$/', '\1:\2', $path);
+  if (drush_is_windows(_drush_get_os()) && !drush_is_cygwin(_drush_get_os())) {
+    $path = preg_replace('/^\/cygdrive\/([A-Za-z])(.*)$/', '\1:\2', $path);
+  }
 
   return $path;
 }


### PR DESCRIPTION
fixes issue #1226 
simple change to `_drush_convert_path()` function in `includes/environment.inc` to filter out alteration of `/cygdrive/` paths when the php is cygwin's php - I've not tested under cygwin with the standard non-cygwin-based php so this change may have broken that scenario.