### PR TITLE
Make batch updates to show progress while performing.

### DIFF
--- a/commands/core/drupal/update_7.inc
+++ b/commands/core/drupal/update_7.inc
@@ -115,7 +115,16 @@ function drush_update_do_one($module, $number, $dependency_map,  &$context) {
     drupal_set_installed_schema_version($module, $number);
   }
 
-  $context['message'] = 'Performed update: ' . $function;
+  $message = 'Performed update: ' . $function;
+
+  // Show execution progress for batch updates.
+  if (isset($context['sandbox']['max'])) {
+    $items = $context['sandbox']['progress'] . '/' . $context['sandbox']['max'];
+    $percentage = round(($context['sandbox']['progress'] * 100) / $context['sandbox']['max']) . '%';
+    $message .= ' - ' . $percentage . ' (' . $items . ')';
+  }
+
+  $context['message'] = $message;
 }
 
 /**


### PR DESCRIPTION
When batch update is happening it looks like this:

    Performed update: some_module_update_7041
    Performed update: some_module_update_7042
    Performed update: some_module_update_7042
    Performed update: some_module_update_7042
    Performed update: some_module_update_7042

It's not very informative, hard to understand how much iterations left. The only way is to return something like progress string in the update hook.
How about to make batch updates to look like this:

    Performed update: some_module_update_7041
    Performed update: some_module_update_7042 - 25% (100/400)
    Performed update: some_module_update_7042 - 50% (200/400)
    Performed update: some_module_update_7042 - 75% (300/400)
    Performed update: some_module_update_7042 - 100% (400/400)
