### PR TITLE
Call drush_main() directly from the Drush finder if it is already loaded.

### DIFF
--- a/drush
+++ b/drush
@@ -109,5 +109,7 @@
  * Drush is installed on the remote end.
  */
 
-include __DIR__ . '/includes/startup.inc';
+if (!function_exists("drush_startup")) {
+  include __DIR__ . '/includes/startup.inc';
+}
 drush_startup($argv);

--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -276,7 +276,12 @@ function drush_startup($argv) {
   // In that case, there should always be a drush.launcher in
   // the same directory this script is stored in; use that.
   if (empty($found_script)) {
-    $found_script = dirname(__DIR__) . "/drush.launcher";
+    if (function_exists("drush_main")) {
+      exit(drush_main());
+    }
+    else {
+      $found_script = dirname(__DIR__) . "/drush.launcher";
+    }
   }
 
   // Emit a message in verbose mode advertising the location of the


### PR DESCRIPTION
Just a quick prototype that I am putting here for now. Should be merged in with #675, and change the "main" from "drush.php" to "drush", and it would probably work.