### PR TITLE
Issue #1766: Replace Drupal version number pattern-based classes with named services.

### DIFF
--- a/commands/core/queue.drush.inc
+++ b/commands/core/queue.drush.inc
@@ -62,7 +62,7 @@ function drush_queue_run_validate($queue_name) {
  * Return the appropriate queue class.
  */
 function drush_queue_get_class() {
-  return drush_get_class('Drush\Queue\Queue');
+  return drush_get_service('queue');
 }
 
 /**

--- a/commands/core/role.drush.inc
+++ b/commands/core/role.drush.inc
@@ -267,10 +267,10 @@ function drush_role_perm($action, $rid, $permission = NULL) {
  * @param string $role_name
  * @return RoleBase
  *
- * @see drush_get_class().
+ * @see drush_get_service().
  */
 function drush_role_get_class($role_name = DRUPAL_ANONYMOUS_RID) {
-  return drush_get_class('Drush\Role\Role', func_get_args());
+  return drush_get_service('role', func_get_args());
 }
 
 /**

--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -594,7 +594,7 @@ function drush_sql_get_class($db_spec = NULL) {
  * @return Drush\Sql\SqlVersion
  */
 function drush_sql_get_version() {
-  return drush_get_class('Drush\Sql\Sql', array(), array(drush_drupal_major_version())) ?: NULL;
+  return drush_get_service('sql');
 }
 
 /**

--- a/commands/user/user.drush.inc
+++ b/commands/user/user.drush.inc
@@ -240,10 +240,10 @@ function drush_usersingle_get_class($account) {
  *
  * @return \Drush\User\UserVersion
  *
- * @see drush_get_class().
+ * @see drush_get_service().
  */
 function drush_user_get_class() {
-  return drush_get_class('Drush\User\User');
+  return drush_get_service('user');
 }
 
 /**

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -119,6 +119,27 @@ function drush_get_class($class_name, $constructor_args = array(), $variations =
 }
 
 /**
+ * Instantiate a service object for the given service name.
+ *
+ * @param string $service_name
+ *   The name of the service for which it's class will be instantiated.
+ * @param array $constructor_args
+ *   Any additional parameters to be passed to the class constructor.
+ *
+ * @return mixed
+ *   An instantiated object representing the service requested.
+ */
+function drush_get_service($service_name, $constructor_args = array()) {
+  $service_class_name = drush_get_bootstrap_object()->get_service($service_name);
+  if (class_exists($service_class_name)) {
+    $reflectionClass = new ReflectionClass($service_class_name);
+    return $reflectionClass->newInstanceArgs($constructor_args);
+  }
+
+  return drush_set_error('DRUSH_GET_CLASS_ERROR', dt('Unable to load class !class', array('!class' => $service_class_name)));
+}
+
+/**
  * Generate an .ini file. used by archive-dump."
  *
  * @param array $ini

--- a/lib/Drush/Boot/BaseBoot.php
+++ b/lib/Drush/Boot/BaseBoot.php
@@ -3,6 +3,16 @@
 namespace Drush\Boot;
 
 abstract class BaseBoot implements Boot {
+  /**
+   * A list of Drush services provide by this CMS.
+   *
+   * Some commands may require certain services, such as the "sql" service for
+   * executing the "sql-cli" command. Each service is keyed by it's unique name
+   * and has the value of the fully qualified class name.
+   *
+   * @var array
+   */
+  protected $services = array();
 
   function __construct() {
   }
@@ -20,6 +30,18 @@ abstract class BaseBoot implements Boot {
     drush_enforce_requirement_bootstrap_phase($command);
     drush_enforce_requirement_core($command);
     drush_enforce_requirement_drush_dependencies($command);
+  }
+
+  function get_services() {
+    return $this->services;
+  }
+
+  function get_service($service_name) {
+    return isset($this->services[$service_name]) ? $this->services[$service_name] : FALSE;
+  }
+
+  function add_service($service_name, $class_name) {
+    $this->services[$service_name] = $class_name;
   }
 
   function report_command_error($command) {

--- a/lib/Drush/Boot/Boot.php
+++ b/lib/Drush/Boot/Boot.php
@@ -91,6 +91,43 @@ interface Boot {
   function enforce_requirement(&$command);
 
   /**
+   * Get a list of Drush services supported by this CMS.
+   *
+   * Services are a mapping from named string to control classes. Examples
+   * include the diffent Sql, Batch, and User classes used in Drupal 7/8.
+   *
+   * @see Drush\Boot\Boot::add_service()
+   *
+   * @return array
+   */
+  function get_services();
+
+  /**
+   * Given a service name, return a single service class name.
+   *
+   * @param string $service_name
+   *   The name of the service whose class is being retrieved.
+   *
+   * @return string|FALSE
+   */
+  function get_service($service_name);
+
+  /**
+   * Add a Drush service supported by this CMS.
+   *
+   * Services are typically registered upon the instantiation of a boot class in
+   * its constructor.
+   *
+   * @see Drush\Boot\Boot::get_services()
+   *
+   * @param string $service_name
+   *   The name of the service being registered.
+   * @param string $class_name
+   *   The fully qualified class name for the given service.
+   */
+  function add_service($service_name, $class_name);
+
+  /**
    * Called by Drush if a command is not found, or if the
    * command was found, but did not meet requirements.
    *

--- a/lib/Drush/Boot/DrupalBoot6.php
+++ b/lib/Drush/Boot/DrupalBoot6.php
@@ -4,6 +4,19 @@ namespace Drush\Boot;
 
 class DrupalBoot6 extends DrupalBoot {
 
+  function __construct() {
+    // Add services supported by Drupal 6.
+    $this->add_service('queue', 'Drush\Queue\Queue6');
+    $this->add_service('role', 'Drush\Role\Role6');
+    $this->add_service('sql', 'Drush\Sql\Sql6');
+    // @todo: Switch engines to use services instead of class names?
+    //$this->add_service('status_info', 'Drush\UpdateService\StatusInfoDrupal6');
+    $this->add_service('user', 'Drush\User\User6');
+    $this->add_service('user_single', 'Drush\User\UserSingle6');
+
+    parent::__construct();
+  }
+
   function valid_root($path) {
     if (!empty($path) && is_dir($path) && file_exists($path . '/index.php')) {
       // Drupal 6 root.

--- a/lib/Drush/Boot/DrupalBoot7.php
+++ b/lib/Drush/Boot/DrupalBoot7.php
@@ -4,6 +4,19 @@ namespace Drush\Boot;
 
 class DrupalBoot7 extends DrupalBoot {
 
+  function __construct() {
+    // Add services supported by Drupal 7.
+    $this->add_service('queue', 'Drush\Queue\Queue7');
+    $this->add_service('role', 'Drush\Role\Role7');
+    $this->add_service('sql', 'Drush\Sql\Sql7');
+    // @todo: Switch engines to use services instead of class names?
+    //$this->add_service('status_info', 'Drush\UpdateService\StatusInfoDrupal7');
+    $this->add_service('user', 'Drush\User\User7');
+    $this->add_service('user_single', 'Drush\User\UserSingle7');
+
+    parent::__construct();
+  }
+
   function valid_root($path) {
     if (!empty($path) && is_dir($path) && file_exists($path . '/index.php')) {
       // Drupal 7 root.

--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -8,6 +8,19 @@ use Drupal\Core\DrupalKernel;
 
 class DrupalBoot8 extends DrupalBoot {
 
+  function __construct() {
+    // Add services supported by Drupal 8.
+    $this->add_service('queue', 'Drush\Queue\Queue8');
+    $this->add_service('role', 'Drush\Role\Role8');
+    $this->add_service('sql', 'Drush\Sql\Sql8');
+    // @todo: Switch engines to use services instead of class names?
+    //$this->add_service('status_info', 'Drush\UpdateService\StatusInfoDrupal8');
+    $this->add_service('user', 'Drush\User\User8');
+    $this->add_service('user_single', 'Drush\User\UserSingle8');
+
+    parent::__construct();
+  }
+
   /**
    * @var \Drupal\Core\DrupalKernelInterface
    */


### PR DESCRIPTION
Proof of concept for https://github.com/drush-ops/drush/issues/1766.

This mostly untested PR just attempts to show how `drush_get_class()` could be replaced with a named-services approach, where each boot class would keep track of the services it supported.
