### PR TITLE
Bootstrap & db credentials logging (+ comment cleanup)

### DIFF
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -280,9 +280,16 @@ function drush_bootstrap_value($context, $value = null) {
 }
 
 /**
- * Helper function listing phases.
+ * Returns an array that determines what bootstrap phases
+ * are necessary to bootstrap the CMS.
  *
- * For commands that need to iterate through the phases, such as help
+ * @param bool $function_names
+ *   (optional) If TRUE, return an array of method names index by their
+ *   corresponding phase values. Otherwise return an array of phase values.
+ *
+ * @return array
+ *
+ * @see \Drush\Boot\Boot::bootstrap_phases()
  */
 function _drush_bootstrap_phases($function_names = FALSE) {
   $result = array();
@@ -302,8 +309,18 @@ function _drush_bootstrap_phases($function_names = FALSE) {
  * This function will sequentially bootstrap each
  * lower phase up to the phase that has been requested.
  *
- * @param phase
- *   The bootstrap phase to bootstrap to.  @see \Drush\Boot::bootstrap_phases
+ * @param int $phase
+ *   The bootstrap phase to bootstrap to.
+ * @param int $phase_max
+ *   (optional) The maximum level to boot to. This does not have a use in this
+ *   function itself but can be useful for other code called from within this
+ *   function, to know if e.g. a caller is in the process of booting to the
+ *   specified level. If specified, it should never be lower than $phase.
+ *
+ * @return bool
+ *   TRUE if the specified bootstrap phase has completed.
+ *
+ * @see \Drush\Boot\Boot::bootstrap_phases()
  */
 function drush_bootstrap($phase, $phase_max = FALSE) {
   $bootstrap = drush_get_bootstrap_object();
@@ -361,10 +378,10 @@ function drush_bootstrap($phase, $phase_max = FALSE) {
  * http://en.wikipedia.org/wiki/HTTP_referer
  *
  *
- * @param phase
+ * @param int $phase
  *   The bootstrap phase to test
  *
- * @returns
+ * @return bool
  *   TRUE if the specified bootstrap phase has completed.
  */
 function drush_has_boostrapped($phase) {
@@ -384,12 +401,13 @@ function drush_has_boostrapped($phase) {
  * store the result from that execution in a local static. This avoids
  * validating phases multiple times.
  *
- * @param phase
- *   The bootstrap phase to validate to.  @see \Drush\Boot::bootstrap_phases
+ * @param int $phase
+ *   The bootstrap phase to validate to.
  *
- * @return
- *   True if bootstrap is possible, False if the validation failed.
+ * @return bool
+ *   TRUE if bootstrap is possible, FALSE if the validation failed.
  *
+ * @see \Drush\Boot\Boot::bootstrap_phases()
  */
 function drush_bootstrap_validate($phase) {
   $bootstrap = drush_get_bootstrap_object();
@@ -423,8 +441,11 @@ function drush_bootstrap_validate($phase) {
 /**
  * Bootstrap to the specified phase.
  *
- * @param $max_phase_index
+ * @param int $max_phase_index
  *   Only attempt bootstrap to the specified level.
+ *
+ * @return bool
+ *   TRUE if the specified bootstrap phase has completed.
  */
 function drush_bootstrap_to_phase($max_phase_index) {
   // If $max_phase_index is DRUSH_BOOTSTRAP_MAX, then
@@ -464,15 +485,14 @@ function drush_bootstrap_to_phase($max_phase_index) {
 /**
  * Bootstrap to the highest level possible, without triggering any errors.
  *
- * @param $max_phase_index
- *   Only attempt bootstrap to the specified level.
+ * @param int $max_phase_index
+ *   (optional) Only attempt bootstrap to the specified level.
  *
- *  @return int
- *    The maximum phase to which we bootstrapped.
+ * @return int
+ *   The maximum phase to which we bootstrapped.
  */
 function drush_bootstrap_max($max_phase_index = FALSE) {
   $phases = _drush_bootstrap_phases();
-  $phase_index = DRUSH_BOOTSTRAP_DRUSH;
   if (!$max_phase_index) {
     $max_phase_index = count($phases);
   }

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -448,12 +448,11 @@ function drush_bootstrap_validate($phase) {
  *   TRUE if the specified bootstrap phase has completed.
  */
 function drush_bootstrap_to_phase($max_phase_index) {
-  // If $max_phase_index is DRUSH_BOOTSTRAP_MAX, then
-  // we will bootstrap as far as we can.  drush_bootstrap_max
-  // is different than drush_bootstrap_to_phase in that
-  // it is not an error if DRUSH_BOOTSTRAP_LOGIN is not reached.
   if ($max_phase_index == DRUSH_BOOTSTRAP_MAX) {
-    drush_bootstrap_max();
+    // Bootstrap as far as we can without throwing an error, but log for
+    // debugging purposes.
+    drush_log(dt("Trying to bootstrap as far as we can."), 'debug');
+    drush_bootstrap_max(FALSE, TRUE);
     return TRUE;
   }
 
@@ -487,18 +486,21 @@ function drush_bootstrap_to_phase($max_phase_index) {
  *
  * @param int $max_phase_index
  *   (optional) Only attempt bootstrap to the specified level.
+ * @param bool $log_failure
+ *   (optional) If TRUE, log (with level 'debug') when a bootstrap phase failed
+ *   to validate; otherwise be quiet.
  *
  * @return int
  *   The maximum phase to which we bootstrapped.
  */
-function drush_bootstrap_max($max_phase_index = FALSE) {
-  $phases = _drush_bootstrap_phases();
+function drush_bootstrap_max($max_phase_index = FALSE, $log_failure = FALSE) {
+  $phases = _drush_bootstrap_phases(TRUE);
   if (!$max_phase_index) {
     $max_phase_index = count($phases);
   }
 
-  // Try to bootstrap to the maximum possible level, without generating errors
-  foreach ($phases as $phase_index) {
+  // Try to bootstrap to the maximum possible level, without generating errors.
+  foreach ($phases as $phase_index => $current_phase) {
     if ($phase_index > $max_phase_index) {
       // Stop trying, since we achieved what was specified.
       break;
@@ -510,6 +512,12 @@ function drush_bootstrap_max($max_phase_index = FALSE) {
       }
     }
     else {
+      if ($log_failure) {
+        // drush_bootstrap_validate() only logs successful validations. For us,
+        // knowing what failed can also be important.
+        $previous = drush_get_context('DRUSH_BOOTSTRAP_PHASE');
+        drush_log(dt("Bootstrap phase !function() failed to validate; continuing at !current().", array('!function' => $current_phase, '!current' => $phases[$previous])), 'debug');
+      }
       break;
     }
   }

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -362,6 +362,9 @@ function drush_valid_root($path) {
 
 /**
  * Tests the currently loaded database credentials to ensure a database connection can be made.
+ *
+ * @return bool
+ *   TRUE if database credentials are valid.
  */
 function drush_valid_db_credentials() {
   try {

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -363,21 +363,33 @@ function drush_valid_root($path) {
 /**
  * Tests the currently loaded database credentials to ensure a database connection can be made.
  *
+ * @param bool $log_errors
+ *   (optional) If TRUE, log error conditions; otherwise be quiet.
+ *
  * @return bool
  *   TRUE if database credentials are valid.
  */
-function drush_valid_db_credentials() {
+function drush_valid_db_credentials($log_errors = FALSE) {
   try {
     $sql = drush_sql_get_class();
     if (!$sqlVersion = drush_sql_get_version()) {
+      if ($log_errors) {
+        drush_log(dt('While checking DB credentials, could not instantiate SQLVersion class.', array()), 'error');
+      }
       return FALSE;
     }
     if (!$sqlVersion->valid_credentials($sql->db_spec())) {
+      if ($log_errors) {
+        drush_log(dt('DB credentials are invalid.', array()), 'error');
+      }
       return FALSE;
     }
     return $sql->query('SELECT 1;');
   }
   catch (Exception $e) {
+    if ($log_errors) {
+      drush_log(dt('Checking DB credentials yielded error: @e', array('@e' => $e->getMessage())), 'error');
+    }
     return FALSE;
   }
 }

--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -458,7 +458,7 @@ abstract class DrupalBoot extends BaseBoot {
    * phase.
    */
   function bootstrap_drupal_database_validate() {
-    if (!drush_valid_db_credentials()) {
+    if (!drush_valid_db_credentials(TRUE)) {
       return drush_bootstrap_error('DRUSH_DRUPAL_DB_ERROR');
     }
     return TRUE;


### PR DESCRIPTION
### problem description

If a drupal command has bootstrap level DRUSH_BOOTSTRAP_MAX, there is no indication of this in the debug log. Nothing says that drush is calling drush_bootstrap_max() or when it tries/fails to boot reach a higher boot level.

So e.g. if drush_bootstrap_max() is trying and failing to boot to the database level, it's not telling you that. All you see is that a certain drush command is booting at bootstrap_drupal_configuration() level. This can confuse people like me who
- encounter a ContainerNotInitializedException, like the one in https://github.com/drush-ops/drush/pull/1753
- stupidly forget to specify a --uri option in an environment where this is needed for anything to work... and then spend hours debugging unneccessary things.

(And with Drupal 8 still being new, I guess there is a relatively high chance of strange exceptions occuring.)

### proposed solution

The pull request implements 'debug' level logging to:
- say that drupal_bootstrap_max() is going to be used;
- if validation for a bootstrap level failed during drupal_bootstrap_max(), explicitly log this;
- separately: if drush_valid_db_credentials() returns FALSE, also log this. Especially useful for people who stupidly forget to specify a --uri option.

This means some logged info is duplicate-ish. Leaving it up to you to judge whether that's OK.

Note: an extra optional argument was introduced to drush_valid_db_credentials() because I didn't want to modify existing behavior, but I'm not sure if that's necessary because the current drush code base contains only one call to drush_valid_db_credentials().
(For drupal_bootstrap_max(), the optional $log_failure defaulting to FALSE is definitely necessary because drupal_bootstrap_max() is called a lot, recursively.)

Also: re-commented function documentation while trying to understand what was going on, in a separate commit. I guess that's a good task for someone who's new to the code.



Below: logs for 'drush cc drush' in an environment without a configured default/settings.php. "Cache/Scanning" lines removed.

=== Before:

```
Starting Drush preflight. [0.01 sec, 2.74 MB]                                    [preflight]
 ...
Bootstrap to phase 0. [0.21 sec, 8.35 MB]                                        [bootstrap]
Drush bootstrap phase : bootstrap_drupal_root() [0.23 sec, 9.03 MB]              [bootstrap]
Initialized Drupal 8.0.0-rc2 root directory at /Volumes/SSD2/www/8 [0.24 sec,       [notice]
9.03 MB]
Find command files for phase 1 (max=7) [0.24 sec, 6.68 MB]                           [debug]
 ...
Drush bootstrap phase : bootstrap_drupal_site() [0.26 sec, 7.68 MB]              [bootstrap]
Initialized Drupal site default at sites/default [0.26 sec, 7.68 MB]                [notice]
Find command files for phase 2 (max=7) [0.27 sec, 7.69 MB]                           [debug]
Drush bootstrap phase : bootstrap_drupal_configuration() [0.27 sec, 7.69 MB]     [bootstrap]
Find command files for phase 3 (max=7) [0.28 sec, 7.91 MB]                           [debug]
Found command: cache-clear (commandfile=cache) [0.28 sec, 7.94 MB]               [bootstrap]
Calling hook drush_cache_clear_pre_validate [0.39 sec, 10.43 MB]                     [debug]
 *BOOM* ERROR, SEE PR 1753
```

=== After:

```
Starting Drush preflight. [0.03 sec, 2.74 MB]                                    [preflight]
 ...
Bootstrap to phase 0. [0.48 sec, 8.35 MB]                                        [bootstrap]
Trying to bootstrap as far as we can. [0.49 sec, 8.36 MB]                            [debug] <<
Drush bootstrap phase : bootstrap_drupal_root() [0.51 sec, 9.03 MB]              [bootstrap]
Initialized Drupal 8.0.0-rc2 root directory at /Volumes/SSD2/www/8 [0.53 sec,       [notice]
9.03 MB]
Find command files for phase 1 (max=7) [0.54 sec, 6.68 MB]                           [debug]
 ...
Drush bootstrap phase : bootstrap_drupal_site() [0.59 sec, 7.68 MB]              [bootstrap]
Initialized Drupal site default at sites/default [0.6 sec, 7.68 MB]                 [notice]
Find command files for phase 2 (max=7) [0.61 sec, 7.69 MB]                           [debug]
Drush bootstrap phase : bootstrap_drupal_configuration() [0.61 sec, 7.69 MB]     [bootstrap]
Find command files for phase 3 (max=7) [0.62 sec, 7.91 MB]                           [debug]
Checking DB credentials yielded error: Unable to find a matching SQL Class. Drush[error]     <<
cannot find your database connection details. [0.62 sec, 7.95 MB]                            <<
Bootstrap phase bootstrap_drupal_database() failed to validate; continuing at        [debug] <<
bootstrap_drupal_configuration(). [0.62 sec, 7.94 MB]                                        <<
Found command: cache-clear (commandfile=cache) [0.62 sec, 7.94 MB]               [bootstrap]
Calling hook drush_cache_clear_pre_validate [0.91 sec, 10.43 MB]                     [debug]
 *BOOM* ERROR, SEE PR 1753
```