### PR TITLE
Issue #1769: Reversed order of array replacement when merging include…

### DIFF
--- a/commands/make/make.utilities.inc
+++ b/commands/make/make.utilities.inc
@@ -79,7 +79,7 @@ function _make_parse_info_file($makefile) {
             make_error('BUILD_ERROR', dt("Cannot determine include file location: !include", array('!include' => $include)));
           }
 
-          $info = array_replace_recursive(_make_parse_info_file($include_makefile), $info);
+          $info = array_replace_recursive(_make_parse_info_file($info, $include_makefile));
           // Move core back to the top of the list, where
           // make_generate_from_makefile() expects it.
           array_reverse($info['projects']);


### PR DESCRIPTION
Reversed order of array replacement when merging included makefiles - later includes override previous values.

See issues #1769 and #1268 