### PR TITLE
#894: Try downloading via https when http URLs are provided.

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -796,7 +796,7 @@ function drush_download_file($url, $destination = FALSE, $cache_duration = 0) {
  */
 function drush_download_file_name($url) {
   if ($cache_dir = drush_directory_cache('download')) {
-    $cache_name = str_replace(array(':', '/', '?', '='), '-', $url);
+    $cache_name = str_replace('https', 'http', str_replace(array(':', '/', '?', '='), '-', $url));
     return $cache_dir . "/" . $cache_name;
   }
   else {
@@ -829,6 +829,15 @@ function _drush_is_url($url) {
  *   downloaded.
  */
 function _drush_download_file($url, $destination, $overwrite = TRUE) {
+  // If the requested download URL is http://, try 'https://' first.
+  // Fall back to http:// if the secure URL does not work.
+  if (preg_match('#http://#', $url)) {
+    $secure_url = str_replace('http://', 'https://', $url);
+    $result = _drush_download_file($secure_url, $destination, $overwrite);
+    if ($result) {
+      return $result;
+    }
+  }
   static $use_wget;
   if ($use_wget === NULL) {
     $use_wget = drush_shell_exec('wget --version');


### PR DESCRIPTION
Try https anywhere the caller requests http.  This will increase privacy for sure, but perhaps this is only security-theater vis-a-vis MITM attacks, as the attacker could simply interfere with the https connection, and then take advantage of the fact that we fall back to the insecure connection.

It probably wouldn't be a good idea to universally reject http in Drush, though, so I am uncertain whether this PR is enough of an improvement to be worthwhile.