### PR TITLE
Update pm-enable tests and fix underlying issues with --resolve-dependencies

### DIFF
--- a/commands/core/drupal/environment.inc
+++ b/commands/core/drupal/environment.inc
@@ -85,7 +85,7 @@ function drush_check_module_dependencies($modules, $module_info) {
       }
     }
     $status[$key]['unmet-dependencies'] = $unmet_dependencies;
-    $status[$key]['dependencies'] = array_keys($dependencies);
+    $status[$key]['dependencies'] = $dependencies;
   }
 
   return $status;

--- a/commands/core/drupal/environment_6.inc
+++ b/commands/core/drupal/environment_6.inc
@@ -67,7 +67,10 @@ function drush_check_module_dependencies($modules, $module_info) {
       );
     }
     $status[$key]['unmet-dependencies'] = $unmet_dependencies;
-    $status[$key]['dependencies'] = $dependencies;
+    $status[$key]['dependencies'] = array();
+    foreach ($dependencies as $dependency) {
+      $status[$key]['dependencies'][$dependency] = array('name' => $dependency);
+    }
   }
 
   return $status;

--- a/commands/core/drupal/environment_7.inc
+++ b/commands/core/drupal/environment_7.inc
@@ -77,7 +77,7 @@ function drush_check_module_dependencies($modules, $module_info) {
       }
     }
     $status[$key]['unmet-dependencies'] = $unmet_dependencies;
-    $status[$key]['dependencies'] = array_keys($dependencies);
+    $status[$key]['dependencies'] = $dependencies;
   }
 
   return $status;

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -955,7 +955,7 @@ function drush_pm_enable_validate() {
     // with matching names.
     if (!empty($unknown)) {
       $found = array();
-      foreach ($unknown as $key => $name) {
+      foreach ($unknown as $name) {
         drush_log(dt('!extension was not found.', array('!extension' => $name)), 'warning');
         $project = drush_pm_enable_find_project_from_extension($name);
         if (!empty($project)) {
@@ -996,8 +996,8 @@ function drush_pm_enable_validate() {
       $unmet_dependencies = array();
       foreach ($dependencies as $module => $info) {
         if (!empty($info['unmet-dependencies'])) {
-          foreach ($info['unmet-dependencies'] as $unmet_module) {
-            $unmet_project = drush_pm_enable_find_project_from_extension($unmet_module);
+          foreach ($info['unmet-dependencies'] as $unmet) {
+            $unmet_project = (!empty($info['dependencies'][$unmet]['project'])) ? $info['dependencies'][$unmet]['project'] : drush_pm_enable_find_project_from_extension($unmet);
             if (!empty($unmet_project)) {
               $unmet_dependencies[$module][$unmet_project] = $unmet_project;
             }
@@ -1045,7 +1045,8 @@ function drush_pm_enable_validate() {
       }
       elseif (!empty($info['dependencies'])) {
         // Make sure we have an assoc array.
-        $assoc = array_combine($info['dependencies'], $info['dependencies']);
+        $dependencies_list = array_keys($info['dependencies']);
+        $assoc = array_combine($dependencies_list, $dependencies_list);
         $all_dependencies = array_merge($all_dependencies, $assoc);
       }
     }

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -1030,6 +1030,10 @@ function drush_pm_enable_validate() {
       // Restore DRUSH_AFFIRMATIVE context.
       drush_set_context('DRUSH_AFFIRMATIVE', $drush_affirmative);
       // Refresh module cache after downloading the new modules.
+      if (drush_drupal_major_version() >= 8) {
+        \Drush\Drupal\ExtensionDiscovery::reset();
+        system_list_reset();
+      }
       $extension_info = drush_get_extensions();
       $recheck = TRUE;
     }

--- a/lib/Drush/Drupal/ExtensionDiscovery.php
+++ b/lib/Drush/Drupal/ExtensionDiscovery.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drush\Drupal;
+
+use \Drupal\Core\Extension\ExtensionDiscovery as DrupalExtensionDiscovery;
+
+class ExtensionDiscovery extends DrupalExtensionDiscovery {
+  static public function reset() {
+    static::$files = array();
+  }
+}
+

--- a/lib/Drush/UpdateService/Project.php
+++ b/lib/Drush/UpdateService/Project.php
@@ -602,7 +602,7 @@ class Project {
       $xml = simplexml_import_dom($dom);
 
       // Extract last update time and the notes.
-      $last_updated = $xml->xpath('//div[@class="last-updated"]');
+      $last_updated = $xml->xpath('//div[contains(@class,"views-field-changed")]');
       $last_updated = $last_updated[0]->asXML();
       $notes = $xml->xpath('//div[contains(@class,"field-name-body")]');
       $notes = (!empty($notes)) ? $notes[0]->asXML() : dt("There're no release notes.");
@@ -611,7 +611,7 @@ class Project {
       $header = array();
       $header[] = '<hr>';
       $header[] = dt("> RELEASE NOTES FOR '!name' PROJECT, VERSION !version:", array('!name' => strtoupper($project_name), '!version' => $version));
-      $header[] = dt("> !last_updated.", array('!last_updated' => $last_updated));
+      $header[] = dt("> !last_updated.", array('!last_updated' => trim(drush_html_to_text($last_updated))));
       if ($print_status) {
         $header[] = '> ' . implode(', ', $this->parsed['releases'][$version]['release_status']);
       }

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -26,15 +26,25 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
     $options = $options_no_pipe + array(
       'pipe' => NULL,
     );
+
+    // Test pm-download downloads a module and pm-list lists it.
     $this->drush('pm-download', array('devel'), $options);
     $this->drush('pm-list', array(), $options + array('no-core' => NULL, 'status' => 'disabled,not installed'));
     $out = $this->getOutput();
     $list = $this->getOutputAsList();
     $this->assertTrue(in_array('devel', $list));
 
+    // Test pm-enable enables a module and shows the permissions it provides.
     $this->drush('pm-enable', array('devel'), $options_no_pipe);
     $output = $this->getOutput();
     $this->assertContains('access devel information', $output);
+
+    // Test pm-list shows the module as enabled.
+    $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
+    $list = $this->getOutputAsList();
+    $this->assertTrue(in_array('devel', $list));
+
+    // Test pm-info shows some module info.
     $this->drush('pm-info', array('devel'), $options);
     $output = $this->getOutputFromJSON('devel');
     $expected = array(
@@ -48,24 +58,23 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
       $this->assertEquals($expected[$key], $value);
     }
 
-    $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
-    $list = $this->getOutputAsList();
-    $this->assertTrue(in_array('devel', $list));
-    // In D7, the testing profile uses 'bartik', whereas in D8, 'classy' is used.
+    // Test the testing install profile theme is installed.
     $themeToCheck = UNISH_DRUPAL_MAJOR_VERSION >= 8 ? 'classy' : (UNISH_DRUPAL_MAJOR_VERSION == 7 ? 'bartik' : 'garland');
     $this->assertTrue(in_array($themeToCheck, $list), 'Themes are in the pm-list');
 
-    if (UNISH_DRUPAL_MAJOR_VERSION <= 7) {
-      $path = UNISH_DRUPAL_MAJOR_VERSION == 7 ? 'devel/settings' : 'admin/settings/devel';
-      $this->drush('sql-query', array("SELECT path FROM menu_router WHERE path = '$path';"), array('root' => $this->webroot(), 'uri' => key($sites)));
-      $list = $this->getOutputAsList();
-      $this->assertTrue(in_array($path, $list), 'Cache was cleared after modules were enabled');
-    }
+    // Test cache was cleared after enabling a module.
+    $table = UNISH_DRUPAL_MAJOR_VERSION >= 8 ? 'router' : 'menu_router';
+    $path = UNISH_DRUPAL_MAJOR_VERSION >= 8 ? '/admin/config/development/devel' : (UNISH_DRUPAL_MAJOR_VERSION == 7 ? 'devel/settings' : 'admin/settings/devel');
+    $this->drush('sql-query', array("SELECT path FROM $table WHERE path = '$path';"), array('root' => $this->webroot(), 'uri' => key($sites)));
+    $list = $this->getOutputAsList();
+    $this->assertTrue(in_array($path, $list), 'Cache was cleared after modules were enabled');
 
+    // Test pm-list filtering.
     $this->drush('pm-list', array(), $options + array('package' => 'Core'));
     $list = $this->getOutputAsList();
     $this->assertFalse(in_array('devel', $list), 'Devel is not part of core package');
 
+    // Test module disabling.
     if (UNISH_DRUPAL_MAJOR_VERSION <= 7) {
       $this->drush('pm-disable', array('devel'), $options);
       $this->drush('pm-list', array(), $options + array('status' => 'disabled'));
@@ -73,29 +82,36 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
       $this->assertTrue(in_array('devel', $list));
     }
 
+    // Test module uninstall.
     $this->drush('pm-uninstall', array('devel'), $options);
     $this->drush('pm-list', array(), $options + array('status' => 'not installed', 'type' => 'module'));
     $list = $this->getOutputAsList();
     $this->assertTrue(in_array('devel', $list));
 
     // Test pm-enable is able to download dependencies.
-    if (UNISH_DRUPAL_MAJOR_VERSION >= 8) {
-      $this->markTestSkipped("pathauto does not have a release for Drupal 8 yet.");
+    // @todo pathauto has no usable D8 release yet.
+    if (UNISH_DRUPAL_MAJOR_VERSION <=7) {
+      $this->drush('pm-download', array('pathauto'), $options);
+      $this->drush('pm-enable', array('pathauto'), $options + array('resolve-dependencies' => TRUE));
+      $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
+      $list = $this->getOutputAsList();
+      $this->assertTrue(in_array('token', $list));
     }
-
-    $this->drush('pm-download', array('pathauto'), $options);
-    $this->drush('pm-enable', array('pathauto'), $options + array('resolve-dependencies' => TRUE));
-    $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
-    $list = $this->getOutputAsList();
-    $this->assertTrue(in_array('token', $list));
 
     // Test that pm-enable downloads missing projects and dependencies.
-    $this->drush('pm-enable', array('views'), $options + array('resolve-dependencies' => TRUE));
+    $this->drush('pm-enable', array('panels'), $options + array('resolve-dependencies' => TRUE));
     $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
     $list = $this->getOutputAsList();
-    if (UNISH_DRUPAL_MAJOR_VERSION == 6) {
-      $this->markTestSkipped("Drupal 6 Views does not depend on CTools.");
-    }
     $this->assertTrue(in_array('ctools', $list));
+
+    // Test that pm-enable downloads missing projects
+    // and dependencies with project namespace (date:date_popup).
+    if (UNISH_DRUPAL_MAJOR_VERSION == 7) {
+      $this->drush('pm-enable', array('date_datepicker_inline'), $options + array('resolve-dependencies' => TRUE));
+      $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
+      $list = $this->getOutputAsList();
+      $this->assertTrue(in_array('date_popup', $list));
+    }
+
   }
 }

--- a/tests/pmReleaseNotesTest.php
+++ b/tests/pmReleaseNotesTest.php
@@ -16,7 +16,7 @@ class pmReleaseNotesCase extends CommandUnishTestCase {
     $expected = <<< EXPECTED
 ------------------------------------------------------------------------------
 > RELEASE NOTES FOR 'DRUPAL' PROJECT, VERSION 7.1:
-> Last updated: May 25, 2011 - 20:21 .
+> Last updated:  May 25, 2011 - 20:59.
 > Security
 ------------------------------------------------------------------------------
 EXPECTED;


### PR DESCRIPTION
##### Updated pm-enable tests:

 1. Test cache was cleared/rebuild for D8 also
 2. Don't skip the full test! just avoid doing concrete tests
 3. Test pm-enable's resolve-dependencies for D6,7,8 (it was doing it only for D7). Expected to fail in D8 because of #5
 4. Add a new test to resolve-dependencies with projects namespace. Expected to fail for D7 because of #1731

##### Fixes

* #1731
* rln command. Due to changes in d.o html.
* #5