### PR TITLE
Issue #1607: Removing calls to the deprecated conf_path() in Drupal 8.

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -1001,7 +1001,8 @@ function drush_core_quick_drupal() {
       // Current CLI user is also the web server user, which is for development
       // only. Hence we can safely make the site directory writable. This makes
       // it easier to delete and edit settings.php.
-      @chmod(conf_path(), 0700);
+      $drush_uri = _drush_bootstrap_selected_uri();
+      @chmod(drush_conf_path($drush_uri), 0700);
       drush_invoke('runserver', array($server));
     }
   }

--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -539,13 +539,14 @@ function _core_path_aliases($project = '') {
     $paths['%root'] = $drupal_root;
     if ($site_root = drush_get_context('DRUSH_DRUPAL_SITE_ROOT')) {
       $paths['%site'] = $site_root;
-      if (is_dir($modules_path = conf_path() . '/modules')) {
+      $drush_uri = _drush_bootstrap_selected_uri();
+      if (is_dir($modules_path = drush_conf_path($drush_uri) . '/modules')) {
         $paths['%modules'] = $modules_path;
       }
       else {
         $paths['%modules'] = ltrim($site_wide . '/modules', '/');
       }
-      if (is_dir($themes_path = conf_path() . '/themes')) {
+      if (is_dir($themes_path = drush_conf_path($drush_uri) . '/themes')) {
         $paths['%themes'] = $themes_path;
       }
       else {

--- a/commands/core/drupal/environment.inc
+++ b/commands/core/drupal/environment.inc
@@ -346,7 +346,8 @@ function _drush_theme_admin() {
 }
 
 function _drush_file_public_path() {
-  return Settings::get('file_public_path', conf_path() . '/files');
+  $drush_uri = _drush_bootstrap_selected_uri();
+  return Settings::get('file_public_path', drush_conf_path($drush_uri) . '/files');
 }
 
 function _drush_file_private_path() {

--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -380,7 +380,8 @@ abstract class DrupalBoot extends BaseBoot {
   function bootstrap_drupal_site_validate_settings_present() {
     $site = drush_bootstrap_value('site', $_SERVER['HTTP_HOST']);
 
-    $conf_path = drush_bootstrap_value('conf_path', \conf_path(TRUE, TRUE));
+    $drush_uri = _drush_bootstrap_selected_uri();
+    $conf_path = drush_bootstrap_value('conf_path', \drush_conf_path($drush_uri, TRUE));
     $conf_file = "$conf_path/settings.php";
     if (!file_exists($conf_file)) {
       return drush_bootstrap_error('DRUPAL_SITE_SETTINGS_NOT_FOUND', dt("Could not find a Drupal settings.php file at !file.",

--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -46,8 +46,9 @@ class DrupalBoot8 extends DrupalBoot {
   }
 
   function contrib_modules_paths() {
+    $drush_uri = _drush_bootstrap_selected_uri();
     return array(
-      $this->kernel->getSitePath() . '/modules',
+      drush_conf_path($drush_uri) . '/modules',
       'sites/all/modules',
       'modules',
     );
@@ -58,8 +59,9 @@ class DrupalBoot8 extends DrupalBoot {
    * themes can be found
    */
   function contrib_themes_paths() {
+    $drush_uri = _drush_bootstrap_selected_uri();
     return array(
-      $this->kernel->getSitePath() . '/themes',
+      drush_conf_path($drush_uri) . '/themes',
       'sites/all/themes',
       'themes',
     );

--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -47,7 +47,7 @@ class DrupalBoot8 extends DrupalBoot {
 
   function contrib_modules_paths() {
     return array(
-      conf_path() . '/modules',
+      $this->kernel->getSitePath() . '/modules',
       'sites/all/modules',
       'modules',
     );
@@ -59,7 +59,7 @@ class DrupalBoot8 extends DrupalBoot {
    */
   function contrib_themes_paths() {
     return array(
-      conf_path() . '/themes',
+      $this->kernel->getSitePath() . '/themes',
       'sites/all/themes',
       'themes',
     );


### PR DESCRIPTION
This is my first time even looking at drush code, so, well, we'll see if this works.