### PR TITLE
Prevent the alias file search from recursing into the files directory.

### DIFF
--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -414,7 +414,7 @@ function drush_sitealias_alias_path($alias_path_context = NULL) {
     }
     $site_dir = drush_sitealias_uri_to_site_dir($uri, $drupal_root);
     if ($site_dir) {
-      $site_paths[] = drush_sitealias_alias_base_directory("$drupal_root/sites/$site_dir");
+      $site_paths[] = drush_sitealias_alias_base_directory("$drupal_root/sites/$site_dir/drush");
     }
   }
   $alias_path = (array) drush_get_context('ALIAS_PATH', array());
@@ -842,7 +842,7 @@ function _drush_sitealias_cache_alias($alias_name, $alias_record) {
     drush_sitealias_add_to_alias_path($alias_record['root'] . '/sites/all/drush');
     $site_dir = drush_sitealias_local_site_path($alias_record);
     if (isset($site_dir)) {
-      drush_sitealias_add_to_alias_path($site_dir);
+      drush_sitealias_add_to_alias_path($site_dir . '/drush');
     }
   }
 }


### PR DESCRIPTION
At some time between `7.0.00-alpha9` and `8.0.0-beta14`, the alias search started recursing into the site's **files** directory. With sites that might have many tens of gigs of files, this effectively causes drush to hang with no feedback:

```
Starting Drush preflight. [0.02 sec, 2.21 MB]                                                                                                                             [preflight]
Starting to load command files [0.02 sec, 2.21 MB]                                                                                                                        [bootstrap]
Cache HIT cid: 8.0.0-beta14-commandfiles-0-b5f59610fb1c6eb6b2fe1c7cb8faeb84 [0.02 sec, 2.27 MB]                                                                               [debug]
```
This fix forces it to look into `sites/default/drush` as it does with other paths, rather than `sites/default`.