### PR TITLE
#1493 - override alias records with cli context options

### DIFF
--- a/includes/command.inc
+++ b/includes/command.inc
@@ -700,7 +700,12 @@ function drush_redispatch_get_options() {
   $global_option_list = drush_get_global_options(FALSE);
   foreach (drush_get_context('alias') as $key => $value) {
     if (array_key_exists($key, $global_option_list)) {
-      $options[$key] = $value;
+      if (isset($cli_context[$key])) {
+        $options[$key] = $cli_context[$key];
+      }
+      else {
+        $options[$key] = $value;
+      }
     }
   }
 


### PR DESCRIPTION
First stab at fixing the issue where command line arguments (especially --uri) can't override site aliases. 