### PR TITLE
Update the default l10n server constant url

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -9,7 +9,7 @@ use \Drush\UpdateService\ReleaseInfo;
 /**
  * Default localization server for downloading translations.
  */
-define('MAKE_DEFAULT_L10N_SERVER', 'https://localize.drupal.org/l10n_server.xml');
+define('MAKE_DEFAULT_L10N_SERVER', 'http://ftp.drupal.org/files/translations/l10n_server.xml');
 
 /**
  * Make refuses to build makefiles whose api version is mismatched


### PR DESCRIPTION
Possible fix for failing drush make if you use default server url

Ref: https://www.drupal.org/node/2484343