### PR TITLE
Make drush_is_local_host() only match unambiguously local hostnames.

### DIFF
--- a/drush.api.php
+++ b/drush.api.php
@@ -203,6 +203,22 @@ function hook_drush_command_alter(&$command) {
 }
 
 /**
+ * Adjust the contents of a site alias.
+ */
+function hook_drush_sitealias_alter(&$alias_record) {
+  // If the alias is "remote", but the remote site is
+  // the system this command is running on, convert the
+  // alias record to a local alias.
+  if (isset($alias_record['remote-host'])) {
+    $uname = php_uname('n');
+    if ($alias_record['remote-host'] == $uname) {
+      unset($alias_record['remote-host']);
+      unset($alias_record['remote-user']);
+    }
+  }
+}
+
+/**
  * Take action after a project has been downloaded.
  */
 function hook_drush_pm_post_download($project, $release) {

--- a/examples/example.aliases.drushrc.php
+++ b/examples/example.aliases.drushrc.php
@@ -199,11 +199,9 @@
  *   used on the remote machine in the 'remote-port' setting.
  * - 'remote-host': The fully-qualified domain name of the remote system
  *   hosting the Drupal instance. **Important Note: The remote-host option
- *   must be omitted for local sites, as this option controls whether or not
- *   rsync parameters are for local or remote machines.
- * - '#check-local': Test to see if 'remote-host' is the local machine; if
- *   it is, then 'remote-host' will be ignore. Useful when sharing aliases
- *   among multiple machines.
+ *   must be omitted for local sites, as this option controls various
+ *   operations, such as whether or not rsync parameters are for local or
+ *   remote machines, and so on. @see hook_drush_sitealias_alter() in drush.api.php
  * - 'remote-user': The username to log in as when using ssh or rsync.
  * - 'os': The operating system of the remote server.  Valid values
  *   are 'Windows' and 'Linux'. Be sure to set this value for all remote

--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1132,7 +1132,7 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
   $ssh_options = $site_record['ssh-options'];
   $os = drush_os($site_record);
 
-  if (array_key_exists('#check-local', $site_record) && drush_is_local_host($hostname)) {
+  if (drush_is_local_host($hostname)) {
     $hostname = null;
   }
 

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -619,30 +619,17 @@ function drush_read_drush_info() {
  *   True if the host is local.
  */
 function drush_is_local_host($host) {
-  // In order for this to work right, you must use 'localhost' or '127.0.0.1'
-  // or the machine returned by 'uname -n' for your 'remote-host' entry in
-  // your site alias.
-  if (($host == 'localhost') || ($host == '127.0.0.1')) {
+  // Check to see if the provided host is "local".
+  // @see hook_drush_sitealias_alter() in drush.api.php.
+  if (
+    ($host == 'localhost') ||
+    ($host == '127.0.0.1') ||
+    preg_match('/\.local$/', $host)
+  ) {
     return TRUE;
   }
 
-  // We'll start out by asking for uname -n via php_uname, since
-  // that is most portable.  On Linux, uname -n returns the contents of
-  // /etc/hostname, which, according to `man hostname`, should never
-  // contain the fqdn.  We will therefore also try `hostname -f`, and
-  // see if we can get the fqdn from that.
-  $uname = php_uname('n');
-  if ((strpos($uname,'.') === FALSE) && (!drush_is_windows())) {
-    $hostname = exec('hostname -f');
-    if (!empty($hostname)) {
-      $uname = $hostname;
-    }
-  }
-  // We will require an exact match if we have the fqdn for this
-  // host; if we only have the short name, then we will consider it
-  // to be a match if it matches the first part of the remote-host
-  // item (up to the first dot).
-  return (strpos($uname,'.') !== FALSE) ? ($host == $uname) : substr($host . '.',0,strlen($uname)+1) == $uname . '.';
+  return FALSE;
 }
 
 /**

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1050,15 +1050,14 @@ function drush_sitealias_is_bootstrapped_site($alias_record) {
  *   Returns TRUE if the alias refers to a remote site, FALSE if it does not, or NULL is unsure.
  */
 function drush_sitealias_is_remote_site($alias) {
-  if (is_array($alias)) {
-    $site_record = $alias;
+  if (is_array($alias) && !empty($alias['remote-host'])) {
+    return TRUE;
   }
-  else {
-    if (!is_string($alias) || !strlen($alias)) {
-      return NULL;
-    }
-    $site_record = drush_sitealias_get_record($alias);
+  if (!is_string($alias) || !strlen($alias)) {
+    return NULL;
   }
+
+  $site_record = drush_sitealias_get_record($alias);
   if ($site_record) {
     if (!empty($site_record['remote-host'])) {
       return TRUE;

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1050,11 +1050,15 @@ function drush_sitealias_is_bootstrapped_site($alias_record) {
  *   Returns TRUE if the alias refers to a remote site, FALSE if it does not, or NULL is unsure.
  */
 function drush_sitealias_is_remote_site($alias) {
-  if (!is_string($alias) || !strlen($alias)) {
-    return NULL;
+  if (is_array($alias)) {
+    $site_record = $alias;
   }
-
-  $site_record = drush_sitealias_get_record($alias);
+  else {
+    if (!is_string($alias) || !strlen($alias)) {
+      return NULL;
+    }
+    $site_record = drush_sitealias_get_record($alias);
+  }
   if ($site_record) {
     if (!empty($site_record['remote-host'])) {
       return TRUE;
@@ -1774,7 +1778,7 @@ function drush_sitealias_set_alias_context($site_alias_settings, $prefix = '') {
   // and 'remote-user' if 'remote-host' is actually the local machine.
   // This prevents drush from using the remote dispatch mechanism (the command
   // is just run directly on the local machine, bootstrapping to the specified alias)
-  elseif (array_key_exists('remote-host', $site_alias_settings) && array_key_exists('#check-local', $site_alias_settings) && drush_is_local_host($site_alias_settings['remote-host'])) {
+  elseif (array_key_exists('remote-host', $site_alias_settings) && drush_is_local_host($site_alias_settings['remote-host'])) {
     $skip_list[] = 'remote-host';
     $skip_list[] = 'remote-user';
   }


### PR DESCRIPTION
Also fixes a problem in drush_sitealias_is_remote_site(), which did not accept alias records, even though some callers used it as if it did.

With this change, users will have to implement an alias alter hook if they want "remote" aliases to act like local aliases when used on the system they point at.  Drush cannot really know the right way to test for local for every system, so it is best to not try, save for completely unambiguous options such as 'localhost' and '.local'.  This PR also eliminates the inconsistently-used "#check-local" item in site aliases -- an earlier, failed attempt to fix this problem.