### PR TITLE
Add a --config parameter to import config after install.

### DIFF
--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -85,6 +85,7 @@ function site_install_drush_help_alter(&$command) {
     else {
       unset($command['options']['writable']);
       unset($command['options']['keep-config']);
+      unset($command['options']['config']);
     }
   }
 }

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -57,7 +57,7 @@ function site_install_drush_command() {
       ),
       'writable' => 'Make CMI and other dirs writable by both web and CLI users. Suitable for non Prod environments.',
       'keep-config' => 'Keep CMI directories untouched. This preserves existing configuration.',
-      'config' => 'After installation, override all configuration and UUIDs that were generated during installation with config from this file path.'
+      'config' => 'Update site UUID and then import configuration from this path.'
     ),
     'examples' => array(
       'drush site-install expert --locale=uk' => '(Re)install using the expert install profile. Set default language to Ukrainian.',
@@ -104,11 +104,11 @@ function drush_core_site_install_validate() {
     drush_set_context('DRUSH_SELECTED_URI', 'http://' . $sites_subdir);
   }
 
-  if ($source = drush_get_option('config')) {
-    if (!file_exists($source)) {
+  if ($config = drush_get_option('config')) {
+    if (!file_exists($config)) {
       return drush_set_error('config_import_target', 'The config source directory does not exist.');
     }
-    if (!is_dir($source)) {
+    if (!is_dir($config)) {
       return drush_set_error('config_import_target', 'The config source is not a directory.');
     }
   }

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -1,6 +1,7 @@
 <?php
 
 use Drush\Log\LogLevel;
+use Drupal\Core\Config\FileStorage;
 
 function site_install_drush_command() {
   $items['site-install'] = array(
@@ -55,7 +56,8 @@ function site_install_drush_command() {
         'example-value' => 'directory_name',
       ),
       'writable' => 'Make CMI and other dirs writable by both web and CLI users. Suitable for non Prod environments.',
-      'keep-config' => 'Keep CMI directories untouched. This preserves existing configuration.'
+      'keep-config' => 'Keep CMI directories untouched. This preserves existing configuration.',
+      'config' => 'After installation, override all configuration and UUIDs that were generated during installation with config from this file path.'
     ),
     'examples' => array(
       'drush site-install expert --locale=uk' => '(Re)install using the expert install profile. Set default language to Ukrainian.',
@@ -99,6 +101,15 @@ function drush_core_site_install_validate() {
     }
     // Make sure that we will bootstrap to the 'sites-subdir' site.
     drush_set_context('DRUSH_SELECTED_URI', 'http://' . $sites_subdir);
+  }
+
+  if ($source = drush_get_option('config')) {
+    if (!file_exists($source)) {
+      return drush_set_error('config_import_target', 'The config source directory does not exist.');
+    }
+    if (!is_dir($source)) {
+      return drush_set_error('config_import_target', 'The config source is not a directory.');
+    }
   }
 }
 
@@ -289,4 +300,13 @@ function drush_core_site_install($profile = NULL) {
   }
   drush_include_engine('drupal', 'site_install');
   drush_core_site_install_version($profile, $form_options);
+
+  // Post installation run the configuration import.
+  if ($config = drush_get_option('config')) {
+    // Set the destination site UUID to match the source UUID, to bypass a core fail-safe.
+    $source_storage = new FileStorage($config);
+    drush_op('drush_config_set', 'system.site', 'uuid', $source_storage->read('system.site')['uuid']);
+    // Run a full configuration import.
+    drush_invoke_process('@self', 'config-import', array(), array('source' => $config));
+  }
 }

--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -298,6 +298,12 @@ function drush_core_site_install($profile = NULL) {
       $form_options[$key] = $value;
     }
   }
+
+  // If the profile is not explicitly set, default to the 'minimal' for an issue-free config import.
+  if (empty($profile) && drush_get_option('config')) {
+    $profile = 'minimal';
+  }
+
   drush_include_engine('drupal', 'site_install');
   drush_core_site_install_version($profile, $form_options);
 


### PR DESCRIPTION
Passing  a --config parameter (eg. `drush site-install --config=path/to/config`) triggers the equivalent of a `drush config-import --source=path/to/config` after the installation is complete.

This is all-or-nothing, any UUIDs generated during the site installation will be overwritten, any config created during the installation that is not represented in the --config directory will be deleted.

A use case for feature is CI/testing where the source directory contains a known set of configuration to be tested.

For history of this feature see drush-ops/drush#1635