### PR TITLE
Bring back sqlite support

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -570,14 +570,16 @@ function drush_sql_get_class($db_spec = NULL) {
   $target = drush_get_option('target', 'default');
 
   // Try a few times to quickly get $db_spec.
-  if ($db_spec) {
+  if (!empty($db_spec)) {
     return drush_get_class(array('Drush\Sql\Sql', 'Drupal\Driver\Database\\' .  $db_spec['driver'] . '\Drush'), array($db_spec), array($db_spec['driver']));
   }
   elseif ($url = drush_get_option('db-url')) {
     $url =  is_array($url) ? $url[$database] : $url;
     $db_spec = drush_convert_db_from_db_url($url);
-    $db_spec['db_prefix'] = drush_get_option('db-prefix');
-    return drush_sql_get_class($db_spec);
+    if (!empty($db_spec)) {
+      $db_spec['db_prefix'] = drush_get_option('db-prefix');
+      return drush_sql_get_class($db_spec);
+    }
   }
   elseif (($databases = drush_get_option('databases')) && (array_key_exists($database, $databases)) && (array_key_exists($target, $databases[$database]))) {
     $db_spec = $databases[$database][$target];

--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -571,15 +571,15 @@ function drush_sql_get_class($db_spec = NULL) {
 
   // Try a few times to quickly get $db_spec.
   if (!empty($db_spec)) {
-    return drush_get_class(array('Drush\Sql\Sql', 'Drupal\Driver\Database\\' .  $db_spec['driver'] . '\Drush'), array($db_spec), array($db_spec['driver']));
+    if (!empty($db_spec['driver'])) {
+      return drush_get_class(array('Drush\Sql\Sql', 'Drupal\Driver\Database\\' .  $db_spec['driver'] . '\Drush'), array($db_spec), array($db_spec['driver']));
+    }
   }
   elseif ($url = drush_get_option('db-url')) {
     $url =  is_array($url) ? $url[$database] : $url;
     $db_spec = drush_convert_db_from_db_url($url);
-    if (!empty($db_spec)) {
-      $db_spec['db_prefix'] = drush_get_option('db-prefix');
-      return drush_sql_get_class($db_spec);
-    }
+    $db_spec['db_prefix'] = drush_get_option('db-prefix');
+    return drush_sql_get_class($db_spec);
   }
   elseif (($databases = drush_get_option('databases')) && (array_key_exists($database, $databases)) && (array_key_exists($target, $databases[$database]))) {
     $db_spec = $databases[$database][$target];

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1597,13 +1597,13 @@ function drush_sitealias_uri_to_site_dir($uri, $site_root = NULL) {
 }
 
 /**
- * Convert from an old-style database URL to an array of database settings
+ * Convert from an old-style database URL to an array of database settings.
  *
  * @param db_url
- *   A Drupal 6 db-url string to convert, or an array with a 'default' element.
+ *   A Drupal 6 db url string to convert, or an array with a 'default' element.
  * @return array
  *   An array of database values containing only the 'default' element of
- *   the db_url.
+ *   the db url. If the parse fails the array is empty.
  */
 function drush_convert_db_from_db_url($db_url) {
   if (is_array($db_url)) {

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -884,8 +884,7 @@ function drush_sitealias_convert_db_spec_to_db_url($db_spec) {
     $result .= "@";
   }
   // Host is required, unless this is an sqlite db.
-  if (isset($db_spec["host"]))
-  {
+  if (isset($db_spec["host"])) {
     $result .= urlencode($db_spec["host"]);
     if (isset($db_spec["port"])) {
       $result .= ":" . urlencode($db_spec["port"]);
@@ -1612,11 +1611,13 @@ function drush_convert_db_from_db_url($db_url) {
   else {
     $db_url_default = $db_url;
   }
+
   $url = parse_url($db_url_default);
   // If parse_url failed, return an empty array
   if (!is_array($url)) {
     return array();
   }
+
   // Fill in defaults to prevent notices.
   $url += array(
     'driver' => NULL,
@@ -1628,29 +1629,23 @@ function drush_convert_db_from_db_url($db_url) {
     'database' => NULL,
   );
   $url = (object)array_map('urldecode', $url);
-  $host = $url->host;
-  $database = substr($url->path, 1);
+
+  // Convert url parts to database spec.
   if ($url->scheme == 'sqlite') {
-    $host = '';
-    // The sqlite path with start with a / if there
-    // is both a host and a path component; sqlite
-    // databases without an absolute path will have only
-    // a host component.
-    if (isset($url->path)) {
-      $database = '/' . $url->host  . $url->path;
-    }
-    else {
-      $database = $url->host;
-    }
+    // parse_url() splits the path to the database in host and path.
+    $database = $url->host  . $url->path;
+    $url->host = '';
+  }
+  else {
+    // The database name is $url->path without the leading slash.
+    $database = substr($url->path, 1);
   }
   return array(
     'driver' => $url->scheme == 'mysqli' ? 'mysql' : $url->scheme,
     'username' => $url->user,
     'password' => $url->pass,
     'port' => $url->port,
-    'host' => $host,
-    // Remove leading / character from database names, unless we're installing
-    // to SQLite (which won't have a slash there unless it's part of a path).
+    'host' => $url->host,
     'database' => $database,
   );
 }

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1605,6 +1605,8 @@ function drush_sitealias_uri_to_site_dir($uri, $site_root = NULL) {
  *   the db url. If the parse fails the array is empty.
  */
 function drush_convert_db_from_db_url($db_url) {
+  $db_spec = array();
+
   if (is_array($db_url)) {
     $db_url_default = $db_url['default'];
   }
@@ -1612,42 +1614,38 @@ function drush_convert_db_from_db_url($db_url) {
     $db_url_default = $db_url;
   }
 
-  $url = parse_url($db_url_default);
-  // If parse_url failed, return an empty array
-  if (!is_array($url)) {
-    return array();
-  }
-
-  // Fill in defaults to prevent notices.
-  $url += array(
-    'driver' => NULL,
-    'user' => NULL,
-    'pass' => NULL,
-    'host' => NULL,
-    'port' => NULL,
-    'path' => NULL,
-    'database' => NULL,
-  );
-  $url = (object)array_map('urldecode', $url);
-
-  // Convert url parts to database spec.
-  if ($url->scheme == 'sqlite') {
-    // parse_url() splits the path to the database in host and path.
-    $database = $url->host  . $url->path;
-    $url->host = '';
+  // If it's a sqlite database, pick the database path and we're done.
+  if (strpos($db_url_default, 'sqlite://') === 0) {
+    $db_spec = array(
+      'driver'   => 'sqlite',
+      'database' => substr($db_url_default, strlen('sqlite://')),
+    );
   }
   else {
-    // The database name is $url->path without the leading slash.
-    $database = substr($url->path, 1);
+    $url = parse_url($db_url_default);
+    if ($url) {
+      // Fill in defaults to prevent notices.
+      $url += array(
+        'scheme' => NULL,
+        'user'   => NULL,
+        'pass'   => NULL,
+        'host'   => NULL,
+        'port'   => NULL,
+        'path'   => NULL,
+      );
+      $url = (object)array_map('urldecode', $url);
+      $db_spec = array(
+        'driver'   => $url->scheme == 'mysqli' ? 'mysql' : $url->scheme,
+        'username' => $url->user,
+        'password' => $url->pass,
+        'host' => $url->host,
+        'port' => $url->port,
+        'database' => ltrim($url->path, '/'),
+      );
+    }
   }
-  return array(
-    'driver' => $url->scheme == 'mysqli' ? 'mysql' : $url->scheme,
-    'username' => $url->user,
-    'password' => $url->pass,
-    'port' => $url->port,
-    'host' => $url->host,
-    'database' => $database,
-  );
+
+  return $db_spec;
 }
 
 /**


### PR DESCRIPTION
 * Fix sqlite support. Reported in #1336. Broke with 8027687a96fdebc0d71527cbc8702e3dad5bc0ea
 * Add support for absolute urls. We did never supported it before: parse_url() is unable to parse them.
 * Prevent drush_sql_get_class() from trying to load a class if db_spec is not valid ("Unable to load class Drupal\Driver\Database\\Drush")
