### PR TITLE
Fix '.local' being assumed as localhost

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -619,8 +619,7 @@ function drush_is_local_host($host) {
   // @see hook_drush_sitealias_alter() in drush.api.php.
   if (
     ($host == 'localhost') ||
-    ($host == '127.0.0.1') ||
-    preg_match('/\.local$/', $host)
+    ($host == '127.0.0.1')
   ) {
     return TRUE;
   }


### PR DESCRIPTION
This fixes a bug from https://github.com/drush-ops/drush/commit/5fd73516d9d09c856fb4c70748bc0ca5dcd5ea54 / PR #1618 .

`drush_is_local_host()` added a test for the hostname ending in .local - but <a href="https://en.wikipedia.org/wiki/Multicast_DNS">.local is used for mDNS</a> and means machines on the local network, not the localhost itself. This breaks vagrant machines using mDNS for automatic publishing of records, but would also break using .local addresses for physical machines as well.