### PR TITLE
Order of operations fix when discovering drupal root.

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -190,7 +190,7 @@ function drush_site_path($path = NULL) {
     // Move up dir by dir and check each.
     // Stop if we get to a Drupal root.   We don't care
     // if it is DRUSH_SELECTED_DRUPAL_ROOT or some other root.
-    while ($path = _drush_shift_path_up($path) && !drush_valid_root($path)) {
+    while (($path = _drush_shift_path_up($path)) && !drush_valid_root($path)) {
       if (file_exists($path . '/settings.php')) {
         $site_path = $path;
         break;


### PR DESCRIPTION
When I do a drush updb in this directory /var/www/example.com/sites/example.com/modules,I would expect it to run the database update for my site.  This use to work in version 5 but  not when updated to version 7.x it has stopped working.  This is the error I get when running the command. 
```
drush updb
Command updatedb needs a higher bootstrap level to run - you will need to invoke drush from a more functional Drupal environment to run this command.                                                                                        [error]
The drush command 'updb' could not be executed.                                                                                                                                                                                              [error]
Could not find a Drupal settings.php file at sites/default/settings.php.
```

It seem there is a bug in the function drush_site_path() in the first while loop in the file includes/environment.inc
```
 while ($path = _drush_shift_path_up($path) && !drush_valid_root($path)) {
```
$path returns TRUE unless enclosed in parenthesis by the rules of order of operations like
```
 while (($path = _drush_shift_path_up($path)) && !drush_valid_root($path)) {
```