### PR TITLE
Log recoverable an fatal error an stop the execution of the script.

### DIFF
--- a/examples/example.drushrc.php
+++ b/examples/example.drushrc.php
@@ -160,10 +160,10 @@
 
 /**
  * Specify the error handling of recoverable errors (E_RECOVERABLE_ERROR).
- * Defaults to "ignore". Will stop further execution of Drush, when set to "halt"
- * (same behaviour as Drupal core).
+ * Defaults to 1 and will stop execution of Drush.
+ * When set to 0, execution will continue.
  */
-# $options['recoverable-errors-handling'] = 'halt';
+# $options['halt-on-error'] = 0;
 
 /**
  * Specify options to pass to ssh in backend invoke.  The default is to prohibit

--- a/examples/example.drushrc.php
+++ b/examples/example.drushrc.php
@@ -159,6 +159,13 @@
 # $options['php-notices'] = 'warning';
 
 /**
+ * Specify the error handling of recoverable errors (E_RECOVERABLE_ERROR).
+ * Defaults to "ignore". Will stop further execution of Drush, when set to "halt"
+ * (same behaviour as Drupal core).
+ */
+# $options['recoverable-errors-handling'] = 'halt';
+
+/**
  * Specify options to pass to ssh in backend invoke.  The default is to prohibit
  * password authentication, and is included here, so you may add additional
  * parameters without losing the default configuration.

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -308,6 +308,7 @@ function drush_get_global_options($brief = FALSE) {
     $options['confirm-rollback']    = array('description' => 'Wait for confirmation before doing a rollback when something goes wrong.');
     $options['complete-debug']      = array('hidden' => TRUE, 'description' => "Turn on debug mode forf completion code");
     $options['php-options']         = array('description' => "Options to pass to `php` when running drush.  Only effective when using the drush.launcher script.", 'never-propagate' => TRUE, 'example-value' => '-d error_reporting="E_ALL"');
+    $options['halt-on-error']       = array('propagate' => TRUE, 'description' => "Controls error handling of recoverable errors (E_RECOVERABLE_ERROR). --halt-on-error=1: Execution is halted. --halt-on-error=0: Drush execution continues");
     $options['deferred-sanitization'] = array('hidden' => TRUE, 'description' => "Defer calculating the sanitization operations until after the database has been copied. This is done automatically if the source database is remote.");
     $options['remote-host']         = array('hidden' => TRUE, 'description' => 'Remote site to execute drush command on. Managed by site alias.');
     $options['remote-user']         = array('hidden' => TRUE, 'description' => 'User account to use with a remote drush command. Managed by site alias.');

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -30,7 +30,7 @@ function drush_error_handler($errno, $message, $filename, $line, $context) {
     $type = drush_get_option('php-notices', 'notice');
 
     // Bitmask value that constitutes an error needing to be logged.
-    $error = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR;
+    $error = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
     if ($errno & $error) {
       $type = 'error';
     }
@@ -42,6 +42,10 @@ function drush_error_handler($errno, $message, $filename, $line, $context) {
     }
 
     drush_log($message . ' ' . basename($filename) . ':' . $line, $type);
+
+    if ($errno == E_RECOVERABLE_ERROR) {
+      exit(DRUSH_APPLICATION_ERROR);
+    }
 
     return TRUE;
   }

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -28,7 +28,7 @@ function drush_error_handler($errno, $message, $filename, $line, $context) {
   if ($errno & error_reporting()) {
     // By default we log notices.
     $type = drush_get_option('php-notices', 'notice');
-    $recoverable_errors_handling = drush_get_option('recoverable-errors-handling', 'skip');
+    $recoverable_errors_handling = drush_get_option('recoverable-errors-handling', 'ignore');
 
     // Bitmask value that constitutes an error needing to be logged.
     $error = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -28,6 +28,7 @@ function drush_error_handler($errno, $message, $filename, $line, $context) {
   if ($errno & error_reporting()) {
     // By default we log notices.
     $type = drush_get_option('php-notices', 'notice');
+    $recoverable_errors_handling = drush_get_option('recoverable-errors-handling', 'skip');
 
     // Bitmask value that constitutes an error needing to be logged.
     $error = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
@@ -43,7 +44,7 @@ function drush_error_handler($errno, $message, $filename, $line, $context) {
 
     drush_log($message . ' ' . basename($filename) . ':' . $line, $type);
 
-    if ($errno == E_RECOVERABLE_ERROR) {
+    if ($recoverable_errors_handling == 'halt' && $errno == E_RECOVERABLE_ERROR) {
       exit(DRUSH_APPLICATION_ERROR);
     }
 

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -28,7 +28,7 @@ function drush_error_handler($errno, $message, $filename, $line, $context) {
   if ($errno & error_reporting()) {
     // By default we log notices.
     $type = drush_get_option('php-notices', 'notice');
-    $recoverable_errors_handling = drush_get_option('recoverable-errors-handling', 'ignore');
+    $halt_on_error = drush_get_option('halt-on-error', TRUE);
 
     // Bitmask value that constitutes an error needing to be logged.
     $error = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
@@ -44,7 +44,7 @@ function drush_error_handler($errno, $message, $filename, $line, $context) {
 
     drush_log($message . ' ' . basename($filename) . ':' . $line, $type);
 
-    if ($recoverable_errors_handling == 'halt' && $errno == E_RECOVERABLE_ERROR) {
+    if ($errno == E_RECOVERABLE_ERROR && $halt_on_error) {
       exit(DRUSH_APPLICATION_ERROR);
     }
 

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -146,6 +146,11 @@ function drush_format($input, $metadata = NULL, $format = NULL) {
  */
 function dt($string, $args = array()) {
   $output = NULL;
+
+  if (!is_array($args)) {
+    $args = array($args);
+  }
+
   if (function_exists('t') && drush_drupal_major_version() == 7) {
     $output = t($string, $args);
   }

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -146,11 +146,6 @@ function drush_format($input, $metadata = NULL, $format = NULL) {
  */
 function dt($string, $args = array()) {
   $output = NULL;
-
-  if (!is_array($args)) {
-    $args = array($args);
-  }
-
   if (function_exists('t') && drush_drupal_major_version() == 7) {
     $output = t($string, $args);
   }


### PR DESCRIPTION
Fixed handling of recoverable fatal errors in the same way as Drupal do.

- Error will be logged as an error instead of a notice.
- Execution of the script will be stopped. 