### PR TITLE
Just say "--no"

### DIFF
--- a/commands/core/archive.drush.inc
+++ b/commands/core/archive.drush.inc
@@ -16,7 +16,7 @@ function archive_drush_command() {
       'description' => 'Describe the archive contents.',
       'tags' => 'Add tags to the archive manifest. Delimit multiple by commas.',
       'destination' => 'The full path and filename in which the archive should be stored. If omitted, it will be saved to the drush-backups directory and a filename will be generated.',
-      'overwrite' => 'Do not fail if the destination file exists; overwrite it instead.',
+      'overwrite' => 'Do not fail if the destination file exists; overwrite it instead. Default is --no-overwrite.',
       'generator' => 'The generator name to store in the MANIFEST file. The default is "Drush archive-dump".',
       'generatorversion' => 'The generator version number to store in the MANIFEST file. The default is ' . DRUSH_VERSION . '.',
       'pipe' => 'Only print the destination of the archive. Useful for scripts that don\'t pass --destination.',
@@ -50,7 +50,7 @@ function archive_drush_command() {
       ),
       'db-su' => 'Account to use when creating the new database. Optional.',
       'db-su-pw' => 'Password for the "db-su" account. Optional.',
-      'overwrite' => 'Allow drush to overwrite any files in the destination.',
+      'overwrite' => 'Allow drush to overwrite any files in the destination. Default is --no-overwrite.',
       'tar-options' => 'Options passed thru to the tar command.',
     ),
     'examples' => array(

--- a/commands/core/browse.drush.inc
+++ b/commands/core/browse.drush.inc
@@ -13,7 +13,7 @@ function browse_drush_command() {
       'path' => 'Path to open. If omitted, the site front page will be opened.',
     ),
     'options' => array(
-      'browser' => 'Specify a particular browser (defaults to operating system default). Set to 0 to suppress opening a browser.',
+      'browser' => 'Specify a particular browser (defaults to operating system default). Use --no-brower to suppress opening a browser.',
       'redirect-port' => 'The port that the web server is redirected to (e.g. when running within a Vagrant environment)',
     ),
     'examples' => array(

--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -122,7 +122,7 @@ function core_drush_command() {
       'cache-clear',
     ),
     'options' => array(
-      'entity-updates' => 'Run automatic entity schema updates at the end of any update hooks.',
+      'entity-updates' => 'Run automatic entity schema updates at the end of any update hooks. Defaults to --no-entity-updates.',
     ),
     'aliases' => array('updb'),
   );
@@ -179,7 +179,7 @@ function core_drush_command() {
       'item' => 'Optional.  The status item line(s) to display.',
     ),
     'options' => array(
-      'show-passwords' => 'Show database password.',
+      'show-passwords' => 'Show database password.  Defaults to --no-show-passwords.',
       'full' => 'Show all file paths and drush aliases in the report, even if there are a lot.',
       'project' => array(
         'description' => 'One or more projects that should be added to the path list',
@@ -281,7 +281,7 @@ function core_drush_command() {
       'command' => 'The shell command to be executed.',
     ),
     'options' => array(
-      'escape' => 'Escape parameters before executing them with the shell. Default is escape; use --escape=0 to disable.',
+      'escape' => 'Escape parameters before executing them with the shell. Default is escape; use --no-escape to disable.',
     ) + drush_shell_exec_proc_build_options(),
     'required-arguments' => TRUE,
     'allow-additional-options' => TRUE,
@@ -868,7 +868,7 @@ function drush_core_status() {
 
 // Command callback. Show all global options. Exposed via topic command.
 function drush_core_global_options() {
-  drush_print(dt('These options are applicable to most drush commands.'));
+  drush_print(dt('These options are applicable to most drush commands. Most options can be disabled by using --no-option (i.e. --no-debug to disable --debug.)'));
   drush_print();
   $fake = drush_global_options_command(FALSE);
   return drush_format_help_section($fake, 'options');

--- a/commands/core/outputformat.drush.inc
+++ b/commands/core/outputformat.drush.inc
@@ -65,7 +65,7 @@ function outputformat_drush_engine_type_info() {
         'hidden' => TRUE,
       ),
       'field-labels' => array(
-        'description' => 'Add field labels before first line of data. Default is on; --field-labels=0 to disable.',
+        'description' => 'Add field labels before first line of data. Default is on; use --no-field-labels to disable.',
         'default' => '1',
         'key' => 'include-field-labels',
       ),

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -44,7 +44,7 @@ function site_install_drush_command() {
         'description' => 'A short language code. Sets the default site language. Language files must already be present. You may use download command to get them.',
         'example-value' => 'en-GB',
       ),
-      'clean-url'=> 'Defaults to 1',
+      'clean-url'=> 'Defaults to clean; use --no-clean-url to disable. Note that Drupal 8 and later requires clean.',
       'site-name' => 'Defaults to Site-Install',
       'site-mail' => 'From: for system mailings. Defaults to admin@example.com',
       'sites-subdir' => array(

--- a/commands/core/ssh.drush.inc
+++ b/commands/core/ssh.drush.inc
@@ -13,7 +13,7 @@ function ssh_drush_command() {
       'bash' => 'Bash to execute on target. Optional, except when site-alias is a list.',
     ),
     'options' => array(
-      'cd' => "Directory to change to. Use a full path, TRUE for the site's Drupal root directory, or FALSE for the remote user's home directory. Defaults to the Drupal root.",
+      'cd' => "Directory to change to. Use a full path, TRUE for the site's Drupal root directory, or --no-cd for the ssh default (usually the remote user's home directory). Defaults to the Drupal root.",
     ) + drush_shell_exec_proc_build_options(),
     'handle-remote-commands' => TRUE,
     'strict-option-handling' => TRUE,

--- a/commands/runserver/runserver.drush.inc
+++ b/commands/runserver/runserver.drush.inc
@@ -32,13 +32,13 @@ function runserver_drush_command() {
     'description' => 'Runs PHP\'s built-in http server for development.',
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
     'arguments' => array(
-      'addr:port/path' => 'Host IP address and port number to bind to and path to open in web browser. Format is addr:port/path, default 127.0.0.1:8888, all elements optional. See examples for shorthand.',
+      'addr:port/path' => 'Host IP address and port number to bind to and path to open in web browser. Format is addr:port/path, default 127.0.0.1:8888, all elements optional. See examples for shorthand. Only opens a browser if a path is specified.',
     ),
     'options' => array(
       'variables' => 'Key-value array of variables to override in the $conf array for the running site. By default disables drupal_http_request_fails to avoid errors on Windows (which supports only one connection at a time). Comma delimited list of name=value pairs (or array in drushrc).',
       'default-server' => 'A default addr:port/path to use for any values not specified as an argument.',
       'user' => 'If opening a web browser, automatically log in as this user (user ID or username). Default is to log in as uid 1.',
-      'browser' => 'If opening a web browser, which browser to user (defaults to operating system default).',
+      'browser' => 'If opening a web browser, which browser to user (defaults to operating system default). Use --no-browser to avoid opening a browser.',
       'dns' => 'Resolve hostnames/IPs using DNS/rDNS (if possible) to determine binding IPs and/or human friendly hostnames for URLs and browser.',
     ),
     'aliases' => array('rs'),

--- a/commands/user/user.drush.inc
+++ b/commands/user/user.drush.inc
@@ -197,7 +197,7 @@ function user_drush_command() {
       'path' => 'Optional path to redirect to after logging in.',
     ),
     'options' => array(
-      'browser' => 'Optional value denotes which browser to use (defaults to operating system default). Set to 0 to suppress opening a browser.',
+      'browser' => 'Optional value denotes which browser to use (defaults to operating system default). Use --no-browser to suppress opening a browser.',
       'uid' => 'A uid to log in as.',
       'redirect-port' => 'A custom port for redirecting to (e.g. when running within a Vagrant environment)',
       'name' => 'A user name to log in as.',

--- a/includes/context.inc
+++ b/includes/context.inc
@@ -570,6 +570,9 @@ function _drush_get_option($option, $context) {
   elseif (array_key_exists($option, $context)) {
     return $context[$option];
   }
+  elseif (array_key_exists('no-' . $option, $context)) {
+    return FALSE;
+  }
 
   return NULL;
 }

--- a/includes/context.inc
+++ b/includes/context.inc
@@ -562,16 +562,17 @@ function drush_get_merged_prefixed_options($prefix) {
 function _drush_get_option($option, $context) {
   if (is_array($option)) {
     foreach ($option as $current) {
-      if (array_key_exists($current, $context)) {
-        return $context[$current];
+      $current_value = _drush_get_option($current, $context);
+      if (isset($current_value)) {
+        return $current_value;
       }
     }
   }
-  elseif (array_key_exists($option, $context)) {
-    return $context[$option];
-  }
   elseif (array_key_exists('no-' . $option, $context)) {
     return FALSE;
+  }
+  elseif (array_key_exists($option, $context)) {
+    return $context[$option];
   }
 
   return NULL;


### PR DESCRIPTION
This PR supports --no- options as an alternate for =0 (e.g. --no-browser inste…ad of --browser=0).

I noticed that since forever ago (Drush 5, or whenever it was), Drush had a provision for --no options.  The function drush_append_negation_options() ensures that --no-foo does not raise an error if there is any command option --foo.  However, despite this assurance, nothing in Drush ever allowed these options to actually work.

This PR introduces a minor enhancement that does just that.  If this looks acceptable, I could update the documentation for options where --no makes sense.