### PR TITLE
Refactored make_move_build

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -731,6 +731,30 @@ function make_move_build($build_path) {
       }
     }
 
+    // Libraries don't need special sauce.
+    // Support the following paths
+    //  - sites/xyz/libraries
+    //  - profiles/profilename/libraries
+    $info_lib = glob($tmp_path . DIRECTORY_SEPARATOR . '__build__' . '/*\/*/libraries/*', GLOB_ONLYDIR);
+    foreach ($info_lib as $dir) {
+      $destination = $build_path . str_replace($tmp_path . DIRECTORY_SEPARATOR . '__build__', '', $dir);
+      if (is_dir($destination)) {
+        $overwrite = drush_get_option('overwrite', FALSE) ? FILE_EXISTS_OVERWRITE : FILE_EXISTS_MERGE;
+        if ($overwrite) {
+          $files = drush_scan_directory($dir, '/./', array('.', '..'), 0, FALSE);
+          foreach ($files as $file) {
+            $ret = $ret && drush_copy_dir($file->filename, $destination . DIRECTORY_SEPARATOR . $file->basename, $overwrite);
+          }
+        }
+        else {
+          $ret = $ret && drush_copy_dir($dir, $destination);
+        }
+      }
+      else {
+        $ret = $ret && drush_copy_dir($dir, $destination);
+      }
+    }
+
   }
   else {
     drush_mkdir(dirname($build_path));

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -682,10 +682,23 @@ function make_move_build($build_path) {
 
       // Loop through the parts looking for key folder names.
       foreach ($path_parts as $key => $part) {
-        // If the current path part is not a key folder directory we can just continue.
+
+        // If the current path part is not a key directory we can just continue.
         if (!in_array($part, $directory_keys)) {
           continue;
         }
+
+        // Because we can have a profile, theme, library, module, or just empty folder with the same names we need to
+        // Check to see if our found key contains the .info file.
+        $check_parts = array_slice($path_parts, 0, $key + 1);
+        $path = implode(DIRECTORY_SEPARATOR, $check_parts);
+        $full_path = $path . DIRECTORY_SEPARATOR . $path_parts[$key] . ".info";
+
+        // The info file we are looking for is not here.
+        if (!is_file($full_path)) {
+          continue;
+        }
+
         // We found part of the path in the keys. Log its depth. Keying with the part name as it is possible to have
         // nested directories of the same name.
         $found[$part] = $key;

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -663,28 +663,51 @@ function make_move_build($build_path) {
   $tmp_path = make_tmp();
   $ret = TRUE;
   if ($build_path == '.' || (drush_get_option('no-core', FALSE) && file_exists($build_path))) {
-    $info = drush_scan_directory($tmp_path . DIRECTORY_SEPARATOR . '__build__', '/./', array('.', '..'), 0, FALSE, 'filename', 0, TRUE);
-    foreach ($info as $file) {
-      $destination = $build_path . DIRECTORY_SEPARATOR . $file->basename;
-      if (file_exists($destination)) {
-        // To prevent the removal of top-level directories such as 'modules' or
-        // 'themes', descend in a level if the file exists.
-        // TODO: This only protects one level of directories from being removed.
-        $overwrite = drush_get_option('overwrite', FALSE) ? FILE_EXISTS_OVERWRITE : FILE_EXISTS_MERGE;
-        if (is_dir($destination)) {
-          $files = drush_scan_directory($file->filename, '/./', array('.', '..'), 0, FALSE);
-          foreach ($files as $file) {
-            $ret = $ret && drush_copy_dir($file->filename, $destination . DIRECTORY_SEPARATOR . $file->basename, $overwrite);
-          }
+
+    // All modules/themes/profiles must have a .info file right? Right?
+    $info = drush_scan_directory($tmp_path . DIRECTORY_SEPARATOR . '__build__', '/.\.info/', array('.', '..'), 0, TRUE, 'name', 0, TRUE);
+
+    // Keys to directory names.
+    $directory_keys = array_keys($info);
+
+    // Top level modules.
+    $tlm = array();
+
+    // Because some modules can contain other modules with .info files we need to do some more clean up of the dir scan.
+    // Iterate through the directory paths and weed out ones that have a parent path that contains a .info file.
+    foreach ($info as $file_info) {
+      // Break up the parts of the path.
+      $path_parts = explode(DIRECTORY_SEPARATOR, dirname($file_info->filename));
+      $found = array();
+
+      // Loop through the parts looking for key folder names.
+      foreach ($path_parts as $key => $part) {
+        // If the current path part is not a key folder directory we can just continue.
+        if (!in_array($part, $directory_keys)) {
+          continue;
         }
-        else {
-          $ret = $ret && drush_copy_dir($file->filename, $destination, $overwrite);
-        }
+        // We found part of the path in the keys. Log its depth. Keying with the part name as it is possible to have
+        // nested directories of the same name.
+        $found[$part] = $key;
       }
-      else {
-        $ret = $ret && drush_copy_dir($file->filename, $destination);
+
+      // The top most directory index found.
+      $min = !empty($found) ? min($found) : 0;
+      if (array_search($file_info->name, $path_parts) == $min) {
+        // If this file is the closest to the top of the directory tree add it.
+        $tlm[$file_info->name] = $file_info;
       }
     }
+
+    // Recursively iterate through the directory tree so we are only overwriting the directories that are available
+    // and not removing items outside of what is being built to. We only want to go as deep as the top level modules
+    // (TLM) identified above.
+    $overwrite = drush_get_option('overwrite', FALSE) ? FILE_EXISTS_OVERWRITE : FILE_EXISTS_MERGE;
+    foreach ($tlm as $project_key => $file) {
+      $destination = $build_path . DIRECTORY_SEPARATOR . dirname(str_replace($tmp_path . "/__build__/", "", dirname($file->filename))) . DIRECTORY_SEPARATOR . $file->name;
+      $ret = $ret && drush_copy_dir(dirname($file->filename), $destination, $overwrite);
+    }
+
   }
   else {
     drush_mkdir(dirname($build_path));
@@ -702,7 +725,33 @@ function make_move_build($build_path) {
   if (!$ret) {
     return drush_set_error('MAKE_CANNOT_MOVE_BUILD', dt("Cannot move build into place."));
   }
+
   return $ret;
+
+  // if ($build_path == '.' || (drush_get_option('no-core', FALSE) && file_exists($build_path))) {
+  //   $info = drush_scan_directory($tmp_path . DIRECTORY_SEPARATOR . '__build__', '/./', array('.', '..'), 0, FALSE, 'filename', 0, TRUE);
+  //   foreach ($info as $file) {
+  //     $destination = $build_path . DIRECTORY_SEPARATOR . $file->basename;
+  //     if (file_exists($destination)) {
+  //       // To prevent the removal of top-level directories such as 'modules' or
+  //       // 'themes', descend in a level if the file exists.
+  //       // TODO: This only protects one level of directories from being removed.
+  //       $overwrite = drush_get_option('overwrite', FALSE) ? FILE_EXISTS_OVERWRITE : FILE_EXISTS_MERGE;
+  //       if (is_dir($destination)) {
+  //         $files = drush_scan_directory($file->filename, '/./', array('.', '..'), 0, FALSE);
+  //         foreach ($files as $file) {
+  //           $ret = $ret && drush_copy_dir($file->filename, $destination . DIRECTORY_SEPARATOR . $file->basename, $overwrite);
+  //         }
+  //       }
+  //       else {
+  //         $ret = $ret && drush_copy_dir($file->filename, $destination, $overwrite);
+  //       }
+  //     }
+  //     else {
+  //       $ret = $ret && drush_copy_dir($file->filename, $destination);
+  //     }
+  //   }
+  // }
 }
 
 /**

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -717,7 +717,11 @@ function make_move_build($build_path) {
     // (TLM) identified above.
     $overwrite = drush_get_option('overwrite', FALSE) ? FILE_EXISTS_OVERWRITE : FILE_EXISTS_MERGE;
     foreach ($tlm as $project_key => $file) {
-      $destination = $build_path . DIRECTORY_SEPARATOR . dirname(str_replace($tmp_path . "/__build__/", "", dirname($file->filename))) . DIRECTORY_SEPARATOR . $file->name;
+      // Todo: This needs to be cleaned up.
+      $destination = $build_path . DIRECTORY_SEPARATOR;
+      $sub_dest = str_replace($tmp_path . "/__build__/", "", $file->filename);
+      $sub_dest_clean = str_replace($file->basename, "", $sub_dest);
+      $destination .= $sub_dest_clean;
       $ret = $ret && drush_copy_dir(dirname($file->filename), $destination, $overwrite);
     }
 

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -726,7 +726,7 @@ function make_move_build($build_path) {
         $ret = $ret && drush_copy_dir(dirname($file->filename), $destination, $overwrite);
       }
       else {
-        drush_mkdir($destination);
+        drush_mkdir(dirname($destination));
         $ret = $ret && drush_copy_dir(dirname($file->filename), $destination);
       }
     }

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -740,31 +740,6 @@ function make_move_build($build_path) {
   }
 
   return $ret;
-
-  // if ($build_path == '.' || (drush_get_option('no-core', FALSE) && file_exists($build_path))) {
-  //   $info = drush_scan_directory($tmp_path . DIRECTORY_SEPARATOR . '__build__', '/./', array('.', '..'), 0, FALSE, 'filename', 0, TRUE);
-  //   foreach ($info as $file) {
-  //     $destination = $build_path . DIRECTORY_SEPARATOR . $file->basename;
-  //     if (file_exists($destination)) {
-  //       // To prevent the removal of top-level directories such as 'modules' or
-  //       // 'themes', descend in a level if the file exists.
-  //       // TODO: This only protects one level of directories from being removed.
-  //       $overwrite = drush_get_option('overwrite', FALSE) ? FILE_EXISTS_OVERWRITE : FILE_EXISTS_MERGE;
-  //       if (is_dir($destination)) {
-  //         $files = drush_scan_directory($file->filename, '/./', array('.', '..'), 0, FALSE);
-  //         foreach ($files as $file) {
-  //           $ret = $ret && drush_copy_dir($file->filename, $destination . DIRECTORY_SEPARATOR . $file->basename, $overwrite);
-  //         }
-  //       }
-  //       else {
-  //         $ret = $ret && drush_copy_dir($file->filename, $destination, $overwrite);
-  //       }
-  //     }
-  //     else {
-  //       $ret = $ret && drush_copy_dir($file->filename, $destination);
-  //     }
-  //   }
-  // }
 }
 
 /**

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -722,7 +722,13 @@ function make_move_build($build_path) {
       $sub_dest = str_replace($tmp_path . "/__build__/", "", $file->filename);
       $sub_dest_clean = str_replace($file->basename, "", $sub_dest);
       $destination .= $sub_dest_clean;
-      $ret = $ret && drush_copy_dir(dirname($file->filename), $destination, $overwrite);
+      if (file_exists($destination)) {
+        $ret = $ret && drush_copy_dir(dirname($file->filename), $destination, $overwrite);
+      }
+      else {
+        drush_mkdir($destination);
+        $ret = $ret && drush_copy_dir(dirname($file->filename), $destination);
+      }
     }
 
   }


### PR DESCRIPTION
Changed the logic of the make_move_build command so that it recursively merges or overwrites builds when using the --no-core option. 
