### PR TITLE
(make) Fixed error when translation download fails.

### DIFF
--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -433,7 +433,7 @@ class DrushMakeProject {
             $update_url = $cache[$l10n_server];
           }
           else {
-            make_error('XML_ERROR', dt("Could not retrieve l10n update url for !project.", array('!project' => $project['name'])));
+            make_error('XML_ERROR', dt("Could not retrieve l10n update url for !project.", array('!project' => $this->name)));
             return FALSE;
           }
         }


### PR DESCRIPTION
If a translation fails to download, you get a completely unhelpful error message:

    Could not retrieve l10n update url for

This is because there's no such variable $project.

Surprisingly, I think this has been a bug for over 4 years (ever since the feature to pull translations was added): https://github.com/drush-ops/drush/commit/ab353291b39cccdbd69f51887d1f963196c1509c