### PR TITLE
#1671: drush_build_drush_command() should never replace DRUSH_COMMAND

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -434,15 +434,11 @@ function drush_build_drush_command($drush_path = NULL, $php = NULL, $os = NULL, 
   $additional_options = '';
   $prefix = '';
   if (!$drush_path) {
-    $drush_finder = drush_is_windows($os) ? 'drush.bat' : 'drush';
     if (!$remote_command) {
       $drush_path = DRUSH_COMMAND;
-      if (drush_which($drush_finder)) {
-        $drush_path = $drush_finder;
-      }
     }
     else {
-      $drush_path = $drush_finder;
+      $drush_path = drush_is_windows($os) ? 'drush.bat' : 'drush';
     }
   }
   // If the path to drush points to drush.php, then we will need to


### PR DESCRIPTION
drush_build_drush_command() should not decide to use a local drush finder script; it is the responsibility of backend.inc (drush_backend_invoke_concurrent(), to be specific) to make that determination.