### PR TITLE
Error when normalizing info with no 'projects' section

### DIFF
--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -98,6 +98,10 @@ function _make_parse_info_file($makefile) {
  * Expand shorthand elements, so that we have an associative array.
  */
 function make_normalize_info(&$info) {
+  if (empty($info['projects'])) {
+    return;
+  }
+
   foreach($info['projects'] as $key => $project) {
     if (is_numeric($key) && is_string($project)) {
       unset($info['projects'][$key]);


### PR DESCRIPTION
Make files that are discovered in modules doesn't contain the `projects` section because they usually just download one ore more libraries. For example running a make that downloads the [Font Awesome Icons](https://www.drupal.org/project/fontawesome) gives this error:

```shell
...
fontawesome-7.x-2.1 downloaded.
Found makefile: fontawesome.make
Invalid argument supplied for foreach() make.utilities.inc:101
fontawesome downloaded from https://github.com/FortAwesome/Font-Awesome/archive/master.zip.
...
```

because the make file looks like:

```ini
core = 7.x
api = 2

libraries[fontawesome][type] = "libraries"
libraries[fontawesome][download][type] = "get"
libraries[fontawesome][download][url] = "https://github.com/FortAwesome/Font-Awesome/archive/master.zip"
libraries[fontawesome][directory_name] = "fontawesome"
libraries[fontawesome][destination] = "libraries"
```

No, `projects` section.