### PR TITLE
Require ext-pcntl in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "symfony/process": "2.4.5"
   },
   "suggest": {
+      "ext-pcntl": "*",
       "drush/config-extra": "Provides configuration workflow commands, such as config-merge."
   },
   "autoload": {


### PR DESCRIPTION
Since #1595 we rely on pcntl_exec(). Some php binaries are not compiled with it (ex https://github.com/docker-library/php). Adding an explicit dependency in composer.json helps identifying the problem.