### PR TITLE
Default to --temp mode when not using --git in config-merge.

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -188,7 +188,7 @@ function config_drush_command() {
         'example-value' => 'origin',
       ),
       'temp' => array(
-        'description' => "Export destination site's configuration to a temporary directory.",
+        'description' => "Export destination site's configuration to a temporary directory.  Defaults to --temp; use --temp=0 to disable. Always ignored in --git mode.",
         'example-value' => 'path',
       ),
     ),
@@ -713,7 +713,7 @@ function drush_config_merge($alias = '', $config_label = 'staging') {
     'git-transport' => drush_get_option('git', FALSE),
     'remote' => drush_get_option('remote', 'origin'),
     'tool' => drush_get_option('tool', ''),
-    'temp' => drush_get_option('temp', ''),
+    'temp' => drush_get_option('temp', TRUE),
     'config-label' => $config_label,
     'live-site' => $alias,
     'dev-site' => '@self',


### PR DESCRIPTION
When running config-merge in rsync mode, it is often the case that the default 'config' directories are not writable by the web server.  In this case, --temp must be used, or config-merge will fail.

In the instances where the 'config' directories _are_ writable, there is never a need to export the configuration to these locations; --temp is always a workable option when in rsync mode.  --temp is already ignored when using --git.

This patch makes --temp the default for rsync mode, as this is a more sensible default.