### PR TITLE
Prevent warnings when projects don't have recommended_major release

### DIFF
--- a/lib/Drush/UpdateService/Project.php
+++ b/lib/Drush/UpdateService/Project.php
@@ -380,12 +380,14 @@ class Project {
    */
   public function getRecommendedOrSupportedRelease() {
     $majors = array();
-    if (!empty($this->parsed['recommended_major']) || $this->parsed['recommended_major'] == 0) {
+
+    $recommended_major = empty($this->parsed['recommended_major']) ? 0 : $this->parsed['recommended_major'];
+    if ($recommended_major != 0) {
       $majors[] = $this->parsed['recommended_major'];
     }
     $supported = explode(',', $this->parsed['supported_majors']);
     foreach ($supported as $v) {
-      if ($v != $this->parsed['recommended_major']) {
+      if ($v != $recommended_major) {
         $majors[] = $v;
       }
     }


### PR DESCRIPTION
Lots of projects with Drupal 8 releases don't have a recommended_major release yet. This visibilize an old bug in Drush.