### PR TITLE
Also support objects in the YAML formatter.

### DIFF
--- a/commands/core/outputformat/yaml.inc
+++ b/commands/core/outputformat/yaml.inc
@@ -20,7 +20,7 @@ class drush_outputformat_yaml extends drush_outputformat {
     $dumper->setIndentation(2);
     // The level where you switch to inline YAML is set to PHP_INT_MAX to
     // ensure this does not occur.
-    $output = $dumper->dump($input, PHP_INT_MAX);
+    $output = $dumper->dump($input, PHP_INT_MAX, NULL, NULL, TRUE);
     return $output;
   }
 }


### PR DESCRIPTION
Set the `objectSupport` flag to TRUE. Fixes #1417.