### PR TITLE
Add a caster for the container

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -138,6 +138,7 @@ function _drush_core_cli_get_casters() {
     'Drupal\Core\Field\FieldItemInterface' => 'Drush\Psysh\Caster::castFieldItem',
     'Drupal\Core\Config\Entity\ConfigEntityInterface' => 'Drush\Psysh\Caster::castConfigEntity',
     'Drupal\Core\Config\ConfigBase' => 'Drush\Psysh\Caster::castConfig',
+    'Drupal\Component\DependencyInjection\Container' => 'Drush\Psysh\Caster::castContainer',
   ];
 }
 

--- a/lib/Drush/Psysh/Caster.php
+++ b/lib/Drush/Psysh/Caster.php
@@ -77,4 +77,19 @@ class Caster {
     return $array;
   }
 
+  /**
+   * Casts \Drupal\Component\DependencyInjection\Container classes.
+   */
+  public static function castContainer($container, $array, $stub, $isNested) {
+    if (!$isNested) {
+      $service_ids = $container->getServiceIds();
+      sort($service_ids);
+      foreach ($service_ids as $service_id) {
+        $array[BaseCaster::PREFIX_VIRTUAL . $service_id] = get_class($container->get($service_id));
+      }
+    }
+
+    return $array;
+  }
+
 }

--- a/lib/Drush/Psysh/Caster.php
+++ b/lib/Drush/Psysh/Caster.php
@@ -85,7 +85,8 @@ class Caster {
       $service_ids = $container->getServiceIds();
       sort($service_ids);
       foreach ($service_ids as $service_id) {
-        $array[BaseCaster::PREFIX_VIRTUAL . $service_id] = get_class($container->get($service_id));
+        $service = $container->get($service_id);
+        $array[BaseCaster::PREFIX_VIRTUAL . $service_id] = is_object($service) ? get_class($service) : $service;
       }
     }
 


### PR DESCRIPTION
Quick attempt for a container caster. This is not ideal, as we have to get every service... Better than nothing, and probably better than just showing the service IDs.

If you just want the service IDs you can run the devel `devel-container-services` (dcs) command.