### PR TITLE
Improve queue running (exception handling, time limits, summary messages)

### DIFF
--- a/commands/core/queue.drush.inc
+++ b/commands/core/queue.drush.inc
@@ -20,6 +20,9 @@ function queue_drush_command() {
       'queue_name' => 'The name of the queue to run, as defined in either hook_queue_info or hook_cron_queue_info.',
     ),
     'required-arguments' => TRUE,
+    'options' => array(
+      'time-limit' => 'The maximum number of seconds allowed to run the queue',
+    ),
   );
   $items['queue-list'] = array(
     'description' => 'Returns a list of all defined queues',
@@ -46,16 +49,13 @@ function queue_drush_command() {
  * Validation callback for drush queue-run.
  */
 function drush_queue_run_validate($queue_name) {
-  $queue = drush_queue_get_class();
-  $queue->validate('queue-run');
-}
-
-/**
- * Validation callback for drush queue-list.
- */
-function drush_queue_list_validate() {
-  $queue = drush_queue_get_class();
-  $queue->validate('queue-list');
+  try {
+    $queue = drush_queue_get_class();
+    $queue->getInfo($queue_name);
+  }
+  catch (\Drush\Queue\QueueException $exception) {
+    return drush_set_error('DRUSH_QUEUE_RUN_VALIDATION_ERROR', $exception->getMessage());
+  }
 }
 
 /**
@@ -76,7 +76,11 @@ function drush_queue_get_class() {
  */
 function drush_queue_run($queue_name) {
   $queue = drush_queue_get_class();
-  $queue->run($queue_name);
+  $time_limit = (int) drush_get_option('time-limit');
+  $start = microtime(TRUE);
+  $count = $queue->run($queue_name, $time_limit);
+  $elapsed = microtime(TRUE) - $start;
+  drush_log(dt('Processed @count items from the @name queue in @elapsed sec.', array('@count' => $count, '@name' => $queue_name, '@elapsed' => round($elapsed, 2))), drush_get_error() ? 'warning' : 'ok');
 }
 
 /**

--- a/lib/Drush/Queue/Queue6.php
+++ b/lib/Drush/Queue/Queue6.php
@@ -7,21 +7,15 @@ class Queue6 extends Queue7 {
   /**
    * {@inheritdoc}
    */
-  public function validate($command) {
+  public function getQueues() {
     // Drupal 6 has no core queue capabilities, and thus requires contrib.
     if (!module_exists('drupal_queue')) {
-      $args = array('!command' => $command, '!dependencies' => 'drupal_queue');
-      throw new QueueException(dt('Command !command needs the following modules installed/enabled to run: !dependencies.', $args));
+      throw new QueueException(dt('The drupal_queue module need to be installed/enabled.'));
     }
     else {
       drupal_queue_include();
     }
-  }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getQueues() {
     if (!isset($this->queues)) {
       $this->queues = module_invoke_all('cron_queue_info');
       drupal_alter('cron_queue_info', $this->queues);

--- a/lib/Drush/Queue/Queue7.php
+++ b/lib/Drush/Queue/Queue7.php
@@ -10,30 +10,32 @@ class Queue7 extends QueueBase {
    * {@inheritdoc}
    */
   public function getQueues() {
-    if (!isset($this->queues)) {
-      $this->queues = module_invoke_all('cron_queue_info');
+    if (!isset(static::$queues)) {
+      static::$queues = module_invoke_all('cron_queue_info');
       drupal_alter('cron_queue_info', $this->queues);
-      foreach($this->queues as $name => $queue) {
-        $this->queues[$name]['worker callback'] = $queue['worker callback'];
+      foreach (static::$queues as $name => $queue) {
+        static::$queues[$name]['worker callback'] = $queue['worker callback'];
         if (isset($queue['time'])) {
-          $this->queues[$name]['cron']['time'] = $queue['time'];
+          static::$queues[$name]['cron']['time'] = $queue['time'];
         }
       }
       // Merge in queues from modules that implement hook_queue_info.
       // Currently only defined by the queue_ui module.
       $info_queues = module_invoke_all('queue_info');
-      foreach($info_queues as $name => $queue) {
-        $this->queues[$name]['worker callback'] = $queue['cron']['callback'];
+      foreach ($info_queues as $name => $queue) {
+        static::$queues[$name]['worker callback'] = $queue['cron']['callback'];
         if (isset($queue['cron']['time'])) {
-          $this->queues[$name]['cron']['time'] = $queue['cron']['time'];
+          static::$queues[$name]['cron']['time'] = $queue['cron']['time'];
         }
       }
     }
-    return $this->queues;
+    return static::$queues;
   }
 
   /**
    * {@inheritdoc}
+   *
+   * @return \DrupalQueueInterface
    */
   public function getQueue($name) {
     return DrupalQueue::get($name);
@@ -42,15 +44,28 @@ class Queue7 extends QueueBase {
   /**
    * {@inheritdoc}
    */
-  public function run($name) {
+  public function run($name, $time_limit = 0) {
     $info = $this->getInfo($name);
     $function = $info['worker callback'];
-    $end = time() + (isset($info['cron']['time']) ? $info['cron']['time'] : 15);
+    $end = time() + $time_limit;
     $queue = $this->getQueue($name);
-    while (time() < $end && ($item = $queue->claimItem())) {
-      $function($item->data);
-      $queue->deleteItem($item);
+    $count = 0;
+
+    while ((!$time_limit || time() < $end) && ($item = $queue->claimItem())) {
+      try {
+        drush_log(dt('Processing item @id from @name queue.', array('@name' => $name, 'id' => $item->item_id)), 'info');
+        $function($item->data);
+        $queue->deleteItem($item);
+        $count++;
+      }
+      catch (\Exception $e) {
+        // In case of exception log it and leave the item in the queue
+        // to be processed again later.
+        drush_set_error('DRUSH_QUEUE_EXCEPTION', $e->getMessage());
+      }
     }
+
+    return $count;
   }
 
 }

--- a/lib/Drush/Queue/QueueBase.php
+++ b/lib/Drush/Queue/QueueBase.php
@@ -9,17 +9,7 @@ abstract class QueueBase implements QueueInterface {
    *
    * @var array
    */
-  protected $queues;
-
-  /**
-   * Validate the given command.
-   *
-   * @param string $command
-   *   The command to validate.
-   */
-  public function validate($command = '') {
-    // No default validation.
-  }
+  protected static $queues;
 
   /**
    * Lists all available queues.
@@ -41,11 +31,11 @@ abstract class QueueBase implements QueueInterface {
    * {@inheritdoc}
    */
   public function getInfo($name) {
-    $this->getQueues();
-    if (!isset($this->queues[$name])) {
+    $queues = $this->getQueues();
+    if (!isset($queues[$name])) {
       throw new QueueException(dt('Could not find the !name queue.', array('!name' => $name)));
     }
-    return $this->queues[$name];
+    return $queues[$name];
   }
 
 }

--- a/lib/Drush/Queue/QueueInterface.php
+++ b/lib/Drush/Queue/QueueInterface.php
@@ -17,8 +17,14 @@ interface QueueInterface {
    *
    * @param string $name
    *   The name of the queue to run.
+   * @param int $time_limit
+   *   The maximum number of seconds that the queue can run. By default the
+   *   queue will be run as long as possible.
+   *
+   * @return int
+   *   The number of items successfully processed from the queue.
    */
-  public function run($name);
+  public function run($name, $time_limit = 0);
 
   /**
    * Returns a given queue definition.

--- a/tests/resources/queue_script-D7.php
+++ b/tests/resources/queue_script-D7.php
@@ -1,12 +1,12 @@
 <?php
-$feed = array(
+
+// Create a new feed.
+aggregator_save_feed(array(
   'title' => 'test',
   'url' => 'http://drupal.org/project/issues/rss/drupal?categories=All',
   'refresh' => 3600,
   'block' => 5,
-);
+));
 
-// Create a new feed.
-aggregator_save_feed($feed);
 // Let cron call DrupalQueue::createItem() for us.
 aggregator_cron();

--- a/tests/resources/queue_script-D8.php
+++ b/tests/resources/queue_script-D8.php
@@ -1,11 +1,13 @@
 <?php
 
-$values = array(
+use Drupal\aggregator\Entity\Feed;
+
+// Create a new feed.
+$feed = Feed::create(array(
   'title' => 'test',
   'url' => 'http://drupal.org/project/issues/rss/drupal?categories=All',
   'refresh' => 3600,
-);
-$feed = entity_create('aggregator_feed', $values);
+));
 $feed->save();
 
 // Let cron call QueueInterface::createItem() for us.


### PR DESCRIPTION
* Adds exception handling to queue running (including the SuspendQueueException logic from Drupal 8). An exception should not prevent the rest of the queue items from being processed.
* Adds a summary message of how many items were processed. Currently you get absolutely no output from the queue-run command unless there was an exception.