### PR TITLE
Raise minimum PHP to 5.4.5 (like Drupal 8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 language: php
 php:
 #  See master-fulltest branch for broader PHP version testing.
-  - 5.4
+  - 5.5
 
 # http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "drush.complete.sh"
   ],
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.4.5",
     "d11wtq/boris": "~1.0",
     "symfony/yaml": "~2.2",
     "symfony/var-dumper": "^2.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d5bb6cd6768a39b3c79c56dfd44dd7ae",
+    "hash": "0839439a1593f281a4ae602ee11a1cf7",
     "packages": [
         {
             "name": "d11wtq/boris",
@@ -1170,7 +1170,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.5"
     },
     "platform-dev": []
 }

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -45,11 +45,7 @@ and MySQL to use in the command line interface. This is independent of the php
 version selected in the MAMP application settings.  Under OS X, edit (or create
 if it does not already exist) a file called .bash_profile in your home folder.
 
-To use php 5.3.x, add this line to .bash_profile:
-
-    export PATH="/Applications/MAMP/Library/bin:/Applications/MAMP/bin/php5.3/bin:$PATH"
-
-If you want to use php 5.4.x, add this line instead:
+If you want to use php 5.4.x, add this line:
 
     export PATH="/Applications/MAMP/Library/bin:/Applications/MAMP/bin/php5.4/bin:$PATH"
     
@@ -144,14 +140,7 @@ be passed to php on the command line when Drush is executed.
 
 Drush requires a fairly unrestricted php environment to run in.  In particular,
 you should insure that safe_mode, open_basedir, disable_functions and
-disable_classes are empty.  If you are using php 5.3.x, you may also need to
-add the following definitions to your php.ini file:
-
-```ini
-magic_quotes_gpc = Off
-magic_quotes_runtime = Off
-magic_quotes_sybase = Off
-```
+disable_classes are empty.
 
 Drushrc.php
 -----------

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@ Each version of Drush supports multiple Drupal versions.  Drush 7 is current sta
 
 Drush Version | Branch  | PHP | Compatible Drupal versions | Code Status
 ------------- | ------  | --- | -------------------------- | -----------
-Drush 8       | [master](https://travis-ci.org/drush-ops/drush)  | 5.4.0+ | D6, D7, D8                 | <img src="https://travis-ci.org/drush-ops/drush.svg?branch=master">
+Drush 8       | [master](https://travis-ci.org/drush-ops/drush)  | 5.4.5+ | D6, D7, D8                 | <img src="https://travis-ci.org/drush-ops/drush.svg?branch=master">
 Drush 7       | [7.x](https://travis-ci.org/drush-ops/drush) | 5.3.0+ | D6, D7                     | <img src="https://travis-ci.org/drush-ops/drush.svg?branch=7.x">
 Drush 6       | [6.x](https://travis-ci.org/drush-ops/drush) | 5.3.0+ | D6, D7                     | <img src="https://travis-ci.org/drush-ops/drush.svg?branch=6.x">
 Drush 5       | [5.x](https://travis-ci.org/drush-ops/drush) | 5.2.0+ | D6, D7                     | Unsupported

--- a/drush
+++ b/drush
@@ -124,12 +124,6 @@ if [ -n "$PHP_OPTIONS" ] ; then
   php_options="$php_options $PHP_OPTIONS"
 fi
 
-# If on PHP 5.3, disable magic_quotes_gpc and friends
-PHP_MINOR_VERSION="`\"$php\" -r 'print PHP_MINOR_VERSION;'`"
-if [ $PHP_MINOR_VERSION -le 3 ] ; then
-  php_options="$php_options -d magic_quotes_gpc=Off -d magic_quotes_runtime=Off -d magic_quotes_sybase=Off"
-fi
-
 # Pass in the path to php so that drush knows which one to use if it
 # re-launches itself to run subcommands.  We will also pass in the php options.
 # Important note: Any options added here must be removed  when Drush processes

--- a/drush.php
+++ b/drush.php
@@ -5,7 +5,7 @@
  * @file
  * drush is a PHP script implementing a command line shell for Drupal.
  *
- * @requires PHP CLI 5.3.0, or newer.
+ * @requires PHP CLI 5.4.5, or newer.
  */
 
 exit(drush_main());

--- a/examples/example.bashrc
+++ b/examples/example.bashrc
@@ -287,7 +287,7 @@ function dssh() {
 }
 
 # Drush checks the current PHP version to ensure compatibility, and fails with
-# an error if less than the supported minimum (currently 5.3.0). If you would
+# an error if less than the supported minimum (currently 5.4.5). If you would
 # like to try to run Drush on a lower version of PHP, you can un-comment the
 # line below to skip this check. Note, however, that this is un-supported.
 

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -65,7 +65,7 @@ function drush_preflight_prepare() {
   // PHP_VERSION, such as drush_json_encode(), runserver/runserver.drush.inc, and also
   // adjust _drush_environment_check_php_ini() and the php_prohibited_options
   // list in the drush script.  See http://drupal.org/node/1748228
-  define('DRUSH_MINIMUM_PHP', '5.3.0');
+  define('DRUSH_MINIMUM_PHP', '5.4.5');
   if (version_compare(phpversion(), DRUSH_MINIMUM_PHP) < 0 && !getenv('DRUSH_NO_MIN_PHP')) {
     return drush_set_error('DRUSH_REQUIREMENTS_ERROR', dt('Your command line PHP installation is too old. Drush requires at least PHP !version. To suppress this check, set the environment variable DRUSH_NO_MIN_PHP=1', array('!version' => DRUSH_MINIMUM_PHP)));
   }

--- a/lib/Drush/Sql/SqlVersion.php
+++ b/lib/Drush/Sql/SqlVersion.php
@@ -24,7 +24,7 @@ class SqlVersion {
    * by drush_valid_db_credentials().
    */
   public function valid_credentials($db_spec) {
-    // Drupal >=7 requires PDO and Drush requires php 5.3 which ships with PDO
+    // Drupal >=7 requires PDO and Drush requires php 5.4+ which ships with PDO
     // but it may be compiled with --disable-pdo.
     if (!class_exists('\PDO')) {
       drush_log(dt('PDO support is required.'), 'bootstrap');


### PR DESCRIPTION
- Lets avoid using Drupal 5.4 features for a while so commits are more easily backported
- Unish test suite now tests on 5.5 by default. The *-fulltest branches have broader PHP version testing.