### PR TITLE
fix(mimetype) Add mime type for .sql files

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -902,6 +902,7 @@ function drush_mime_content_type($filename) {
     $filename = basename(current(explode('?', $filename, 2)));
     $extension_mimetype = array(
       '.tar'     => 'application/x-tar',
+      '.sql'     => 'application/octet-stream',
     );
     foreach ($extension_mimetype as $extension => $ct) {
       if (substr($filename, -strlen($extension)) === $extension) {


### PR DESCRIPTION
Fix #1292 

Adds a default mime type for .sql files since finfo returns application/octet-stream for that file type.