### PR TITLE
Add diff feature to make-update

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -154,6 +154,8 @@ function make_drush_command() {
         'description' => 'Save to a file. If not provided, the updated makefile will be dump to stdout.',
         'example-value' => 'updated.make',
       ),
+      'security-only'  => 'Only update modules that have security updates available.',
+      'diff' => 'Return the diff instead of the whole new makefile.',
     ),
     'engines' => array('release_info', 'update_status'),
   );

--- a/commands/make/update.make.inc
+++ b/commands/make/update.make.inc
@@ -5,6 +5,9 @@
  * make-update command implementation.
  */
 
+use SebastianBergmann\Diff\LCS\TimeEfficientImplementation;
+use SebastianBergmann\Diff\Differ;
+
 /**
  * Command callback for make-update.
  */
@@ -87,8 +90,8 @@ function drush_make_update($makefile = NULL) {
       $header .= "+++ New\n";
     }
 
-    $differ = new SebastianBergmann\Diff\Differ($header);
-    $lcs = new SebastianBergmann\Diff\LCS\TimeEfficientImplementation();
+    $differ = new Differ($header);
+    $lcs = new TimeEfficientImplementation();
     $diff = $differ->diff($old, $new, $lcs);
 
     if (!$file) {

--- a/commands/make/update.make.inc
+++ b/commands/make/update.make.inc
@@ -14,6 +14,7 @@ function drush_make_update($makefile = NULL) {
 
   make_prepare_projects(FALSE, $info);
   $make_projects = drush_get_option('DRUSH_MAKE_PROJECTS', FALSE);
+  $diff = drush_get_option('diff');
 
   // Pick projects coming from drupal.org and adjust its structure
   // to feed update_status engine.
@@ -63,6 +64,38 @@ function drush_make_update($makefile = NULL) {
     if (!$security_only || ($security_only && $project_update_info['status'] == DRUSH_UPDATESTATUS_NOT_SECURE)) {
       $make_projects[$project_name]['download']['full_version'] = $project_update_info['recommended'];
     }
+  }
+
+  if ($diff) {
+    ob_start();
+    make_generate_from_makefile(NULL, $makefile);
+    $old = ob_get_clean();
+
+    drush_set_option('DRUSH_MAKE_PROJECTS', $make_projects);
+
+    ob_start();
+    make_generate_from_makefile(NULL, $makefile);
+    $new = ob_get_clean();
+
+    $file = drush_get_option('result-file');
+
+    $header = "--- {$makefile}\n";
+    if ($file) {
+      $header .= "+++ {$file}\n";
+    }
+    else {
+      $header .= "+++ New\n";
+    }
+
+    $differ = new SebastianBergmann\Diff\Differ($header);
+    $lcs = new SebastianBergmann\Diff\LCS\TimeEfficientImplementation();
+    $diff = $differ->diff($old, $new, $lcs);
+
+    if (!$file) {
+      return drush_print($diff);
+    }
+
+    return file_put_contents($file, $diff);
   }
 
   // Inject back make projects and generate the updated makefile.


### PR DESCRIPTION
The `drush make-update` command turns out to be really useful. However, I miss being able to see a diff between the old makefile and the newly (updated) one. Especially if you have a big makefile, it's not apparent which modules got updated.

By specifying the `--diff` flag, `drush make-update` gives you a diff between the new and old makefile.
