### PR TITLE
Add an update finished callback.

### DIFF
--- a/commands/core/drupal/update.inc
+++ b/commands/core/drupal/update.inc
@@ -230,9 +230,18 @@ function drush_get_update_list() {
 /**
  * Process and display any returned update output.
  *
+ * @see \Drupal\system\Controller\DbUpdateController::batchFinished()
  * @see \Drupal\system\Controller\DbUpdateController::results()
  */
 function drush_update_finished($success, $results, $operations) {
+
+  if (!drush_get_option('cache-clear', TRUE)) {
+    drush_log(dt("Skipping cache-clear operation due to --cache-clear=0 option."), 'warning');
+  }
+  else {
+    drupal_flush_all_caches();
+  }
+
   foreach ($results as $module => $updates) {
     if ($module != '#abort') {
       foreach ($updates as $number => $queries) {

--- a/commands/core/drupal/update.inc
+++ b/commands/core/drupal/update.inc
@@ -207,7 +207,7 @@ function drush_update_batch() {
     'title' => 'Updating',
     'init_message' => 'Starting updates',
     'error_message' => 'An unrecoverable error has occurred. You can find the error message below. It is advised to copy it to the clipboard for reference.',
-    // 'finished' => array('finished' => array('\Drupal\system\Controller\DbUpdateController', 'batchFinished')),
+    'finished' => 'drush_update_finished',
     'file' => 'includes/update.inc',
   );
   batch_set($batch);
@@ -227,8 +227,31 @@ function drush_get_update_list() {
   return $return;
 }
 
+/**
+ * Process and display any returned update output.
+ *
+ * @see \Drupal\system\Controller\DbUpdateController::results()
+ */
 function drush_update_finished($success, $results, $operations) {
-  // Nothing to do here. All caches already cleared. Kept as documentation of 'finished' callback.
+  foreach ($results as $module => $updates) {
+    if ($module != '#abort') {
+      foreach ($updates as $number => $queries) {
+        foreach ($queries as $query) {
+          // If there is no message for this update, don't show anything.
+          if (empty($query['query'])) {
+            continue;
+          }
+
+          if ($query['success']) {
+            drush_log($query['query']);
+          }
+          else {
+            drush_set_error(dt('Failed: ' . $query['query']));
+          }
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/commands/core/drupal/update.inc
+++ b/commands/core/drupal/update.inc
@@ -243,10 +243,10 @@ function drush_update_finished($success, $results, $operations) {
           }
 
           if ($query['success']) {
-            drush_log($query['query']);
+            drush_log(strip_tags($query['query']));
           }
           else {
-            drush_set_error(dt('Failed: ' . $query['query']));
+            drush_set_error(dt('Failed: ') . strip_tags($query['query']));
           }
         }
       }


### PR DESCRIPTION
- Displays any error (or informational) messages set during update
  hooks.
- If an error is set during updates, updb will now exit non-zero.
- Fixes #1509