### PR TITLE
Fixed #1627: Project type not set correctly.

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -387,7 +387,6 @@ function make_prepare_projects($recursion, $info, $contrib_destination = '', $bu
     // Merge the known data onto the project info.
     $project += array(
       'name'                => $key,
-      'type'                => 'module',
       'core'                => $info['core'],
       'translations'        => $translations,
       'build_path'          => $build_path,
@@ -424,7 +423,6 @@ function make_prepare_projects($recursion, $info, $contrib_destination = '', $bu
       $request = make_prepare_request($project);
       $is_core = $release_info->checkProject($request, 'core');
       $project['download_type'] = ($is_core ? 'core' : 'contrib');
-      $project['type'] = $is_core ? 'core' : $project['type'];
     }
     else {
       $project['download_type'] = ($project['name'] == 'drupal' ? 'core' : 'contrib');


### PR DESCRIPTION
Fixes #1627 

tl;dr: as of fcaf417c7a78c9619f949178fb93304b4fa0fe7c and e8125d083afe9087ced958a1356bb361116793e4, if you don't specify a project type in your makefile, it will be automatically set to `module`, even if it's actually theme or profile.