### PR TITLE
Give a little bit more help getting to Drush 8

### DIFF
--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -69,7 +69,7 @@ class DrupalBoot8 extends DrupalBoot {
   }
 
   function bootstrap_drupal_root_validate() {
-    return drush_set_error('DRUSH_DRUPAL_VERSION_UNSUPPORTED', dt('Drush !drush_version does not support Drupal 8.', array('!drush_version' => DRUSH_VERSION)));
+    return drush_set_error('DRUSH_DRUPAL_VERSION_UNSUPPORTED', dt('Drush !drush_version does not support Drupal 8. You will need Drush version 8 or higher. See http://docs.drush.org/en/master/install/ for details.', array('!drush_version' => DRUSH_VERSION)));
   }
 
   function bootstrap_drupal_database() {


### PR DESCRIPTION
I got the error today about "Drush 7.0.0 does not support Drupal 8." but it took me a good 10-15 minutes to figure out how to fix that. (Luckily these instructions still work https://drupalize.me/blog/201408/upgrading-drush-work-drupal-8)

Let's give people a bit more help.