### PR TITLE
Allow Drush to search recursively inside any specified alias path.

### DIFF
--- a/examples/example.aliases.drushrc.php
+++ b/examples/example.aliases.drushrc.php
@@ -50,6 +50,20 @@
  *        a. The /drush and /sites/all/drush folders for the current Drupal site
  *        b. The /drush folder in the directory above the current Drupal site
  *
+ * These locations are searched recursively.  If there is a folder called
+ * 'site-aliases' in any search path, then Drush will search for site aliases
+ * only inside that directory.
+ *
+ * The preferred locations for alias files, then, are:
+ *
+ *   /etc/drush/site-aliases
+ *   $HOME/.drush/site-aliases
+ *   $ROOT/drush/site-aliases
+ *   $ROOT/sites/all/drush/site-aliases
+ *   $ROOT/../drush/site-aliases
+ *
+ * Or any path set in $options['alias-path'] or via --alias-path.
+ *
  * Folders and files containing other versions of drush in their names will
  * be *skipped* (e.g. mysite.aliases.drush4rc.php or
  * drush4/mysite.aliases.drushrc.php). Names containing the current version of

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -356,13 +356,13 @@ function _drush_preflight_alias_path() {
   $alias_path =& drush_get_context('ALIAS_PATH');
   $default_prefix_configuration = drush_is_windows() ? getenv('ALLUSERSPROFILE') . '/Drush' : '';
   $site_wide_configuration_dir = drush_get_context('ETC_PREFIX', $default_prefix_configuration) . '/etc/drush';
-  $alias_path[] = $site_wide_configuration_dir;
+  $alias_path[] = drush_sitealias_alias_base_directory($site_wide_configuration_dir);
 
-  $alias_path[] = dirname(__FILE__) . '/..';
+  $alias_path[] = drush_sitealias_alias_base_directory(dirname(__FILE__) . '/..');
 
   $server_home = drush_server_home();
   if (isset($server_home)) {
-    $alias_path[] = $server_home . '/.drush';
+    $alias_path[] = drush_sitealias_alias_base_directory($server_home . '/.drush');
   }
 }
 

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -427,7 +427,7 @@ function drush_sitealias_alias_path($alias_path_context = NULL) {
  * anywhere inside the specified directory for aliases.
  */
 function drush_sitealias_alias_base_directory($dir) {
-  $potential_location = $dir . '/aliases';
+  $potential_location = $dir . '/site-aliases';
   if (is_dir($potential_location)) {
     return $potential_location;
   }

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -406,19 +406,32 @@ function drush_sitealias_alias_path($alias_path_context = NULL) {
   // look for alias files in /drush and /sites/all/drush.
   $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
   if (!empty($drupal_root)) {
-    $site_paths[] = $drupal_root . '/drush';
-    $site_paths[] = $drupal_root . '/sites/all/drush';
+    $site_paths[] = drush_sitealias_alias_base_directory($drupal_root . '/drush');
+    $site_paths[] = drush_sitealias_alias_base_directory($drupal_root . '/sites/all/drush');
     $uri = drush_get_context('DRUSH_SELECTED_URI');
     if (empty($uri)) {
       $uri = 'default';
     }
     $site_dir = drush_sitealias_uri_to_site_dir($uri, $drupal_root);
     if ($site_dir) {
-      $site_paths[] = "$drupal_root/sites/$site_dir";
+      $site_paths[] = drush_sitealias_alias_base_directory("$drupal_root/sites/$site_dir");
     }
   }
   $alias_path = (array) drush_get_context('ALIAS_PATH', array());
   return array_unique(array_merge($context_path, $alias_path, $site_paths));
+}
+
+/**
+ * If there is a directory 'aliases' in the specified search location,
+ * then search ONLY in that directory for aliases.  Otherwise, search
+ * anywhere inside the specified directory for aliases.
+ */
+function drush_sitealias_alias_base_directory($dir) {
+  $potential_location = $dir . '/aliases';
+  if (is_dir($potential_location)) {
+    return $potential_location;
+  }
+  return $dir;
 }
 
 /**
@@ -616,7 +629,7 @@ function _drush_sitealias_find_alias_files($aliasname = NULL, $alias_path_contex
   foreach ($alias_path as $path) {
     // Find all of the matching files in this location
     foreach ($alias_files as $file_pattern_to_search_for) {
-      $alias_files_to_consider = array_merge($alias_files_to_consider, array_keys(drush_scan_directory($path, $file_pattern_to_search_for, drush_filename_blacklist(), 0, FALSE)));
+      $alias_files_to_consider = array_merge($alias_files_to_consider, array_keys(drush_scan_directory($path, $file_pattern_to_search_for, drush_filename_blacklist(), 0, TRUE)));
     }
   }
 
@@ -1683,8 +1696,8 @@ function _drush_sitealias_set_record_element(&$alias_record, $key, $value) {
  * @param prefix
  *   The prefix value to afix to the beginning of every
  *   key set.
- * @return array
- *   A site alias record, if found.
+ * @return boolean
+ *   TRUE is an alias was found and processed.
  */
 function _drush_sitealias_set_context_by_name($alias, $prefix = '') {
   if ($alias) {
@@ -2190,34 +2203,23 @@ function drush_sitealias_cache_alias_by_path($alias_record) {
  */
 function drush_sitealias_lookup_alias_by_path($path, $allow_best_match=FALSE) {
   $result = drush_sitealias_quick_lookup_cached_alias_by_path($path);
-  $fallback = $fallback_default = array();
+  $fallback = array();
   if (empty($result)) {
     $aliases = _drush_sitealias_find_and_load_all_aliases();
     foreach ($aliases as $name => $alias_record) {
-      if (!isset($alias_record['remote-host']) && isset($alias_record['root']) && isset($alias_record['#name']) && isset($alias_record['#file'])) {
-        $site_dir = drush_sitealias_local_site_path($alias_record);
-        if (!empty($site_dir)) {
-          if (substr($path, 0, strlen($site_dir)) == $site_dir) {
-            $result = $alias_record;
-            break;
-          }
-          if (substr($path, 0, strlen($alias_record['root'])) == $alias_record['root']) {
-            $fallback = $alias_record;
-            // There might be multiple 'fallback' records in a multisite situation.
-            // If so, favor the one associated with the 'default' folder, if any.
-            if (substr($site_dir, -7) == 'default') {
-              $fallback_default = $alias_record;
-            }
-          }
+      if (!isset($alias_record['remote-host']) && isset($alias_record['root']) && isset($alias_record['uri']) && isset($alias_record['#name']) && isset($alias_record['#file'])) {
+        if ($path == drush_sitealias_local_site_path($alias_record)) {
+          $result = $alias_record;
+          break;
+        }
+        if (substr($path, 0, strlen($alias_record['root'])) == $alias_record['root']) {
+          $fallback = $alias_record;
         }
       }
     }
   }
   if (empty($result) && $allow_best_match) {
     $result = $fallback;
-    if (!empty($fallback_default)) {
-      $result = $fallback_default;
-    }
   }
   if (!empty($result)) {
     _drush_sitealias_add_inherited_values_to_record($result);

--- a/tests/siteAliasTest.php
+++ b/tests/siteAliasTest.php
@@ -114,4 +114,38 @@ EOD;
   public function testBadAlias() {
     $this->drush('sa', array('@badalias'), array(), NULL, NULL, self::EXIT_ERROR);
   }
+
+  /**
+   * Ensure that Drush searches deep inside specified search locations
+   * for alias files.
+   */
+  public function testDeepAliasSearching() {
+    $aliasPath = UNISH_SANDBOX . '/aliases';
+    mkdir($aliasPath);
+    $deepPath = $aliasPath . '/deep';
+    mkdir($deepPath);
+    $aliasFile = $deepPath . '/baz.aliases.drushrc.php';
+    $aliasContents = <<<EOD
+  <?php
+  // Writtne by Unish. This file is safe to delete.
+  \$aliases['deep'] = array(
+    'remote-host' => 'fake.remote-host.com',
+    'remote-user' => 'www-admin',
+    'root' => '/fake/path/to/root',
+    'uri' => 'default',
+    'command-specific' => array(
+      'rsync' => array(
+        'delete' => TRUE,
+      ),
+    ),
+  );
+EOD;
+    file_put_contents($aliasFile, $aliasContents);
+    $options = array(
+      'alias-path' => $aliasPath,
+      'simulate' => TRUE,
+    );
+
+    $this->drush('sa', array('@deep'), $options);
+  }
 }


### PR DESCRIPTION
Currently, Drush only considers alias files that appear immediately inside any given alias searchpath directory.  This PR expands the search to include any directory that is anywhere deep inside any specified searchpath directory.

For the most part, this should not cause Drush to search for alias files too deeply.  The current default alias search path only includes folders that are specific to Drush.  For example:
```
  /etc/drush
  $HOME/.composer/vendor/drush/drush
  $HOME/.drush
  $ROOT/drush
  $ROOT/sites/all/drush
  $ROOT/../drush
```
I'm not sure why Drush searches its own directory for aliases, but it does.

These directories do, for the most part, only contain Drush files, and therefore should not be too crowded with deeply-nested folders.  The one exception here is $HOME/.drush, which might contain a 'vendor' directory if folks use the recommended `cd $HOME/.drush && composer include ...` technique to get global Drush commandfiles that are managed by composer.  In this case, there might be some very deep hierarchies that we'd rather not search.

To work around this, this PR further restricts searching to inside a folder 'aliases', if it exists in any search location.  If a folder named 'aliases' does not exist, then the entire search location is searched.

I suppose an alternate idea would be to deeply search $LOCATION/aliases, and also consider alias files contained directly inside $LOCATION.  In this instance, though, the --alias-path location should probably always be searched recursively.  This is slightly awkward vis-a-vis the current implementation of alias file searching, but not insurmountably so.