### PR TITLE
Avoid warning in make_normalize_info()

### DIFF
--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -98,17 +98,19 @@ function _make_parse_info_file($makefile) {
  * Expand shorthand elements, so that we have an associative array.
  */
 function make_normalize_info(&$info) {
-  foreach($info['projects'] as $key => $project) {
-    if (is_numeric($key) && is_string($project)) {
-      unset($info['projects'][$key]);
-      $info['projects'][$project] = array(
-        'version' => '',
-      );
-    }
-    if (is_string($key) && is_numeric($project)) {
-      $info['projects'][$key] = array(
-        'version' => $project,
-      );
+  if (!empty($info['projects'])) {
+    foreach($info['projects'] as $key => $project) {
+      if (is_numeric($key) && is_string($project)) {
+        unset($info['projects'][$key]);
+        $info['projects'][$project] = array(
+          'version' => '',
+        );
+      }
+      if (is_string($key) && is_numeric($project)) {
+        $info['projects'][$key] = array(
+          'version' => $project,
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
A warning was thrown in make_normalize_info() if a make file didn't
contain any projects. A typical use case of this is modules supplying
a make file (for recursive) use with only libraries in them.
