### PR TITLE
Fix fatal error running updb in Drupal 8

### DIFF
--- a/commands/core/drupal/update.inc
+++ b/commands/core/drupal/update.inc
@@ -103,6 +103,7 @@ function update_main() {
   // In D8, we expect to be in full bootstrap.
   drush_bootstrap_to_phase(DRUSH_BOOTSTRAP_DRUPAL_FULL);
 
+  require_once DRUPAL_ROOT . '/core/includes/schema.inc';
   require_once DRUPAL_ROOT . '/core/includes/install.inc';
   require_once DRUPAL_ROOT . '/core/includes/update.inc';
   drupal_load_updates();


### PR DESCRIPTION
Fixes the following fatal error when running `drush updb`
```
Call Stack:
    0.0002     232896   1. {main}() /usr/share/php/drush/drush.php:0
    0.0002     233456   2. drush_main() /usr/share/php/drush/drush.php:11
    0.2346    7335992   3. Drush\Boot\BaseBoot->bootstrap_and_dispatch() /usr/share/php/drush/drush.php:70
    0.2624    6914752   4. drush_dispatch() /usr/share/php/drush/lib/Drush/Boot/BaseBoot.php:62
    0.3865    9087960   5. call_user_func_array() /usr/share/php/drush/includes/command.inc:178
    0.3865    9088128   6. drush_command() /usr/share/php/drush/includes/command.inc:178
    0.3868    9089112   7. _drush_invoke_hooks() /usr/share/php/drush/includes/command.inc:210
    0.3875    9122824   8. call_user_func_array() /usr/share/php/drush/includes/command.inc:359
    0.3876    9122992   9. drush_core_updatedb() /usr/share/php/drush/includes/command.inc:359
    0.3895    9292792  10. update_main() /usr/share/php/drush/commands/core/core.drush.inc:460
    0.3976    7685944  11. drupal_load_updates() /usr/share/php/drush/commands/core/drupal/update.inc:108
Drush command terminated abnormally due to an unrecoverable error. 
Error: Call to undefined function drupal_get_installed_schema_version() in /var/www/d8/core/includes/install.inc, line 80
```