### PR TITLE
Fix typo in libraries safe path check

### DIFF
--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -299,7 +299,7 @@ function make_validate_info_file($info) {
             }
             // Prevent malicious attempts to access other areas of the
             // filesystem.
-            elseif (in_array($attribute, array('contrib-destination', 'directory_name')) && !make_safe_path($value)) {
+            elseif (in_array($attribute, array('contrib_destination', 'directory_name')) && !make_safe_path($value)) {
               $args = array(
                 '!path' => $value,
                 '!attribute' => $attribute,


### PR DESCRIPTION
This fixes a simple typo in the path check for libraries, when checking for malicious paths. Everywhere else, this check is done with `contrib_destination`, but for libraries, it was `contrib-destination`.