### PR TITLE
When calling user-password or user-login, blocked users should be prompted to be unblocked.

### DIFF
--- a/commands/user/user.drush.inc
+++ b/commands/user/user.drush.inc
@@ -358,9 +358,8 @@ function drush_user_password($inputs) {
     if (empty($pass)) {
       $pass = drush_prompt(dt('Password'), NULL, TRUE, TRUE);
     }
-    foreach ($userlist->accounts as $account) {
-      $userlist->each('password', array($pass));
-    }
+    $userlist->each('checkIsActive');
+    $userlist->each('password', array($pass));
     drush_log(dt('Changed password for !users', array('!users' => $userlist->names())), 'success');
   }
 }
@@ -407,6 +406,7 @@ function drush_user_login($inputs = '', $path = NULL) {
       // No user option or argument was passed, so we default to uid 1.
         $userlist = new UserList(1);
     }
+    $userlist->each('checkIsActive');
     $links = $userlist->each('passResetUrl', array($path));
   }
   $port = drush_get_option('redirect-port', FALSE);

--- a/lib/Drush/User/UserSingle7.php
+++ b/lib/Drush/User/UserSingle7.php
@@ -28,7 +28,7 @@ class UserSingle7 extends UserSingleBase {
     foreach (array('created', 'access', 'login') as $key) {
       $userinfo['user_' . $key] = format_date($userinfo[$key]);
     }
-    $userinfo['user_status'] = $userinfo['status'] ? 'active' : 'blocked';
+    $userinfo['user_status'] = $this->getStatus();
     return $userinfo;
   }
 
@@ -51,5 +51,12 @@ class UserSingle7 extends UserSingleBase {
 
   public function id() {
     return $this->account->uid;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStatus() {
+    return $this->account->status ? self::STATUS_ACTIVE : self::STATUS_BLOCKED;
   }
 }


### PR DESCRIPTION
I found it really odd that I can run `drush user-login` for a blocked account, but it does not warn me that the account is blocked. Hence the one-time login link will fail every time. I thought it would be nice if the user would be prompted to unblock the user when running these commands.

This also cleans up that the user-password command ran too many times (looped through each account, but then called each() on the user list each time).
