### PR TITLE
Remove `global` option in composer command for docs on `One Drush per Project`

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -84,12 +84,12 @@ You should first follow the instructions "Composer - One Drush for all Projects"
 * To install Drush 7.x (stable):
 
         cd /path/to/site/composer-root
-        composer global require drush/drush:7.*
+        composer require drush/drush:7.*
 
 * To install Drush 8.x (dev) which is required for Drupal 8:
 
         cd /path/to/site/composer-root
-        composer global require drush/drush:dev-master
+        composer require drush/drush:dev-master
 
 * Run `composer install` for a new project or `composer update` for an existing one. Do so from the same directory as composer.json.
 * Optional: Copy the examples/drush.wrapper file to your project root and modify to taste. This is a handy launcher script; add --local here to turn off all global configuration locations, and maintain absolute control over the configuration settings for the site.


### PR DESCRIPTION
The suggested composer command for `One Drush per Project` is the same as `One Drush for all Projects`. I think the intended command omits the `global` option. If that's correct, we could also use a note on how to path the `drush` command to your local instance. 