### PR TITLE
#1637: Replace !var substitutions before calling D8 translate()

### DIFF
--- a/includes/output.inc
+++ b/includes/output.inc
@@ -150,6 +150,10 @@ function dt($string, $args = array()) {
   // The language system requires a working container which has the string
   // translation service.
   else if (drush_drupal_major_version() >= 8 && \Drupal::hasService('string_translation')) {
+    // Drupal 8 deprecates (and will eventually remove) !var replacements,
+    // so we'll pre-replace these before calling translate().
+    $legacy_args = find_legacy_dt_args($args);
+    $string = strtr($string, $legacy_args);
     $output = \Drupal::translation()->translate($string, $args);
   }
   else if (function_exists('t') && drush_drupal_major_version() <= 7 && function_exists('theme')) {
@@ -166,6 +170,18 @@ function dt($string, $args = array()) {
     }
   }
   return $output;
+}
+
+/**
+ * Return an array containing all of the items in the input
+ * array that begin with a '!'.
+ *
+ * Since array_filter operates on the array value, and there
+ * is no corresponding function that operates on the key, we
+ * will flip the array twice to filter on the key.
+ */
+function find_legacy_dt_args($args) {
+  return array_flip(array_filter(array_flip($args), function ($v) { return $v[0] == '!'; } ));
 }
 
 /**


### PR DESCRIPTION
Drupal 8 may remove processing of !var substitutions. These are used all over Drush and also in Drush contrib modules; better to pre-process our strings before variable substitutions are removed for us by D8.