### PR TITLE
Make sure top-level files are also merged

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -670,10 +670,15 @@ function make_move_build($build_path) {
         // To prevent the removal of top-level directories such as 'modules' or
         // 'themes', descend in a level if the file exists.
         // TODO: This only protects one level of directories from being removed.
-        $files = drush_scan_directory($file->filename, '/./', array('.', '..'), 0, FALSE);
         $overwrite = drush_get_option('overwrite', FALSE) ? FILE_EXISTS_OVERWRITE : FILE_EXISTS_MERGE;
-        foreach ($files as $file) {
-          $ret = $ret && drush_copy_dir($file->filename, $destination . DIRECTORY_SEPARATOR . $file->basename, $overwrite);
+        if (is_dir($destination)) {
+          $files = drush_scan_directory($file->filename, '/./', array('.', '..'), 0, FALSE);
+          foreach ($files as $file) {
+            $ret = $ret && drush_copy_dir($file->filename, $destination . DIRECTORY_SEPARATOR . $file->basename, $overwrite);
+          }
+        }
+        else {
+          $ret = $ret && drush_copy_dir($file->filename, $destination, $overwrite);
         }
       }
       else {


### PR DESCRIPTION
I was noticing that when you do a

```drush make xxx.make --projects=drupal```

On a current site so that it's updated, the top-level files are not copied, this is because an attempt to prevent removing top-level directories possible when overwriting files.

Probably not the best way of doing all this, see #1269 , but this is a fix following the same logic.