### PR TITLE
Fix for PHP 5.3.3.

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -114,7 +114,7 @@ function drush_get_class($class_name, $constructor_args = array(), $variations =
       $variant_class_name = $class_name . implode('', array_slice($variations, 0, $i));
       if (class_exists($variant_class_name)) {
         $reflectionClass = new ReflectionClass($variant_class_name);
-        return $reflectionClass->newInstanceArgs($constructor_args);
+        return !empty($constructor_args) ? $reflectionClass->newInstanceArgs($constructor_args) : $reflectionClass->newInstanceArgs();
       }
     }
   }


### PR DESCRIPTION
fix for "Exception 'ReflectionException' with message 'Class Drush\Sql\Sql7 does not have a constructor, so you cannot pass any constructor arguments"