### PR TITLE
Issue #1742: Fix array_flip error in find_legacy_dt_args() function when the dt() function was chained many times

### DIFF
--- a/includes/output.inc
+++ b/includes/output.inc
@@ -185,7 +185,13 @@ function dt($string, $args = array()) {
  * will flip the array twice to filter on the key.
  */
 function find_legacy_dt_args($args) {
-  return array_flip(array_filter(array_flip($args), function ($v) { return $v[0] == '!'; } ));
+  $legacy_args = [];
+  foreach ($args as $arg => $replacement) {
+    if ($arg[0] == '!') {
+      $legacy_args[$arg] = $replacement;
+    }
+  }
+  return $legacy_args;
 }
 
 /**


### PR DESCRIPTION
Fixes #1742 for master.