### PR TITLE
Invalidate rendered cache tag instead of render bin

### DIFF
--- a/commands/core/drupal/cache_8.inc
+++ b/commands/core/drupal/cache_8.inc
@@ -83,5 +83,5 @@ function drush_cache_clear_block() {
  * Clears the render cache entries.
  */
 function drush_cache_clear_render() {
-  \Drupal::cache('render')->deleteAll();
+  Cache::invalidateTags(['rendered']);
 }


### PR DESCRIPTION
For example dynamic page cache uses a separate bin and currently, drush cc render doesn't invalidate that.

Additionally, using the cache tag can also invalidate varnish/fastly if the site is using such an integration.