### PR TITLE
Preserve project type in lock file for non-pm projects.

### DIFF
--- a/commands/make/generate.contents.make.inc
+++ b/commands/make/generate.contents.make.inc
@@ -121,7 +121,7 @@ function make_generate_from_makefile($file, $makefile) {
     if ($project['name'] == $name) {
       unset($projects[$name]['name']);
     }
-    if ($project['type'] == 'module' && !isset($info[$name]['type'])) {
+    if ($project['type'] == 'module' && $project['download']['type'] === 'pm' && !isset($info[$name]['type'])) {
       unset($projects[$name]['type']);  // Module is the default
     }
     if (!(isset($project['download']['type'])) || ($project['download']['type'] == 'pm')) {


### PR DESCRIPTION
Let's say my site requires a contrib project hosted outside of Drupal contrib and my make file contains the following:

```
projects[myproject][subdir] = "contrib"
projects[myproject][type] = "module"
projects[myproject][download][type] = "git"
projects[myproject][download][url] = "git@github.com:somebody/myproject.module.git"
projects[myproject][download][branch] = "master"
```

If I exclude the `projects[myproject][type] = "module"` part, the build will fail with the error `No release history was found for the requested project (myproject).`.

Whenever a lock file is generated it will exclude that same line in the generated output causing a build from the lock file to fail for the same reason. This PR additionally checks that the download type === 'pm' before unsetting the type for a project when generating the output used for the lock file.
