### PR TITLE
Do not check memory limit if it is set to unlimited

### DIFF
--- a/commands/core/drupal/batch.inc
+++ b/commands/core/drupal/batch.inc
@@ -177,7 +177,7 @@ function _drush_batch_worker() {
     $queue = _batch_queue($current_set);
 
     // If we are in progressive mode, break processing after 1 second.
-    if ((memory_get_usage() * 2) >= drush_memory_limit()) {
+    if (drush_memory_limit() > 0 && (memory_get_usage() * 2) >= drush_memory_limit()) {
       drush_log(dt("Batch process has consumed in excess of 50% of available memory. Starting new thread"), "batch");
       // Record elapsed wall clock time.
       $current_set['elapsed'] = round((microtime(TRUE) - $current_set['start']) * 1000, 2);


### PR DESCRIPTION
If you have the memory limit set to unlimited then there's a pretty confusing message about memory usage. This should avoid that.

batch_7.inc probably needs the same fix.