### PR TITLE
Load install file before running update function

### DIFF
--- a/commands/core/drupal/update.inc
+++ b/commands/core/drupal/update.inc
@@ -44,6 +44,8 @@ function drush_update_do_one($module, $number, $dependency_map,  &$context) {
 
   $context['log'] = FALSE;
 
+  \Drupal::moduleHandler()->loadInclude($module, 'install');
+
   $ret = array();
   if (function_exists($function)) {
     try {
@@ -65,6 +67,10 @@ function drush_update_do_one($module, $number, $dependency_map,  &$context) {
     if ($context['log']) {
       $ret['queries'] = Database::getLog($function);
     }
+  }
+  else {
+    $ret['#abort'] = array('success' => FALSE);
+    drush_set_error('DRUSH_UPDATE_FUNCTION_NOT_FOUND', dt('Update function @function not found', array('@function' => $function)));
   }
 
   if (isset($context['sandbox']['#finished'])) {


### PR DESCRIPTION
I was testing custom updates and they just silently didn't do anything.

I don't know why exactly but it looks like the .install file is (no longer?) included, so those functions weren't found and silently ignored.

I made sure that the necessary .install file is loaded and also added an error if a function can't be found.. it's not something that should ever happen (with my fix..), but if it does, then there is at least an error.