### PR TITLE
Disable zend assertions in the shell for PHP7

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -44,6 +44,10 @@ function drush_cli_core_cli() {
   $shell = new Shell($configuration);
 
   if ($drupal_major_version >= 8) {
+    // Disable zend assertions (on by default). As this will show warnings when
+    // exiting the shell. The below call to Handle::register() will enable
+    // regular assertions.
+    ini_set('zend.assertions', 0);
     // Register the assertion handler so exceptions are thrown instead of errors
     // being triggered. This plays nicer with PsySH.
     Handle::register();


### PR DESCRIPTION
The warning about serializing the container is back when exiting the shell when using PHP7. This happens if zend assertions are enabled, which is the default setting. The Handle::register() enables assertion exceptions. Core might want to make some tweaks to how this is handled in the register() method.

I think it does not matter if we set this ini setting regardless. Lower versions (PHP5) will just not care about it. Otherwise, we could check `PHP_MAJOR_VERSION`.
