### PR TITLE
Keep up with changes in Drupal 8's index.php.

### DIFF
--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -101,8 +101,8 @@ class DrupalBoot8 extends DrupalBoot {
 
   function bootstrap_drupal_configuration() {
     $this->request = Request::createFromGlobals();
-    $classloader = drush_drupal_load_autoloader(DRUPAL_ROOT);
-    $this->kernel = DrupalKernel::createFromRequest($this->request, $classloader, 'prod');
+    $autoloader = drush_drupal_load_autoloader(DRUPAL_ROOT);
+    $this->kernel = new DrupalKernel('prod', $autoloader);
 
     // Unset drupal error handler and restore drush's one.
     restore_error_handler();


### PR DESCRIPTION
Drupal 8's index.php is slightly different than it used to be.  Drush is still following the old pattern; while this works today, it would probably be prudent to keep up with changes in Drupal, just in case the old method is changed or removed someday.