### PR TITLE
Fixes PHP 5.3.3 bug for RHEL, SL6, etc

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -110,7 +110,10 @@ function drush_get_class($class_name, $constructor_args = array(), $variations =
       $variant_class_name = $class_name . implode('', array_slice($variations, 0, $i));
       if (class_exists($variant_class_name)) {
         $reflectionClass = new ReflectionClass($variant_class_name);
-        return $reflectionClass->newInstanceArgs($constructor_args);
+
+        // Avoid PHP 5.3.3 bug.
+        // @see https://bugs.php.net/bug.php?id=52854
+        return empty($constructor_args) ? $reflectionClass->newInstanceArgs() : $reflectionClass->newInstanceArgs($constructor_args);
       }
     }
   }

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -253,7 +253,10 @@ function _drush_format_table($rows, $header = FALSE, $widths = array(), $console
   // Add defaults.
   $tbl = new ReflectionClass('Console_Table');
   $console_table_options += array(CONSOLE_TABLE_ALIGN_LEFT , '');
-  $tbl = $tbl->newInstanceArgs($console_table_options);
+
+  // Avoid PHP 5.3.3 bug.
+  // @see https://bugs.php.net/bug.php?id=52854
+  $tbl = empty($console_table_options) ? $tbl->newInstanceArgs() : $tbl->newInstanceArgs($console_table_options);
 
   $auto_widths = drush_table_column_autowidth($rows, $widths);
 


### PR DESCRIPTION
Mentioned in #544 & #1440 & #1474. However, those were all closed. I wouldn't bother with yet another patch on this, but I keep running across older sites that I support that the client isn't able to upgrade for a variety of reasons. These are running RHEL and tell me that they still have support.