### PR TITLE
Prevent endless loop on Windows.

### DIFF
--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -238,12 +238,17 @@ function drush_startup($argv) {
   //
   if (empty($found_script)) {
     $c = getcwd();
-    while (!empty($c) && ($c != "/")) {
+    // Windows can give us lots of different strings to represent the root
+    // directory as it often includes the drive letter. If we get the same
+    // result from dirname() twice in a row, then we know we're at the root.
+    $last = '';
+    while (!empty($c) && ($c != $last)) {
       $found_script = find_wrapper_or_launcher($c);
       if ($found_script) {
         chdir($c);
         break;
       }
+      $last = $c;
       $c = dirname($c);
     }
   }


### PR DESCRIPTION
This will handle the various flavors of root that `dirname()` on Windows gives us (eg: c:\, d:\, / or \)