### PR TITLE
Fix the catch ConfigException

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Config\StorageComparer;
 use Drupal\Core\Config\ConfigImporter;
+use Drupal\Core\Config\ConfigException;
 use Drupal\Core\Config\FileStorage;
 use Drush\Config\StorageWrapper;
 use Drush\Config\CoreExtensionFilter;


### PR DESCRIPTION
Now we have the problem:

![image](https://cloud.githubusercontent.com/assets/2082480/9426009/6cc706e2-4930-11e5-861b-25ef9d716573.png)

an uncaught exception in console.

I think we need to add ConfigException namespace importing to fix it.

As result:

![image](https://cloud.githubusercontent.com/assets/2082480/9426023/ec4a9136-4930-11e5-910e-6661ab444769.png)
