### PR TITLE
Add a storage wrapper / storage filter to Drush config import and export

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -106,7 +106,7 @@ function config_drush_command() {
         'example-value' => 'branchname',
       ),
       'destination' => 'An arbitrary directory that should receive the exported files. An alternative to label argument',
-      'module-adjustments' => 'A list of modules to always enable.',
+      'ignored-modules' => 'A list of modules to ignore during export (e.g. to avoid listing dev-only modules in exported configuration).',
     ),
   );
 
@@ -122,7 +122,7 @@ function config_drush_command() {
       ),
       'source' => 'An arbitrary directory that holds the configuration files. An alternative to label argument',
       'partial' => 'Allows for partial config imports from the source directory. Only updates and new configs will be processed with this flag (missing configs will not be deleted).',
-      'module-adjustments' => 'A list of modules to always enable.',
+      'ignored-modules' => 'A list of modules to ignore during import (e.g. to avoid disabling dev-only modules that are not enabled in the imported configuration).',
     ),
     'core' => array('8+'),
     'aliases' => array('cim'),
@@ -500,10 +500,10 @@ function drush_config_import_validate() {
 
 function _drush_config_get_storage_filters() {
   $result = array();
-  $module_adjustments = drush_get_option('module-adjustments');
+  $module_adjustments = drush_get_option('ignored-modules');
   if (!empty($module_adjustments)) {
     if (is_string($module_adjustments)) {
-      $module_adjustments = array_flip(explode(',', $module_adjustments));
+      $module_adjustments = explode(',', $module_adjustments);
     }
     $result[] = new CoreExtensionFilter($module_adjustments);
   }

--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -8,6 +8,8 @@
 use Drupal\Core\Config\StorageComparer;
 use Drupal\Core\Config\ConfigImporter;
 use Drupal\Core\Config\FileStorage;
+use Drush\Config\StorageWrapper;
+use Drush\Config\CoreExtensionFilter;
 use Symfony\Component\Yaml\Parser;
 
 /**
@@ -104,6 +106,7 @@ function config_drush_command() {
         'example-value' => 'branchname',
       ),
       'destination' => 'An arbitrary directory that should receive the exported files. An alternative to label argument',
+      'module-adjustments' => 'A list of modules to always enable.',
     ),
   );
 
@@ -119,6 +122,7 @@ function config_drush_command() {
       ),
       'source' => 'An arbitrary directory that holds the configuration files. An alternative to label argument',
       'partial' => 'Allows for partial config imports from the source directory. Only updates and new configs will be processed with this flag (missing configs will not be deleted).',
+      'module-adjustments' => 'A list of modules to always enable.',
     ),
     'core' => array('8+'),
     'aliases' => array('cim'),
@@ -367,12 +371,30 @@ function _drush_config_export($destination, $destination_dir, $branch) {
   if (!$comment) {
     $comment = "Exported configuration.";
   }
+  $storage_filters = _drush_config_get_storage_filters();
   if (count(glob($destination_dir . '/*')) > 0) {
     // Retrieve a list of differences between the active and target configuration (if any).
     $target_storage = new FileStorage($destination_dir);
     /** @var \Drupal\Core\Config\StorageInterface $active_storage */
     $active_storage = Drupal::service('config.storage');
-    $config_comparer = new StorageComparer($active_storage, $target_storage, Drupal::service('config.manager'));
+    $comparison_source = $active_storage;
+
+    // If the output is being filtered, then write a temporary copy before doing
+    // any comparison.
+    if (!empty($storage_filters)) {
+      $tmpdir = drush_tempdir();
+      drush_copy_dir($destination_dir, $tmpdir, FILE_EXISTS_OVERWRITE);
+      $comparison_source = new FileStorage($tmpdir);
+      $comparison_source_filtered = new StorageWrapper($comparison_source, $storage_filters);
+      foreach ($active_storage->listAll() as $name) {
+        // Copy active storage to our temporary active store.
+        if ($existing = $active_storage->read($name)) {
+          $comparison_source_filtered->write($name, $existing);
+        }
+      }
+    }
+
+    $config_comparer = new StorageComparer($comparison_source, $target_storage, Drupal::service('config.manager'));
     if (!$config_comparer->createChangelist()->hasChanges()) {
       return drush_log(dt('There are no changes to export.'), 'ok');
     }
@@ -402,6 +424,10 @@ function _drush_config_export($destination, $destination_dir, $branch) {
   // Write all .yml files.
   $source_storage = Drupal::service('config.storage');
   $destination_storage = new FileStorage($destination_dir);
+  // If therea re any filters, then attach them to the destination storage
+  if (!empty($storage_filters)) {
+    $destination_storage = new StorageWrapper($destination_storage, $storage_filters);
+  }
   foreach ($source_storage->listAll() as $name) {
     $destination_storage->write($name, $source_storage->read($name));
   }
@@ -472,6 +498,18 @@ function drush_config_import_validate() {
   }
 }
 
+function _drush_config_get_storage_filters() {
+  $result = array();
+  $module_adjustments = drush_get_option('module-adjustments');
+  if (!empty($module_adjustments)) {
+    if (is_string($module_adjustments)) {
+      $module_adjustments = array_flip(explode(',', $module_adjustments));
+    }
+    $result[] = new CoreExtensionFilter($module_adjustments);
+  }
+  return $result;
+}
+
 /**
  * Command callback. Import from specified config directory (defaults to staging).
  */
@@ -500,6 +538,13 @@ function drush_config_import($source = NULL) {
   $source_storage = new FileStorage($source_dir);
   /** @var \Drupal\Core\Config\StorageInterface $active_storage */
   $active_storage = Drupal::service('config.storage');
+  // If our configuration storage is being filtered, then attach all filters
+  // to the source storage object.  We will use the filtered values uniformly
+  // for comparison, full imports, and partial imports.
+  $storage_filters = _drush_config_get_storage_filters();
+  if (!empty($storage_filters)) {
+    $source_storage = new StorageWrapper($source_storage, $storage_filters);
+  }
   if (drush_get_option('partial', FALSE)) {
     // With partial imports, the comparison must only be made against configs
     // that exist in the source directory.

--- a/lib/Drush/Config/CoreExtensionFilter.php
+++ b/lib/Drush/Config/CoreExtensionFilter.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @file
+ * Definition of Drush\Config\StorageFilter.
+ */
+
+namespace Drush\Config;
+
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * This filter adjusts the data going to and coming from
+ * the core.extension configuration object.
+ *
+ * Modules named in this list cause the following actions:
+ *
+ *   * On read, items from the "adjustments" list are examined
+ *     one at a time.  If their value is numeric, it is used as
+ *     the module weight, and merged in with the data being read
+ *     from the existing core.extension configuration item, forcing
+ *     the extension to be enabled.  If the value is non-numeric,
+ *     such as FALSE or NULL or "disable", then the item will be
+ *     removed from the list, forcing the extension to be disabled.
+ *
+ *   * On write, the existing storage configuration object
+ *     is read.  Items in the data being written are replaced
+ *     with their value from the existing configuration data
+ *     iff the item exists in the "adjustments" list.
+ *
+ * The data from core.extension looks like this:
+ *
+ * module:
+ *   modulename: weight
+ * theme:
+ *   themename: weight
+ *
+ * The "adjustments" lists should contain a list of "modulename: weight"
+ * pairs.  Use non-numeric weights to indicate "disabled".  Only
+ * the module list is adjusted; the theme list is not altered.
+ */
+class CoreExtensionFilter implements StorageFilter {
+
+  protected $adjustments;
+  protected $alwaysDisabled;
+
+  function __construct($adjustments = array()) {
+    $this->adjustments = $adjustments;
+  }
+
+  public function filterRead($name, $data) {
+    if ($name != 'core.extension') {
+      return $data;
+    }
+    foreach($this->adjustments as $module => $weight) {
+      if (is_numeric($weight)) {
+        $data['module'][$module] = $weight;
+      }
+      else {
+        unset($data['module'][$module]);
+      }
+    }
+    return $data;
+  }
+
+  public function filterWrite($name, array $data, StorageInterface $storage) {
+    if ($name != 'core.extension') {
+      return $data;
+    }
+    $originalData = $storage->read($name);
+    foreach($this->adjustments as $module => $weight) {
+      if (is_array($originalData) && array_key_exists($module, $originalData['module'])) {
+        $data['module'][$module] = $originalData['module'][$module];
+      }
+      else {
+        unset($data['module'][$module]);
+      }
+    }
+    return $data;
+  }
+
+}

--- a/lib/Drush/Config/StorageFilter.php
+++ b/lib/Drush/Config/StorageFilter.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @file
+ * Definition of Drush\Config\StorageFilter.
+ */
+
+namespace Drush\Config;
+
+use Drupal\Core\Config\StorageInterface;
+
+interface StorageFilter {
+
+  /**
+   * Filters configuration data after it is read from storage.
+   *
+   * @param string $name
+   *   The name of a configuration object to load.
+   * @param array $data
+   *   The configuration data to filter.
+   *
+   * @return array $data
+   *   The filtered data.
+   */
+  public function filterRead($name, $data);
+
+  /**
+   * Filter configuration data before it is written to storage.
+   *
+   * @param string $name
+   *   The name of a configuration object to save.
+   * @param array $data
+   *   The configuration data to filter.
+   * @param StorageInterface
+   *   The storage object that the filtered data will be
+   *   written to.  Provided in case the filter needs to
+   *   read the existing configuration before writing it.
+   *
+   * @return array $data
+   *   The filtered data.
+   */
+  public function filterWrite($name, array $data, StorageInterface $storage);
+
+}

--- a/lib/Drush/Config/StorageWrapper.php
+++ b/lib/Drush/Config/StorageWrapper.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * @file
+ * Definition of Drush\Config\StorageWrapper.
+ */
+
+namespace Drush\Config;
+
+use Drupal\Core\Config\StorageInterface;
+
+class StorageWrapper implements StorageInterface {
+
+  /**
+   * The storage container that we are wrapping.
+   *
+   * @var \Drupal\Core\Config\StorageInterface
+   */
+  protected $storage;
+  protected $filters;
+
+  /**
+   * Create a StorageWrapper with some storage and a filter.
+   */
+  function __construct($storage, $filterOrFilters) {
+    $this->storage = $storage;
+    $this->filters = is_array($filterOrFilters) ? $filterOrFilters : array($filterOrFilters);
+  }
+
+  /**
+   * Returns whether a configuration object exists.
+   *
+   * @param string $name
+   *   The name of a configuration object to test.
+   *
+   * @return bool
+   *   TRUE if the configuration object exists, FALSE otherwise.
+   */
+  public function exists($name) {
+    return $this->storage->exists($name);
+  }
+
+  /**
+   * Reads configuration data from the storage.
+   *
+   * @param string $name
+   *   The name of a configuration object to load.
+   *
+   * @return array|bool
+   *   The configuration data stored for the configuration object name. If no
+   *   configuration data exists for the given name, FALSE is returned.
+   */
+  public function read($name) {
+    $data = $this->storage->read($name);
+
+    foreach ($this->filters as $filter) {
+      $data = $filter->filterRead($name, $data);
+    }
+
+    return $data;
+  }
+
+  /**
+   * Reads configuration data from the storage.
+   *
+   * @param array $names
+   *   List of names of the configuration objects to load.
+   *
+   * @return array
+   *   A list of the configuration data stored for the configuration object name
+   *   that could be loaded for the passed list of names.
+   */
+  public function readMultiple(array $names) {
+    $dataList = $this->storage->readMultiple($names);
+    $result = array();
+
+    foreach ($dataList as $name => $data) {
+      foreach ($this->filters as $filter) {
+        $data = $filter->filterRead($name, $data);
+      }
+      $result[$name] = $data;
+    }
+
+    return $result;
+  }
+
+  /**
+   * Writes configuration data to the storage.
+   *
+   * @param string $name
+   *   The name of a configuration object to save.
+   * @param array $data
+   *   The configuration data to write.
+   *
+   * @return bool
+   *   TRUE on success, FALSE in case of an error.
+   *
+   * @throws \Drupal\Core\Config\StorageException
+   *   If the back-end storage does not exist and cannot be created.
+   */
+  public function write($name, array $data) {
+    foreach ($this->filters as $filter) {
+      $data = $filter->filterWrite($name, $data, $this->storage);
+    }
+
+    return $this->storage->write($name, $data);
+  }
+
+  /**
+   * Deletes a configuration object from the storage.
+   *
+   * @param string $name
+   *   The name of a configuration object to delete.
+   *
+   * @return bool
+   *   TRUE on success, FALSE otherwise.
+   */
+  public function delete($name) {
+    return $this->storage->delete($name);
+  }
+
+  /**
+   * Renames a configuration object in the storage.
+   *
+   * @param string $name
+   *   The name of a configuration object to rename.
+   * @param string $new_name
+   *   The new name of a configuration object.
+   *
+   * @return bool
+   *   TRUE on success, FALSE otherwise.
+   */
+  public function rename($name, $new_name) {
+    return $this->storage->rename($name, $new_name);
+  }
+
+  /**
+   * Encodes configuration data into the storage-specific format.
+   *
+   * @param array $data
+   *   The configuration data to encode.
+   *
+   * @return string
+   *   The encoded configuration data.
+   *
+   * This is a publicly accessible static method to allow for alternative
+   * usages in data conversion scripts and also tests.
+   */
+  public function encode($data) {
+    return $this->storage->encode($data);
+  }
+
+  /**
+   * Decodes configuration data from the storage-specific format.
+   *
+   * @param string $raw
+   *   The raw configuration data string to decode.
+   *
+   * @return array
+   *   The decoded configuration data as an associative array.
+   *
+   * This is a publicly accessible static method to allow for alternative
+   * usages in data conversion scripts and also tests.
+   */
+  public function decode($raw) {
+    return $this->storage->decode($raw);
+  }
+
+  /**
+   * Gets configuration object names starting with a given prefix.
+   *
+   * Given the following configuration objects:
+   * - node.type.article
+   * - node.type.page
+   *
+   * Passing the prefix 'node.type.' will return an array containing the above
+   * names.
+   *
+   * @param string $prefix
+   *   (optional) The prefix to search for. If omitted, all configuration object
+   *   names that exist are returned.
+   *
+   * @return array
+   *   An array containing matching configuration object names.
+   */
+  public function listAll($prefix = '') {
+    return $this->storage->listAll($prefix);
+  }
+
+  /**
+   * Deletes configuration objects whose names start with a given prefix.
+   *
+   * Given the following configuration object names:
+   * - node.type.article
+   * - node.type.page
+   *
+   * Passing the prefix 'node.type.' will delete the above configuration
+   * objects.
+   *
+   * @param string $prefix
+   *   (optional) The prefix to search for. If omitted, all configuration
+   *   objects that exist will be deleted.
+   *
+   * @return boolean
+   *   TRUE on success, FALSE otherwise.
+   */
+  public function deleteAll($prefix = '') {
+    return $this->storage->deleteAll($prefix);
+  }
+
+  /**
+   * Creates a collection on the storage.
+   *
+   * A configuration storage can contain multiple sets of configuration objects
+   * in partitioned collections. The collection name identifies the current
+   * collection used.
+   *
+   * Implementations of this method must provide a new instance to avoid side
+   * effects caused by the fact that Config objects have their storage injected.
+   *
+   * @param string $collection
+   *   The collection name. Valid collection names conform to the following
+   *   regex [a-zA-Z_.]. A storage does not need to have a collection set.
+   *   However, if a collection is set, then storage should use it to store
+   *   configuration in a way that allows retrieval of configuration for a
+   *   particular collection.
+   *
+   * @return \Drupal\Core\Config\StorageInterface
+   *   A new instance of the storage backend with the collection set.
+   */
+  public function createCollection($collection) {
+    return $this->storage->createCollection($collection);
+  }
+
+  /**
+   * Gets the existing collections.
+   *
+   * A configuration storage can contain multiple sets of configuration objects
+   * in partitioned collections. The collection key name identifies the current
+   * collection used.
+   *
+   * @return array
+   *   An array of existing collection names.
+   */
+  public function getAllCollectionNames() {
+    return $this->storage->getAllCollectionNames();
+  }
+
+  /**
+   * Gets the name of the current collection the storage is using.
+   *
+   * @return string
+   *   The current collection name.
+   */
+  public function getCollectionName() {
+    return $this->storage->getCollectionName();
+  }
+
+}

--- a/lib/Drush/Config/StorageWrapper.php
+++ b/lib/Drush/Config/StorageWrapper.php
@@ -28,27 +28,14 @@ class StorageWrapper implements StorageInterface {
   }
 
   /**
-   * Returns whether a configuration object exists.
-   *
-   * @param string $name
-   *   The name of a configuration object to test.
-   *
-   * @return bool
-   *   TRUE if the configuration object exists, FALSE otherwise.
+   * {@inheritdoc}
    */
   public function exists($name) {
     return $this->storage->exists($name);
   }
 
   /**
-   * Reads configuration data from the storage.
-   *
-   * @param string $name
-   *   The name of a configuration object to load.
-   *
-   * @return array|bool
-   *   The configuration data stored for the configuration object name. If no
-   *   configuration data exists for the given name, FALSE is returned.
+   * {@inheritdoc}
    */
   public function read($name) {
     $data = $this->storage->read($name);
@@ -61,14 +48,7 @@ class StorageWrapper implements StorageInterface {
   }
 
   /**
-   * Reads configuration data from the storage.
-   *
-   * @param array $names
-   *   List of names of the configuration objects to load.
-   *
-   * @return array
-   *   A list of the configuration data stored for the configuration object name
-   *   that could be loaded for the passed list of names.
+   * {@inheritdoc}
    */
   public function readMultiple(array $names) {
     $dataList = $this->storage->readMultiple($names);
@@ -85,18 +65,7 @@ class StorageWrapper implements StorageInterface {
   }
 
   /**
-   * Writes configuration data to the storage.
-   *
-   * @param string $name
-   *   The name of a configuration object to save.
-   * @param array $data
-   *   The configuration data to write.
-   *
-   * @return bool
-   *   TRUE on success, FALSE in case of an error.
-   *
-   * @throws \Drupal\Core\Config\StorageException
-   *   If the back-end storage does not exist and cannot be created.
+   * {@inheritdoc}
    */
   public function write($name, array $data) {
     foreach ($this->filters as $filter) {
@@ -107,150 +76,63 @@ class StorageWrapper implements StorageInterface {
   }
 
   /**
-   * Deletes a configuration object from the storage.
-   *
-   * @param string $name
-   *   The name of a configuration object to delete.
-   *
-   * @return bool
-   *   TRUE on success, FALSE otherwise.
+   * {@inheritdoc}
    */
   public function delete($name) {
     return $this->storage->delete($name);
   }
 
   /**
-   * Renames a configuration object in the storage.
-   *
-   * @param string $name
-   *   The name of a configuration object to rename.
-   * @param string $new_name
-   *   The new name of a configuration object.
-   *
-   * @return bool
-   *   TRUE on success, FALSE otherwise.
+   * {@inheritdoc}
    */
   public function rename($name, $new_name) {
     return $this->storage->rename($name, $new_name);
   }
 
   /**
-   * Encodes configuration data into the storage-specific format.
-   *
-   * @param array $data
-   *   The configuration data to encode.
-   *
-   * @return string
-   *   The encoded configuration data.
-   *
-   * This is a publicly accessible static method to allow for alternative
-   * usages in data conversion scripts and also tests.
+   * {@inheritdoc}
    */
   public function encode($data) {
     return $this->storage->encode($data);
   }
 
   /**
-   * Decodes configuration data from the storage-specific format.
-   *
-   * @param string $raw
-   *   The raw configuration data string to decode.
-   *
-   * @return array
-   *   The decoded configuration data as an associative array.
-   *
-   * This is a publicly accessible static method to allow for alternative
-   * usages in data conversion scripts and also tests.
+   * {@inheritdoc}
    */
   public function decode($raw) {
     return $this->storage->decode($raw);
   }
 
   /**
-   * Gets configuration object names starting with a given prefix.
-   *
-   * Given the following configuration objects:
-   * - node.type.article
-   * - node.type.page
-   *
-   * Passing the prefix 'node.type.' will return an array containing the above
-   * names.
-   *
-   * @param string $prefix
-   *   (optional) The prefix to search for. If omitted, all configuration object
-   *   names that exist are returned.
-   *
-   * @return array
-   *   An array containing matching configuration object names.
+   * {@inheritdoc}
    */
   public function listAll($prefix = '') {
     return $this->storage->listAll($prefix);
   }
 
   /**
-   * Deletes configuration objects whose names start with a given prefix.
-   *
-   * Given the following configuration object names:
-   * - node.type.article
-   * - node.type.page
-   *
-   * Passing the prefix 'node.type.' will delete the above configuration
-   * objects.
-   *
-   * @param string $prefix
-   *   (optional) The prefix to search for. If omitted, all configuration
-   *   objects that exist will be deleted.
-   *
-   * @return boolean
-   *   TRUE on success, FALSE otherwise.
+   * {@inheritdoc}
    */
   public function deleteAll($prefix = '') {
     return $this->storage->deleteAll($prefix);
   }
 
   /**
-   * Creates a collection on the storage.
-   *
-   * A configuration storage can contain multiple sets of configuration objects
-   * in partitioned collections. The collection name identifies the current
-   * collection used.
-   *
-   * Implementations of this method must provide a new instance to avoid side
-   * effects caused by the fact that Config objects have their storage injected.
-   *
-   * @param string $collection
-   *   The collection name. Valid collection names conform to the following
-   *   regex [a-zA-Z_.]. A storage does not need to have a collection set.
-   *   However, if a collection is set, then storage should use it to store
-   *   configuration in a way that allows retrieval of configuration for a
-   *   particular collection.
-   *
-   * @return \Drupal\Core\Config\StorageInterface
-   *   A new instance of the storage backend with the collection set.
+   * {@inheritdoc}
    */
   public function createCollection($collection) {
     return $this->storage->createCollection($collection);
   }
 
   /**
-   * Gets the existing collections.
-   *
-   * A configuration storage can contain multiple sets of configuration objects
-   * in partitioned collections. The collection key name identifies the current
-   * collection used.
-   *
-   * @return array
-   *   An array of existing collection names.
+   * {@inheritdoc}
    */
   public function getAllCollectionNames() {
     return $this->storage->getAllCollectionNames();
   }
 
   /**
-   * Gets the name of the current collection the storage is using.
-   *
-   * @return string
-   *   The current collection name.
+   * {@inheritdoc}
    */
   public function getCollectionName() {
     return $this->storage->getCollectionName();


### PR DESCRIPTION
**Goal**

Keep "development" modules such as "devel" enabled on the development machine, but disabled on the production machine.  It should be possible to store configuration in git, and make configuration changes on both dev and prod, and merge them via config-merge without causing repetitious conflicts between the dev modules' state, and the configuration state stored in the repository.

**Why This is Hard**

The Drupal 8 configuration management system defines "staging" and "active" configurations, and allows us to make more if we need them.  Couldn't we just make a "development" configuration, and then, in a post-config-import hook, copy "staging" to "development", apply the development module configuration changes, and run config-import on the development configuration set?

Besides the minor issue of recursion, which could be worked out, the larger issue that we have is that the development configuration changes are now in the active configuration in the database; if we make other config changes, and want to export those to commit them to the git repository, then the config changes we want are mixed in with the config changes automatically applied to enable dev modules.  This is not desirable.

**What About settings.php?**

If you want to change a simple configuration value, and have it active only on a dev machine, you can easily add configuration overrides to settings.php, like this:

`$config['system.site']['name'] = 'Local Install of Awesome Widgets, Inc.';`

This works for most kinds of configuration settings that you'd like to adjust on the dev site only; unfortunately, core.extension cannot be altered like this, as enabling / disabling modules is done in hooks that run at value import / set time, and settings.php only allows values to be overridden.

(If someone can get settings.php config overrides to work with modules, that would be a cool alternative to this, but I don't think it's possible.)

**Proposed Solution**

This PR adds "StorageWrapper" and "StorageFilter" classes, and hooks them in to config-merge and config-export.  A "StorageWrapper" is simply a wrapper class for any StorageInterface object.  When a method of StorageWrapper is called, it simply calls through to its delegate storage object.  In the case of reading and writing configuration, it allows the "StorageFilter" object to adjust the configuration values before it is read or written.  To keep this class simple, it does not allow configuration files or collections to be added or removed; only the values they store can be adjusted.

Drush config-import and config-export will apply a StorageWrapper to the FileStorage object used to read or write (respectively) configuration to the file system, and filter them with any active StorageFilter objects.  The configuration is also filtered as necessary prior to being used by the StorageComparer, so that the user gets accurate reports  

The proposal on the table is to put at least this much into Drush core.

**Interim Implementation**

Just having the ability to apply filters is not enough, of course; it is also necessary to use the filters to do something.  As previously mentioned, configuration overrides in settings.php cover most of the desired use cases, so this PR provides just one simple filter designed only to enable and disable modules.

This one filter is currently hard-coded into config-import / config-export, but the intention is to hook it.  Also, the exact UX for exposing this feature is still preliminary; feedback on options and usage appreciated.

Finally, we also need to decide on packaging.  This could conceivably be placed in the "examples" folder, like the sync-enable policy, or maybe the implementation goes in config-extra.
