### PR TITLE
Fixes #1827: Download Console_Table from GitHub rather than Pear.

### DIFF
--- a/commands/pm/release_info/updatexml.inc
+++ b/commands/pm/release_info/updatexml.inc
@@ -211,7 +211,7 @@ function release_info_print_releasenotes($requests, $print_status = TRUE, $tmpfi
       $xml = simplexml_import_dom($dom);
 
       // Extract last update time and the notes.
-      $last_updated = $xml->xpath('//div[@class="last-updated"]');
+      $last_updated = $xml->xpath('//div[contains(@class,"views-field-changed")]');
       $last_updated = $last_updated[0]->asXML();
       $notes = $xml->xpath('//div[contains(@class,"field-name-body")]');
       $notes = $notes[0]->asXML();
@@ -220,7 +220,7 @@ function release_info_print_releasenotes($requests, $print_status = TRUE, $tmpfi
       $header = array();
       $header[] = '<hr>';
       $header[] = dt("> RELEASE NOTES FOR '!name' PROJECT, VERSION !version:", array('!name' => strtoupper($name), '!version' => $version));
-      $header[] = dt("> !last_updated.", array('!last_updated' => $last_updated));
+      $header[] = dt("> !last_updated.", array('!last_updated' => trim(drush_html_to_text($last_updated))));
       if ($print_status) {
         $header[] = '> ' . implode(', ', $project['releases'][$version]['release_status']);
        }

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -13,12 +13,12 @@
 /**
  * Supported version of Console Table. This is displayed in the manual install help.
  */
-define('DRUSH_TABLE_VERSION', '1.1.3');
+define('DRUSH_TABLE_VERSION', '1.1.5');
 
 /**
  * Base URL for automatic file download of PEAR packages.
  */
-define('DRUSH_PEAR_BASE_URL', 'http://download.pear.php.net/package/');
+define('CONSOLE_TABLE_BASE_URL', 'https://github.com/RobLoach/Console_Table/archive/');
 
 /**
  * Log PHP errors to the Drush log. This is in effect until Drupal's error
@@ -147,7 +147,7 @@ function drush_environment_table_lib() {
       }
 
       // Download and extract Console_Table, and confirm success.
-      if (drush_lib_fetch(DRUSH_PEAR_BASE_URL . 'Console_Table-' . DRUSH_TABLE_VERSION . '.tgz')) {
+      if (drush_lib_fetch(CONSOLE_TABLE_BASE_URL . DRUSH_TABLE_VERSION . '.tar.gz')) {
         // Remove unneccessary package.xml file which ends up in /lib.
         drush_op('unlink', $lib . '/package.xml');
       }

--- a/tests/pmReleaseNotesTest.php
+++ b/tests/pmReleaseNotesTest.php
@@ -14,7 +14,7 @@ class pmReleaseNotesCase extends Drush_CommandTestCase {
     $expected = <<< EXPECTED
 ------------------------------------------------------------------------------
 > RELEASE NOTES FOR 'DRUPAL' PROJECT, VERSION 7.1:
-> Last updated: May 25, 2011 - 20:21 .
+> Last updated:  May 25, 2011 - 20:59.
 > Security
 ------------------------------------------------------------------------------
 EXPECTED;


### PR DESCRIPTION
This will make the installation of the Drush 6.x branch dependent on GitHub rather than Pear.  This will hopefully be an improvement.

Note that the oldest version of the Console Table available on GitHub is 1.1.5, so I used that. Previously, we were using 1.1.3.