### PR TITLE
Add a modified version of drush-psysh commands

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -1,5 +1,9 @@
 <?php
 
+use Drupal\Component\Assertion\Handle;
+use Drush\Psysh\DrushHelpCommand;
+use Drush\Psysh\DrushCommand;
+
 /**
  * Implements hook_drush_command().
  */
@@ -22,9 +26,27 @@ function drush_cli_core_cli() {
   if (drush_drupal_major_version() >= 8) {
     // Register the assertion handler so exceptions are thrown instead of errors
     // being triggered. This plays nicer with PsySH.
-    \Drupal\Component\Assertion\Handle::register();
+    Handle::register();
     $shell->setScopeVariables(['container' => \Drupal::getContainer()]);
   }
+
+  // Add drush commands in the shell.
+  $commands = [new DrushHelpCommand()];
+
+  foreach (drush_get_commands() as $name => $config) {
+    // Ignore some commands that don't make sense inside PsySH.
+    if (in_array($name, ['help', 'drush-psysh', 'php-eval', 'core-cli', 'php'])) {
+      continue;
+    }
+    // Don't add hidden commands or aliases.
+    if ($config['hidden'] || $name !== $config['command']) {
+      continue;
+    }
+
+    $commands[] = new DrushCommand($config);
+  }
+
+  $shell->addCommands($commands);
 
   // PsySH will never return control to us, but our shutdown handler will still
   // run after the user presses ^D.  Mark this command as completed to avoid a

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -3,6 +3,7 @@
 use Drupal\Component\Assertion\Handle;
 use Drush\Psysh\DrushHelpCommand;
 use Drush\Psysh\DrushCommand;
+use Drush\Psysh\Shell;
 
 /**
  * Implements hook_drush_command().
@@ -21,7 +22,7 @@ function cli_drush_command() {
  * Command callback.
  */
 function drush_cli_core_cli() {
-  $shell = new Psy\Shell();
+  $shell = new Shell();
 
   if (drush_drupal_major_version() >= 8) {
     // Register the assertion handler so exceptions are thrown instead of errors

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -33,16 +33,7 @@ function drush_cli_core_cli() {
   // Add drush commands in the shell.
   $commands = [new DrushHelpCommand()];
 
-  foreach (drush_get_commands() as $name => $config) {
-    // Ignore some commands that don't make sense inside PsySH.
-    if (in_array($name, ['help', 'drush-psysh', 'php-eval', 'core-cli', 'php'])) {
-      continue;
-    }
-    // Don't add hidden commands or aliases.
-    if ($config['hidden'] || $name !== $config['command']) {
-      continue;
-    }
-
+  foreach (_drush_core_cli_get_commands() as $name => $config) {
     $commands[] = new DrushCommand($config);
   }
 
@@ -53,4 +44,24 @@ function drush_cli_core_cli() {
   // spurious error message.
   drush_set_context('DRUSH_EXECUTION_COMPLETED', TRUE);
   $shell->run();
+}
+
+/**
+ * Returns a filtered list of drush commands used for CLI commands.
+ *
+ * @return array
+ */
+function _drush_core_cli_get_commands() {
+  $commands = drush_get_commands();
+  $ignored_commands = ['help', 'drush-psysh', 'php-eval', 'core-cli', 'php'];
+
+  foreach ($commands as $name => $config) {
+    // Ignore some commands that don't make sense inside PsySH, are hidden, or
+    // are aliases.
+    if (in_array($name, $ignored_commands) || !empty($config['hidden']) || ($name !== $config['command'])) {
+      unset($commands[$name]);
+    }
+  }
+
+  return $commands;
 }

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -48,7 +48,7 @@ function drush_cli_core_cli() {
 }
 
 /**
- * Returns a filtered list of drush commands used for CLI commands.
+ * Returns a filtered list of Drush commands used for CLI commands.
  *
  * @return array
  */

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -34,8 +34,13 @@ function drush_cli_core_cli() {
   // Add drush commands in the shell.
   $commands = [new DrushHelpCommand()];
 
-  foreach (_drush_core_cli_get_commands() as $name => $config) {
-    $commands[] = new DrushCommand($config);
+  foreach (drush_commands_categorize(_drush_core_cli_get_commands()) as $category_data) {
+    $category_title = (string) $category_data['title'];
+    foreach ($category_data['commands'] as $command_config) {
+      $command = new DrushCommand($command_config);
+      $command->setCategory($category_title);
+      $commands[] = $command;
+    }
   }
 
   $shell->addCommands($commands);

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -31,13 +31,14 @@ function drush_cli_core_cli() {
     $shell->setScopeVariables(['container' => \Drupal::getContainer()]);
   }
 
-  // Add drush commands in the shell.
+  // Add Drush commands to the shell.
   $commands = [new DrushHelpCommand()];
 
   foreach (drush_commands_categorize(_drush_core_cli_get_commands()) as $category_data) {
     $category_title = (string) $category_data['title'];
     foreach ($category_data['commands'] as $command_config) {
       $command = new DrushCommand($command_config);
+      // Set the category label on each.
       $command->setCategory($category_title);
       $commands[] = $command;
     }

--- a/commands/core/druplicon.drush.inc
+++ b/commands/core/druplicon.drush.inc
@@ -9,7 +9,9 @@
  */
 function druplicon_drush_help_alter(&$command) {
   if ($command['command'] == 'global-options' && $command['#brief'] === FALSE) {
-    $command['options']['druplicon'] = 'Shows the druplicon as glorious ASCII art.';
+    $command['options']['druplicon'] = [
+      'description' => 'Shows the druplicon as glorious ASCII art.',
+    ];
   }
 }
 

--- a/lib/Drush/Psysh/DrushCommand.php
+++ b/lib/Drush/Psysh/DrushCommand.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * @file
+ * Drush Command class.
+ *
+ * Original author: Justin Hileman
+ *
+ * DrushCommand is a PsySH proxy command which accepts a drush command config
+ * array and tries to build an appropriate PsySH command for it.
+ */
+
+namespace Drush\Psysh;
+
+use Psy\Command\Command as BaseCommand;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Main DrushCommand class.
+ */
+class DrushCommand extends BaseCommand {
+
+  /**
+   * @var array
+   */
+  private $config;
+
+  /**
+   * @var string
+   */
+  private $category;
+
+  /**
+   * DrushCommand constructor.
+   *
+   * This accepts the drush command configuration array and does a pretty
+   * decent job of building a PsySH command proxy for it. Wheee!
+   *
+   * @param array $config
+   *   Drush command configuration array.
+   */
+  public function __construct(array $config) {
+    $this->config = $config;
+    parent::__construct();
+  }
+
+  /**
+   * Get Category of this command.
+   */
+  public function getCategory() {
+    if (isset($this->category)) {
+      return $this->category;
+    }
+
+    $category = $this->config['category'];
+    $title = drush_command_invoke_all('drush_help', "meta:$category:title");
+
+    if (!$title) {
+      // If there is no title, then check to see if the
+      // command file is stored in a folder with the same
+      // name as some other command file (e.g. 'core') that
+      // defines a title.
+      $category = basename($this->config['path']);
+      $title = drush_command_invoke_all('drush_help', "meta:$category:title");
+    }
+
+    return $this->category = empty($title) ? 'Other commands' : $title[0];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this
+      ->setName($this->config['command'])
+      ->setAliases($this->buildAliasesFromConfig())
+      ->setDefinition($this->buildDefinitionFromConfig())
+      ->setDescription($this->config['description'])
+      ->setHelp($this->buildHelpFromConfig());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    // @todo support aliases
+    $args = $input->getArguments();
+    $command = array_shift($args);
+
+    $return = drush_invoke_process('@self', $command, array_values($args), $input->getOptions());
+
+    if ($return['error_status'] > 0) {
+      foreach ($return['error_log'] as $error_type => $errors) {
+        $output->write($errors);
+      }
+      // Add a newline after so the shell returns on a new line.
+      $output->writeln('');
+    }
+    else {
+      // @todo If the command is successful drush prints the output, can we stop
+      // that and just write to the output here?
+      //$output->page($return['output']);
+    }
+  }
+
+  /**
+   * Extract drush command aliases from config array.
+   *
+   * @return array
+   *   The command aliases.
+   */
+  protected function buildAliasesFromConfig() {
+    return !empty($this->config['aliases']) ? $this->config['aliases'] : [];
+  }
+
+  /**
+   * Build a command definition from drush command configuration array.
+   *
+   * Currently, adds all non-hidden arguments and options, and makes a decent
+   * effort to guess whether an option accepts a value or not. It isn't always
+   * right :P
+   *
+   * @return array
+   *   the command definition.
+   */
+  protected function buildDefinitionFromConfig() {
+    $def = [];
+
+    if (isset($this->config['arguments']) && !empty($this->config['arguments'])) {
+
+      $required_args = $this->config['required-arguments'];
+      if ($required_args === FALSE) {
+        $required_args = 0;
+      }
+      elseif ($required_args === TRUE) {
+        $required_args = count($this->config['arguments']);
+      }
+
+      foreach ($this->config['arguments'] as $name => $arg) {
+        if (!is_array($arg)) {
+          $arg = array('description' => $arg);
+        }
+
+        if (isset($arg['hidden']) && $arg['hidden']) {
+          continue;
+        }
+
+        $req = ($required_args-- > 0) ? InputArgument::REQUIRED : InputArgument::OPTIONAL;
+
+        $def[] = new InputArgument($name, $req, $arg['description'], NULL);
+      }
+    }
+
+    if (isset($this->config['options']) && !empty($this->config['options'])) {
+      foreach ($this->config['options'] as $name => $opt) {
+        if (!is_array($opt)) {
+          $opt = array('description' => $opt);
+        }
+
+        if (isset($opt['hidden']) && $opt['hidden']) {
+          continue;
+        }
+
+        // TODO: figure out if there's a way to detect
+        // InputOption::VALUE_NONE (i.e. flags) via the config array.
+        if (isset($opt['value']) && $opt['value'] !== 'optional') {
+          $req = InputOption::VALUE_REQUIRED;
+        }
+        else {
+          $req = InputOption::VALUE_OPTIONAL;
+        }
+
+        $def[] = new InputOption($name, '', $req, $opt['description']);
+      }
+    }
+
+    return $def;
+  }
+
+  /**
+   * Build a command help from the drush configuration array.
+   *
+   * Currently it's a word-wrapped description, plus any examples provided.
+   *
+   * @return string
+   *   The help string.
+   */
+  private function buildHelpFromConfig() {
+    $help = wordwrap($this->config['description']);
+
+    $examples = array();
+    foreach ($this->config['examples'] as $ex => $def) {
+      // Skip empty examples and things with obvious pipes...
+      if ($ex === '' || strpos($ex, '|') !== FALSE) {
+        continue;
+      }
+
+      $ex = preg_replace('/^drush\s+/', '', $ex);
+      $examples[$ex] = $def;
+    }
+
+    if (!empty($examples)) {
+      $help .= "\n\ne.g.";
+
+      foreach ($examples as $ex => $def) {
+        $help .= sprintf("\n<return>// %s</return>\n", wordwrap(OutputFormatter::escape($def), 75, "</return>\n<return>// "));
+        $help .= sprintf("<return>>>> %s</return>\n", OutputFormatter::escape($ex));
+      }
+    }
+
+    return $help;
+  }
+
+}

--- a/lib/Drush/Psysh/DrushCommand.php
+++ b/lib/Drush/Psysh/DrushCommand.php
@@ -34,7 +34,7 @@ class DrushCommand extends BaseCommand {
   /**
    * DrushCommand constructor.
    *
-   * This accepts the drush command configuration array and does a pretty
+   * This accepts the Drush command configuration array and does a pretty
    * decent job of building a PsySH command proxy for it. Wheee!
    *
    * @param array $config
@@ -93,7 +93,11 @@ class DrushCommand extends BaseCommand {
       $command = $first;
     }
 
-    $return = drush_invoke_process($alias, $command, array_values($args), $input->getOptions(), ['backend' => TRUE]);
+    $options = $input->getOptions();
+    // Force the 'backend' option to TRUE.
+    $options['backend'] = TRUE;
+
+    $return = drush_invoke_process($alias, $command, array_values($args), $options, ['interactive' => TRUE]);
 
     if ($return['error_status'] > 0) {
       foreach ($return['error_log'] as $error_type => $errors) {
@@ -108,7 +112,7 @@ class DrushCommand extends BaseCommand {
   }
 
   /**
-   * Extract drush command aliases from config array.
+   * Extract Drush command aliases from config array.
    *
    * @return array
    *   The command aliases.
@@ -118,7 +122,7 @@ class DrushCommand extends BaseCommand {
   }
 
   /**
-   * Build a command definition from drush command configuration array.
+   * Build a command definition from Drush command configuration array.
    *
    * Currently, adds all non-hidden arguments and options, and makes a decent
    * effort to guess whether an option accepts a value or not. It isn't always
@@ -182,7 +186,7 @@ class DrushCommand extends BaseCommand {
   }
 
   /**
-   * Build a command help from the drush configuration array.
+   * Build a command help from the Drush configuration array.
    *
    * Currently it's a word-wrapped description, plus any examples provided.
    *

--- a/lib/Drush/Psysh/DrushCommand.php
+++ b/lib/Drush/Psysh/DrushCommand.php
@@ -1,11 +1,9 @@
 <?php
 /**
  * @file
- * Drush Command class.
+ * Contains \Drush\Psysh\DrushCommand.
  *
- * Original author: Justin Hileman
- *
- * DrushCommand is a PsySH proxy command which accepts a drush command config
+ * DrushCommand is a PsySH proxy command which accepts a Drush command config
  * array and tries to build an appropriate PsySH command for it.
  */
 
@@ -19,7 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Main DrushCommand class.
+ * Main Drush command.
  */
 class DrushCommand extends BaseCommand {
 

--- a/lib/Drush/Psysh/DrushCommand.php
+++ b/lib/Drush/Psysh/DrushCommand.php
@@ -86,11 +86,23 @@ class DrushCommand extends BaseCommand {
    * {@inheritdoc}
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    // @todo support aliases
     $args = $input->getArguments();
-    $command = array_shift($args);
+    $first = array_shift($args);
 
-    $return = drush_invoke_process('@self', $command, array_values($args), $input->getOptions(), ['backend' => TRUE]);
+    // If the first argument is an alias, assign the next argument as the
+    // command.
+    if (strpos($first, '@') === 0) {
+      $alias = $first;
+      $command = array_shift($args);
+    }
+    // Otherwise, default the alias to '@self' and use the first argument as the
+    // command.
+    else {
+      $alias = '@self';
+      $command = $first;
+    }
+
+    $return = drush_invoke_process($alias, $command, array_values($args), $input->getOptions(), ['backend' => TRUE]);
 
     if ($return['error_status'] > 0) {
       foreach ($return['error_log'] as $error_type => $errors) {

--- a/lib/Drush/Psysh/DrushCommand.php
+++ b/lib/Drush/Psysh/DrushCommand.php
@@ -90,7 +90,7 @@ class DrushCommand extends BaseCommand {
     $args = $input->getArguments();
     $command = array_shift($args);
 
-    $return = drush_invoke_process('@self', $command, array_values($args), $input->getOptions());
+    $return = drush_invoke_process('@self', $command, array_values($args), $input->getOptions(), ['backend' => TRUE]);
 
     if ($return['error_status'] > 0) {
       foreach ($return['error_log'] as $error_type => $errors) {
@@ -100,9 +100,7 @@ class DrushCommand extends BaseCommand {
       $output->writeln('');
     }
     else {
-      // @todo If the command is successful drush prints the output, can we stop
-      // that and just write to the output here?
-      //$output->page($return['output']);
+      $output->page(drush_backend_get_result());
     }
   }
 

--- a/lib/Drush/Psysh/DrushCommand.php
+++ b/lib/Drush/Psysh/DrushCommand.php
@@ -29,7 +29,7 @@ class DrushCommand extends BaseCommand {
   /**
    * @var string
    */
-  private $category;
+  private $category = '';
 
   /**
    * DrushCommand constructor.
@@ -49,23 +49,16 @@ class DrushCommand extends BaseCommand {
    * Get Category of this command.
    */
   public function getCategory() {
-    if (isset($this->category)) {
-      return $this->category;
-    }
+    return $this->category;
+  }
 
-    $category = $this->config['category'];
-    $title = drush_command_invoke_all('drush_help', "meta:$category:title");
-
-    if (!$title) {
-      // If there is no title, then check to see if the
-      // command file is stored in a folder with the same
-      // name as some other command file (e.g. 'core') that
-      // defines a title.
-      $category = basename($this->config['path']);
-      $title = drush_command_invoke_all('drush_help', "meta:$category:title");
-    }
-
-    return $this->category = empty($title) ? 'Other commands' : $title[0];
+  /**
+   * Sets the category title.
+   *
+   * @param string $category_title
+   */
+  public function setCategory($category_title) {
+    $this->category = $category_title;
   }
 
   /**

--- a/lib/Drush/Psysh/DrushCommand.php
+++ b/lib/Drush/Psysh/DrushCommand.php
@@ -125,11 +125,11 @@ class DrushCommand extends BaseCommand {
    *   the command definition.
    */
   protected function buildDefinitionFromConfig() {
-    $def = [];
+    $definitions = [];
 
     if (isset($this->config['arguments']) && !empty($this->config['arguments'])) {
-
       $required_args = $this->config['required-arguments'];
+
       if ($required_args === FALSE) {
         $required_args = 0;
       }
@@ -137,45 +137,45 @@ class DrushCommand extends BaseCommand {
         $required_args = count($this->config['arguments']);
       }
 
-      foreach ($this->config['arguments'] as $name => $arg) {
-        if (!is_array($arg)) {
-          $arg = array('description' => $arg);
+      foreach ($this->config['arguments'] as $name => $argument) {
+        if (!is_array($argument)) {
+          $argument = ['description' => $argument];
         }
 
-        if (isset($arg['hidden']) && $arg['hidden']) {
+        if (!empty($argument['hidden'])) {
           continue;
         }
 
-        $req = ($required_args-- > 0) ? InputArgument::REQUIRED : InputArgument::OPTIONAL;
+        $input_type = ($required_args-- > 0) ? InputArgument::REQUIRED : InputArgument::OPTIONAL;
 
-        $def[] = new InputArgument($name, $req, $arg['description'], NULL);
+        $definitions[] = new InputArgument($name, $input_type, $argument['description'], NULL);
       }
     }
 
-    if (isset($this->config['options']) && !empty($this->config['options'])) {
-      foreach ($this->config['options'] as $name => $opt) {
-        if (!is_array($opt)) {
-          $opt = array('description' => $opt);
+    if (!empty($this->config['options'])) {
+      foreach ($this->config['options'] as $name => $option) {
+        if (!is_array($option)) {
+          $option = ['description' => $option];
         }
 
-        if (isset($opt['hidden']) && $opt['hidden']) {
+        if (!empty($option['hidden'])) {
           continue;
         }
 
-        // TODO: figure out if there's a way to detect
-        // InputOption::VALUE_NONE (i.e. flags) via the config array.
-        if (isset($opt['value']) && $opt['value'] !== 'optional') {
-          $req = InputOption::VALUE_REQUIRED;
+        // @todo: Figure out if there's a way to detect InputOption::VALUE_NONE
+        // (i.e. flags) via the config array.
+        if (isset($option['value']) && $option['value'] === 'required') {
+          $input_type = InputOption::VALUE_REQUIRED;
         }
         else {
-          $req = InputOption::VALUE_OPTIONAL;
+          $input_type = InputOption::VALUE_OPTIONAL;
         }
 
-        $def[] = new InputOption($name, '', $req, $opt['description']);
+        $definitions[] = new InputOption($name, '', $input_type, $option['description']);
       }
     }
 
-    return $def;
+    return $definitions;
   }
 
   /**
@@ -189,10 +189,10 @@ class DrushCommand extends BaseCommand {
   private function buildHelpFromConfig() {
     $help = wordwrap($this->config['description']);
 
-    $examples = array();
+    $examples = [];
     foreach ($this->config['examples'] as $ex => $def) {
       // Skip empty examples and things with obvious pipes...
-      if ($ex === '' || strpos($ex, '|') !== FALSE) {
+      if (($ex === '') || (strpos($ex, '|') !== FALSE)) {
         continue;
       }
 

--- a/lib/Drush/Psysh/DrushHelpCommand.php
+++ b/lib/Drush/Psysh/DrushHelpCommand.php
@@ -20,13 +20,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Help command.
  *
  * Lists available commands, and gives command-specific help when asked nicely.
+ *
+ * This replaces the PsySH help command to list commands by category.
  */
 class DrushHelpCommand extends BaseCommand {
 
   /**
-   *
+   * Label for PsySH commands.
    */
-  const NON_DRUSH_CATEGORY = 'PsySH commands';
+  const PSYSH_CATEGORY = 'PsySH commands';
 
   /**
    * The currently set subcommand.
@@ -99,7 +101,7 @@ class DrushHelpCommand extends BaseCommand {
           $category = (string) $command->getCategory();
         }
         else {
-          $category = static::NON_DRUSH_CATEGORY;
+          $category = static::PSYSH_CATEGORY;
         }
 
         if (!isset($categories[$category])) {

--- a/lib/Drush/Psysh/DrushHelpCommand.php
+++ b/lib/Drush/Psysh/DrushHelpCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * @file
+ * Drush help command.
+ *
+ * Original author: Justin Hileman
+ */
+
+namespace Drush\Psysh;
+
+use Psy\Command\Command as BaseCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Help command.
+ *
+ * Lists available commands, and gives command-specific help when asked nicely.
+ */
+class DrushHelpCommand extends BaseCommand {
+
+  /**
+   *
+   */
+  const NON_DRUSH_CATEGORY = 'PsySH commands';
+
+  /**
+   * The currently set subcommand.
+   *
+   * @var \Symfony\Component\Console\Command\Command
+   */
+  protected $command;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this
+      ->setName('help')
+      ->setAliases(['?'])
+      ->setDefinition([
+        new InputArgument('command_name', InputArgument::OPTIONAL, 'The command name', NULL),
+      ])
+      ->setDescription('Show a list of commands. Type `help [foo]` for information about [foo].');
+  }
+
+  /**
+   * Helper for setting a subcommand to retrieve help for.
+   *
+   * @param \Symfony\Component\Console\Command\Command $command
+   */
+  public function setCommand(Command $command) {
+    $this->command = $command;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    if ($this->command !== NULL) {
+      // Help for an individual command.
+      $output->page($this->command->asText());
+      $this->command = NULL;
+    }
+    elseif ($name = $input->getArgument('command_name')) {
+      // Help for an individual command.
+      $output->page($this->getApplication()->get($name)->asText());
+    }
+    else {
+      $categories = array();
+
+      // List available commands.
+      $commands = $this->getApplication()->all();
+
+      // Find the alignment width.
+      $width = 0;
+      foreach ($commands as $command) {
+        $width = strlen($command->getName()) > $width ? strlen($command->getName()) : $width;
+      }
+      $width += 2;
+
+      foreach ($commands as $name => $command) {
+        if ($name !== $command->getName()) {
+          continue;
+        }
+
+        if ($command->getAliases()) {
+          $aliases = sprintf('  <comment>Aliases:</comment> %s', implode(', ', $command->getAliases()));
+        }
+        else {
+          $aliases = '';
+        }
+
+        if ($command instanceof DrushCommand) {
+          $category = (string) $command->getCategory();
+        }
+        else {
+          $category = self::NON_DRUSH_CATEGORY;
+        }
+
+        if (!isset($categories[$category])) {
+          $categories[$category] = [];
+        }
+
+        $categories[$category][] = sprintf("    <info>%-${width}s</info> %s%s", $name, $command->getDescription(), $aliases);
+      }
+
+      $messages = [];
+
+      foreach ($categories as $name => $category) {
+        $messages[] = '';
+        $messages[] = sprintf('<comment>%s</comment>', OutputFormatter::escape($name));
+        foreach ($category as $message) {
+          $messages[] = $message;
+        }
+      }
+
+      $output->page($messages);
+    }
+  }
+
+}

--- a/lib/Drush/Psysh/DrushHelpCommand.php
+++ b/lib/Drush/Psysh/DrushHelpCommand.php
@@ -71,7 +71,7 @@ class DrushHelpCommand extends BaseCommand {
       $output->page($this->getApplication()->get($name)->asText());
     }
     else {
-      $categories = array();
+      $categories = [];
 
       // List available commands.
       $commands = $this->getApplication()->all();
@@ -99,7 +99,7 @@ class DrushHelpCommand extends BaseCommand {
           $category = (string) $command->getCategory();
         }
         else {
-          $category = self::NON_DRUSH_CATEGORY;
+          $category = static::NON_DRUSH_CATEGORY;
         }
 
         if (!isset($categories[$category])) {

--- a/lib/Drush/Psysh/DrushHelpCommand.php
+++ b/lib/Drush/Psysh/DrushHelpCommand.php
@@ -2,9 +2,7 @@
 
 /**
  * @file
- * Drush help command.
- *
- * Original author: Justin Hileman
+ * Contains \Drush\Psysh\DrushCommand.
  */
 
 namespace Drush\Psysh;

--- a/lib/Drush/Psysh/Shell.php
+++ b/lib/Drush/Psysh/Shell.php
@@ -9,7 +9,6 @@ namespace Drush\Psysh;
 
 use Psy\Shell as BaseShell;
 use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Input\InputInterface;
 
 class Shell extends BaseShell {
 

--- a/lib/Drush/Psysh/Shell.php
+++ b/lib/Drush/Psysh/Shell.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drush\Psysh\Shell.
+ */
+
+namespace Drush\Psysh;
+
+use Psy\Shell as BaseShell;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Input\InputInterface;
+
+class Shell extends BaseShell {
+
+  /**
+   * Get a command (if one exists) for the current input string.
+   *
+   * @param string $input
+   *
+   * @return null|Command
+   */
+  protected function getCommand($input) {
+    if ($name = $this->getCommandFromInput($input)) {
+      return $this->get($name);
+    }
+  }
+
+  /**
+   * Check whether a command is set for the current input string.
+   *
+   * @param string $input
+   *
+   * @return bool True if the shell has a command for the given input.
+   */
+  protected function hasCommand($input) {
+    if ($name = $this->getCommandFromInput($input)) {
+      return $this->has($name);
+    }
+
+    return false;
+  }
+
+  /**
+   * Get the command from the current input, takes aliases into account.
+   *
+   * @param string $input
+   *   The raw input
+   *
+   * @return string|NULL
+   *   The current command.
+   */
+  protected function getCommandFromInput($input) {
+    // Remove the alias from the start of the string before parsing and
+    // returning the command. Essentially, when choosing a command, we're
+    // ignoring the site alias.
+    $input = preg_replace('|^\@[^\s]+|', '', $input);
+
+    $input = new StringInput($input);
+    return $input->getFirstArgument();
+  }
+
+}


### PR DESCRIPTION
Modified version of the commands from https://github.com/grota/drush-psysh

This needed a bit of work to get working properly with drush, I guess just the newer version.

The help command needed a couple of fixes but mainly the DrushCommand execution needed some work to run correctly. This initial attempt is working pretty well though!

Based on discussion in https://github.com/drush-ops/drush/issues/1754
 
### Problems

- ~~After running a command, you need to use the psysh `exit` command twice to exit the shell session~~
- ~~Can we stop drush printing the output? I would prefer to pass it to the output object (@todo in the code)~~
- ~~Doesn't have support for site aliases yet (command aliases are fine), could be some sort of follow up?~~