### PR TITLE
Add a UNISH_INCLUDE environment variable

### DIFF
--- a/tests/Unish/CommandUnishTestCase.php
+++ b/tests/Unish/CommandUnishTestCase.php
@@ -230,6 +230,13 @@ abstract class CommandUnishTestCase extends UnishTestCase {
     $hide_stderr = FALSE;
     $cmd[] = UNISH_DRUSH;
 
+    // If the UNISH_INCLUDE environment variable is set, then include  the specified
+    // commandfiles directory (allow Drush extensions to use Drush's unit test framework)
+    $include=getenv('UNISH_INCLUDE');
+    if ($include) {
+      $cmd[] = "--include='$include'";
+    }
+
     // insert global options
     foreach ($options as $key => $value) {
       if (in_array($key, $global_option_list)) {


### PR DESCRIPTION
This allows Drush extensions to use Unish functional tests to test their commands.

Already using this in [drush-ops/config-extra](https://github.com/drush-ops/config-extra/blob/master/runtests.sh), but let me know if you know of a better way to do this.  Without adding --include to `drush` callbacks, Drush will not be able to find the commandfiles it is supposed to be testing.

If this PR is okay, I can set up travis to run the config-extra functional tests on every commit once this is available.