### PR TITLE
Automatically set prompt to the alias record for the current site

### DIFF
--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -348,6 +348,7 @@ function drush_sitealias_site_set_validate() {
  */
 function drush_sitealias_site_set($site = '@none') {
   if ($filename = drush_sitealias_get_envar_filename()) {
+    $current = is_file($filename) ? trim(file_get_contents($filename)) : "@none";
     $last_site_filename = drush_sitealias_get_envar_filename('drush-drupal-prev-site-');
     if ($site == '-') {
       if (file_exists($last_site_filename)) {
@@ -356,6 +357,19 @@ function drush_sitealias_site_set($site = '@none') {
       else {
         $site = '@none';
       }
+    }
+    if ($site == '@self') {
+      $path = drush_cwd();
+      $site_record = drush_sitealias_lookup_alias_by_path($path, TRUE);
+      if (isset($site_record['#name'])) {
+        $site = '@' . $site_record['#name'];
+      }
+      else {
+        $site = '@none';
+      }
+    }
+    if ($current == $site) {
+      return;
     }
     if (_drush_sitealias_set_context_by_name($site)) {
       if (file_exists($filename)) {
@@ -375,7 +389,7 @@ function drush_sitealias_site_set($site = '@none') {
       }
     }
     else {
-      drush_set_error('DRUPAL_SITE_NOT_FOUND', dt("Could not find a site definition for !site.", array('!site' => $site)));
+      return drush_set_error('DRUPAL_SITE_NOT_FOUND', dt("Could not find a site definition for !site.", array('!site' => $site)));
     }
   }
 }

--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -348,7 +348,7 @@ function drush_sitealias_site_set_validate() {
  */
 function drush_sitealias_site_set($site = '@none') {
   if ($filename = drush_sitealias_get_envar_filename()) {
-    $current = is_file($filename) ? trim(file_get_contents($filename)) : "@none";
+    $current = drush_sitealias_site_get() ?: "@none";
     $last_site_filename = drush_sitealias_get_envar_filename('drush-drupal-prev-site-');
     if ($site == '-') {
       if (file_exists($last_site_filename)) {

--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -348,7 +348,6 @@ function drush_sitealias_site_set_validate() {
  */
 function drush_sitealias_site_set($site = '@none') {
   if ($filename = drush_sitealias_get_envar_filename()) {
-    $current = drush_sitealias_site_get() ?: "@none";
     $last_site_filename = drush_sitealias_get_envar_filename('drush-drupal-prev-site-');
     if ($site == '-') {
       if (file_exists($last_site_filename)) {
@@ -367,9 +366,11 @@ function drush_sitealias_site_set($site = '@none') {
       else {
         $site = '@none';
       }
-    }
-    if ($current == $site) {
-      return;
+      // Using 'site-set @self' is quiet if there is no change.
+      $current = is_file($filename) ? trim(file_get_contents($filename)) : "@none";
+      if ($current == $site) {
+        return;
+      }
     }
     if (_drush_sitealias_set_context_by_name($site)) {
       if (file_exists($filename)) {

--- a/examples/example.bashrc
+++ b/examples/example.bashrc
@@ -149,6 +149,15 @@ fi
 # that will ssh to the remote server when a remote site
 # specification is used.
 function cddl() {
+  fastcddl "$1"
+  use @self
+}
+
+# Use this function instead of 'cddl' if you have a very large number
+# of alias files, and the 'cddl' function is getting too slow as a result.
+# This function does not automatically set your prompt to the site that
+# you 'cd' to, as 'cddl' does.
+function fastcddl() {
   s="$1"
   if [ -z "$s" ]
   then
@@ -172,14 +181,12 @@ function cddl() {
   else
     builtin cd "$s";
   fi
-  use @self
 }
 
-# Works just like the `cd` shell alias above, with one additional
+# Works just like the `cddl` shell alias above, with one additional
 # feature: `cdd @remote-site` works like `ssh @remote-site`,
 # whereas cd above will fail unless the site alias is local.  If
-# you prefer the `ssh` behavior, you can rename this shell alias
-# to `cd`.
+# you prefer this behavior, you can add `alias cd='cdd'` to your .bashrc
 function cdd() {
   s="$1"
   if [ -z "$s" ]

--- a/examples/example.bashrc
+++ b/examples/example.bashrc
@@ -172,6 +172,7 @@ function cddl() {
   else
     builtin cd "$s";
   fi
+  use @self
 }
 
 # Works just like the `cd` shell alias above, with one additional

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -2188,20 +2188,29 @@ function drush_sitealias_cache_alias_by_path($alias_record) {
  * @return
  *   An alias record for the provided path
  */
-function drush_sitealias_lookup_alias_by_path($path) {
+function drush_sitealias_lookup_alias_by_path($path, $allow_best_match=FALSE) {
   $result = drush_sitealias_quick_lookup_cached_alias_by_path($path);
+  $fallback = array();
   if (empty($result)) {
     $aliases = _drush_sitealias_find_and_load_all_aliases();
     foreach ($aliases as $name => $alias_record) {
       if (!isset($alias_record['remote-host']) && isset($alias_record['root']) && isset($alias_record['uri']) && isset($alias_record['#name']) && isset($alias_record['#file'])) {
         if ($path == drush_sitealias_local_site_path($alias_record)) {
           $result = $alias_record;
-          _drush_sitealias_add_inherited_values_to_record($result);
-          drush_sitealias_cache_alias_by_path($result);
-          return $result;
+          break;
+        }
+        if (substr($path, 0, strlen($alias_record['root'])) == $alias_record['root']) {
+          $fallback = $alias_record;
         }
       }
     }
+  }
+  if (empty($result) && $allow_best_match) {
+    $result = $fallback;
+  }
+  if (!empty($result)) {
+    _drush_sitealias_add_inherited_values_to_record($result);
+    drush_sitealias_cache_alias_by_path($result);
   }
   return $result;
 }

--- a/tests/siteSetTest.php
+++ b/tests/siteSetTest.php
@@ -19,18 +19,24 @@ class siteSetCommandCase extends CommandUnishTestCase {
     $output = $this->getOutput();
     $this->assertEquals("Site set to $alias\n$alias", $output);
 
+    $this->drush('site-set', array());
+    $output = $this->getOutput();
+    $this->assertEquals('Site set to @none', $output);
+
+    // No output when we set the site to the same site it was already set to
+    $this->drush('site-set', array());
+    $output = $this->getOutput();
+    $this->assertEquals('', $output);
+
     $this->drush('site-set', array($alias));
     $expected = 'Site set to ' . $alias;
     $output = $this->getOutput();
     $this->assertEquals($expected, $output);
 
-    $this->drush('site-set', array());
+    $this->drush('ev', array("drush_invoke('site-set', '@none'); drush_invoke('site-set', '$alias'); drush_invoke('site-set', '@none'); drush_invoke('site-set', '-'); print drush_sitealias_site_get();"));
     $output = $this->getOutput();
-    $this->assertEquals('Site set to @none', $output);
-
-    $this->drush('ev', array("drush_invoke('site-set', '$alias'); drush_invoke('site-set', '@none'); drush_invoke('site-set', '-'); print drush_sitealias_site_get();"));
-    $output = $this->getOutput();
-    $this->assertEquals("Site set to $alias
+    $this->assertEquals("Site set to @none
+Site set to $alias
 Site set to @none
 Site set to $alias
 $alias", $output);

--- a/tests/siteSetTest.php
+++ b/tests/siteSetTest.php
@@ -23,11 +23,6 @@ class siteSetCommandCase extends CommandUnishTestCase {
     $output = $this->getOutput();
     $this->assertEquals('Site set to @none', $output);
 
-    // No output when we set the site to the same site it was already set to
-    $this->drush('site-set', array());
-    $output = $this->getOutput();
-    $this->assertEquals('', $output);
-
     $this->drush('site-set', array($alias));
     $expected = 'Site set to ' . $alias;
     $output = $this->getOutput();


### PR DESCRIPTION
There are ~~two~~ *three* prerequisites for this patch:

1. The user must source examples/example.bashrc
2. The user must also define `alias cd=cddl`
3. *The user must use a PS1 that contains $(__drush_ps1)*

If ~~both~~ *all three* of these are true, then with this PR, any time the user 'cd's to a Drupal root that has a matching site alias, their prompt will switch to contain the name of the alias to the current site.

There is also a change in behavior here.  If the user 'cd's to a directory that does not contain a Drupal site, then Drush will automatically `use @none`.  This insures that your prompt matches your cwd; however, without this PR, you could formerly `use @alias`, and have your site selection persist when 'cd'ing to different non-Drupal directories.

It would be easy enough to change it around, so the current behavior (sticky 'use') is maintained; however, I suspect that 'auto' + 'sticky' might be a little annoying.  I don't use `use` much, so I'm not sure, but I like the auto-prompt switching feature.

Auto-prompt switching is particularly useful when using #1399.  If you are going to use color as an indicator of what type of site you're currently operating on, it's handy if the prompt picks up available site aliases automatically when switching sites via 'cd' instead of 'use'.