### PR TITLE
Adding a check if the drush_get_username() and the remote-user in $si…

### DIFF
--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1933,7 +1933,9 @@ function drush_sitealias_evaluate_path($path, &$additional_options, $local_only 
     drush_sitealias_set_alias_context($site_alias_settings);
 
     // Use 'remote-host' from settings if available; otherwise site is local
-    if (array_key_exists('remote-host', $site_alias_settings) && !drush_is_local_host($site_alias_settings['remote-host'])) {
+    // also check if the remote-user is the same (use remote if the ssh user is different)
+    // this prevents errors on local machines when a different remote user is used on shared environments
+    if (array_key_exists('remote-host', $site_alias_settings) && !drush_is_local_host($site_alias_settings['remote-host']) || (drush_get_username() != $site_alias_settings['remote-user'])) {
       $machine = drush_remote_host($site_alias_settings);
     }
     else {


### PR DESCRIPTION
…te_alias_settings differ. If so we use a ssh connection instead of the local to circumvent problems on shared environments (where rsync will fail because of restricted file permissions).

This was already brought up #1529 and #1530  but the fixes weren't entirely approved.

I now implemented it with the feedback of Johnattan (https://github.com/drush-ops/drush/issues/1528#issuecomment-132916754).

Please let me know if this is sufficient. I'd be happy to move this issue forward.

/bastian