### PR TITLE
Allow Drush to bootstrap a Drupal (8, 7, 6) site that has a valid but empty database.

### DIFF
--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -454,6 +454,35 @@ abstract class DrupalBoot extends BaseBoot {
     return TRUE;
   }
 
+  // This is a bootstrap helper function designed to be called
+  // from the bootstrap_drupal_database_validate() methods of
+  // derived DrupalBoot classes.  If a database exists, but is
+  // empty, then the Drupal database bootstrap will fail.  To
+  // prevent this situation, we test for some table that is needed
+  // in an ordinary bootstrap, and return FALSE from the validate
+  // function if it does not exist, so that we do not attempt to
+  // start the database bootstrap.
+  function bootstrap_drupal_database_has_table($required_tables) {
+    try {
+      $sql = drush_sql_get_class();
+      $spec = $sql->db_spec();
+      $prefix = $spec['prefix'];
+      $tables = $sql->listTables();
+      foreach ((array)$required_tables as $required_table) {
+        if (!in_array($prefix . $required_table, $tables)) {
+          return FALSE;
+        }
+      }
+    }
+    catch (Exception $e) {
+      // Usually the checks above should return a result without
+      // throwing an exception, but we'll catch any that are
+      // thrown just in case.
+      return FALSE;
+    }
+    return TRUE;
+  }
+
   /**
    * Boostrap the Drupal database.
    */

--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -467,9 +467,13 @@ abstract class DrupalBoot extends BaseBoot {
       $sql = drush_sql_get_class();
       $spec = $sql->db_spec();
       $prefix = $spec['prefix'];
+      if (!is_array($prefix)) {
+        $prefix = array('default' => $prefix);
+      }
       $tables = $sql->listTables();
       foreach ((array)$required_tables as $required_table) {
-        if (!in_array($prefix . $required_table, $tables)) {
+        $prefix_key = array_key_exists($required_table, $prefix) ? $required_table : 'default';
+        if (!in_array($prefix[$prefix_key] . $required_table, $tables)) {
           return FALSE;
         }
       }

--- a/lib/Drush/Boot/DrupalBoot6.php
+++ b/lib/Drush/Boot/DrupalBoot6.php
@@ -52,6 +52,10 @@ class DrupalBoot6 extends DrupalBoot {
     return $core;
   }
 
+  function bootstrap_drupal_database_validate() {
+    return parent::bootstrap_drupal_database_validate() && $this->bootstrap_drupal_database_has_table('cache');
+  }
+
   function bootstrap_drupal_database() {
     drupal_bootstrap(DRUPAL_BOOTSTRAP_DATABASE);
     parent::bootstrap_drupal_database();

--- a/lib/Drush/Boot/DrupalBoot7.php
+++ b/lib/Drush/Boot/DrupalBoot7.php
@@ -49,6 +49,32 @@ class DrupalBoot7 extends DrupalBoot {
     return $core;
   }
 
+  function bootstrap_drupal_database_validate() {
+    if (!parent::bootstrap_drupal_database_validate()) {
+      return FALSE;
+    }
+    // This is like drush_valid_db_credentials, but
+    // for Drupal 7, we also want to know if the
+    // {blocked_ips} table exists, as the bootstrap will
+    // fail if it does not.  If that is the situation,
+    // then we'll return FALSE here in validate, so that
+    // we do not attempt to start the database bootstrap.
+    try {
+      $sql = drush_sql_get_class();
+      $result = $sql->query('SELECT * from blocked_ips limit 1;');
+      if ($result === false) {
+        return FALSE;
+      }
+    }
+    catch (Exception $e) {
+      // Usually the query above should return a result without
+      // throwing an exception, but we'll catch any that are
+      // thrown just in case.
+      return FALSE;
+    }
+    return TRUE;
+  }
+
   function bootstrap_drupal_database() {
     drupal_bootstrap(DRUPAL_BOOTSTRAP_DATABASE);
     parent::bootstrap_drupal_database();

--- a/lib/Drush/Boot/DrupalBoot7.php
+++ b/lib/Drush/Boot/DrupalBoot7.php
@@ -50,31 +50,7 @@ class DrupalBoot7 extends DrupalBoot {
   }
 
   function bootstrap_drupal_database_validate() {
-    if (!parent::bootstrap_drupal_database_validate()) {
-      return FALSE;
-    }
-    // This is like drush_valid_db_credentials, but
-    // for Drupal 7, we also want to know if the
-    // {blocked_ips} table exists, as the bootstrap will
-    // fail if it does not.  If that is the situation,
-    // then we'll return FALSE here in validate, so that
-    // we do not attempt to start the database bootstrap.
-    try {
-      $sql = drush_sql_get_class();
-      $spec = $sql->db_spec();
-      $prefix = $spec['prefix'];
-      $tables = $sql->listTables();
-      if (!in_array($prefix . "blocked_ips", $tables)) {
-        return FALSE;
-      }
-    }
-    catch (Exception $e) {
-      // Usually the checks above should return a result without
-      // throwing an exception, but we'll catch any that are
-      // thrown just in case.
-      return FALSE;
-    }
-    return TRUE;
+    return parent::bootstrap_drupal_database_validate() && $this->bootstrap_drupal_database_has_table('blocked_ips');
   }
 
   function bootstrap_drupal_database() {

--- a/lib/Drush/Boot/DrupalBoot7.php
+++ b/lib/Drush/Boot/DrupalBoot7.php
@@ -61,13 +61,15 @@ class DrupalBoot7 extends DrupalBoot {
     // we do not attempt to start the database bootstrap.
     try {
       $sql = drush_sql_get_class();
-      $result = $sql->query('SELECT * from blocked_ips limit 1;');
-      if ($result === false) {
+      $spec = $sql->db_spec();
+      $prefix = $spec['prefix'];
+      $tables = $sql->listTables();
+      if (!in_array($prefix . "blocked_ips", $tables)) {
         return FALSE;
       }
     }
     catch (Exception $e) {
-      // Usually the query above should return a result without
+      // Usually the checks above should return a result without
       // throwing an exception, but we'll catch any that are
       // thrown just in case.
       return FALSE;

--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -68,6 +68,10 @@ class DrupalBoot8 extends DrupalBoot {
     return $core;
   }
 
+  function bootstrap_drupal_database_validate() {
+    return parent::bootstrap_drupal_database_validate() && $this->bootstrap_drupal_database_has_table('key_value');
+  }
+
   function bootstrap_drupal_database() {
     // D8 omits this bootstrap level as nothing special needs to be done.
     parent::bootstrap_drupal_database();

--- a/lib/Drush/Sql/Sql6.php
+++ b/lib/Drush/Sql/Sql6.php
@@ -10,6 +10,8 @@ class Sql6 extends SqlVersion {
       $url =  is_array($url) ? $url[$database] : $url;
       $db_spec = drush_convert_db_from_db_url($url);
       $db_spec['db_prefix'] = isset($GLOBALS['db_prefix']) ? $GLOBALS['db_prefix'] : drush_get_option('db-prefix', NULL);
+      // For uniformity with code designed for Drupal 7/8 db_specs, copy the 'db_prefix' to 'prefix'.
+      $db_spec['prefix'] = $db_spec['db_prefix'];
     }
     return $db_spec;
   }

--- a/tests/sqlConnectTest.php
+++ b/tests/sqlConnectTest.php
@@ -22,29 +22,47 @@ class SqlConnectCase extends CommandUnishTestCase {
 
     // Get the connection details with sql-connect and check its structure.
     $this->drush('sql-connect', array(), $options);
-    $output = $this->getOutput();
+    $connectionString = $this->getOutput();
 
     // Not all drivers need -e option like sqlite
     $shell_options = "-e";
     $db_driver = $this->db_driver();
     if ($db_driver == 'mysql') {
-      $this->assertRegExp('/^mysql --user=[^\s]+ --password=.* --database=[^\s]+ --host=[^\s]+/', $output);
+      $this->assertRegExp('/^mysql --user=[^\s]+ --password=.* --database=[^\s]+ --host=[^\s]+/', $connectionString);
     }
     elseif ($db_driver == 'sqlite') {
-      $this->assertContains('sqlite3', $output);
+      $this->assertContains('sqlite3', $connectionString);
       $shell_options = '';
     }
     elseif ($db_driver == 'pgsql') {
-      $this->assertRegExp('/^psql -q --dbname=[^\s]+ --host=[^\s]+ --port=[^\s]+ --username=[^\s]+/', $output);
+      $this->assertRegExp('/^psql -q --dbname=[^\s]+ --host=[^\s]+ --port=[^\s]+ --username=[^\s]+/', $connectionString);
     }
     else {
       $this->markTestSkipped('sql-connect test does not recognize database type in ' . UNISH_DB_URL);
     }
 
     // Issue a query and check the result to verify the connection.
-    $this->execute($output . ' ' . $shell_options . ' "SELECT uid FROM users where uid = 1;"');
+    $this->execute($connectionString . ' ' . $shell_options . ' "SELECT uid FROM users where uid = 1;"');
     $output = $this->getOutput();
     $this->assertContains('1', $output);
 
+    // Run 'core-status' and insure that we can bootstrap Drupal.
+    $this->drush('core-status', array("Drupal bootstrap"), $options);
+    $output = $this->getOutput();
+    $this->assertContains('Successful', $output);
+
+    // Test to see if 'sql-create' can erase the database.
+    // The only output is a confirmation string, so we'll run
+    // other commands to confirm that this worked.
+    $this->drush('sql-create', array(), $options);
+
+    // Try to execute a query.  This should give a "table not found" error.
+    $this->execute($connectionString . ' ' . $shell_options . ' "SELECT uid FROM users where uid = 1;"', self::EXIT_ERROR);
+
+    // We should still be able to run 'core-status' without getting an
+    // error, although Drupal should not bootstrap any longer.
+    $this->drush('core-status', array("Drupal bootstrap"), $options);
+    $output = $this->getOutput();
+    $this->assertNotContains('Successful', $output);
   }
 }


### PR DESCRIPTION
This situation originally cropped up in issue [1996004](https://www.drupal.org/node/1996004) on drupal.org.  The fix committed at that time worked well enough to allow `drush status` and `drush sql-sync` to work on sites with empty databases.  With the new bootstrap and sql class changes, though, these things no longer work.

The original fix suggested in that issue was to just wrap the database bootstrap phase in a try / catch, which seemed to work okay, but raised issues of stability, since it allowed Drush to continue working after a partially-completed database bootstrap.  The potential side effects for that were (and remain) unknown.

This PR provides a better option; it tests to see if one of the database tables needed in Drupal 7's database bootstrap exists in Drush's bootstrap database validate method; if that table does not exist, then validate returns FALSE, which cleanly stops the database bootstrap before it begins.  This is correct behavior; we'll see what Travis has to say about the results.

Note, however, that there is a weakness in this PR in that it does not work with databases that use a db-prefix; see related issue #1441, which interferes somewhat with supporting db-prefixes here.  While I tend to dislike db-prefixes, it would probably be undesirable to make it impossible to bootstrap any site that used them.  We could potentially fix bootstrapping without fixing --db-prefixes by assembling the table name ourself rather than using `{blocked_ips}`, but that would be a little hack-ish.

Supporting operations on sites with empty databases is important in scenarios where you might, for example, want to have Travis automatically run tests on a scratch Drupal site every time a commit is pushed to a GitHub repository.  I'm working on such a thing right now (extending from the [Badcamp behat example repository](https://github.com/arithmetric/badcamp2014-behat-travisci)); the site-install use case works fine, but this bug makes it harder to support the sql-sync use case (e.g. to copy an existing site to serve as the starting point for the tests).

Let me know what you think about the db-prefix stuff.