### PR TITLE
Allow Drush commands to be defined in YAML files rather than via php.

### DIFF
--- a/commands/core/image.drush.inc
+++ b/commands/core/image.drush.inc
@@ -27,21 +27,6 @@ function image_drush_command() {
     ),
     'aliases' => array('if'),
   );
-  $items['image-derive'] = array(
-    'description' => 'Create an image derivative.',
-    'core' => array('7+'),
-    'drupal dependencies' => array('image'),
-    'arguments' => array(
-      'style' => 'An image style machine name.',
-      'source' => 'Path to a source image. Optionally prepend stream wrapper scheme.',
-    ),
-    'required arguments' => TRUE,
-    'options' => array(),
-    'examples' => array(
-      'drush image-derive thumbnail themes/bartik/logo.png' => 'Save thumbnail sized derivative of logo image.',
-    ),
-    'aliases' => array('id'),
-  );
   return $items;
 }
 

--- a/commands/core/image.drush.yml
+++ b/commands/core/image.drush.yml
@@ -1,6 +1,7 @@
 image-derive:
   description: Create an image derivative.
-  core: 7+
+  core:
+    - 7+
   'drupal dependencies':
     - image
   arguments:

--- a/commands/core/image.drush.yml
+++ b/commands/core/image.drush.yml
@@ -1,0 +1,14 @@
+image-derive:
+  description: Create an image derivative.
+  core: 7+
+  'drupal dependencies':
+    - image
+  arguments:
+    style: An image style machine name.
+    source: Path to a source image. Optionally prepend stream wrapper scheme.
+  'required arguments': true
+  options: []
+  examples:
+    'drush image-derive thumbnail themes/bartik/logo.png': Save thumbnail sized derivative of logo image.
+  aliases:
+    - id

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1,5 +1,7 @@
 <?php
 
+use Symfony\Component\Yaml\Yaml;
+
 /**
  * @defgroup dispatching Command dispatching functions.
  * @{
@@ -1007,38 +1009,48 @@ function drush_get_commands($reset = FALSE) {
 
   $list = drush_commandfile_list();
   foreach ($list as $commandfile => $path) {
+    $result = array();
+
+    // Try to load commands from a YAML command file.
+    $yaml_commandfile = basename($path, '.inc') . '.yml';
+    if (file_exists($yaml_commandfile)) {
+      $result += Yaml::parse($yaml_commandfile);
+    }
+
+    // Try to load commands from hook_drush_command().
     if (drush_command_hook($commandfile, 'drush_command')) {
       $function = $commandfile . '_drush_command';
-      $result = $function();
-      foreach ((array)$result as $key => $command) {
-        // Add some defaults and normalize the command descriptor.
-        $command += drush_command_defaults($key, $commandfile, $path);
+      $result += $function();
+    }
 
-        // Add engine data.
-        drush_merge_engine_data($command);
+    foreach ($result as $key => $command) {
+      // Add some defaults and normalize the command descriptor.
+      $command += drush_command_defaults($key, $commandfile, $path);
 
-        // Translate command.
-        drush_command_translate($command);
+      // Add engine data.
+      drush_merge_engine_data($command);
 
-        // If the command callback is not 'drush_command', then
-        // copy the callback function to an alternate element
-        // of the command array that will be called when Drush
-        // calls the command function hooks.  Then, set the
-        // callback to drush_command so that the function hooks
-        // will be called.
-        if (($command['callback'] != 'drush_command') && $command['invoke hooks']) {
-          $command['primary function'] = $command['callback'];
-          $command['callback'] = 'drush_command';
-        }
+      // Translate command.
+      drush_command_translate($command);
 
-        $commands[$key] = $command;
-        // For every alias, make a copy of the command and store it in the command list
-        // using the alias as a key
-        if (isset($command['aliases']) && count($command['aliases'])) {
-          foreach ($command['aliases'] as $alias) {
-            $commands[$alias] = $command;
-            $commands[$alias]['is_alias'] = TRUE;
-          }
+      // If the command callback is not 'drush_command', then
+      // copy the callback function to an alternate element
+      // of the command array that will be called when Drush
+      // calls the command function hooks.  Then, set the
+      // callback to drush_command so that the function hooks
+      // will be called.
+      if (($command['callback'] != 'drush_command') && $command['invoke hooks']) {
+        $command['primary function'] = $command['callback'];
+        $command['callback'] = 'drush_command';
+      }
+
+      $commands[$key] = $command;
+      // For every alias, make a copy of the command and store it in the command list
+      // using the alias as a key
+      if (isset($command['aliases']) && count($command['aliases'])) {
+        foreach ($command['aliases'] as $alias) {
+          $commands[$alias] = $command;
+          $commands[$alias]['is_alias'] = TRUE;
         }
       }
     }

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1012,7 +1012,7 @@ function drush_get_commands($reset = FALSE) {
     $result = array();
 
     // Try to load commands from a YAML command file.
-    $yaml_commandfile = basename($path, '.inc') . '.yml';
+    $yaml_commandfile = dirname($path) . '/' . basename($path, '.inc') . '.yml';
     if (file_exists($yaml_commandfile)) {
       $result += Yaml::parse($yaml_commandfile);
     }


### PR DESCRIPTION
Implements the idea in http://blog.riff.org/2015_10_23_drupal_8_tip_of_the_day_replace_hook_drush_command_by_a_yaml_file#comment-4168

This allows command files to be static YAML files as well as PHP, similar to how permissions are implemented in Drupal 8.