### PR TITLE
Add current alias support in current command data.

### DIFF
--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1037,7 +1037,10 @@ function drush_get_commands($reset = FALSE) {
         if (isset($command['aliases']) && count($command['aliases'])) {
           foreach ($command['aliases'] as $alias) {
             $commands[$alias] = $command;
+            // Actually is_alias flag could be replaced with usage of current_alias.
+            // But it's here for backwards compatibility.
             $commands[$alias]['is_alias'] = TRUE;
+            $commands[$alias]['current_alias'] = $alias;
           }
         }
       }


### PR DESCRIPTION
# Motivation
I struggled many times with commands with long and not-intuitive options.

# Solution
I've researched and figured out that impossible to know within invoked command, what alias was used for call actually.

My patch introduce new key for $command data, and intented to use in next way:
```php
$command = drush_get_command();
if (array_key_exists('current_alias', $command) && $command['current_alias'] == 'some-alias') {
  // Set up some specific stuff or default options values.
}
```

I've strongly motivated to remove 'is_alias' flag at all, because we just could check if 'current_alias'  is not empty. But probably it's not very compatibility-friendly...