### PR TITLE
Added default option for php executable in drush runserver.

### DIFF
--- a/commands/runserver/runserver.drush.inc
+++ b/commands/runserver/runserver.drush.inc
@@ -192,7 +192,7 @@ function drush_core_runserver($uri = NULL) {
       drush_start_browser($browse, 2);
     }
     // Start the server using 'php -S'.
-    $php = drush_get_option('php');
+    $php = drush_get_option('php', 'php');
     drush_shell_exec_interactive($php . ' -S ' . $addr . ':' . $uri['port'] . ' --define auto_prepend_file="' . DRUSH_BASE_PATH . '/commands/runserver/runserver-prepend.php"');
   }
   else {


### PR DESCRIPTION
The option 'php' in the cli context is not set when running drush.php from PhpStorm to debug. I think it is a good thing to at least try the php executable in PATH if no php executable is defined.