### PR TITLE
Do not chdir in Drush Finder unless really at a Drupal root.

### DIFF
--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -242,7 +242,7 @@ function drush_startup($argv) {
     // directory as it often includes the drive letter. If we get the same
     // result from dirname() twice in a row, then we know we're at the root.
     $last = '';
-    while (!empty($c) && ($c != $last)) {
+    while (!empty($c) && ($c != $last) && file_exists("$c/index.php")) {
       $found_script = find_wrapper_or_launcher($c);
       if ($found_script) {
         chdir($c);


### PR DESCRIPTION
Don't confuse arbitrary 'drush' scripts located above the pwd for a site-local Drush; require an 'index.php' before changing the cwd to an arbitrary location.