### PR TITLE
Make a local $container variable available in drush cli

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -21,6 +21,9 @@ function drush_cli_core_cli() {
   // Use the Symfony var-dumper to inspect variables.
   $boris->setInspector(new \Drush\Boris\VarDumperInspector());
 
+  // Set a local $container variable.
+  $boris->setLocal(['container' => \Drupal::getContainer()]);
+
   // Boris will never return control to us, but our shutdown
   // handler will still run after the user presses ^D.  Mark
   // this command as completed to avoid a spurious error message.

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -21,8 +21,10 @@ function drush_cli_core_cli() {
   // Use the Symfony var-dumper to inspect variables.
   $boris->setInspector(new \Drush\Boris\VarDumperInspector());
 
-  // Set a local $container variable.
-  $boris->setLocal(['container' => \Drupal::getContainer()]);
+  if (drush_drupal_major_version() >= 8) {
+    // Set a local $container variable for Drupal 8.
+    $boris->setLocal(['container' => \Drupal::getContainer()]);
+  }
 
   // Boris will never return control to us, but our shutdown
   // handler will still run after the user presses ^D.  Mark


### PR DESCRIPTION
It would be cool to have a local `$container` variable available in the REPL.