### PR TITLE
Allow local domain name to register as local host

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -618,7 +618,7 @@ function drush_is_local_host($host) {
   // In order for this to work right, you must use 'localhost' or '127.0.0.1'
   // or the machine returned by 'uname -n' for your 'remote-host' entry in
   // your site alias.
-  if (($host == 'localhost') || ($host == '127.0.0.1')) {
+  if (($host == 'localhost') || ($host == '127.0.0.1') || (gethostbyname($host) == '127.0.0.1')) {
     return TRUE;
   }
 


### PR DESCRIPTION
This small change allows `drush_is_local_host()` to be a little more flexible. For example, this will prevent a "The source and destination cannot both be remote." error when doing a `drush sql-sync @alias.prd @alias.dev`, using this config (assuming dev.example.com has a host entry of 127.0.0.1):

````
$aliases['dev'] = array(
  '#check-local' => TRUE,
  'uri' => 'http://dev.example.com',
  ''remote-host' => 'dev.example.com',
);

$aliases['prd'] = array(
  'uri' => 'http://prd.example.com',
  ''remote-host' => 'prd.example.com',
);
````
