### PR TITLE
Pass shell ppid from Drush finder 

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -272,6 +272,7 @@ function drush_get_global_options($brief = FALSE) {
   $options['yes']                = array('short-form' => 'y', 'context' => 'DRUSH_AFFIRMATIVE', 'description' => "Assume 'yes' as answer to all prompts.");
   $options['no']                 = array('short-form' => 'n', 'context' => 'DRUSH_NEGATIVE', 'description' => "Assume 'no' as answer to all prompts.");
   $options['simulate']           = array('short-form' => 's', 'context' => 'DRUSH_SIMULATE', 'never-propagate' => TRUE, 'description' => "Simulate all relevant actions (don't actually change the system).");
+  $options['shell-pid']          = array('hidden' => TRUE, 'description' => 'Used by the Drush "Finder" script to pass in the PID of the shell for site-set.', 'context' => 'DRUSH_SHELL_PPID', 'never-propogate' => TRUE);
   $options['pipe']               = array('short-form' => 'p', 'hidden' => TRUE, 'description' => "Emit a compact representation of the command for scripting.");
   $options['help']               = array('short-form' => 'h', 'description' => "This help system.");
 

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -272,7 +272,7 @@ function drush_get_global_options($brief = FALSE) {
   $options['yes']                = array('short-form' => 'y', 'context' => 'DRUSH_AFFIRMATIVE', 'description' => "Assume 'yes' as answer to all prompts.");
   $options['no']                 = array('short-form' => 'n', 'context' => 'DRUSH_NEGATIVE', 'description' => "Assume 'no' as answer to all prompts.");
   $options['simulate']           = array('short-form' => 's', 'context' => 'DRUSH_SIMULATE', 'never-propagate' => TRUE, 'description' => "Simulate all relevant actions (don't actually change the system).");
-  $options['shell-pid']          = array('hidden' => TRUE, 'description' => 'Used by the Drush "Finder" script to pass in the PID of the shell for site-set.', 'context' => 'DRUSH_SHELL_PPID', 'never-propogate' => TRUE);
+  $options['shell-pid']          = array('hidden' => TRUE, 'description' => 'Used by the Drush "Finder" script to pass in the PID of the shell for site-set.', 'context' => 'DRUSH_SHELL_PPID', 'never-propagate' => TRUE);
   $options['pipe']               = array('short-form' => 'p', 'hidden' => TRUE, 'description' => "Emit a compact representation of the command for scripting.");
   $options['help']               = array('short-form' => 'h', 'description' => "This help system.");
 

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -263,6 +263,7 @@ function _drush_preflight_global_options() {
   drush_set_context('DRUSH_VERBOSE',     drush_get_option(array('verbose', 'debug'), FALSE));
   drush_set_context('DRUSH_DEBUG', drush_get_option('debug'));
   drush_set_context('DRUSH_SIMULATE',    drush_get_option('simulate', FALSE));
+  drush_set_context('DRUSH_SHELL_PPID',    drush_get_option('shell-pid', FALSE));
 
   // Backend implies affirmative unless negative is explicitly specified
   drush_set_context('DRUSH_NEGATIVE',    drush_get_option('no', FALSE));

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -2157,14 +2157,18 @@ function drush_sitealias_site_get() {
  *   Returns the full path to temp file if possible, or FALSE if not.
  */
 function drush_sitealias_get_envar_filename($filename_prefix = 'drush-drupal-site-') {
-  if (!function_exists('posix_getppid')) {
+  $shell_pid = drush_get_context('DRUSH_SHELL_PPID');
+  if (!$shell_pid && function_exists('posix_getppid')) {
+    $shell_pid = posix_getppid();
+  }
+  if (!$shell_pid) {
     return FALSE;
   }
 
   $tmp = getenv('TMPDIR') ? getenv('TMPDIR') : '/tmp';
   $username = drush_get_username();
 
-  return "{$tmp}/drush-env-{$username}/{$filename_prefix}" . posix_getppid();
+  return "{$tmp}/drush-env-{$username}/{$filename_prefix}" . $shell_pid;
 }
 
 /**

--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -285,6 +285,12 @@ function drush_startup($argv) {
     fwrite(STDERR, "Using the Drush script found at $found_script\n");
   }
 
+  // If we have posix_getppid, then pass in the shell pid so
+  // that 'site-set' et. al. can work correctly.
+  if (function_exists('posix_getppid')) {
+    array_unshift($arguments, "--shell-pid=" . posix_getppid());
+  }
+
   if (function_exists("pcntl_exec")) {
     // Get the current environment for pnctl_exec.
     $env = drush_env();


### PR DESCRIPTION
The Drush finder (and before it, the Drush wrapper, for those who used it) broke the site-set command, because the parent process ID for the Drush application is no longer set to the shell that called Drush.

This PR passes in the shell PID from the Drush Finder, so that it is available when needed.