### PR TITLE
Speed up pm-download a lot by trying to rename tmp dir into place

### DIFF
--- a/commands/pm/download.pm.inc
+++ b/commands/pm/download.pm.inc
@@ -215,7 +215,7 @@ function drush_pm_download() {
     }
 
     // Copy the project to the install location.
-    if (drush_op('_drush_recursive_copy', $request['full_project_path'], $request['project_install_location'])) {
+    if (drush_op('drush_move_dir', $request['full_project_path'], $request['project_install_location'])) {
       drush_log(dt("Project !project (!version) downloaded to !dest.", array('!project' => $request['name'], '!version' => $release['version'], '!dest' => $request['project_install_location'])), LogLevel::SUCCESS);
       // Adjust full_project_path to the final project location.
       $request['full_project_path'] = $request['project_install_location'];


### PR DESCRIPTION
Still uses copy as a fallback plan, since drush_move_dir already does that.
