### PR TITLE
Do not add --local flag when redispatching to a site-local Drush

### DIFF
--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -735,7 +735,7 @@ function drush_file_append_data($file, $data) {
 function drush_is_nested_directory($base_dir, $test_is_nested) {
   // Ensure there is always exactly one '/' at the end of $base_dir
   $base_dir = rtrim($base_dir, '/') . '/';
-  return substr($test_is_nexted, 0, strlen($base_dir)) == $base_dir;
+  return substr($test_is_nested, 0, strlen($base_dir)) == $base_dir;
 }
 
 /**

--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -729,5 +729,15 @@ function drush_file_append_data($file, $data) {
 }
 
 /**
+ * Return 'TRUE' if one directory is located anywhere inside
+ * the other.
+ */
+function drush_is_nested_directory($base_dir, $test_is_nested) {
+  // Ensure there is always exactly one '/' at the end of $base_dir
+  $base_dir = rtrim($base_dir, '/') . '/';
+  return substr($test_is_nexted, 0, strlen($base_dir)) == $base_dir;
+}
+
+/**
  * @} End of "defgroup filesystemfunctions".
  */

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -567,17 +567,15 @@ function drush_preflight_command_dispatch() {
     $this_drush = drush_find_drush();
     // If there is a local drush selected, and it is not the
     // same drush that is currently running, redispatch to it.
-    // We compare the dirname instead of the full dir + filename
-    // so that the finder / launcher will compare as the "same"
-    // Note that the "wrapper" will be in a different directory
-    // than the launcher; however, the wrapper should set --local,
-    // and therefore will not be considered here due to the
-    // 'empty($is_local)' test above.
-    if (file_exists($local_drush) && (dirname($this_drush) != dirname($local_drush))) {
+    // We assume that if the current Drush is nested inside
+    // the current Drupal root (or, more specifically, the
+    // current Drupal root's parent), then it is a site-local Drush.
+    // We avoid redispatching in that instance to prevent an
+    // infinite loop.
+    if (file_exists($local_drush) && !drush_is_nested_directory(dirname($root), $this_drush)) {
       $uri = drush_get_context('DRUSH_SELECTED_URI');
       $aditional_options = array(
         'root' => $root,
-        'local' => TRUE,
       );
       if (!empty($uri)) {
         $aditional_options['uri'] = $uri;


### PR DESCRIPTION
Drush will automatically redispatch to a site-local Drush in `drush_preflight_command_dispatch()` if it finds that the current Drupal site has a site-local Drush, and a different (presumably global) Drush is being used.  This use case happens whenever you run `drush @localsite somecommnad` for a local site that has a site-local Drush.  The Drush finder does not handle this case, as the finder does not parse site alias files.  In instances where the Drush finder **does** redispatch, it does not add the --local flag.  `drush_preflight_command_dispatch()` adds --local only because it was implemented before we decided that --local should only be added if the user deliberately adds it via a Drush wrapper script. It was an oversight that it was not removed earlier.