### PR TITLE
Add VarDumper casters for Entity and Config classes to the shell

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -31,13 +31,17 @@ function cli_drush_command() {
  * Command callback.
  */
 function drush_cli_core_cli() {
-  $shell = new Shell();
+  $configuration = new \Psy\Configuration();
+  $shell = new Shell($configuration);
 
   if (drush_drupal_major_version() >= 8) {
     // Register the assertion handler so exceptions are thrown instead of errors
     // being triggered. This plays nicer with PsySH.
     Handle::register();
     $shell->setScopeVariables(['container' => \Drupal::getContainer()]);
+
+    // Add Drupal 8 specific casters to the shell configuration.
+    $configuration->addCasters(_drush_core_cli_get_casters());
   }
 
   // Add Drush commands to the shell.
@@ -87,6 +91,55 @@ function _drush_core_cli_get_commands() {
   }
 
   return $commands;
+}
+
+/**
+ * Returns a mapped array of casters for use in the shell.
+ *
+ * These are Symfony VarDumper casters.
+ * See http://symfony.com/doc/current/components/var_dumper/advanced.html#casters
+ * for more information.
+ *
+ * @return array.
+ *   An array of caster callbacks keyed by class or interface.
+ */
+function _drush_core_cli_get_casters() {
+  return [
+    'Drupal\Core\Entity\ContentEntityInterface' => function($entity, $array, $stub, $isNested) {
+      if (!$isNested) {
+        foreach ($entity as $property => $item) {
+          $array[Symfony\Component\VarDumper\Caster\Caster::PREFIX_PROTECTED . $property] = $item;
+        }
+      }
+
+      return $array;
+    },
+    'Drupal\Core\Field\FieldItemListInterface' => function($list_item, $array, $stub, $isNested) {
+      if (!$isNested) {
+        $array[Symfony\Component\VarDumper\Caster\Caster::PREFIX_PROTECTED . 'list'] = $list_item->getValue();
+      }
+
+      return $array;
+    },
+    'Drupal\Core\Config\Entity\ConfigEntityInterface' => function($entity, $array, $stub, $isNested) {
+      if (!$isNested) {
+        foreach ($entity->toArray() as $property => $value) {
+          $array[Symfony\Component\VarDumper\Caster\Caster::PREFIX_PROTECTED . $property] = $value;
+        }
+      }
+
+      return $array;
+    },
+    'Drupal\Core\Config\ConfigBase' => function($config, $array, $stub, $isNested) {
+      if (!$isNested) {
+        foreach ($config->get() as $property => $value) {
+          $array[Symfony\Component\VarDumper\Caster\Caster::PREFIX_VIRTUAL . $property] = $value;
+        }
+      }
+
+      return $array;
+    },
+  ];
 }
 
 /**

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -116,7 +116,16 @@ function _drush_core_cli_get_casters() {
     },
     'Drupal\Core\Field\FieldItemListInterface' => function($list_item, $array, $stub, $isNested) {
       if (!$isNested) {
-        $array[Symfony\Component\VarDumper\Caster\Caster::PREFIX_PROTECTED . 'list'] = $list_item->getValue();
+        foreach ($list_item as $delta => $item) {
+          $array[Symfony\Component\VarDumper\Caster\Caster::PREFIX_VIRTUAL . $delta] = $item;
+        }
+      }
+
+      return $array;
+    },
+    'Drupal\Core\Field\FieldItemInterface' => function($item, $array, $stub, $isNested) {
+      if (!$isNested) {
+        $array[Symfony\Component\VarDumper\Caster\Caster::PREFIX_VIRTUAL . 'value'] = $item->getValue();
       }
 
       return $array;


### PR DESCRIPTION
we can add a few casters to make inspecting some objects a bit nicer. As almost everything is now a protected property, you would have to `dump -a $object` to see everything. So save doing that all the time we can add some casters, these will show properties of entities, config entities, config objects (for now).

So instead of not much:

![1____forks_drush_drush_____sites_d8__php_](https://cloud.githubusercontent.com/assets/1053891/11246933/bf18d9ae-8e11-11e5-8808-e1961fd723a6.png)

We can have properties shown by default like this:

![1____forks_drush_drush_____sites_d8__php_](https://cloud.githubusercontent.com/assets/1053891/11246894/9a2a32e6-8e11-11e5-93b0-eb602cdbaa07.png)