### PR TITLE
Issue #1729: Fixing documentation on composer installing drush 6.x 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ using Compser, consider trying MANUAL INSTALLATION. It is not too hard.
 1. To install Drush
    1. Version 6.x (stable):
 
-      composer global require drush/drush:6.*
+      composer global require drush/drush:6.x
 
    1. Version 7.x (dev) which is required for Drupal 8:
 


### PR DESCRIPTION
6.* does not install the latest version, 6.x does.