### PR TITLE
Fix search path handling for top-level drush/ directory 7.x

### DIFF
--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -95,7 +95,7 @@ abstract class DrupalBoot extends BaseBoot {
     switch ($phase) {
       case DRUSH_BOOTSTRAP_DRUPAL_ROOT:
         $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
-        $searchpath[] = $drupal_root . '../drush';
+        $searchpath[] = $drupal_root . '/../drush';
         $searchpath[] = $drupal_root . '/drush';
         $searchpath[] = $drupal_root . '/sites/all/drush';
 


### PR DESCRIPTION
This change fixes the search path discovery for top-level drush/ directories for 7.x branch. It is intended to resolve issue https://github.com/drush-ops/drush/issues/1546

```php
$searchpath[] = $drupal_root . '../drush';
```

Translates to path/to/drupal/docroot../drush instead of path/to/drupal/docroot/../drush. This breaks inclusion of drush configuration and commands and aliases within a top-level drupal/drush folder.

The workaround is to use sites/all/drush. However, many users might not want to put custom commands and drush configurations in a web-servable location such as sites/all/drush -- especially custom commands and code. It's far safer to keep these commands and code outside of the server-executable context.

So the small fix is:
```php
$searchpath[] = $drupal_root . '/../drush';
```

https://www.drupal.org/u/apotek