### PR TITLE
Filter command aliases for PHP keywords

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -70,14 +70,98 @@ function drush_cli_core_cli() {
 function _drush_core_cli_get_commands() {
   $commands = drush_get_commands();
   $ignored_commands = ['help', 'drush-psysh', 'php-eval', 'core-cli', 'php'];
+  $php_keywords = _drush_core_cli_get_php_keywords();
 
   foreach ($commands as $name => $config) {
-    // Ignore some commands that don't make sense inside PsySH, are hidden, or
-    // are aliases.
-    if (in_array($name, $ignored_commands) || !empty($config['hidden']) || ($name !== $config['command'])) {
+    // Ignore some commands that don't make sense inside PsySH, are PHP keywords
+    // are hidden, or are aliases.
+    if (in_array($name, $ignored_commands) || in_array($name, $php_keywords) || !empty($config['hidden']) || ($name !== $config['command'])) {
       unset($commands[$name]);
+    }
+    else {
+      // Make sure the command aliases don't contain any PHP keywords.
+      if (!empty($config['aliases'])) {
+        $commands[$name]['aliases'] = array_diff($commands[$name]['aliases'], $php_keywords);
+      }
     }
   }
 
   return $commands;
+}
+
+/**
+ * Returns a list of PHP keywords.
+ *
+ * This will act as a blacklist for command and alias names.
+ *
+ * @return array
+ */
+function _drush_core_cli_get_php_keywords() {
+  return [
+    '__halt_compiler',
+    'abstract',
+    'and',
+    'array',
+    'as',
+    'break',
+    'callable',
+    'case',
+    'catch',
+    'class',
+    'clone',
+    'const',
+    'continue',
+    'declare',
+    'default',
+    'die',
+    'do',
+    'echo',
+    'else',
+    'elseif',
+    'empty',
+    'enddeclare',
+    'endfor',
+    'endforeach',
+    'endif',
+    'endswitch',
+    'endwhile',
+    'eval',
+    'exit',
+    'extends',
+    'final',
+    'for',
+    'foreach',
+    'function',
+    'global',
+    'goto',
+    'if',
+    'implements',
+    'include',
+    'include_once',
+    'instanceof',
+    'insteadof',
+    'interface',
+    'isset',
+    'list',
+    'namespace',
+    'new',
+    'or',
+    'print',
+    'private',
+    'protected',
+    'public',
+    'require',
+    'require_once',
+    'return',
+    'static',
+    'switch',
+    'throw',
+    'trait',
+    'try',
+    'unset',
+    'use',
+    'var',
+    'while',
+    'xor',
+  ];
 }

--- a/lib/Drush/Psysh/DrushCommand.php
+++ b/lib/Drush/Psysh/DrushCommand.php
@@ -32,13 +32,6 @@ class DrushCommand extends BaseCommand {
   private $category = '';
 
   /**
-   * PHP reserved keywords.
-   *
-   * @var array
-   */
-  private static $keywords = array('__halt_compiler', 'abstract', 'and', 'array', 'as', 'break', 'callable', 'case', 'catch', 'class', 'clone', 'const', 'continue', 'declare', 'default', 'die', 'do', 'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor', 'endforeach', 'endif', 'endswitch', 'endwhile', 'eval', 'exit', 'extends', 'final', 'for', 'foreach', 'function', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface', 'isset', 'list', 'namespace', 'new', 'or', 'print', 'private', 'protected', 'public', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'trait', 'try', 'unset', 'use', 'var', 'while', 'xor');
-
-  /**
    * DrushCommand constructor.
    *
    * This accepts the Drush command configuration array and does a pretty
@@ -125,11 +118,7 @@ class DrushCommand extends BaseCommand {
    *   The command aliases.
    */
   protected function buildAliasesFromConfig() {
-    $aliases = !empty($this->config['aliases']) ? $this->config['aliases'] : [];
-
-    return array_filter($aliases, function($alias){
-      return !in_array($alias, static::$keywords);
-    });
+    return !empty($this->config['aliases']) ? $this->config['aliases'] : [];
   }
 
   /**

--- a/lib/Drush/Psysh/DrushCommand.php
+++ b/lib/Drush/Psysh/DrushCommand.php
@@ -32,6 +32,13 @@ class DrushCommand extends BaseCommand {
   private $category = '';
 
   /**
+   * PHP reserved keywords.
+   *
+   * @var array
+   */
+  private static $keywords = array('__halt_compiler', 'abstract', 'and', 'array', 'as', 'break', 'callable', 'case', 'catch', 'class', 'clone', 'const', 'continue', 'declare', 'default', 'die', 'do', 'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor', 'endforeach', 'endif', 'endswitch', 'endwhile', 'eval', 'exit', 'extends', 'final', 'for', 'foreach', 'function', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'insteadof', 'interface', 'isset', 'list', 'namespace', 'new', 'or', 'print', 'private', 'protected', 'public', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'trait', 'try', 'unset', 'use', 'var', 'while', 'xor');
+
+  /**
    * DrushCommand constructor.
    *
    * This accepts the Drush command configuration array and does a pretty
@@ -118,7 +125,11 @@ class DrushCommand extends BaseCommand {
    *   The command aliases.
    */
   protected function buildAliasesFromConfig() {
-    return !empty($this->config['aliases']) ? $this->config['aliases'] : [];
+    $aliases = !empty($this->config['aliases']) ? $this->config['aliases'] : [];
+
+    return array_filter($aliases, function($alias){
+      return !in_array($alias, static::$keywords);
+    });
   }
 
   /**


### PR DESCRIPTION
I was testing out something for one of the PsySH PRs and we have a problem with aliases. There is a high chance one of them could conflict with a PHP keyword. E.g. `if` is an alias of `image-flush` this means we can't eval any php code starting with if :)

Maybe we should check commands too to be safe?

Needs a bit of tidy, just trying to post ASAP before my laptop dies (on 2% atm).