### PR TITLE
Register the runtime assertion handler for PsySH

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -20,10 +20,13 @@ function drush_cli_core_cli() {
   $shell = new Psy\Shell();
 
   if (drush_drupal_major_version() >= 8) {
+    // Register the assertion handler so exceptions are thrown instead of errors
+    // being triggered. The plays nicer with PsySH.
+    \Drupal\Component\Assertion\Handle::register();
     $shell->setScopeVariables(['container' => \Drupal::getContainer()]);
   }
 
-  // Psysh will never return control to us, but our shutdown handler will still
+  // PsySH will never return control to us, but our shutdown handler will still
   // run after the user presses ^D.  Mark this command as completed to avoid a
   // spurious error message.
   drush_set_context('DRUSH_EXECUTION_COMPLETED', TRUE);

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -21,7 +21,7 @@ function drush_cli_core_cli() {
 
   if (drush_drupal_major_version() >= 8) {
     // Register the assertion handler so exceptions are thrown instead of errors
-    // being triggered. The plays nicer with PsySH.
+    // being triggered. This plays nicer with PsySH.
     \Drupal\Component\Assertion\Handle::register();
     $shell->setScopeVariables(['container' => \Drupal::getContainer()]);
   }


### PR DESCRIPTION
This is just getting ready for when https://www.drupal.org/node/2536560 is committed into 8.0.x . Once that is in, this will work, then we have a tiny patch that will actually fix the problem consistently by registering that handler in drush php : https://www.drupal.org/node/2550641 .

So we need to hold off until the first issue in done at least.