### PR TITLE
Add a 'core-init' aka 'init' command.

### DIFF
--- a/commands/core/init.drush.inc
+++ b/commands/core/init.drush.inc
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @file
+ *   Set up local Drush configuration.
+ */
+
+/**
+ * Implementation of hook_drush_command().
+ *
+ * @return
+ *   An associative array describing your command(s).
+ */
+function init_drush_command() {
+  $items['core-init'] = array(
+    'description' => 'Initialize local Drush configuration.',
+    'aliases' => array('init'),
+    'bootstrap' => DRUSH_BOOTSTRAP_NONE,
+  );
+  return $items;
+}
+
+/**
+ * Initialize local Drush configuration
+ */
+function drush_init_core_init() {
+  $home = drush_server_home();
+  $drush_config_dir = $home . "/.drush";
+  $drush_config_file = $drush_config_dir . "/drushrc.php";
+  $drush_bashrc = $drush_config_dir . "/drush.bashrc";
+  $examples_dir = DRUSH_BASE_PATH . "/examples";
+  $example_configuration = $examples_dir . "/example.drushrc.php";
+  $example_bashrc = $examples_dir . "/example.bashrc";
+  $bashrc_additions = array();
+
+  // Create a ~/.drush directory if it does not yet exist
+  if (!is_dir($drush_config_dir)) {
+    drush_mkdir($drush_config_dir);
+  }
+
+  // If there is no ~/.drush/drushrc.php, then copy the
+  // example Drush configuration file here
+  if (!is_file($drush_config_file)) {
+    @copy($example_configuration, $drush_config_file);
+    drush_log(dt("Copied example Drush configuration file to !path", array('!path' => $drush_config_file)), 'ok');
+  }
+
+  // If there is no ~/.drush/drush.bashrc file, then copy
+  // the example bashrc file here
+  if (!is_file($drush_bashrc)) {
+    @copy($example_bashrc, $drush_bashrc);
+    $bashrc_additions = array("%$drush_bashrc%" => "# Include Drush bash customizations\n. $drush_bashrc\n\n");
+    drush_log(dt("Copied example Drush bash configuration file to !path", array('!path' => $drush_bashrc)), 'ok');
+  }
+
+  // Decide whether we want to add our Bash commands to
+  // ~/.bashrc or ~/.bash_profile
+  $bashrc = drush_init_find_bashrc($home);
+
+  // If drush is not in the $PATH, then figure out which
+  // path to add so that Drush can be found globally.
+  if (!drush_which("drush")) {
+    $drush_path = drush_find_path_to_drush();
+    $drush_path = preg_replace("%^$home/%", '$HOME/', $drush_path);
+
+    $bashrc_additions = array("%$drush_path%" => "# Path to Drush, added by 'drush init'\n\$PATH=\$PATH:$drush_path\n\n");
+  }
+
+  // Modify the users bashrc file, adding our customizations.
+  $bashrc_contents = "";
+  if (file_exists($bashrc)) {
+    $bashrc_contents = file_get_contents($bashrc);
+  }
+  $new_bashrc_contents = $bashrc_contents;
+  foreach ($bashrc_additions as $pattern => $addition) {
+    // Only put in the addition if the pattern does not already
+    // exist in the bashrc file.
+    if (!preg_match($pattern, $new_bashrc_contents)) {
+      $new_bashrc_contents = $addition . $new_bashrc_contents;
+    }
+  }
+  if ($new_bashrc_contents != $bashrc_contents) {
+    file_put_contents($bashrc, $new_bashrc_contents);
+    drush_log(dt("Updated bash configuration file !path", array('!path' => $bashrc)), 'ok');
+  }
+}
+
+/**
+ * Determine which .bashrc file is best to use on this platform.
+ */
+function drush_init_find_bashrc($home) {
+  return $home . "/.bashrc";
+}
+
+/**
+ * Determine where Drush is located, so that we can add
+ * that location to the $PATH
+ */
+function drush_find_path_to_drush($home) {
+  // First test: is Drush inside a vendor directory?
+  // Does vendor/bin exist?  If so, use that.  We do
+  // not have a good way to locate the 'bin' directory
+  // if it has been relocated in the composer.json config
+  // section.
+  if ($vendor_pos = strpos(DRUSH_BASE_PATH, "/vendor/")) {
+    $vendor_dir = substr(DRUSH_BASE_PATH, 0, $vendor_pos + 7);
+    $vendor_bin = $vendor_dir . '/bin';
+    if (is_dir($vendor_bin)) {
+      return $vendor_bin;
+    }
+  }
+
+  // Fallback is to use the directory that Drush is in.
+  return dirname(DRUSH_BASE_PATH);
+}

--- a/commands/core/init.drush.inc
+++ b/commands/core/init.drush.inc
@@ -59,7 +59,7 @@ function drush_init_core_init() {
   if (!is_file($drush_bashrc)) {
     @copy($example_bashrc, $drush_bashrc);
     $pattern = basename($drush_bashrc);
-    $bashrc_additions = array("%$pattern%" => "# Include Drush bash customizations\n. $drush_bashrc\n\n");
+    $bashrc_additions["%$pattern%"] = "# Include Drush bash customizations\n. $drush_bashrc\n\n";
     drush_log(dt("Copied example Drush bash configuration file to !path", array('!path' => $drush_bashrc)), 'ok');
   }
 
@@ -73,7 +73,7 @@ function drush_init_core_init() {
     $drush_path = drush_find_path_to_drush();
     $drush_path = preg_replace("%^$home/%", '$HOME/', $drush_path);
 
-    $bashrc_additions = array("%$drush_path%" => "# Path to Drush, added by 'drush init'\n\$PATH=\$PATH:$drush_path\n\n");
+    $bashrc_additions["%$drush_path%"] = "# Path to Drush, added by 'drush init'\n\$PATH=\$PATH:$drush_path\n\n";
   }
 
   // Modify the user's bashrc file, adding our customizations.

--- a/commands/core/init.drush.inc
+++ b/commands/core/init.drush.inc
@@ -13,10 +13,18 @@
  */
 function init_drush_command() {
   $items['core-init'] = array(
-    'description' => 'Enrich the bash startup file with completion and aliases. Copy drushrc file to $HOME.',
+    'description' => 'Enrich the bash startup file with completion and aliases. Copy .drushrc file to ~/.drush',
     'aliases' => array('init'),
     'bootstrap' => DRUSH_BOOTSTRAP_NONE,
     'package' => 'core',
+    'global-options' => array('editor', 'bg'),
+    'options' => array(
+      'edit' => 'Open the new config file in an editor.',
+    ),
+    'examples' => array(
+      'drush core-init --edit' => 'Enrich Bash and open drush config file in editor.',
+      'drush core-init --edit --bg' => 'Return to shell prompt as soon as the editor window opens.',
+    ),
   );
   return $items;
 }
@@ -83,6 +91,11 @@ function drush_init_core_init() {
   if ($new_bashrc_contents != $bashrc_contents) {
     file_put_contents($bashrc, $new_bashrc_contents);
     drush_log(dt("Updated bash configuration file !path", array('!path' => $bashrc)), 'ok');
+  }
+
+  if (drush_get_option('edit')) {
+    $exec = drush_get_editor();
+    drush_shell_exec_interactive($exec, $drush_config_file, $drush_config_file);
   }
 }
 

--- a/commands/core/init.drush.inc
+++ b/commands/core/init.drush.inc
@@ -58,7 +58,8 @@ function drush_init_core_init() {
   // the example bashrc file here
   if (!is_file($drush_bashrc)) {
     @copy($example_bashrc, $drush_bashrc);
-    $bashrc_additions = array("%$drush_bashrc%" => "# Include Drush bash customizations\n. $drush_bashrc\n\n");
+    $pattern = basename($drush_bashrc);
+    $bashrc_additions = array("%$pattern%" => "# Include Drush bash customizations\n. $drush_bashrc\n\n");
     drush_log(dt("Copied example Drush bash configuration file to !path", array('!path' => $drush_bashrc)), 'ok');
   }
 

--- a/commands/core/init.drush.inc
+++ b/commands/core/init.drush.inc
@@ -57,7 +57,7 @@ function drush_init_core_init() {
   // ~/.bashrc or ~/.bash_profile
   $bashrc = drush_init_find_bashrc($home);
 
-  // If drush is not in the $PATH, then figure out which
+  // If Drush is not in the $PATH, then figure out which
   // path to add so that Drush can be found globally.
   if (!drush_which("drush")) {
     $drush_path = drush_find_path_to_drush();
@@ -66,7 +66,7 @@ function drush_init_core_init() {
     $bashrc_additions = array("%$drush_path%" => "# Path to Drush, added by 'drush init'\n\$PATH=\$PATH:$drush_path\n\n");
   }
 
-  // Modify the users bashrc file, adding our customizations.
+  // Modify the user's bashrc file, adding our customizations.
   $bashrc_contents = "";
   if (file_exists($bashrc)) {
     $bashrc_contents = file_get_contents($bashrc);

--- a/commands/core/init.drush.inc
+++ b/commands/core/init.drush.inc
@@ -13,9 +13,10 @@
  */
 function init_drush_command() {
   $items['core-init'] = array(
-    'description' => 'Initialize local Drush configuration.',
+    'description' => 'Enrich the bash startup file with completion and aliases. Copy drushrc file to $HOME.',
     'aliases' => array('init'),
     'bootstrap' => DRUSH_BOOTSTRAP_NONE,
+    'package' => 'core',
   );
   return $items;
 }

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1411,7 +1411,7 @@ function _drush_add_commandfiles($searchpath, $phase = NULL, $reset = FALSE) {
       // Assemble a cid specific to the bootstrap phase and searchpaths.
       // Bump $cf_version when making a change to a dev version of Drush
       // that invalidates the commandfile cache.
-      $cf_version = 5;
+      $cf_version = 6;
       $cid = drush_get_cid('commandfiles-' . $phase, array(), array_merge($searchpath, array($cf_version)));
       $command_cache = drush_cache_get($cid);
       if (isset($command_cache->data)) {

--- a/tests/Unish/CommandUnishTestCase.php
+++ b/tests/Unish/CommandUnishTestCase.php
@@ -369,6 +369,31 @@ abstract class CommandUnishTestCase extends UnishTestCase {
     return $string;
   }
 
+  /**
+   * Ensure that an expected log message appears in the Drush log.
+   *
+   *     $this->drush('command', array(), array('backend' => NULL));
+   *     $parsed = $this->parse_backend_output($this->getOutput());
+   *     $this->assertLogHasMessage($parsed['log'], "Expected message", 'debug')
+   *
+   * @param $log Parsed log entries from backend invoke
+   * @param $message The expected message that must be contained in
+   *   some log entry's 'message' field.  Substrings will match.
+   * @param $logType The type of log message to look for; all other
+   *   types are ignored. If FALSE (the default), then all log types
+   *   will be searched.
+   */
+  function assertLogHasMessage($log, $message, $logType = FALSE) {
+    foreach ($log as $entry) {
+      if (!$logType || ($entry['type'] == $logType)) {
+        if (strpos($entry['message'], $message) !== FALSE) {
+          return TRUE;
+        }
+      }
+    }
+    $this->assertTrue(FALSE, "Could not find expected message in log: " . $message);
+  }
+
   function drush_major_version() {
     static $major;
 

--- a/tests/Unish/CommandUnishTestCase.php
+++ b/tests/Unish/CommandUnishTestCase.php
@@ -391,7 +391,7 @@ abstract class CommandUnishTestCase extends UnishTestCase {
         }
       }
     }
-    $this->assertTrue(FALSE, "Could not find expected message in log: " . $message);
+    $this->fail("Could not find expected message in log: " . $message);
   }
 
   function drush_major_version() {

--- a/tests/initCommandTest.php
+++ b/tests/initCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Unish;
+
+/**
+ *  Test to see if the `drush init` command does the
+ *  setup that it is supposed to do.
+ *
+ *  @group base
+ */
+class initCommandCase extends CommandUnishTestCase {
+
+  function testInitCommand() {
+    // Call `drush core-init`
+    $this->drush('core-init', array(), array('backend' => NULL));
+    $parsed = $this->parse_backend_output($this->getOutput());
+    // First test to ensure that the command claimed to have made the expected progress
+    $this->assertLogHasMessage($parsed['log'], "Copied example Drush configuration file", 'ok');
+    $this->assertLogHasMessage($parsed['log'], "Copied example Drush bash configuration file", 'ok');
+    $this->assertLogHasMessage($parsed['log'], "Updated bash configuration file", 'ok');
+    // Next we will test to see if there is evidence that those
+    // operations worked.
+    $home = getenv("HOME");
+    $this->assertTrue(is_file("$home/.drush/drushrc.php"), "The expected ~/.drush/drushrc.php file does not exist");
+    $this->assertTrue(is_file("$home/.drush/drush.bashrc"), "The expected ~/.drush/drush.bashrc file does not exist");
+    $this->assertTrue(is_file("$home/.bashrc"), "The expected ~/.bashrc file does not exist");
+  }
+}

--- a/tests/initCommandTest.php
+++ b/tests/initCommandTest.php
@@ -24,5 +24,11 @@ class initCommandCase extends CommandUnishTestCase {
     $this->assertTrue(is_file("$home/.drush/drushrc.php"), "The expected ~/.drush/drushrc.php file does not exist");
     $this->assertTrue(is_file("$home/.drush/drush.bashrc"), "The expected ~/.drush/drush.bashrc file does not exist");
     $this->assertTrue(is_file("$home/.bashrc"), "The expected ~/.bashrc file does not exist");
+
+    // Non-interactive shells behave differently than interactive login shells,
+    // so we will explicitly source the .bashrc file for our test.
+    $exec = sprintf("bash -c '. %s; alias ddd'", self::escapeshellarg("$home/.bashrc"));
+    $this->execute($exec);
+    $this->assertEquals("alias ddd='drush drupal-directory'", $this->getOutput());
   }
 }

--- a/tests/initCommandTest.php
+++ b/tests/initCommandTest.php
@@ -21,14 +21,12 @@ class initCommandCase extends CommandUnishTestCase {
     // Next we will test to see if there is evidence that those
     // operations worked.
     $home = getenv("HOME");
-    $this->assertTrue(is_file("$home/.drush/drushrc.php"), "The expected ~/.drush/drushrc.php file does not exist");
-    $this->assertTrue(is_file("$home/.drush/drush.bashrc"), "The expected ~/.drush/drush.bashrc file does not exist");
-    $this->assertTrue(is_file("$home/.bashrc"), "The expected ~/.bashrc file does not exist");
+    $this->assertFileExists("$home/.drush/drushrc.php");
+    $this->assertFileExists("$home/.drush/drush.bashrc");
+    $this->assertFileExists("$home/.bashrc");
 
-    // Non-interactive shells behave differently than interactive login shells,
-    // so we will explicitly source the .bashrc file for our test.
-    $exec = sprintf("bash -c '. %s; alias ddd'", self::escapeshellarg("$home/.bashrc"));
-    $this->execute($exec);
-    $this->assertEquals("alias ddd='drush drupal-directory'", $this->getOutput());
+    // Check to see if the .bashrc file sources our drush.bashrc file.
+    $bashrc_contents = file_get_contents("$home/.bashrc");
+    $this->assertContains('drush.bashrc', $bashrc_contents);
   }
 }


### PR DESCRIPTION
A number of cli tools provide an 'init' command to help set up the tool's configuration files after installation.  This PR adds a basic init command to do the same thing for Drush.

There is more we could potentially do here, but this is a start.  It ensures that `drush` is in the global $PATH, and also sets up our example Bash configuration file, so that completion works, and various bash aliases and functions are offered.  Currently, this is done by modifying .bashrc, but we have the opportunity to add heuristics to find the best file for the platform here. I have heard anecdotally that .bash_profile is better for the Macintosh, but my recent experiments on Yosemite show that only .bashrc is sourced for newly-created accounts, so it seems to me that .bashrc is best for Mac and probably all flavors of Linux.  This is easily adjusted if anyone has more specific information about this.  `man bash` is not very helpful, as the behavior of Bash changes depending on how the host system chooses to call it.