### PR TITLE
Prevent dependency hell when users try to use multiple autoloaders

### DIFF
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -542,27 +542,8 @@ function _drush_bootstrap_output_prepare() {
 }
 
 /**
- * Used by a Drush extension to request that its Composer autoload
- * files be loaded by Drush, if they have not already been.
- *
- * Usage:
- *
- * function mycommandfile_drush_init() {
- *   drush_autoload(__FILE__)
- * }
- *
+ * Obsolete; autoloading is handled automatically now.
  */
 function drush_autoload($commandfile) {
-  $already_added = commandfiles_cache()->add($commandfile);
-
-  $dir = dirname($commandfile);
-  $candidates = array("vendor/autoload.php", "../../../vendor/autoload.php");
-  $drush_autoload_file = drush_get_context('DRUSH_VENDOR_PATH', '');
-
-  foreach ($candidates as $candidate) {
-    $autoload = $dir . '/' . $candidate;
-    if (file_exists($autoload) && (realpath($autoload) != $drush_autoload_file)) {
-      include $autoload;
-    }
-  }
+  // No longer does anything
 }

--- a/lib/Drush/Boot/BaseBoot.php
+++ b/lib/Drush/Boot/BaseBoot.php
@@ -17,6 +17,7 @@ abstract class BaseBoot implements Boot {
     drush_enforce_requirement_bootstrap_phase($command);
     drush_enforce_requirement_core($command);
     drush_enforce_requirement_drush_dependencies($command);
+    $this->drush_enforce_requirement_composer_autoloader($command);
   }
 
   function report_command_error($command) {
@@ -49,6 +50,7 @@ abstract class BaseBoot implements Boot {
         $command = drush_parse_command();
         if (is_array($command)) {
           $command += $this->command_defaults();
+
           // Insure that we have bootstrapped to a high enough
           // phase for the command prior to enforcing requirements.
           $bootstrap_result = drush_bootstrap_to_phase($command['bootstrap']);
@@ -56,6 +58,13 @@ abstract class BaseBoot implements Boot {
 
           if ($bootstrap_result && empty($command['bootstrap_errors'])) {
             drush_log(dt("Found command: !command (commandfile=!commandfile)", array('!command' => $command['command'], '!commandfile' => $command['commandfile'])), 'bootstrap');
+
+            // Load the autoload files for any commandfiles that need them.
+            // This is only for non-composer-managed sites.  In composer-managed
+            // sites, we expect that all extensions are required from the
+            // site's composer.json file, in which case their autoloaders will
+            // already have been included safely.
+            commandfiles_cache()->load_autoload_files();
 
             $command_found = TRUE;
             // Dispatch the command(s).
@@ -85,6 +94,59 @@ abstract class BaseBoot implements Boot {
       $this->report_command_error($command);
     }
     return $return;
+  }
+
+  /**
+   * Check to see if this Drupal site is using Composer, and
+   * if it is, we will also check to see if we loaded any foreign
+   * autoload files.  If we do, then fail fast with an error,
+   * and give the use some advice about how to repair their configuration.
+   *
+   * We run this test regardless of bootstrap level, because Drush
+   * will load Drupal's autoload file early, if it exists.
+   */
+  function drush_enforce_requirement_composer_autoloader(&$command) {
+    // n.b. DRUSH_SELECTED_DRUPAL_ROOT should be DRUSH_SELECTED_ROOT or something
+    $root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    if (!empty($root)) {
+      // Check to see if we have a composer.json file.  We will only look in
+      // two locations:  1) the root, and 2) the parent directory above the root.
+      foreach (array('', '/..') as $search_dir) {
+        $dir = realpath($root . $search_dir);
+        if (file_exists($dir . "/composer.json")) {
+          // We are running in the context of a site that has a
+          // composer.json file.  If the current command has a
+          // foreign autoloader, then we will fail right here.
+          // It does not work to load multiple autoloaders that were
+          // independently evaluated; if two components have
+          // the same dependency, but each selected a different version,
+          // then highly unpredictable things can happen.
+          $foreign_autoload_file = commandfiles_cache()->find_autoload_file_for_extension($command['commandfile']);
+          if (!empty($foreign_autoload_file)) {
+            $foreign_autoload_files = commandfiles_cache()->find_autoload_files();
+            $project_names = array_keys($foreign_autoload_files);
+            array_unshift($project_names, "drush/drush");
+            $composer_dir = $root;
+            if (file_exists($root . "/../composer.json")) {
+              $composer_dir = dirname($composer_dir);
+            }
+            $hints = array("    cd $composer_dir");
+            foreach ($project_names as $project_name) {
+              $hints[] = "    composer global require $project_name";
+            }
+            $command['bootstrap_errors']['COMPOSER_AUTOLOADER_ERROR'] = dt("The command !command cannot be used with the site at !root, because it uses a separate autoload file. To use this command, first run:\n!hints", array('!command' => $command['command'], '!root' => $root, '!hints' => implode("\n", $hints)));
+            return FALSE;
+          }
+          else {
+            // If the command that was selected does not need an autoload
+            // file, but there are other commandfiles that do, then we will
+            // erase those other commandfiles from our cached list, so that
+            // none of their hooks run.
+            commandfiles_cache()->prevent_dependency_hell();
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -62,6 +62,7 @@ abstract class DrupalBoot extends BaseBoot {
   function enforce_requirement(&$command) {
     parent::enforce_requirement($command);
     $this->drush_enforce_requirement_drupal_dependencies($command);
+    $this->drush_enforce_requirement_composer_autoloader($command);
   }
 
   function report_command_error($command) {

--- a/lib/Drush/Command/Commandfiles.php
+++ b/lib/Drush/Command/Commandfiles.php
@@ -16,24 +16,45 @@ namespace Drush\Command;
 class Commandfiles implements CommandfilesInterface {
   protected $cache;
   protected $deferred;
+  protected $needs_autoloader;
+  protected $foreign_autoloaders;
 
   function __construct() {
     $this->cache = array();
     $this->deferred = array();
+    $this->needs_autoloader = array();
+    $this->foreign_autoloaders = array();
   }
 
+  /**
+   * @return the list of all cached commandfiles that were loaded.
+   */
   function get() {
   	return $this->cache;
   }
 
+  /**
+   * @return the list of all commandfiles that were added, but have
+   * not been loaded yet (waiting for a higher bootstrap level).
+   */
   function deferred() {
   	return $this->deferred;
   }
 
+  /**
+   * Sort all of the cached commandfiles.  This is called once
+   * Drush has finished calling 'add' for this bootstrap phase.
+   */
   function sort() {
   	ksort($this->cache);
   }
 
+  /**
+   * Add a commandfile to the cache.  The commandfile might not be
+   * immediately added; it may be saved in the 'deferred' list, and
+   * then added on a later bootstrap phase, once it can be determined
+   * to be acceptable.
+   */
   function add($commandfile) {
 	  $load_command = FALSE;
 
@@ -53,17 +74,134 @@ class Commandfiles implements CommandfilesInterface {
 	      	$load_command = TRUE;
 	      }
 	      else {
-		    // Signal that we should try again on
-		    // the next bootstrap phase.
-		    $this->deferred[$module] = $commandfile; 	
+          // Signal that we should try again on
+          // the next bootstrap phase.
+          $this->deferred[$module] = $commandfile;
 	      }
 	    }
 	    if ($load_command) {
-	      $this->cache[$module_versionless] = $commandfile;
-	      require_once $commandfile;
-	      unset($this->deferred[$module]);
+        $this->load($module_versionless, $commandfile);
+        unset($this->deferred[$module]);
 	    }
 	  }
 	  return $load_command;
+  }
+
+  /**
+   * Load a commandfile once it has been determined to be acceptable.
+   */
+  protected function load($key, $path) {
+    $this->cache[$key] = $path;
+    require_once $path;
+    $this->check_needs_autoloader($key, $path);
+  }
+
+  /**
+   * When a commandfile is loaded, check to see if it has need of
+   * an autoload file.  Drush will keep track of this, and load
+   * the autoload file if it is safe to do so.
+   */
+  protected function check_needs_autoloader($key, $path) {
+    $dir = dirname($path);
+    foreach (array('composer.json', '../composer.json') as $composer_file) {
+      $composer_file_path = realpath($dir . '/' . $composer_file);
+      if (file_exists($composer_file_path)) {
+        $this->needs_autoloader[$key] = $composer_file_path;
+        return;
+      }
+    }
+  }
+
+  /**
+   * This function is called if Drush determines that it is safe to load
+   * the autoload files.
+   */
+  function load_autoload_files() {
+    $autoload_files = $this->find_autoload_files();
+    foreach ($autoload_files as $key => $extension_autoload_file) {
+      if (!array_key_exists($extension_autoload_file, $this->foreign_autoloaders)) {
+        include $extension_autoload_file;
+        $this->foreign_autoloaders[$extension_autoload_file][] = $key;
+        drush_log(dt("Loading autoload file for !name.", array('!name' => $key)), 'notice');
+      }
+    }
+  }
+
+  /**
+   * Find all of the autoload files associated with any Drush extension
+   * that has a composer.json file.
+   */
+  function find_autoload_files() {
+    $autoload_files = array();
+
+    foreach ($this->needs_autoloader as $key => $composer_file_path) {
+      $autoload_files += $this->find_autoload_file_for_extension($key);
+    }
+
+    return $autoload_files;
+  }
+
+  function find_autoload_file_for_extension($key) {
+    $autoload_file = array();
+
+    if (array_key_exists($key, $this->needs_autoloader)) {
+      $composer_file_path = $this->needs_autoloader[$key];
+
+      $dir = dirname($composer_file_path);
+      $vendor_dir = $dir . '/vendor';
+      // Load the composer file path, so we can determine if the vendor
+      // directory has been moved.  If the vendor file is in its default
+      // location, or in the location that is indicated in the composer.json
+      // file, then this extension was installed independently.  Otherwise,
+      // this extension was installed by being 'require'd in some other
+      // project's composer.json file (e.g. as part of a Drupal site) or
+      // via 'composer global require'.  In these instances, we can presume
+      // that this extension's requirements have already been loaded as part
+      // of the overall project's autoload.php file.
+      $composer_contents = json_decode(file_get_contents($composer_file_path));
+      if (isset($composer_contents->name)) {
+        $name = $composer_contents->name;
+        if (isset($composer_contents->config["vendor-dir"])) {
+          $vendor_dir = $composer_contents->config["vendor-dir"];
+        }
+        $vendor_dir = realpath($vendor_dir);
+        $drush_vendor_dir = drush_get_context('DRUSH_VENDOR_PATH', '');
+
+        // If the autoload file exists, and is not the same autoload file
+        // that Drush already loaded, then we will return it as part of
+        // our result set.
+        if (is_dir($vendor_dir) && ($vendor_dir != $drush_vendor_dir)) {
+          $extension_autoload_file = realpath($vendor_dir . '/autoload.php');
+          if (file_exists($extension_autoload_file)) {
+            $autoload_file[$name] = $extension_autoload_file;
+          }
+        }
+      }
+    }
+
+    return $autoload_file;
+  }
+
+  /**
+   * Prevent dependency hell by forgetting about any commandfile
+   * that has a foreign autoload file (an autoload.php that is
+   * different than the one containing all of the autoload data
+   * for Drush and the Drupal site).
+   *
+   * This function is only called if we are attempting to bootstrap
+   * a site that uses Composer.
+   */
+  function prevent_dependency_hell() {
+    foreach ($this->needs_autoloader as $key => $composer_file_path) {
+      $has_autoload_file = $this->find_autoload_file_for_extension($key);
+      if (!empty($has_autoload_file)) {
+        drush_log(dt("Forgetting about Drush extension !extension to prevent potential autoloading problems.", array('!extension' => $key)), 'debug');
+        unset($this->cache[$key]);
+      }
+    }
+    // Now that we have forgotten about the extensions that need autoloaders,
+    // clear our list of extensions that need autoloading, so that we do not
+    // inadvertantly load any autoloaders later.
+    $this->needs_autoloader = array();
   }
 }


### PR DESCRIPTION
When using a composer-managed Drupal site, including any Drupal 8 site, enormous, difficult-to-diagnose problems can arise if multiple autoloaders are used.  This patch detects this situation, and fails with an error if the user tries to use a global Drush command with a foreign autoloader (that is, any autoload.php file that is different than the autoload.php file for the Drupal site being used).  I spent a whole day the first time this happened to me; as Composer usage becomes more common, this sort of mistake will happen more frequently.  This patch will probably save a lot of people from some significant agony.

In the event that we see a user is trying to use a command that requires a foreign autoloader, we print out a sequence of commands to help the user fix the problem, by running `composer require a/b` in the context of their Drupal site, for all projects `a\b` that have their own autoload.php file, and also for `drush/drush`, since you shouldn't find any global Drush commands if there is already a site-local Drush in use.

If the user is trying to use a command that does NOT require a foreign autoloader on a Composer-managed Drupal site, then we will unset any other global commandfile that requires a foreign autoloader, preventing its command hooks from running.

This PR has no affect on global commandfiles that do not require a foreign autoloader, nor does it have any affect on global commands that are run without a Drupal site, or that are run with a Drupal site that is not composer-managed.  This does allow for the slight possible for dependency hell if conflicts arise between an extension and Drush itself; however, since the extensions must be run with Drush during development, they are unlikely to have problems.  I think we can start off with it semi-loose like this, and then tighten it down a bit later. In particular, I'd like to backport this as a bugfix to Drush 7, and then perhaps tighten it down for Drush 8 once that is done.
