### PR TITLE
Stop by bootstrap to DRUPAL_ROOT when searching for commandfiles

### DIFF
--- a/lib/Drush/Boot/Boot.php
+++ b/lib/Drush/Boot/Boot.php
@@ -48,11 +48,12 @@ interface Boot {
   function bootstrap_phases();
 
   /**
-   * Lists the key bootstrap phases where Drush should
-   * stop and look for more commandfiles.  In Drupal, Drush
-   * first does just a preflight, and if the selected
-   * command is not found after preflight, then a full
-   * bootstrap is done.
+   * List of bootstrap phases where Drush should stop and look for commandfiles.
+   *
+   * This allows us to bootstrap to a minimum neccesary to find commands.
+   *
+   * Once a command is found, Drush will ensure a bootstrap to the phase
+   * declared by the command.
    *
    * @return array of PHASE indexes.
    */

--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -48,7 +48,7 @@ abstract class DrupalBoot extends BaseBoot {
    * bootstrap to the phase declared by the command.
    */
   function bootstrap_init_phases() {
-    return array(DRUSH_BOOTSTRAP_DRUSH, DRUSH_BOOTSTRAP_DRUPAL_FULL);
+    return array(DRUSH_BOOTSTRAP_DRUSH, DRUSH_BOOTSTRAP_DRUPAL_ROOT, DRUSH_BOOTSTRAP_DRUPAL_FULL);
   }
 
   function enforce_requirement(&$command) {

--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -41,11 +41,19 @@ abstract class DrupalBoot extends BaseBoot {
   }
 
   /**
-   * The phases where Drush will look to see if new commandfiles
-   * have been defined.  For Drupal, we first do a preflight, and
-   * if a command is not found at that point, we next attempt a full
-   * bootstrap.  If a command is found after preflight, then we
-   * bootstrap to the phase declared by the command.
+   * List of bootstrap phases where Drush should stop and look for commandfiles.
+   *
+   * For Drupal, we try at these bootstrap phases:
+   *
+   *   - Drush preflight: to find commandfiles in any system location,
+   *     out of a Drupal installation.
+   *   - Drupal root: to find commandfiles based on Drupal core version.
+   *   - Drupal full: to find commandfiles defined within a Drupal directory.
+   *
+   * Once a command is found, Drush will ensure a bootstrap to the phase
+   * declared by the command.
+   *
+   * @return array of PHASE indexes.
    */
   function bootstrap_init_phases() {
     return array(DRUSH_BOOTSTRAP_DRUSH, DRUSH_BOOTSTRAP_DRUPAL_ROOT, DRUSH_BOOTSTRAP_DRUPAL_FULL);


### PR DESCRIPTION
Drush is unable to detect drupal-version-specific commandfiles without a full bootstrap.

This is not neccesary for such commandfiles that only want to operate on `DRUPAL_ROOT` or `DRUPAL_SITE` phases. Indeed it is very bad if the site is not installed yet.

My case: I'm willing to provide `settingsphp.d8.drush.inc` and `settingsphp.d7.drush.inc` for https://www.drupal.org/project/settingsphp. Drush fails with "command not found" because I'm running on a site not installed yet so it can't bootstrap to `DRUPAL_FULL` and the commandfiles are not reachable from the Drush preflight phase.
