### PR TITLE
Fix fatal error on old Drupal core betas (update.post_update_registry service)

### DIFF
--- a/commands/core/drupal/update.inc
+++ b/commands/core/drupal/update.inc
@@ -113,7 +113,12 @@ function update_main() {
   $pending = update_get_update_list();
 
   // Pending hook_post_update_X() implementations.
-  $post_updates = \Drupal::service('update.post_update_registry')->getPendingUpdateInformation();
+  try {
+    $post_updates = \Drupal::service('update.post_update_registry')->getPendingUpdateInformation();
+  }
+  catch (\Exception $e) {
+    $post_updates = array();
+  }
 
   $start = array();
 
@@ -206,7 +211,12 @@ function drush_update_batch() {
   }
 
   // Apply post update hooks.
-  $post_updates = \Drupal::service('update.post_update_registry')->getPendingUpdateFunctions();
+  try {
+    $post_updates = \Drupal::service('update.post_update_registry')->getPendingUpdateFunctions();
+  }
+  catch (\Exception $e) {
+    $post_updates = array();
+  }
   if ($post_updates) {
     $operations[] = ['drush_drupal_cache_clear_all', []];
     foreach ($post_updates as $function) {


### PR DESCRIPTION
Hello!

Drupal 8 is released and it's time to update beta installations all over the world :wink: 

Today I updated beta10 to 8.0.0
The process was not that easy. I used beta2beta module, and I had to update it step-by-step first: beta10 > 11 > 12 > 13 > 14 > beta15 > 8.0.0

On early beta updates, I got a fatal error: `You have requested a non-existent service "update.post_update_registry".`

I simply wrapped `\Drupal::service('update.post_update_registry')` with a try/catch block, and then it worked fine. Can we have this committed?