### PR TITLE
Run terminate before the shell runs to avoid database errors when the core-cli command finishes

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -75,14 +75,14 @@ function drush_cli_core_cli() {
     $bootstrap->terminate();
   }
 
-  $shell->run();
-
   // To fix the above problem in Drupal 7, the connection can be closed manually.
-  // This will make sure a new connection is created again if/when needed in
-  // registered shutdown functions.
+  // This will make sure a new connection is created again in child loops. So
+  // any shutdown functions will still run ok after the shell has exited.
   if (drush_drupal_major_version() == 7) {
     Database::closeConnection();
   }
+
+  $shell->run();
 }
 
 /**

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -63,6 +63,18 @@ function drush_cli_core_cli() {
   // run after the user presses ^D.  Mark this command as completed to avoid a
   // spurious error message.
   drush_set_context('DRUSH_EXECUTION_COMPLETED', TRUE);
+
+  // Run the terminate event before the shell is run. Otherwise, if the shell
+  // is forking processes (the default), any child processes will close the
+  // database connection when they are closed. So when we return back to the
+  // parent process after, there is no connection. Call terminate() regardless,
+  // this is a no-op for all DrupalBoot classes except DrupalBoot8. This will be
+  // called after the command in preflight still, but the subscriber instances
+  // are already created from before.
+  if ($bootstrap = drush_get_bootstrap_object()) {
+    $bootstrap->terminate();
+  }
+
   $shell->run();
 }
 

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -66,16 +66,23 @@ function drush_cli_core_cli() {
 
   // Run the terminate event before the shell is run. Otherwise, if the shell
   // is forking processes (the default), any child processes will close the
-  // database connection when they are closed. So when we return back to the
-  // parent process after, there is no connection. Call terminate() regardless,
-  // this is a no-op for all DrupalBoot classes except DrupalBoot8. This will be
-  // called after the command in preflight still, but the subscriber instances
-  // are already created from before.
+  // database connection when they are killed. So when we return back to the
+  // parent process after, there is no connection. This will be called after the
+  // command in preflight still, but the subscriber instances are already
+  // created from before. Call terminate() regardless, this is a no-op for all
+  // DrupalBoot classes except DrupalBoot8.
   if ($bootstrap = drush_get_bootstrap_object()) {
     $bootstrap->terminate();
   }
 
   $shell->run();
+
+  // To fix the above problem in Drupal 7, the connection can be closed manually.
+  // This will make sure a new connection is created again if/when needed in
+  // registered shutdown functions.
+  if (drush_drupal_major_version() == 7) {
+    Database::closeConnection();
+  }
 }
 
 /**


### PR DESCRIPTION
See comment for explanation. This is not ideal but it does work, not sure there is a better way at the moment to be honest. This will actually run terminate() twice, but because we already have the subscriber instances created before the shell is run, when the shell exits they still work.