### PR TITLE
User login shortcut no browser

### DIFF
--- a/commands/user/user.drush.inc
+++ b/commands/user/user.drush.inc
@@ -189,7 +189,7 @@ function user_drush_command() {
   );
   $items['user-login'] = array(
     'description' => 'Display a one time login link for the given user account (defaults to uid 1).',
-    'aliases' => array('uli'),
+    'aliases' => array('uli', 'ulil'),
     'bootstrap' => DRUSH_BOOTSTRAP_NONE,
     'handle-remote-commands' => TRUE,
     'arguments' => array(
@@ -206,6 +206,7 @@ function user_drush_command() {
     'examples' => array(
       'drush user-login ryan node/add/blog' => 'Displays and opens default web browser (if configured or detected) for a one-time login link for the user with the username ryan and redirect to the path node/add/blog.',
       'drush user-login --browser=firefox --mail=drush@example.org admin/settings/performance' => 'Open firefox web browser, login as the user with the e-mail address drush@example.org and redirect to the path admin/settings/performance.',
+      'drush ulil ryan' => 'Use ulil alias to always get login link without opening of browser.',
     ),
   );
   return $items;
@@ -370,6 +371,12 @@ function drush_user_password($inputs) {
  */
 function drush_user_login($inputs = '', $path = NULL) {
   $args = func_get_args();
+
+  $command = drush_get_command();
+  // The ulil alias is actually a shortcut for --browser=0 option.
+  if (array_key_exists('current_alias', $command) && $command['current_alias'] == 'ulil') {
+    drush_set_option('browser', FALSE);
+  }
 
   // Redispatch if called against a remote-host so a browser is started on the
   // the *local* machine.

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1037,7 +1037,10 @@ function drush_get_commands($reset = FALSE) {
         if (isset($command['aliases']) && count($command['aliases'])) {
           foreach ($command['aliases'] as $alias) {
             $commands[$alias] = $command;
+            // Actually is_alias flag could be replaced with usage of current_alias.
+            // But it's here for backwards compatibility.
             $commands[$alias]['is_alias'] = TRUE;
+            $commands[$alias]['current_alias'] = $alias;
           }
         }
       }


### PR DESCRIPTION
# Motivation
From my practice it's a common case of user-login command usage is just to get link without being logged in browser.
In the same time it's quite painful to append each time '--browser=0'.

# Solution
This solution is based on this pull request — #1706 and serve as an example of usage in the same time.
I've didn't find any other convinient way to achieve this.