### PR TITLE
Detailed error message when pcntl_exec() fails 

### DIFF
--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -295,7 +295,7 @@ function drush_startup($argv) {
     if (!$error) {
       $errno = pcntl_get_last_error();
       $strerror = pcntl_strerror($errno);
-      fwrite(STDERR, "Error has ocurred executing the Drush script found at $found_script\n");
+      fwrite(STDERR, "Error has occurred executing the Drush script found at $found_script\n");
       fwrite(STDERR, "(errno {$errno}) $strerror\n");
     }
     exit(1);

--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -291,7 +291,13 @@ function drush_startup($argv) {
 
     // Launch the new script in the same process.
     // If the launch succeeds, then it will not return.
-    pcntl_exec($found_script, $arguments, $env);
+    $error = pcntl_exec($found_script, $arguments, $env);
+    if (!$error) {
+      $errno = pcntl_get_last_error();
+      $strerror = pcntl_strerror($errno);
+      fwrite(STDERR, "Error has ocurred executing the Drush script found at $found_script\n");
+      fwrite(STDERR, "(errno {$errno}) $strerror\n");
+    }
     exit(1);
   }
   else {


### PR DESCRIPTION
I accidentally created a drush file (without execution permissions) at the root of the project, and without knowing, the drush execution was broken.
Drush was giving me this error:
```
PHP Warning:  pcntl_exec(): Error has occurred: (errno 13) Permission denied in /usr/local/share/drush/includes/startup.inc on line 294
```

Took me a while to understand that the permission denied was related to the drush script execution found in the root of the project.
Maybe something more described could help:
```
PHP Warning:  pcntl_exec(): Error has occurred: (errno 13) Permission denied in /usr/local/share/drush/includes/startup.inc on line 294
Error has occurred executing the Drush script found at /home/vagrant/project/builds/20151016-134102/drush
(errno 13) Permission denied
```
Looks a little verbose, but I think could be a first step into improvement.