### PR TITLE
Allow site and Drupal version specific CLI history

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -15,6 +15,9 @@ function cli_drush_command() {
     'aliases' => array('php'),
     'bootstrap' => DRUSH_BOOTSTRAP_MAX,
     'topics' => array('docs-repl'),
+    'options' => array(
+      'version-history' => 'Use command history based on Drupal version (Default is per site).',
+    ),
   );
   $items['docs-repl'] = array(
     'description' => 'repl.md',
@@ -31,10 +34,15 @@ function cli_drush_command() {
  * Command callback.
  */
 function drush_cli_core_cli() {
+  $drupal_major_version = drush_drupal_major_version();
   $configuration = new \Psy\Configuration();
+
+  // Set the Drush specific history file path.
+  $configuration->setHistoryFile(drush_history_path_cli());
+
   $shell = new Shell($configuration);
 
-  if (drush_drupal_major_version() >= 8) {
+  if ($drupal_major_version >= 8) {
     // Register the assertion handler so exceptions are thrown instead of errors
     // being triggered. This plays nicer with PsySH.
     Handle::register();
@@ -78,7 +86,7 @@ function drush_cli_core_cli() {
   // To fix the above problem in Drupal 7, the connection can be closed manually.
   // This will make sure a new connection is created again in child loops. So
   // any shutdown functions will still run ok after the shell has exited.
-  if (drush_drupal_major_version() == 7) {
+  if ($drupal_major_version == 7) {
     Database::closeConnection();
   }
 
@@ -130,6 +138,55 @@ function _drush_core_cli_get_casters() {
     'Drupal\Core\Config\Entity\ConfigEntityInterface' => 'Drush\Psysh\Caster::castConfigEntity',
     'Drupal\Core\Config\ConfigBase' => 'Drush\Psysh\Caster::castConfig',
   ];
+}
+
+/**
+ * Returns the file path for the CLI history.
+ *
+ * This can either be site specific (default) or Drupal version specific.
+ *
+ * @return string.
+ */
+function drush_history_path_cli() {
+  $drupal_major_version = drush_drupal_major_version();
+  $drush_core_directory = _drush_core_directory('root', 'path', TRUE);
+  $cli_directory = drush_directory_cli();
+  $file_name = drush_get_option('version-history', FALSE) ? "drupal-$drupal_major_version" : 'drupal-site-' . md5($drush_core_directory);
+
+  return "$cli_directory/$file_name";
+}
+
+/**
+ * The path to the global cli directory.
+ *
+ * @return string
+ */
+function drush_directory_cli() {
+  $cli_locations = [];
+
+  $home = drush_server_home();
+
+  if ($home) {
+    $cli_locations[$home] = '.drush/cli';
+  }
+
+  $cli_locations[drush_find_tmp()] = 'drush-' . drush_get_username() . '/cli';
+
+  foreach ($cli_locations as $base => $dir) {
+    if (!empty($base) && is_writable($base)) {
+      $cli_dir = $base . '/' . $dir;
+
+      if (drush_mkdir($cli_dir)) {
+        return $cli_dir;
+      }
+      else {
+        drush_clear_error();
+      }
+    }
+  }
+
+  return drush_set_error('DRUSH_NO_WRITABLE_CACHE', dt('Drush must have a writable cli directory; please insure that one of the following locations is writable: @locations',
+    array('@locations' => implode(',', array_keys($cli_locations)))));
 }
 
 /**

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -151,9 +151,15 @@ function drush_history_path_cli() {
   $drupal_major_version = drush_drupal_major_version();
   $drush_core_directory = _drush_core_directory('root', 'path', TRUE);
   $cli_directory = drush_directory_cli();
-  $file_name = drush_get_option('version-history', FALSE) ? "drupal-$drupal_major_version" : 'drupal-site-' . md5($drush_core_directory);
 
-  return "$cli_directory/$file_name";
+  $file_name = drush_get_option('version-history', FALSE) ? "drupal-$drupal_major_version" : 'drupal-site-' . md5($drush_core_directory);
+  $full_path = "$cli_directory/$file_name";
+
+  if (drush_get_context('DRUSH_VERBOSE')) {
+    drush_print(dt('History: @full_path', ['@full_path' => $full_path]));
+  }
+
+  return $full_path;
 }
 
 /**

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -163,8 +163,7 @@ function drush_history_path_cli() {
       $site_suffix = $site['#name'];
     }
     else {
-      $drush_core_directory = _drush_core_directory('root', 'path', TRUE);
-      $site_suffix = md5($drush_core_directory);
+      $site_suffix = md5(DRUPAL_ROOT);
     }
 
     $file_name = "drupal-site-$site_suffix";
@@ -202,9 +201,6 @@ function drush_directory_cli() {
 
       if (drush_mkdir($cli_dir)) {
         return $cli_dir;
-      }
-      else {
-        drush_clear_error();
       }
     }
   }

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -148,15 +148,33 @@ function _drush_core_cli_get_casters() {
  * @return string.
  */
 function drush_history_path_cli() {
-  $drupal_major_version = drush_drupal_major_version();
-  $drush_core_directory = _drush_core_directory('root', 'path', TRUE);
   $cli_directory = drush_directory_cli();
 
-  $file_name = drush_get_option('version-history', FALSE) ? "drupal-$drupal_major_version" : 'drupal-site-' . md5($drush_core_directory);
+  // If only the Drupal version is being used for the history.
+  if (drush_get_option('version-history', FALSE)) {
+    $drupal_major_version = drush_drupal_major_version();
+    $file_name = "drupal-$drupal_major_version";
+  }
+  // If there is an alias, use that in the site specific name. Otherwise,
+  // use a hash of the root path.
+  else {
+    if ($alias = drush_get_context('DRUSH_TARGET_SITE_ALIAS')) {
+      $site = drush_sitealias_get_record($alias);
+      $site_suffix = $site['#name'];
+    }
+    else {
+      $drush_core_directory = _drush_core_directory('root', 'path', TRUE);
+      $site_suffix = md5($drush_core_directory);
+    }
+
+    $file_name = "drupal-site-$site_suffix";
+  }
+
   $full_path = "$cli_directory/$file_name";
 
+  // Output the history path if verbose is enabled.
   if (drush_get_context('DRUSH_VERBOSE')) {
-    drush_print(dt('History: @full_path', ['@full_path' => $full_path]));
+    drush_log(dt('History: @full_path', ['@full_path' => $full_path]), 'info');
   }
 
   return $full_path;
@@ -191,7 +209,7 @@ function drush_directory_cli() {
     }
   }
 
-  return drush_set_error('DRUSH_NO_WRITABLE_CACHE', dt('Drush must have a writable cli directory; please insure that one of the following locations is writable: @locations',
+  return drush_set_error('DRUSH_NO_WRITABLE_CLI', dt('Drush must have a writable cli directory; please insure that one of the following locations is writable: @locations',
     array('@locations' => implode(',', array_keys($cli_locations)))));
 }
 

--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -148,7 +148,7 @@ function _drush_core_cli_get_casters() {
  * @return string.
  */
 function drush_history_path_cli() {
-  $cli_directory = drush_directory_cli();
+  $cli_directory = drush_directory_cache('cli');
 
   // If only the Drupal version is being used for the history.
   if (drush_get_option('version-history', FALSE)) {
@@ -177,36 +177,6 @@ function drush_history_path_cli() {
   }
 
   return $full_path;
-}
-
-/**
- * The path to the global cli directory.
- *
- * @return string
- */
-function drush_directory_cli() {
-  $cli_locations = [];
-
-  $home = drush_server_home();
-
-  if ($home) {
-    $cli_locations[$home] = '.drush/cli';
-  }
-
-  $cli_locations[drush_find_tmp()] = 'drush-' . drush_get_username() . '/cli';
-
-  foreach ($cli_locations as $base => $dir) {
-    if (!empty($base) && is_writable($base)) {
-      $cli_dir = $base . '/' . $dir;
-
-      if (drush_mkdir($cli_dir)) {
-        return $cli_dir;
-      }
-    }
-  }
-
-  return drush_set_error('DRUSH_NO_WRITABLE_CLI', dt('Drush must have a writable cli directory; please insure that one of the following locations is writable: @locations',
-    array('@locations' => implode(',', array_keys($cli_locations)))));
 }
 
 /**

--- a/examples/example.drushrc.php
+++ b/examples/example.drushrc.php
@@ -299,7 +299,7 @@
 # $command_specific['site-install'] = array('account-name' => 'alice', 'account-pass' => 'secret');
 
 // Use Drupal version specific CLI history instead of per site.
-# $command_specific['core-cli'] = array('version-specific' => TRUE);
+# $command_specific['core-cli'] = array('version-history' => TRUE);
 
 /**
  * Load a drushrc file from the 'drush' folder at the root of the current

--- a/examples/example.drushrc.php
+++ b/examples/example.drushrc.php
@@ -298,6 +298,9 @@
 // Set a predetermined username and password when using site-install.
 # $command_specific['site-install'] = array('account-name' => 'alice', 'account-pass' => 'secret');
 
+// Use Drupal version specific CLI history instead of per site.
+# $command_specific['core-cli'] = array('version-specific' => TRUE);
+
 /**
  * Load a drushrc file from the 'drush' folder at the root of the current
  * git repository.  Example script below by Grayside.  Customize as desired.


### PR DESCRIPTION
The shell history is currently using the PsySH global history. So we get regular psysh and any Drupal sites/versions you are using in the same history. This gets slightly annoying when switching between them.

Let's set the history file path ourselves, and allow this to be per site or per Drupal version! The default will be per site, with an option, `version-history` which can be used to use drupal version specific history instead.

I added an example in the `example.drushrc.php` file as this is a good one for command specific defaults.

It also prints out the history file path when verbose is enabled.

### Directory structure
```
★ tree ~/.drush/cli/
$HOME/.drush/cli/
├── drupal-7
├── drupal-8
├── drupal-site-7a914924f49f52862af4fdc8b1813f52
├── drupal-site-7df5e3082987556585d903657b4cdeec
└── drupal-site-testalias.local
```