### PR TITLE
Bootstrap change in #1257 broke qd with module downloads.

### DIFF
--- a/includes/command.inc
+++ b/includes/command.inc
@@ -150,15 +150,6 @@ function drush_dispatch($command, $arguments = array()) {
   $return = FALSE;
 
   if ($command) {
-    // Insure that we have reached the bootstrap level
-    // desired by the command.  We might not have bootstrapped
-    // far enough if a command uses drush_invoke to call
-    // a subcommand with a higher bootstrap level, for example.
-    $bootstrap_result = drush_bootstrap_to_phase($command['bootstrap']);
-    if (!$bootstrap_result) {
-      return FALSE;
-    }
-
     // Add arguments, if this has not already been done.
     // (If the command was fetched from drush_parse_command,
     // then you cannot provide arguments to drush_dispatch.)


### PR DESCRIPTION
#1257 looks like a nice improvement, but I don't think Drush's bootstrap is quite ready for this.

Here's the failure scenario:

1. drush qd downloads Drupal core
2. If the user specified additional modules to download with qd, then these are pulled in via drush_invoke pm-download.
3. pm-download is marked DRUSH_BOOTSTRAP_MAX.  There is no settings.php file yet, so pm-download gets to DRUSH_BOOTSTRAP_ROOT successfully, but fails on DRUSH_BOOTSTRAP_SITE.  site_validate fails with a bootstrap error, and this error is latched.
4. Drush core-install tries to bootstrap, but fails due to the latched error.

It's unfortunate that I did not find this until after Drush 7 shipped, because in theory, we should not change how bootstrapping works in a stable release.  All the same, I'd like to call this a bugfix, and back out the change with this PR.  This fixes drush qd again.

The real fix probably should involve changing the rules for how the bootstrap validate methods report failures; these methods should not call a failure function that latches the error state, because latched failure state is contrary to the assumptions made by DRUSH_BOOTSTRAP_MAX, which is to say that you can try to bootstrap to any level without causing a problem if the bootstrap fails.  However, it would be too big of a change to do this sort of a change in 7.0 stable, so I think we should first back out this problematic commit in both the master and 7.x branch (presuming Travis is happy with the PR).  We can bring it back later on the master branch.