### PR TITLE
Make 'drush cache-clear' not break when not bootstrapped high enough

### DIFF
--- a/commands/core/views.d8.drush.inc
+++ b/commands/core/views.d8.drush.inc
@@ -455,7 +455,8 @@ function _views_drush_view_is_disabled(View $view) {
  * Adds a cache clear option for views.
  */
 function views_drush_cache_clear(&$types) {
-  if (\Drupal::moduleHandler()->moduleExists('views')) {
+  if (drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_FULL)
+      && \Drupal::moduleHandler()->moduleExists('views')) {
     $types['views'] = 'views_invalidate_cache';
   }
 }


### PR DESCRIPTION
If drush is not bootstrapped to DRUSH_BOOTSTRAP_DRUPAL_FULL, 'drush cc' on D8 throws a ContainerNotInitializedException.

Below fixes this. Unless you care about 'views_invalidate_cache' always running (for some cases of 'cc'?) -- then the fix is more involved.
