### PR TITLE
Avoid PHP bug in 7.x branch

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -110,7 +110,10 @@ function drush_get_class($class_name, $constructor_args = array(), $variations =
       $variant_class_name = $class_name . implode('', array_slice($variations, 0, $i));
       if (class_exists($variant_class_name)) {
         $reflectionClass = new ReflectionClass($variant_class_name);
-        return $reflectionClass->newInstanceArgs($constructor_args);
+
+        // Avoid PHP 5.3.3 bug.
+        // @see https://bugs.php.net/bug.php?id=52854
+        return empty($constructor_args) ? $reflectionClass->newInstanceArgs() : $reflectionClass->newInstanceArgs($constructor_args);
       }
     }
   }

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -253,7 +253,10 @@ function _drush_format_table($rows, $header = FALSE, $widths = array(), $console
   // Add defaults.
   $tbl = new ReflectionClass('Console_Table');
   $console_table_options += array(CONSOLE_TABLE_ALIGN_LEFT , '');
-  $tbl = $tbl->newInstanceArgs($console_table_options);
+
+  // Avoid PHP 5.3.3 bug.
+  // @see https://bugs.php.net/bug.php?id=52854
+  $tbl = empty($console_table_options) ? $tbl->newInstanceArgs() : $tbl->newInstanceArgs($console_table_options);
 
   $auto_widths = drush_table_column_autowidth($rows, $widths);
 


### PR DESCRIPTION
I have recently upgraded Drush to 7.0.0 in order to use the improved version of `drush make`, and I stumbled upon a small bug on the staging server.

I would like to kindly ask you to merge this pull requests. The two changes made avoid [this](https://bugs.php.net/bug.php?id=52854) PHP 5.3.3 bug. The bug has been fixed in PHP 5.3.4.

I know PHP 5.3 has [reached EOL](https://php.net/eol.php) in 14 Aug 2014. But some distributions that ship with 5.3, like RHEL6 (and SL6) are still supported for a while. ([October 31, 2016](https://access.redhat.com/support/policy/updates/errata/#Life_Cycle_Dates), if you don't count the extended life support which goes up to November 30, 2020)

Thank you.