### PR TITLE
Cache filename issues on Windows

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -796,7 +796,7 @@ function drush_download_file($url, $destination = FALSE, $cache_duration = 0) {
  */
 function drush_download_file_name($url) {
   if ($cache_dir = drush_directory_cache('download')) {
-    $cache_name = str_replace(array(':', '/', '?', '='), '-', $url);
+    $cache_name = str_replace(array(':', '/', '?', '=', '\\'), '-', $url);
     return $cache_dir . "/" . $cache_name;
   }
   else {


### PR DESCRIPTION
On Windows, local patches fail to apply due to a backslashes in their cache file name. This pull request resolves that by replacing backslashes as well. See issue #760.