### PR TITLE
Add dependency injection container to Drush.

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -80,7 +80,7 @@ function drush_cli_core_cli() {
   // command in preflight still, but the subscriber instances are already
   // created from before. Call terminate() regardless, this is a no-op for all
   // DrupalBoot classes except DrupalBoot8.
-  if ($bootstrap = drush_get_bootstrap_object()) {
+  if ($bootstrap = \Drush::getBootstrap()) {
     $bootstrap->terminate();
   }
 

--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -499,7 +499,7 @@ function _core_site_credentials($right_margin = 0) {
 function _core_path_aliases($project = '') {
   $paths = array();
   $site_wide = drush_drupal_sitewide_directory();
-  $boot = drush_get_bootstrap_object();
+  $boot = \Drush::getBootstrap();
   if ($drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT')) {
     $paths['%root'] = $drupal_root;
     if ($site_root = drush_get_context('DRUSH_DRUPAL_SITE_ROOT')) {
@@ -580,7 +580,7 @@ function _core_site_status_table($project = '') {
         $status_table['db-name'] = isset($db_spec['database']) ? $db_spec['database'] : NULL;
         $status_table['db-port'] = isset($db_spec['port']) ? $db_spec['port'] : NULL;
         if ($phase > DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION) {
-          $boot_object = drush_get_bootstrap_object();
+          $boot_object = \Drush::getBootstrap();
           $status_table['install-profile'] = $boot_object->get_profile();
           if ($phase > DRUSH_BOOTSTRAP_DRUPAL_FULL) {
             $status_table['bootstrap'] = dt('Successful');
@@ -986,7 +986,7 @@ function drush_core_quick_drupal() {
       // Current CLI user is also the web server user, which is for development
       // only. Hence we can safely make the site directory writable. This makes
       // it easier to delete and edit settings.php.
-      $boot = drush_get_bootstrap_object();
+      $boot = \Drush::getBootstrap();
       @chmod($boot->conf_path(), 0700);
       drush_invoke('runserver', array($server));
     }
@@ -1341,7 +1341,7 @@ function drush_core_twig_compile() {
   require_once DRUSH_DRUPAL_CORE . "/themes/engines/twig/twig.engine";
   // Scan all enabled modules and themes.
   // @todo Refactor to not reuse commandfile paths directly.
-  $boot = drush_get_bootstrap_object();
+  $boot = \Drush::getBootstrap();
   $searchpaths = $boot->commandfile_searchpaths(DRUSH_BOOTSTRAP_DRUPAL_FULL);
   $searchpaths[] = drupal_get_path('theme', drush_theme_get_default());;
   $searchpaths[] = drupal_get_path('theme', drush_theme_get_admin());

--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -887,7 +887,7 @@ function drush_core_quick_drupal() {
   drush_set_option('strict', FALSE); // We fail option validation because do so much internal drush_invoke().
   $makefile = drush_get_option('makefile');
   if (drush_get_option('use-existing', FALSE)) {
-    $root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $root = \Drush::bootstrapManager()->getRoot();
     if (!$root) {
       return drush_set_error('QUICK_DRUPAL_NO_ROOT_SPECIFIED', 'Must specify site with --root when using --use-existing.');
     }
@@ -943,9 +943,9 @@ function drush_core_quick_drupal() {
     drush_set_option('db-url', 'sqlite://' . $base . '/sites/' . strtolower(drush_get_option('sites-subdir', 'default')) . "/$name.sqlite");
   }
   // We have just created a site root where one did not exist before.
-  // We therefore must manually reset DRUSH_SELECTED_DRUPAL_ROOT to
+  // We therefore must manually reset the selected root to
   // our new root, and force a bootstrap to DRUSH_BOOTSTRAP_DRUPAL_ROOT.
-  drush_set_context('DRUSH_SELECTED_DRUPAL_ROOT', $root);
+  \Drush::bootstrapManager()->setRoot($root);
   if (!drush_bootstrap_to_phase(DRUSH_BOOTSTRAP_DRUPAL_ROOT)) {
     return drush_set_error('QUICK_DRUPAL_ROOT_LOCATE_FAIL', 'Unable to locate Drupal root directory.');
   }
@@ -1302,7 +1302,7 @@ function drush_core_execute() {
   $cmd = implode(' ', $args);
   // If we selected a Drupal site, then cwd to the site root prior to exec
   $cwd = FALSE;
-  if ($selected_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT')) {
+  if ($selected_root = \Drush::bootstrapManager()->getRoot()) {
     if (is_dir($selected_root)) {
       $cwd = getcwd();
       drush_op('chdir', $selected_root);

--- a/commands/core/drupal/environment.inc
+++ b/commands/core/drupal/environment.inc
@@ -198,7 +198,7 @@ function drush_module_enable($modules) {
   drush_module_install($modules);
 
   // Our logger got blown away during the container rebuild above.
-  $boot = drush_select_bootstrap_class();
+  $boot = \Drush::bootstrapManager()->getBootstrap();
   $boot->add_logger();
 
   // Flush all caches. No longer needed in D8 per https://github.com/drush-ops/drush/issues/1207
@@ -226,7 +226,7 @@ function drush_module_disable($modules) {
 function drush_module_uninstall($modules) {
   \Drupal::service('module_installer')->uninstall($modules);
   // Our logger got blown away during the container rebuild above.
-  $boot = drush_select_bootstrap_class();
+  $boot = \Drush::bootstrapManager()->getBootstrap();
   $boot->add_logger();
 }
 
@@ -319,7 +319,7 @@ function drush_theme_disable($themes) {
 function drush_theme_uninstall($themes) {
   \Drupal::service('theme_handler')->uninstall($themes);
   // Our logger got blown away during the container rebuild above.
-  $boot = drush_select_bootstrap_class();
+  $boot = \Drush::bootstrapManager()->getBootstrap();
   $boot->add_logger();
 }
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,10 @@
   "autoload": {
     "psr-0": {
       "Drush":        "lib/"
-    }
+    },
+    "files": [
+      "lib/Drush.php"
+    ]
   },
   "autoload-dev": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,23 @@
       "Drush":        "lib/"
     },
     "files": [
-      "lib/Drush.php"
+      "lib/Drush.php",
+      "includes/startup.inc",
+      "includes/bootstrap.inc",
+      "includes/environment.inc",
+      "includes/command.inc",
+      "includes/drush.inc",
+      "includes/engines.inc",
+      "includes/backend.inc",
+      "includes/batch.inc",
+      "includes/context.inc",
+      "includes/sitealias.inc",
+      "includes/exec.inc",
+      "includes/drupal.inc",
+      "includes/output.inc",
+      "includes/cache.inc",
+      "includes/filesystem.inc",
+      "includes/dbtng.inc"
     ]
   },
   "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     "psy/psysh": "~0.6",
     "symfony/yaml": "2.7.*",
     "symfony/var-dumper": "^2.6.3",
-    "symfony/dependency-injection": "*",
-    "symfony/config": "*",
+    "symfony/dependency-injection": "2.7.*",
+    "symfony/config": "~2.2",
     "pear/console_table": "~1.2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "psy/psysh": "~0.6",
     "symfony/yaml": "2.7.*",
     "symfony/var-dumper": "^2.6.3",
-    "symfony/dependency-injection": "2.7.*",
+    "symfony/dependency-injection": "2.7.6",
     "symfony/config": "~2.2",
     "pear/console_table": "~1.2.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "psy/psysh": "~0.6",
     "symfony/yaml": "2.7.*",
     "symfony/var-dumper": "^2.6.3",
-    "symfony/dependency-injection": "2.7.6",
+    "symfony/dependency-injection": "2.7.*",
     "symfony/config": "~2.2",
     "pear/console_table": "~1.2.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -51,23 +51,7 @@
       "Drush":        "lib/"
     },
     "files": [
-      "lib/Drush.php",
-      "includes/startup.inc",
-      "includes/bootstrap.inc",
-      "includes/environment.inc",
-      "includes/command.inc",
-      "includes/drush.inc",
-      "includes/engines.inc",
-      "includes/backend.inc",
-      "includes/batch.inc",
-      "includes/context.inc",
-      "includes/sitealias.inc",
-      "includes/exec.inc",
-      "includes/drupal.inc",
-      "includes/output.inc",
-      "includes/cache.inc",
-      "includes/filesystem.inc",
-      "includes/dbtng.inc"
+      "lib/Drush.php"
     ]
   },
   "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,8 @@
     "psy/psysh": "~0.6",
     "symfony/yaml": "2.7.*",
     "symfony/var-dumper": "^2.6.3",
+    "symfony/dependency-injection": "*",
+    "symfony/config": "*",
     "pear/console_table": "~1.2.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5483a9ed6ab914076b7aa8305d7b1903",
-    "content-hash": "32fceb4a785595b4e40cf4e602703132",
+    "hash": "8435c9eb245e5b5ad0e26c7d7ef6e8f9",
+    "content-hash": "7092f159ce3306251aa9f5440b18d233",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -455,16 +455,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.7.6",
+            "version": "v2.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "af284e795ec8a08c80d1fc47518fd23004b89847"
+                "reference": "7a201bf08c29e47075047cbb378724ad46dfe217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/af284e795ec8a08c80d1fc47518fd23004b89847",
-                "reference": "af284e795ec8a08c80d1fc47518fd23004b89847",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/7a201bf08c29e47075047cbb378724ad46dfe217",
+                "reference": "7a201bf08c29e47075047cbb378724ad46dfe217",
                 "shasum": ""
             },
             "require": {
@@ -492,7 +492,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\DependencyInjection\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -510,7 +513,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-27 15:38:06"
+            "time": "2015-11-23 10:17:36"
         },
         {
             "name": "symfony/filesystem",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "160e694a860dd8b012104bae69cd2d75",
-    "content-hash": "345215a79dc35e20c5858b0a05b0aba6",
+    "hash": "afef9aa9d988aad79812fb0e143ea9ca",
+    "content-hash": "01111258a3e0b2304ddc2d01e11c7082",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -129,32 +129,38 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v1.4.1",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51"
+                "reference": "c542e5d86a9775abd1021618eb2430278bfc1e01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51",
-                "reference": "f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c542e5d86a9775abd1021618eb2430278bfc1e01",
+                "reference": "c542e5d86a9775abd1021618eb2430278bfc1e01",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3"
+                "php": ">=5.4"
             },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "lib/bootstrap.php"
-                ]
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -170,7 +176,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2015-09-19 14:15:08"
+            "time": "2015-12-04 15:28:43"
         },
         {
             "name": "pear/console_table",
@@ -338,26 +344,77 @@
             "time": "2015-11-12 16:18:56"
         },
         {
-            "name": "symfony/console",
-            "version": "v2.7.7",
+            "name": "symfony/config",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "16bb1cb86df43c90931df65f529e7ebd79636750"
+                "url": "https://github.com/symfony/config.git",
+                "reference": "40bae8658dbbb500ebc19aa9fde22dc4295fc290"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/16bb1cb86df43c90931df65f529e7ebd79636750",
-                "reference": "16bb1cb86df43c90931df65f529e7ebd79636750",
+                "url": "https://api.github.com/repos/symfony/config/zipball/40bae8658dbbb500ebc19aa9fde22dc4295fc290",
+                "reference": "40bae8658dbbb500ebc19aa9fde22dc4295fc290",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9",
+                "symfony/filesystem": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-11-02 20:34:04"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "175871ca8d1ef16ff8d8cac395a1c73afa8d0e63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/175871ca8d1ef16ff8d8cac395a1c73afa8d0e63",
+                "reference": "175871ca8d1ef16ff8d8cac395a1c73afa8d0e63",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1",
-                "symfony/process": "~2.1"
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -367,7 +424,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -394,24 +451,192 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-18 09:54:26"
+            "time": "2015-11-30 12:36:17"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v2.7.7",
+            "name": "symfony/dependency-injection",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "72bcb27411780eaee9469729aace73c0d46fb2b8"
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "b8e19bafc334ee0a9edca028b666f4cd3bba2233"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/72bcb27411780eaee9469729aace73c0d46fb2b8",
-                "reference": "72bcb27411780eaee9469729aace73c0d46fb2b8",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b8e19bafc334ee0a9edca028b666f4cd3bba2233",
+                "reference": "b8e19bafc334ee0a9edca028b666f4cd3bba2233",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "symfony/config": "~2.8|~3.0",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/yaml": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-11-30 08:18:52"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "692d98d813e4ef314b9c22775c86ddbeb0f44884"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/692d98d813e4ef314b9c22775c86ddbeb0f44884",
+                "reference": "692d98d813e4ef314b9c22775c86ddbeb0f44884",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-11-23 10:41:47"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "0b6a8940385311a24e060ec1fe35680e17c74497"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0b6a8940385311a24e060ec1fe35680e17c74497",
+                "reference": "0b6a8940385311a24e060ec1fe35680e17c74497",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2015-11-04 20:28:58"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "e6f3855005f2bfad7d7e72431d374a6478893fe3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e6f3855005f2bfad7d7e72431d374a6478893fe3",
+                "reference": "e6f3855005f2bfad7d7e72431d374a6478893fe3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "twig/twig": "~1.20|~2.0"
             },
             "suggest": {
                 "ext-symfony_debug": ""
@@ -419,7 +644,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -453,7 +678,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2015-11-18 13:41:01"
+            "time": "2015-11-18 13:45:00"
         },
         {
             "name": "symfony/yaml",
@@ -911,16 +1136,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.18",
+            "version": "4.8.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fa33d4ad96481b91df343d83e8c8aabed6b1dfd3"
+                "reference": "ea76b17bced0500a28098626b84eda12dbcf119c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fa33d4ad96481b91df343d83e8c8aabed6b1dfd3",
-                "reference": "fa33d4ad96481b91df343d83e8c8aabed6b1dfd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea76b17bced0500a28098626b84eda12dbcf119c",
+                "reference": "ea76b17bced0500a28098626b84eda12dbcf119c",
                 "shasum": ""
             },
             "require": {
@@ -979,7 +1204,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-11-11 11:32:49"
+            "time": "2015-12-12 07:45:58"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1103,28 +1328,28 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.3.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "~4.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -1147,24 +1372,24 @@
                 }
             ],
             "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
                 "diff"
             ],
-            "time": "2015-02-22 15:13:53"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
+                "reference": "6e7133793a8e5a5714a551a8324337374be209df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6e7133793a8e5a5714a551a8324337374be209df",
+                "reference": "6e7133793a8e5a5714a551a8324337374be209df",
                 "shasum": ""
             },
             "require": {
@@ -1201,7 +1426,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-08-03 06:14:51"
+            "time": "2015-12-02 08:37:27"
         },
         {
             "name": "sebastian/exporter",
@@ -1322,16 +1547,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
                 "shasum": ""
             },
             "require": {
@@ -1371,7 +1596,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-06-21 08:04:50"
+            "time": "2015-11-11 19:50:13"
         },
         {
             "name": "sebastian/version",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "afef9aa9d988aad79812fb0e143ea9ca",
-    "content-hash": "01111258a3e0b2304ddc2d01e11c7082",
+    "hash": "5483a9ed6ab914076b7aa8305d7b1903",
+    "content-hash": "32fceb4a785595b4e40cf4e602703132",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -345,26 +345,26 @@
         },
         {
             "name": "symfony/config",
-            "version": "v3.0.0",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "40bae8658dbbb500ebc19aa9fde22dc4295fc290"
+                "reference": "f21c97aec1b5302d2dc0d17047ea8f4e4ff93aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/40bae8658dbbb500ebc19aa9fde22dc4295fc290",
-                "reference": "40bae8658dbbb500ebc19aa9fde22dc4295fc290",
+                "url": "https://api.github.com/repos/symfony/config/zipball/f21c97aec1b5302d2dc0d17047ea8f4e4ff93aae",
+                "reference": "f21c97aec1b5302d2dc0d17047ea8f4e4ff93aae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
-                "symfony/filesystem": "~2.8|~3.0"
+                "php": ">=5.3.9",
+                "symfony/filesystem": "~2.3|~3.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -391,7 +391,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-02 20:34:04"
+            "time": "2015-11-23 20:38:01"
         },
         {
             "name": "symfony/console",
@@ -455,25 +455,28 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.0.0",
+            "version": "v2.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "b8e19bafc334ee0a9edca028b666f4cd3bba2233"
+                "reference": "af284e795ec8a08c80d1fc47518fd23004b89847"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b8e19bafc334ee0a9edca028b666f4cd3bba2233",
-                "reference": "b8e19bafc334ee0a9edca028b666f4cd3bba2233",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/af284e795ec8a08c80d1fc47518fd23004b89847",
+                "reference": "af284e795ec8a08c80d1fc47518fd23004b89847",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=5.3.9"
+            },
+            "conflict": {
+                "symfony/expression-language": "<2.6"
             },
             "require-dev": {
-                "symfony/config": "~2.8|~3.0",
-                "symfony/expression-language": "~2.8|~3.0",
-                "symfony/yaml": "~2.8|~3.0"
+                "symfony/config": "~2.2",
+                "symfony/expression-language": "~2.6",
+                "symfony/yaml": "~2.1"
             },
             "suggest": {
                 "symfony/config": "",
@@ -483,16 +486,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\DependencyInjection\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -510,7 +510,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-30 08:18:52"
+            "time": "2015-10-27 15:38:06"
         },
         {
             "name": "symfony/filesystem",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8435c9eb245e5b5ad0e26c7d7ef6e8f9",
+    "hash": "ff09ee959d10eaf44f26119eb18bf5e3",
     "content-hash": "7092f159ce3306251aa9f5440b18d233",
     "packages": [
         {
@@ -345,16 +345,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.0",
+            "version": "v2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "f21c97aec1b5302d2dc0d17047ea8f4e4ff93aae"
+                "reference": "17d4b2e64ce1c6ba7caa040f14469b3c44d7f7d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/f21c97aec1b5302d2dc0d17047ea8f4e4ff93aae",
-                "reference": "f21c97aec1b5302d2dc0d17047ea8f4e4ff93aae",
+                "url": "https://api.github.com/repos/symfony/config/zipball/17d4b2e64ce1c6ba7caa040f14469b3c44d7f7d2",
+                "reference": "17d4b2e64ce1c6ba7caa040f14469b3c44d7f7d2",
                 "shasum": ""
             },
             "require": {
@@ -391,20 +391,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-23 20:38:01"
+            "time": "2015-12-26 13:37:56"
         },
         {
             "name": "symfony/console",
-            "version": "v3.0.0",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "175871ca8d1ef16ff8d8cac395a1c73afa8d0e63"
+                "reference": "ebcdc507829df915f4ca23067bd59ee4ef61f6c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/175871ca8d1ef16ff8d8cac395a1c73afa8d0e63",
-                "reference": "175871ca8d1ef16ff8d8cac395a1c73afa8d0e63",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ebcdc507829df915f4ca23067bd59ee4ef61f6c3",
+                "reference": "ebcdc507829df915f4ca23067bd59ee4ef61f6c3",
                 "shasum": ""
             },
             "require": {
@@ -451,20 +451,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-30 12:36:17"
+            "time": "2015-12-22 10:39:06"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.7.7",
+            "version": "v2.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "7a201bf08c29e47075047cbb378724ad46dfe217"
+                "reference": "a8f03d1fc4f9434ee515ba47854f3f93e6728eb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/7a201bf08c29e47075047cbb378724ad46dfe217",
-                "reference": "7a201bf08c29e47075047cbb378724ad46dfe217",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/a8f03d1fc4f9434ee515ba47854f3f93e6728eb7",
+                "reference": "a8f03d1fc4f9434ee515ba47854f3f93e6728eb7",
                 "shasum": ""
             },
             "require": {
@@ -513,20 +513,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-23 10:17:36"
+            "time": "2015-12-26 13:37:43"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.0.0",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "692d98d813e4ef314b9c22775c86ddbeb0f44884"
+                "reference": "c2e59d11dccd135dc8f00ee97f34fe1de842e70c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/692d98d813e4ef314b9c22775c86ddbeb0f44884",
-                "reference": "692d98d813e4ef314b9c22775c86ddbeb0f44884",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c2e59d11dccd135dc8f00ee97f34fe1de842e70c",
+                "reference": "c2e59d11dccd135dc8f00ee97f34fe1de842e70c",
                 "shasum": ""
             },
             "require": {
@@ -562,24 +562,27 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-23 10:41:47"
+            "time": "2015-12-22 10:39:06"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.0.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "0b6a8940385311a24e060ec1fe35680e17c74497"
+                "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0b6a8940385311a24e060ec1fe35680e17c74497",
-                "reference": "0b6a8940385311a24e060ec1fe35680e17c74497",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/49ff736bd5d41f45240cec77b44967d76e0c3d25",
+                "reference": "49ff736bd5d41f45240cec77b44967d76e0c3d25",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
             },
             "type": "library",
             "extra": {
@@ -618,20 +621,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2015-11-04 20:28:58"
+            "time": "2015-11-20 09:19:13"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v2.8.0",
+            "version": "v2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "e6f3855005f2bfad7d7e72431d374a6478893fe3"
+                "reference": "f943f29ae69c42511a2d85adee9d13d835b5c803"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/e6f3855005f2bfad7d7e72431d374a6478893fe3",
-                "reference": "e6f3855005f2bfad7d7e72431d374a6478893fe3",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/f943f29ae69c42511a2d85adee9d13d835b5c803",
+                "reference": "f943f29ae69c42511a2d85adee9d13d835b5c803",
                 "shasum": ""
             },
             "require": {
@@ -681,20 +684,20 @@
                 "debug",
                 "dump"
             ],
-            "time": "2015-11-18 13:45:00"
+            "time": "2015-12-05 11:09:21"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.7",
+            "version": "v2.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "4cfcd7a9fceba662b3c036b7d9a91f6197af046c"
+                "reference": "1d96518eb7775ba42704652dff32269236c5adb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/4cfcd7a9fceba662b3c036b7d9a91f6197af046c",
-                "reference": "4cfcd7a9fceba662b3c036b7d9a91f6197af046c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/1d96518eb7775ba42704652dff32269236c5adb4",
+                "reference": "1d96518eb7775ba42704652dff32269236c5adb4",
                 "shasum": ""
             },
             "require": {
@@ -730,7 +733,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-18 13:41:01"
+            "time": "2015-12-26 13:37:43"
         }
     ],
     "packages-dev": [
@@ -1638,16 +1641,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.7",
+            "version": "v2.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "f6290983c8725d0afa29bdc3e5295879de3e58f5"
+                "reference": "a3fb8f4c4afc4f1b285de5df07e568602934f525"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f6290983c8725d0afa29bdc3e5295879de3e58f5",
-                "reference": "f6290983c8725d0afa29bdc3e5295879de3e58f5",
+                "url": "https://api.github.com/repos/symfony/process/zipball/a3fb8f4c4afc4f1b285de5df07e568602934f525",
+                "reference": "a3fb8f4c4afc4f1b285de5df07e568602934f525",
                 "shasum": ""
             },
             "require": {
@@ -1683,7 +1686,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-19 16:11:24"
+            "time": "2015-12-23 11:03:39"
         }
     ],
     "aliases": [],

--- a/drush-services.yml
+++ b/drush-services.yml
@@ -1,9 +1,31 @@
-parameters:
-  some.arbitrary.group:
-    placeholder: 1
+#
+# Drush services
+#
+# This file defines the core Drush service classes.
+#
 services:
+  #
+  # logger:
+  #   Write messages to the error log.  Note that the Drush logger conforms
+  #   to the Psr/Log standard, but has been enhanced to support backend
+  #   invoke (the remote end can write logs to the initiating end in real
+  #   time, and still return structured results at the end.)
+  #
   logger:
     class: Drush\Log\Logger
+  #
+  # bootstrap.manager:
+  #   The bootstrap manager is responsible for keeping track of the bootstrap
+  #   objects that know how to bootstrap different frameworks.  Drush will have
+  #   a mechanism for this to be extended, e.g. by Backdrop.
+  #
+  bootstrap.manager:
+    class: Drush\Boot\BootstrapManager
+    arguments: ['@bootstrap.default', '@logger']
+    calls:
+      - [add, ["@bootstrap.drupal8"]]
+      - [add, ["@bootstrap.drupal7"]]
+      - [add, ["@bootstrap.drupal6"]]
   bootstrap.default:
     class: Drush\Boot\EmptyBoot
     arguments: ['@logger']
@@ -16,10 +38,3 @@ services:
   bootstrap.drupal6:
     class: Drush\Boot\DrupalBoot6
     arguments: ['@logger']
-  bootstrap.manager:
-    class: Drush\Boot\BootstrapManager
-    arguments: ['@bootstrap.default', '@logger']
-    calls:
-      - [add, ["@bootstrap.drupal8"]]
-      - [add, ["@bootstrap.drupal7"]]
-      - [add, ["@bootstrap.drupal6"]]

--- a/drush-services.yml
+++ b/drush-services.yml
@@ -22,19 +22,21 @@ services:
   bootstrap.manager:
     class: Drush\Boot\BootstrapManager
     arguments: ['@bootstrap.default', '@logger']
-    calls:
-      - [add, ["@bootstrap.drupal8"]]
-      - [add, ["@bootstrap.drupal7"]]
-      - [add, ["@bootstrap.drupal6"]]
   bootstrap.default:
     class: Drush\Boot\EmptyBoot
     arguments: ['@logger']
   bootstrap.drupal8:
     class: Drush\Boot\DrupalBoot8
     arguments: ['@logger']
+    tags:
+      -  { name: bootstrap.boot }
   bootstrap.drupal7:
     class: Drush\Boot\DrupalBoot7
     arguments: ['@logger']
+    tags:
+      -  { name: bootstrap.boot }
   bootstrap.drupal6:
     class: Drush\Boot\DrupalBoot6
     arguments: ['@logger']
+    tags:
+      -  { name: bootstrap.boot }

--- a/drush-services.yml
+++ b/drush-services.yml
@@ -1,0 +1,6 @@
+parameters:
+  some.arbitrary.group:
+    placeholder: 1
+services:
+  logger:
+    class: Drush\Log\Logger

--- a/drush-services.yml
+++ b/drush-services.yml
@@ -4,3 +4,22 @@ parameters:
 services:
   logger:
     class: Drush\Log\Logger
+  bootstrap.default:
+    class: Drush\Boot\EmptyBoot
+    arguments: ['@logger']
+  bootstrap.drupal8:
+    class: Drush\Boot\DrupalBoot8
+    arguments: ['@logger']
+  bootstrap.drupal7:
+    class: Drush\Boot\DrupalBoot7
+    arguments: ['@logger']
+  bootstrap.drupal6:
+    class: Drush\Boot\DrupalBoot6
+    arguments: ['@logger']
+  bootstrap.manager:
+    class: Drush\Boot\BootstrapManager
+    arguments: ['@bootstrap.default', '@logger']
+    calls:
+      - [add, ["@bootstrap.drupal8"]]
+      - [add, ["@bootstrap.drupal7"]]
+      - [add, ["@bootstrap.drupal6"]]

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -109,88 +109,13 @@ define('DRUSH_BOOTSTRAP_DRUPAL_FULL', 5);
  */
 define('DRUSH_BOOTSTRAP_DRUPAL_LOGIN', 6);
 
-/**
- * Return the list of bootstrap objects that are available for
- * initializing a CMS with Drush.  We insure that any given candidate
- * class is instantiated only once.
- *
- * @return \Drush\Boot\Boot[]
- */
-function drush_get_bootstrap_candidates() {
-  $candidate_classes = drush_get_bootstrap_candidate_classnames();
-
-  $cache =& drush_get_context('DRUSH_BOOTSTRAP_CANDIDATE_OBJECTS');
-
-  $result = array();
-  foreach($candidate_classes as $candidate_class) {
-    if (array_key_exists($candidate_class, $cache)) {
-      $result[$candidate_class] = $cache[$candidate_class];
-    }
-    else {
-      $result[$candidate_class] = new $candidate_class;
-    }
-  }
-
-  $cache = $result;
-  return $result;
-}
-
-/**
- * Find the list of bootstrap classnames available for initializing a
- * CMS with Drush.
- *
- * @return array
- */
-function drush_get_bootstrap_candidate_classnames() {
-  // Give all commandfiles a chance to return candidates.  They should
-  // return STRINGS with the class name of the bootstrap object they provide.
-  $candidates = drush_command_invoke_all('bootstrap_candidates');
-  // If a bootstrap class was specified on the command line, consider it first.
-  $bootstrap_class = drush_get_option('bootstrap_class', FALSE);
-  if ($bootstrap_class) {
-    array_unshift($candidates, $bootstrap_class);
-  }
-  // Add candidate bootstrap classes for Drupal
-  foreach (array('8', '7', '6') as $version) {
-    $drupal_bootstrap_class = 'Drush\Boot\DrupalBoot' . $version;
-    $candidates[] = $drupal_bootstrap_class;
-  }
-  // Always consider our default bootstrap class last.
-  $candidates[] = 'Drush\Boot\EmptyBoot';
-
-  return $candidates;
-}
 
 /**
  * Look up the best bootstrap class for the given location
  * from the set of available candidates.
  */
-function drush_bootstrap_class_for_root($path) {
-  drush_load_bootstrap_commandfile_at_path($path);
-  $candidates = drush_get_bootstrap_candidates();
-  foreach ($candidates as $candidate) {
-    if ($candidate->valid_root($path)) {
-      return $candidate;
-    }
-  }
-  return NULL;
-}
-
-/**
- * Check to see if there is a bootstrap class available
- * at the specified location; if there is, load it.
- */
-function drush_load_bootstrap_commandfile_at_path($path) {
-  static $paths = array();
-
-  if (!empty($path) && (!array_key_exists($path, $paths))) {
-    $paths[$path] = TRUE;
-    // Check to see if we have any bootstrap classes in this location.
-    $bootstrap_class_dir = $path . '/drush/bootstrap';
-    if (is_dir($bootstrap_class_dir)) {
-      _drush_add_commandfiles(array($bootstrap_class_dir), DRUSH_BOOTSTRAP_NONE);
-    }
-  }
+function drush_bootstrap_class_for_root($root) {
+  return \Drush::bootstrapManager()->bootstrap_class_for_root($root);
 }
 
 /**
@@ -202,29 +127,14 @@ function drush_load_bootstrap_commandfile_at_path($path) {
  * will always return the same object.
  */
 function drush_select_bootstrap_class() {
-  $root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
-
-  // Once we have selected a Drupal root, we will reduce our bootstrap
-  // candidates down to just the one used to select this site root.
-  $bootstrap = drush_bootstrap_class_for_root($root);
-  // If we have not found a bootstrap class by this point,
-  // then take the last one and use it.  This should be our
-  // default bootstrap class.  The default bootstrap class
-  // should pass through all calls without doing anything that
-  // changes state in a CMS-specific way.
-  if ($bootstrap == NULL) {
-    $candidates = drush_get_bootstrap_candidates();
-    $bootstrap = array_pop($candidates);
-  }
-
-  return $bootstrap;
+  return \Drush::bootstrapManager()->select_bootstrap_class();
 }
 
 /**
  * Don't allow the bootstrap object to change once we start bootstrapping
  */
 function drush_latch_bootstrap_object($bootstrap) {
-  drush_set_context('DRUSH_BOOTSTRAP_OBJECT', $bootstrap);
+  return \Drush::bootstrapManager()->latch($bootstrap);
 }
 
 /**
@@ -235,11 +145,7 @@ function drush_latch_bootstrap_object($bootstrap) {
  * @return \Drush\Boot\Boot
  */
 function drush_get_bootstrap_object() {
-  $bootstrap = drush_get_context('DRUSH_BOOTSTRAP_OBJECT', FALSE);
-  if (!$bootstrap) {
-    $bootstrap = drush_select_bootstrap_class();
-  }
-  return $bootstrap;
+  return \Drush::getBootstrap();
 }
 
 /**

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -109,45 +109,6 @@ define('DRUSH_BOOTSTRAP_DRUPAL_FULL', 5);
  */
 define('DRUSH_BOOTSTRAP_DRUPAL_LOGIN', 6);
 
-
-/**
- * Look up the best bootstrap class for the given location
- * from the set of available candidates.
- */
-function drush_bootstrap_class_for_root($root) {
-  return \Drush::bootstrapManager()->bootstrap_class_for_root($root);
-}
-
-/**
- * Select the bootstrap class to use.  If this is called multiple
- * times, the bootstrap class returned might change on subsequent
- * calls, if the root directory changes.  Once the bootstrap object
- * starts changing the state of the system, however, it will
- * be 'latched', and further calls to drush_select_bootstrap_class()
- * will always return the same object.
- */
-function drush_select_bootstrap_class() {
-  return \Drush::bootstrapManager()->select_bootstrap_class();
-}
-
-/**
- * Don't allow the bootstrap object to change once we start bootstrapping
- */
-function drush_latch_bootstrap_object($bootstrap) {
-  return \Drush::bootstrapManager()->latch($bootstrap);
-}
-
-/**
- * Get the appropriate bootstrap object.  We'll search for a new
- * bootstrap object every time someone asks for one until we start
- * bootstrapping; then we'll returned the same cached one every time.
- *
- * @return \Drush\Boot\Boot
- */
-function drush_get_bootstrap_object() {
-  return \Drush::getBootstrap();
-}
-
 /**
  * Find the URI that has been selected by the cwd
  * if it was not previously set via the --uri / -l option
@@ -194,7 +155,7 @@ function drush_bootstrap_value($context, $value = null) {
 function _drush_bootstrap_phases($function_names = FALSE) {
   $result = array();
 
-  if ($bootstrap = drush_get_bootstrap_object()) {
+  if ($bootstrap = \Drush::getBootstrap()) {
     $result = $bootstrap->bootstrap_phases();
     if (!$function_names) {
       $result = array_keys($result);
@@ -213,7 +174,7 @@ function _drush_bootstrap_phases($function_names = FALSE) {
  *   The bootstrap phase to bootstrap to.  @see \Drush\Boot::bootstrap_phases
  */
 function drush_bootstrap($phase, $phase_max = FALSE) {
-  $bootstrap = drush_get_bootstrap_object();
+  $bootstrap = \Drush::getBootstrap();
   $phases = _drush_bootstrap_phases(TRUE);
   $result = TRUE;
 
@@ -227,7 +188,7 @@ function drush_bootstrap($phase, $phase_max = FALSE) {
   // Once we start bootstrapping past the DRUSH_BOOTSTRAP_DRUSH phase, we
   // will latch the bootstrap object, and prevent it from changing.
   if ($phase > DRUSH_BOOTSTRAP_DRUSH) {
-    drush_latch_bootstrap_object($bootstrap);
+    \Drush::bootstrapManager()->latch($bootstrap);
   }
 
   drush_set_context('DRUSH_BOOTSTRAPPING', TRUE);
@@ -299,7 +260,7 @@ function drush_has_boostrapped($phase) {
  *
  */
 function drush_bootstrap_validate($phase) {
-  $bootstrap = drush_get_bootstrap_object();
+  $bootstrap = \Drush::getBootstrap();
   $phases = _drush_bootstrap_phases(TRUE);
   static $result_cache = array();
 

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1189,7 +1189,7 @@ function drush_command_defaults($key, $commandfile, $path) {
   // additional defaults if needed.  The bootstrap command defaults
   // will be merged into the command object again just before
   // running it in bootstrap_and_dispatch().
-  if ($bootstrap = drush_get_bootstrap_object()) {
+  if ($bootstrap = \Drush::getBootstrap()) {
     $defaults = array_merge($defaults, $bootstrap->command_defaults());
   }
   return $defaults;
@@ -1492,7 +1492,7 @@ function drush_commandfile_list() {
 
 function _drush_find_commandfiles($phase, $phase_max = FALSE) {
   drush_log(dt("Find command files for phase !phase (max=!max)", array('!phase' => $phase, '!max' => (string)$phase_max)), LogLevel::DEBUG);
-  if ($bootstrap = drush_get_bootstrap_object()) {
+  if ($bootstrap = \Drush::getBootstrap()) {
     $searchpath = $bootstrap->commandfile_searchpaths($phase, $phase_max);
     _drush_add_commandfiles($searchpath, $phase);
   }

--- a/includes/complete.inc
+++ b/includes/complete.inc
@@ -252,8 +252,8 @@ function drush_complete_process_argv() {
   // Check for and record any site alias.
   drush_sitealias_check_arg();
   drush_sitealias_check_site_env();
-  // We might have just changed our root--run drush_select_bootstrap_class() again.
-  $bootstrap = drush_select_bootstrap_class();
+  // We might have just changed our root--re-select the bootstrap object to use
+  $bootstrap = \Drush::bootstrapManager()->getBootstrap();
 
   // Return the new argv for easy reference.
   return $argv;

--- a/includes/context.inc
+++ b/includes/context.inc
@@ -110,7 +110,7 @@ function _drush_config_file($context, $prefix = NULL, $version = '') {
     }
   }
 
-  if ($drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT')) {
+  if ($drupal_root = \Drush::bootstrapManager()->getRoot()) {
     $configs['drupal'] = array(
       $drupal_root . '/../drush/' . $config_file,
       $drupal_root . '/sites/all/drush/' . $config_file,

--- a/includes/drupal.inc
+++ b/includes/drupal.inc
@@ -38,7 +38,7 @@ function drush_drupal_version($drupal_root = NULL) {
 
   if (!$version) {
     if (($drupal_root != NULL) || ($drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT'))) {
-      $bootstrap = drush_bootstrap_class_for_root($drupal_root);
+      $bootstrap = \Drush::bootstrapManager()->bootstrapObjectForRoot($drupal_root);
       if ($bootstrap) {
         $version = $bootstrap->get_version($drupal_root);
       }

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -9,10 +9,6 @@ use Drush\Log\Logger;
 use Drush\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-
 /**
  * @name Error status definitions
  * @{
@@ -1265,57 +1261,13 @@ function drush_log($message, $type = LogLevel::NOTICE, $error = null) {
 }
 
 /**
- * Set up our dependency injection container, and load drush-services.yml.
- */
-function drush_init_dependency_injection_container() {
-  // Set up our dependency injection container
-  $container = new ContainerBuilder();
-  $loader = new YamlFileLoader($container, new FileLocator(dirname(__DIR__)));
-  $loader->load('drush-services.yml');
-
-  // Store our DI container the Drush way. We want to phase these
-  // out over time.
-  drush_set_context('DRUSH_DI_CONTAINER', $container);
-}
-
-/**
- * For legacy code.
- *
- * Old code:
- *    $object = drush_get_context('DRUSH_CLASS_LABEL');
- *
- * Better:
- *    $container = drush_get_dependency_injection_container();
- *    $object = $container->get('label');
- *
- * Best:
- *    Construct instances in drush-services.yml, and inject
- *    references to the class instances they need.
- *
- * Future:
- *    We should have a Drush class that has a `getContainer()` method:
- *    $container = \Drupal::getContainer();
- */
-function drush_get_dependency_injection_container() {
-  return drush_get_context('DRUSH_DI_CONTAINER');
-}
-
-/**
- * Future: add some sort of dependency injection to Drush.
- */
-function _drush_create_default_logger() {
-  drush_init_dependency_injection_container();
-}
-
-/**
  * Call the default logger, or the user's log callback, as
  * appropriate.
  */
 function _drush_log($entry) {
   $callback = drush_get_context('DRUSH_LOG_CALLBACK');
   if (!$callback) {
-    $container = drush_get_dependency_injection_container();
-    $callback = $container->get('logger');
+    $callback = \Drush::logger();
   }
 
   if ($callback instanceof LoggerInterface) {

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -9,6 +9,10 @@ use Drush\Log\Logger;
 use Drush\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
 /**
  * @name Error status definitions
  * @{
@@ -1261,11 +1265,46 @@ function drush_log($message, $type = LogLevel::NOTICE, $error = null) {
 }
 
 /**
+ * Set up our dependency injection container, and load drush-services.yml.
+ */
+function drush_init_dependency_injection_container() {
+  // Set up our dependency injection container
+  $container = new ContainerBuilder();
+  $loader = new YamlFileLoader($container, new FileLocator(dirname(__DIR__)));
+  $loader->load('drush-services.yml');
+
+  // Store our DI container the Drush way. We want to phase these
+  // out over time.
+  drush_set_context('DRUSH_DI_CONTAINER', $container);
+}
+
+/**
+ * For legacy code.
+ *
+ * Old code:
+ *    $object = drush_get_context('DRUSH_CLASS_LABEL');
+ *
+ * Better:
+ *    $container = drush_get_dependency_injection_container();
+ *    $object = $container->get('label');
+ *
+ * Best:
+ *    Construct instances in drush-services.yml, and inject
+ *    references to the class instances they need.
+ *
+ * Future:
+ *    We should have a Drush class that has a `getContainer()` method:
+ *    $container = \Drupal::getContainer();
+ */
+function drush_get_dependency_injection_container() {
+  return drush_get_context('DRUSH_DI_CONTAINER');
+}
+
+/**
  * Future: add some sort of dependency injection to Drush.
  */
 function _drush_create_default_logger() {
-  $drush_logger = new Logger();
-  drush_set_context('DRUSH_LOG_CALLBACK', $drush_logger);
+  drush_init_dependency_injection_container();
 }
 
 /**
@@ -1274,6 +1313,10 @@ function _drush_create_default_logger() {
  */
 function _drush_log($entry) {
   $callback = drush_get_context('DRUSH_LOG_CALLBACK');
+  if (!$callback) {
+    $container = drush_get_dependency_injection_container();
+    $callback = $container->get('logger');
+  }
 
   if ($callback instanceof LoggerInterface) {
     $context = $entry;

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -193,7 +193,7 @@ function drush_site_path($path = NULL) {
   else {
     // Move up dir by dir and check each.
     // Stop if we get to a Drupal root.   We don't care
-    // if it is DRUSH_SELECTED_DRUPAL_ROOT or some other root.
+    // if it is the selected or some other root.
     while (($path = _drush_shift_path_up($path)) && !drush_valid_root($path)) {
       if (file_exists($path . '/settings.php')) {
         $site_path = $path;
@@ -202,7 +202,7 @@ function drush_site_path($path = NULL) {
     }
   }
 
-  $site_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+  $site_root = \Drush::bootstrapManager()->getRoot();
   if (file_exists($site_root . '/sites/sites.php')) {
     $sites = array();
     // This will overwrite $sites with the desired mappings.
@@ -236,7 +236,7 @@ function drush_site_path($path = NULL) {
  */
 function drush_site_dir_lookup_from_hostname($hostname, $site_root = NULL) {
   if (!isset($site_root)) {
-    $site_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $site_root = \Drush::bootstrapManager()->getRoot();
   }
   if (!empty($site_root) && file_exists($site_root . '/sites/sites.php')) {
     $sites = array();
@@ -263,7 +263,7 @@ function drush_site_dir_lookup_from_hostname($hostname, $site_root = NULL) {
  * (drushrc.php) stored with the site's drush folders might not be found.
  */
 function drush_conf_path($server_uri, $require_settings = TRUE) {
-  $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+  $drupal_root = \Drush::bootstrapManager()->getRoot();
   if(empty($drupal_root) || empty($server_uri)) {
     return NULL;
   }

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -599,15 +599,6 @@ function _drush_test_os($os, $os_list_to_check) {
 }
 
 /**
- * Read the drush info file.
- */
-function drush_read_drush_info() {
-  $drush_info_file = dirname(__FILE__) . '/../drush.info';
-
-  return parse_ini_file($drush_info_file);
-}
-
-/**
  * Make a determination whether or not the given
  * host is local or not.
  *

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -357,8 +357,8 @@ function drush_locate_root($start_path = NULL) {
  *   The relative path to common.inc (varies by Drupal version), or FALSE if not
  *   a Drupal root.
  */
-function drush_valid_root($path) {
-  $bootstrap_class = drush_bootstrap_class_for_root($path);
+function drush_valid_root($root) {
+  $bootstrap_class = \Drush::bootstrapManager()->bootstrapObjectForRoot($root);
   return $bootstrap_class != NULL;
 }
 

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -7,6 +7,10 @@
 
 use Drush\Log\LogLevel;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
 /**
  * The main Drush function.
  *
@@ -138,8 +142,7 @@ function drush_preflight_prepare() {
   drush_set_context('DRUSH_VENDOR_PATH', dirname($vendor_path));
   drush_set_context('DRUSH_CLASSLOADER', $classloader);
 
-  // Can't log until we have a logger, so we'll create this ASAP.
-  _drush_create_default_logger();
+  drush_init_dependency_injection_container();
 
   // Terminate immediately unless invoked as a command line script
   if (!drush_verify_cli()) {
@@ -160,9 +163,11 @@ function drush_preflight_prepare() {
     return; // An error was logged.
   }
 
-  $drush_info = drush_read_drush_info();
-  define('DRUSH_VERSION', $drush_info['drush_version']);
-  $version_parts = explode('.', DRUSH_VERSION);
+  // Set up for backwards-compatibility. New code should call
+  // \Drush::getVersion() and \Drush::getMajorVersion() directly
+  $drush_version = \Drush::getVersion();
+  $version_parts = explode('.', $drush_version);
+  define('DRUSH_VERSION', $drush_version);
   define('DRUSH_MAJOR_VERSION', $version_parts[0]);
   define('DRUSH_MINOR_VERSION', $version_parts[1]);
 
@@ -181,6 +186,19 @@ function drush_preflight_prepare() {
   _drush_preflight_global_options();
 
   drush_log(dt("Drush preflight prepare loaded autoloader at !autoloader", array('!autoloader' => realpath($vendor_path))), LogLevel::PREFLIGHT);
+}
+
+/**
+ * Set up our dependency injection container, and load drush-services.yml.
+ */
+function drush_init_dependency_injection_container() {
+  // Set up our dependency injection container
+  $container = new ContainerBuilder();
+  $loader = new YamlFileLoader($container, new FileLocator(dirname(__DIR__)));
+  $loader->load('drush-services.yml');
+
+  // Store the container in the \Drush object
+  \Drush::setContainer($container);
 }
 
 /**

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -145,6 +145,8 @@ function drush_preflight_prepare() {
   drush_set_context('DRUSH_VENDOR_PATH', dirname($vendor_path));
   drush_set_context('DRUSH_CLASSLOADER', $classloader);
 
+  // We need to load our services right away, as we cannot log
+  // or do much else until after this is done.
   drush_init_dependency_injection_container();
 
   // Terminate immediately unless invoked as a command line script
@@ -336,9 +338,8 @@ function drush_preflight_root() {
   if ($root) {
     $root = realpath($root);
   }
-  // @todo This context name should not mention Drupal.
   // @todo Drupal code should use DRUSH_DRUPAL_ROOT instead of this constant.
-  drush_set_context('DRUSH_SELECTED_DRUPAL_ROOT', $root);
+  \Drush::bootstrapManager()->setRoot($root);
 
   // Load the config options from Drupal's /drush, ../drush, and sites/all/drush directories,
   // even prior to bootstrapping the root.
@@ -578,7 +579,7 @@ function drush_preflight_command_dispatch() {
   }
   $args = drush_get_arguments();
   $command_name = array_shift($args);
-  $root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+  $root = \Drush::bootstrapManager()->getRoot();
   $local_drush = drush_get_option('drush-script');
   if (empty($local_drush) && !empty($root)) {
     $local_drush = find_wrapper_or_launcher($root);

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -7,10 +7,6 @@
 
 use Drush\Log\LogLevel;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-
 /**
  * The main Drush function.
  *
@@ -147,7 +143,8 @@ function drush_preflight_prepare() {
 
   // We need to load our services right away, as we cannot log
   // or do much else until after this is done.
-  drush_init_dependency_injection_container();
+  $servicesFile = dirname(__DIR__) . "/drush-services.yml";
+  \Drush::loadServices($servicesFile);
 
   // Terminate immediately unless invoked as a command line script
   if (!drush_verify_cli()) {
@@ -191,19 +188,6 @@ function drush_preflight_prepare() {
   _drush_preflight_global_options();
 
   drush_log(dt("Drush preflight prepare loaded autoloader at !autoloader", array('!autoloader' => realpath($vendor_path))), LogLevel::PREFLIGHT);
-}
-
-/**
- * Set up our dependency injection container, and load drush-services.yml.
- */
-function drush_init_dependency_injection_container() {
-  // Set up our dependency injection container
-  $container = new ContainerBuilder();
-  $loader = new YamlFileLoader($container, new FileLocator(dirname(__DIR__)));
-  $loader->load('drush-services.yml');
-
-  // Store the container in the \Drush object
-  \Drush::setContainer($container);
 }
 
 /**

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -119,8 +119,27 @@ function drush_preflight_prepare() {
     return FALSE;
   }
 
-  // Include our autoloader
   $classloader = require $vendor_path;
+
+  // These could be loaded by the autoloader, but that would not
+  // necessarily be advantageous.
+  // See https://github.com/drush-ops/drush/pull/1884#issuecomment-167439930
+  require_once DRUSH_BASE_PATH . '/includes/startup.inc';
+  require_once DRUSH_BASE_PATH . '/includes/bootstrap.inc';
+  require_once DRUSH_BASE_PATH . '/includes/environment.inc';
+  require_once DRUSH_BASE_PATH . '/includes/command.inc';
+  require_once DRUSH_BASE_PATH . '/includes/drush.inc';
+  require_once DRUSH_BASE_PATH . '/includes/engines.inc';
+  require_once DRUSH_BASE_PATH . '/includes/backend.inc';
+  require_once DRUSH_BASE_PATH . '/includes/batch.inc';
+  require_once DRUSH_BASE_PATH . '/includes/context.inc';
+  require_once DRUSH_BASE_PATH . '/includes/sitealias.inc';
+  require_once DRUSH_BASE_PATH . '/includes/exec.inc';
+  require_once DRUSH_BASE_PATH . '/includes/drupal.inc';
+  require_once DRUSH_BASE_PATH . '/includes/output.inc';
+  require_once DRUSH_BASE_PATH . '/includes/cache.inc';
+  require_once DRUSH_BASE_PATH . '/includes/filesystem.inc';
+  require_once DRUSH_BASE_PATH . '/includes/dbtng.inc';
 
   // Stash our vendor path and classloader.
   drush_set_context('DRUSH_VENDOR_PATH', dirname($vendor_path));

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -75,7 +75,7 @@ function drush_main() {
   // the bootstrap object returned from drush_preflight().  This will
   // require some adjustments to Drush bootstrapping.
   // See: https://github.com/drush-ops/drush/pull/1303
-  if ($bootstrap = drush_get_bootstrap_object()) {
+  if ($bootstrap = \Drush::getBootstrap()) {
     $bootstrap->terminate();
   }
   drush_postflight();
@@ -324,7 +324,7 @@ function drush_preflight() {
   drush_set_environment_vars($alias_record);
 
   // Select the bootstrap object and return it.
-  return drush_select_bootstrap_class();
+  return \Drush::bootstrapManager()->getBootstrap();
 }
 
 /**

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -7,6 +7,13 @@
 
 use Drush\Log\LogLevel;
 
+use Drush\Symfony\BootstrapCompilerPass;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
 /**
  * The main Drush function.
  *
@@ -143,8 +150,7 @@ function drush_preflight_prepare() {
 
   // We need to load our services right away, as we cannot log
   // or do much else until after this is done.
-  $servicesFile = dirname(__DIR__) . "/drush-services.yml";
-  \Drush::loadServices($servicesFile);
+  drush_init_dependency_injection_container();
 
   // Terminate immediately unless invoked as a command line script
   if (!drush_verify_cli()) {
@@ -188,6 +194,34 @@ function drush_preflight_prepare() {
   _drush_preflight_global_options();
 
   drush_log(dt("Drush preflight prepare loaded autoloader at !autoloader", array('!autoloader' => realpath($vendor_path))), LogLevel::PREFLIGHT);
+}
+
+/**
+ * Set up our dependency injection container, and load drush-services.yml.
+ */
+function drush_init_dependency_injection_container() {
+  $servicesFile = dirname(__DIR__) . "/drush-services.yml";
+
+  // Set up our dependency injection container.
+  $container = new ContainerBuilder();
+
+  // Add a compiler pass: any Boot object tagged 'bootstrap.boot' will
+  // be added to the BootstrapManager.
+  //$container->addCompilerPass(new BootstrapCompilerPass());
+
+  $loader = new YamlFileLoader($container, new FileLocator(dirname($servicesFile)));
+  $loader->load(basename($servicesFile));
+
+  // Note: this freezes our container, preventing us from adding any further
+  // services to it.
+  // $container->compile();
+
+  // Store the container in the \Drush object
+  \Drush::setContainer($container);
+
+  // We are not ready to compile yet, so we will manually find
+  // all of our 'bootstrap.boot' objects and add them to the container
+  \Drush::addBootstrapManagerReferences();
 }
 
 /**

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -119,24 +119,8 @@ function drush_preflight_prepare() {
     return FALSE;
   }
 
+  // Include our autoloader
   $classloader = require $vendor_path;
-
-  require_once DRUSH_BASE_PATH . '/includes/startup.inc';
-  require_once DRUSH_BASE_PATH . '/includes/bootstrap.inc';
-  require_once DRUSH_BASE_PATH . '/includes/environment.inc';
-  require_once DRUSH_BASE_PATH . '/includes/command.inc';
-  require_once DRUSH_BASE_PATH . '/includes/drush.inc';
-  require_once DRUSH_BASE_PATH . '/includes/engines.inc';
-  require_once DRUSH_BASE_PATH . '/includes/backend.inc';
-  require_once DRUSH_BASE_PATH . '/includes/batch.inc';
-  require_once DRUSH_BASE_PATH . '/includes/context.inc';
-  require_once DRUSH_BASE_PATH . '/includes/sitealias.inc';
-  require_once DRUSH_BASE_PATH . '/includes/exec.inc';
-  require_once DRUSH_BASE_PATH . '/includes/drupal.inc';
-  require_once DRUSH_BASE_PATH . '/includes/output.inc';
-  require_once DRUSH_BASE_PATH . '/includes/cache.inc';
-  require_once DRUSH_BASE_PATH . '/includes/filesystem.inc';
-  require_once DRUSH_BASE_PATH . '/includes/dbtng.inc';
 
   // Stash our vendor path and classloader.
   drush_set_context('DRUSH_VENDOR_PATH', dirname($vendor_path));

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -96,7 +96,7 @@ function drush_sitealias_check_site_env() {
 function drush_sitealias_create_self_alias() {
   $self_record = drush_sitealias_get_record('@self');
   if (!array_key_exists('root', $self_record) && !array_key_exists('remote-host', $self_record)) {
-    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $drupal_root = \Drush::bootstrapManager()->getRoot();
     $uri = drush_get_context('DRUSH_SELECTED_URI');
     if (!empty($drupal_root) && !empty($uri)) {
       // Create an alias '@self'
@@ -406,7 +406,7 @@ function drush_sitealias_alias_path($alias_path_context = NULL) {
 
   // If the user defined the root of a drupal site, then also
   // look for alias files in /drush and /sites/all/drush.
-  $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+  $drupal_root = \Drush::bootstrapManager()->getRoot();
   if (!empty($drupal_root)) {
     $site_paths[] = drush_sitealias_alias_base_directory($drupal_root . '/../drush');
     $site_paths[] = drush_sitealias_alias_base_directory($drupal_root . '/drush');
@@ -669,7 +669,7 @@ function _drush_sitealias_find_and_load_alias($aliasname, $alias_path_context = 
       }
     }
     else {
-      $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+      $drupal_root = \Drush::bootstrapManager()->getRoot();
     }
     if (isset($drupal_root) && !is_array($drupal_root)) {
       drush_sitealias_create_sites_alias($drupal_root);
@@ -1084,7 +1084,7 @@ function drush_sitealias_bootstrapped_site_name() {
     $site_name = $self_record['#name'];
   }
   if (!isset($site_name) || ($site_name == '@self')) {
-    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $drupal_root = \Drush::bootstrapManager()->getRoot();
     if (isset($drupal_root)) {
       $drupal_uri = drush_get_context('DRUSH_SELECTED_URI', 'default');
       $drupal_uri = str_replace('http://', '', $drupal_uri);
@@ -1533,7 +1533,7 @@ function _drush_sitealias_find_record_for_local_site($alias, $drupal_root = NULL
   }
 
   if (!isset($drupal_root)) {
-    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $drupal_root = \Drush::bootstrapManager()->getRoot();
   }
 
   if (!empty($drupal_root)) {

--- a/lib/Drush.php
+++ b/lib/Drush.php
@@ -68,7 +68,7 @@ class Drush {
   /**
    * Return the current Drush version.
    */
-  static public function getVersion() {
+  public static function getVersion() {
     if (!static::$version) {
       $drush_info = static::drush_read_drush_info();
       static::$version = $drush_info['drush_version'];
@@ -76,7 +76,7 @@ class Drush {
     return static::$version;
   }
 
-  static public function getMajorVersion() {
+  public static function getMajorVersion() {
     if (!static::$majorVersion) {
       $drush_version = static::getVersion();
       $version_parts = explode('.', $drush_version);
@@ -85,7 +85,7 @@ class Drush {
     return static::$majorVersion;
   }
 
-  static public function getMinorVersion() {
+  public static function getMinorVersion() {
     if (!static::$minorVersion) {
       $drush_version = static::getVersion();
       $version_parts = explode('.', $drush_version);
@@ -97,7 +97,7 @@ class Drush {
   /**
    * Load a new set of services
    */
-  public function loadServices($servicesFile) {
+  public static function loadServices($servicesFile) {
     // Set up our dependency injection container.
     $container = new ContainerBuilder();
     // Add a compiler pass: any Boot object tagged 'bootstrap.boot' will

--- a/lib/Drush.php
+++ b/lib/Drush.php
@@ -180,6 +180,24 @@ class Drush {
   }
 
   /**
+   * Return the Bootstrap Manager.
+   *
+   * @return Drush\Boot\BootstrapManager
+   */
+  public static function bootstrapManager() {
+    return static::service('bootstrap.manager');
+  }
+
+  /**
+   * Return the Bootstrap object.
+   *
+   * @return Drush\Boot\Boot
+   */
+  public static function getBootstrap() {
+    return static::bootstrapManager()->getBootstrap();
+  }
+
+  /**
    * Read the drush info file.
    */
   private static function drush_read_drush_info() {

--- a/lib/Drush.php
+++ b/lib/Drush.php
@@ -133,7 +133,7 @@ class Drush {
    * are allowed to add extensions, and extensions must be added
    * before we compile the container.
    */
-  function addBootstrapManagerReferences() {
+  public static function addBootstrapManagerReferences() {
       if (static::hasService('bootstrap.manager')) {
       $bootstrapManager = static::service('bootstrap.manager');
       $taggedServices = static::$container->findTaggedServiceIds(

--- a/lib/Drush.php
+++ b/lib/Drush.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drush.
+ */
+
+use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Static Service Container wrapper.
+ *
+ * This code is analagous to the \Drupal class in Drupal 8.
+ *
+ * We would like to move Drush towards the model of using constructor
+ * injection rather than globals. This class serves as a unified global
+ * accessor to arbitrary services for use by legacy Drush code.
+ *
+ * Advice from Drupal 8's 'Drupal' class:
+ *
+ * This class exists only to support legacy code that cannot be dependency
+ * injected. If your code needs it, consider refactoring it to be object
+ * oriented, if possible. When this is not possible, and your code is more
+ * than a few non-reusable lines, it is recommended to instantiate an object
+ * implementing the actual logic.
+ *
+ * @code
+ *   // Legacy procedural code.
+ *   $object = drush_get_context('DRUSH_CLASS_LABEL');
+ *
+ * Better:
+ *   $object = \Drush::service('label');
+ *
+ *   function hook_do_stuff() {
+ *     $lock = lock()->acquire('stuff_lock');
+ *     // ...
+ *   }
+ * @endcode
+ */
+class Drush {
+
+  /**
+   * We should consider moving our VERSION constant here,
+   * to follow the style used in Drupal 8.  For now, we read
+   * our version information from the drush.info file.
+   *
+   * Do any external clients try to read this file?  With
+   * a class constant, any code that includes autoload.php
+   * may reference \Drush::VERSION.  The way we have implemented
+   * it here allows \Drush::getVersion(), or direct parsing
+   * of drush.info, which is better for backwards compatibility.
+   */
+  //const VERSION = '8.0.0-dev';
+
+  /**
+   * The version of Drush from the drush.info file, or FALSE if not read yet.
+   *
+   * @var string|FALSE
+   */
+  protected static $version = FALSE;
+  protected static $majorVersion = FALSE;
+  protected static $minorVersion = FALSE;
+
+  /**
+   * The currently active container object, or NULL if not initialized yet.
+   *
+   * @var \Symfony\Component\DependencyInjection\ContainerInterface|null
+   */
+  protected static $container;
+
+  /**
+   * Return the current Drush version.
+   */
+  static public function getVersion() {
+    if (!static::$version) {
+      $drush_info = static::drush_read_drush_info();
+      static::$version = $drush_info['drush_version'];
+    }
+    return static::$version;
+  }
+
+  static public function getMajorVersion() {
+    if (!static::$majorVersion) {
+      $drush_version = static::getVersion();
+      $version_parts = explode('.', $drush_version);
+      static::$majorVersion = $version_parts[0];
+    }
+    return static::$majorVersion;
+  }
+
+  static public function getMinorVersion() {
+    if (!static::$minorVersion) {
+      $drush_version = static::getVersion();
+      $version_parts = explode('.', $drush_version);
+      static::$minorVersion = $version_parts[1];
+    }
+    return static::$minorVersion;
+  }
+
+  /**
+   * Sets a new global container.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   A new container instance to replace the current.
+   */
+  public static function setContainer(ContainerInterface $container) {
+    static::$container = $container;
+  }
+
+  /**
+   * Unsets the global container.
+   */
+  public static function unsetContainer() {
+    static::$container = NULL;
+  }
+
+  /**
+   * Returns the currently active global container.
+   *
+   * @return \Symfony\Component\DependencyInjection\ContainerInterface|null
+   *
+   * @throws \Drupal\Core\DependencyInjection\ContainerNotInitializedException
+   */
+  public static function getContainer() {
+    if (static::$container === NULL) {
+      throw new ContainerNotInitializedException('\Drush::$container is not initialized yet. \Drupal::setContainer() must be called with a real container.');
+    }
+    return static::$container;
+  }
+
+  /**
+   * Returns TRUE if the container has been initialized, FALSE otherwise.
+   *
+   * @return bool
+   */
+  public static function hasContainer() {
+    return static::$container !== NULL;
+  }
+
+
+  /**
+   * Retrieves a service from the container.
+   *
+   * Use this method if the desired service is not one of those with a dedicated
+   * accessor method below. If it is listed below, those methods are preferred
+   * as they can return useful type hints.
+   *
+   * @param string $id
+   *   The ID of the service to retrieve.
+   *
+   * @return mixed
+   *   The specified service.
+   */
+  public static function service($id) {
+    return static::getContainer()->get($id);
+  }
+
+  /**
+   * Indicates if a service is defined in the container.
+   *
+   * @param string $id
+   *   The ID of the service to check.
+   *
+   * @return bool
+   *   TRUE if the specified service exists, FALSE otherwise.
+   */
+  public static function hasService($id) {
+    // Check hasContainer() first in order to always return a Boolean.
+    return static::hasContainer() && static::getContainer()->has($id);
+  }
+
+  /**
+   * Return the Drush logger object.
+   *
+   * @return LoggerInterface
+   */
+  public static function logger() {
+    return static::service('logger');
+  }
+
+  /**
+   * Read the drush info file.
+   */
+  private static function drush_read_drush_info() {
+    $drush_info_file = dirname(__FILE__) . '/../drush.info';
+
+    return parse_ini_file($drush_info_file);
+  }
+
+}

--- a/lib/Drush.php
+++ b/lib/Drush.php
@@ -32,26 +32,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Better:
  *   $object = \Drush::service('label');
  *
- *   function hook_do_stuff() {
- *     $lock = lock()->acquire('stuff_lock');
- *     // ...
- *   }
  * @endcode
  */
 class Drush {
-
-  /**
-   * We should consider moving our VERSION constant here,
-   * to follow the style used in Drupal 8.  For now, we read
-   * our version information from the drush.info file.
-   *
-   * Do any external clients try to read this file?  With
-   * a class constant, any code that includes autoload.php
-   * may reference \Drush::VERSION.  The way we have implemented
-   * it here allows \Drush::getVersion(), or direct parsing
-   * of drush.info, which is better for backwards compatibility.
-   */
-  //const VERSION = '8.0.0-dev';
 
   /**
    * The version of Drush from the drush.info file, or FALSE if not read yet.

--- a/lib/Drush/Boot/BaseBoot.php
+++ b/lib/Drush/Boot/BaseBoot.php
@@ -3,10 +3,14 @@
 namespace Drush\Boot;
 
 use Drush\Log\LogLevel;
+use Psr\Log\LoggerInterface;
 
 abstract class BaseBoot implements Boot {
 
-  function __construct() {
+  protected $logger;
+
+  function __construct(LoggerInterface $logger) {
+    $this->logger = $logger;
   }
 
   function valid_root($path) {
@@ -60,7 +64,7 @@ abstract class BaseBoot implements Boot {
           $this->enforce_requirement($command);
 
           if ($bootstrap_result && empty($command['bootstrap_errors'])) {
-            drush_log(dt("Found command: !command (commandfile=!commandfile)", array('!command' => $command['command'], '!commandfile' => $command['commandfile'])), LogLevel::BOOTSTRAP);
+            $this->logger->log(LogLevel::BOOTSTRAP, dt("Found command: !command (commandfile=!commandfile)", array('!command' => $command['command'], '!commandfile' => $command['commandfile'])));
 
             $command_found = TRUE;
             // Dispatch the command(s).

--- a/lib/Drush/Boot/BootstrapManager.php
+++ b/lib/Drush/Boot/BootstrapManager.php
@@ -96,14 +96,14 @@ class BootstrapManager {
     if ($this->bootstrap) {
       return $this->bootstrap;
     }
-    return $this->select_bootstrap_class();
+    return $this->selectBootstrapClass();
   }
 
   /**
    * Look up the best bootstrap class for the given location
    * from the set of available candidates.
    */
-  function bootstrap_class_for_root($path) {
+  public function bootstrapObjectForRoot($path) {
     foreach ($this->bootstrapCandidates as $candidate) {
       if ($candidate->valid_root($path)) {
         return $candidate;
@@ -117,13 +117,13 @@ class BootstrapManager {
    * times, the bootstrap class returned might change on subsequent
    * calls, if the root directory changes.  Once the bootstrap object
    * starts changing the state of the system, however, it will
-   * be 'latched', and further calls to drush_select_bootstrap_class()
+   * be 'latched', and further calls to \Drush::getBootstrap()
    * will always return the same object.
    */
-  function select_bootstrap_class() {
+  protected function selectBootstrapClass() {
     // Once we have selected a Drupal root, we will reduce our bootstrap
     // candidates down to just the one used to select this site root.
-    $bootstrap = $this->bootstrap_class_for_root($this->root);
+    $bootstrap = $this->bootstrapObjectForRoot($this->root);
     // If we have not found a bootstrap class by this point,
     // then return our default bootstrap object.  The default bootstrap object
     // should pass through all calls without doing anything that

--- a/lib/Drush/Boot/BootstrapManager.php
+++ b/lib/Drush/Boot/BootstrapManager.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Drush\Boot;
+
+use Psr\Log\LoggerInterface;
+
+class BootstrapManager {
+
+  /**
+   * @var Drush\Boot\Boot[]
+   */
+  protected $bootstrapCandidates = [];
+
+  /**
+   * @var Drush\Boot\Boot
+   */
+  protected $defaultBootstrapObject;
+
+  /**
+   * @var Drush\Boot\Boot
+   */
+  protected $bootstrap;
+
+  /**
+   * @var Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * @var string
+   */
+  protected $root;
+
+  /**
+   * @var string
+   */
+  protected $uri;
+
+  /**
+   * Constructor.
+   *
+   * @param Boot
+   *   The default bootstrap object to use when there are
+   *   no viable candidates to use (e.g. no selected site)
+   * @param LoggerInterface
+   *   The logger
+   */
+  public function __construct(Boot $default, LoggerInterface $logger) {
+    $this->defaultBootstrapObject = $default;
+    $this->logger = $logger;
+  }
+
+  /**
+   * Add a bootstrap object to the list of candidates
+   *
+   * @param Boot|Array
+   *   List of boot candidates
+   */
+  public function add($candidateList) {
+    foreach (func_get_args() as $candidate) {
+      $this->bootstrapCandidates[] = $candidate;
+    }
+  }
+
+  /**
+   * Return the framework root selected by the user.
+   */
+  public function getRoot() {
+    return $this->root;
+  }
+
+  public function setRoot($root) {
+    // TODO: Throw if we already bootstrapped a framework?
+    $this->root = $root;
+  }
+
+  /**
+   * Return the framework root selected by the user.
+   */
+  public function getUri() {
+    return $this->uri;
+  }
+
+  public function setUri($uri) {
+    // TODO: Throw if we already bootstrapped a framework?
+    $this->uri = $root;
+  }
+
+  /**
+   * Return the bootstrap object in use.  This will
+   * be the latched bootstrap object if we have started
+   * bootstrapping; otherwise, it will be whichever bootstrap
+   * object is best for the selected root.
+   */
+  public function getBootstrap() {
+    if ($this->bootstrap) {
+      return $this->bootstrap;
+    }
+    return $this->select_bootstrap_class();
+  }
+
+  /**
+   * Look up the best bootstrap class for the given location
+   * from the set of available candidates.
+   */
+  function bootstrap_class_for_root($path) {
+    foreach ($this->bootstrapCandidates as $candidate) {
+      if ($candidate->valid_root($path)) {
+        return $candidate;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Select the bootstrap class to use.  If this is called multiple
+   * times, the bootstrap class returned might change on subsequent
+   * calls, if the root directory changes.  Once the bootstrap object
+   * starts changing the state of the system, however, it will
+   * be 'latched', and further calls to drush_select_bootstrap_class()
+   * will always return the same object.
+   */
+  function select_bootstrap_class() {
+    // Once we have selected a Drupal root, we will reduce our bootstrap
+    // candidates down to just the one used to select this site root.
+    $bootstrap = $this->bootstrap_class_for_root($this->root);
+    // If we have not found a bootstrap class by this point,
+    // then return our default bootstrap object.  The default bootstrap object
+    // should pass through all calls without doing anything that
+    // changes state in a CMS-specific way.
+    if ($bootstrap == NULL) {
+      $bootstrap = $this->defaultBootstrapObject;
+    }
+
+    return $bootstrap;
+  }
+
+  /**
+   * Once bootstrapping has started, we stash the bootstrap
+   * object being used, and do not allow it to change any
+   * longer.
+   */
+  public function latch($bootstrap) {
+    $this->bootstrap = $bootstrap;
+  }
+
+}

--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -3,6 +3,7 @@
 namespace Drush\Boot;
 
 use Drush\Log\LogLevel;
+use Psr\Log\LoggerInterface;
 
 abstract class DrupalBoot extends BaseBoot {
 

--- a/lib/Drush/Boot/DrupalBoot.php
+++ b/lib/Drush/Boot/DrupalBoot.php
@@ -6,7 +6,8 @@ use Drush\Log\LogLevel;
 
 abstract class DrupalBoot extends BaseBoot {
 
-  function __construct() {
+  function __construct(LoggerInterface $logger) {
+    parent::__construct($logger);
   }
 
   function valid_root($path) {
@@ -111,7 +112,7 @@ abstract class DrupalBoot extends BaseBoot {
     $searchpath = array();
     switch ($phase) {
       case DRUSH_BOOTSTRAP_DRUPAL_ROOT:
-        $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+        $drupal_root = \Drush::bootstrapManager()->getRoot();
         $searchpath[] = $drupal_root . '/../drush';
         $searchpath[] = $drupal_root . '/drush';
         $searchpath[] = $drupal_root . '/sites/all/drush';
@@ -256,7 +257,7 @@ abstract class DrupalBoot extends BaseBoot {
    * context and DRUPAL_ROOT constant if it is considered a valid option.
    */
   function bootstrap_drupal_root_validate() {
-    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+    $drupal_root = \Drush::bootstrapManager()->getRoot();
 
     if (empty($drupal_root)) {
       return drush_bootstrap_error('DRUSH_NO_DRUPAL_ROOT', dt("A Drupal installation directory could not be found"));
@@ -309,7 +310,7 @@ abstract class DrupalBoot extends BaseBoot {
 
     _drush_preflight_global_options();
 
-    drush_log(dt("Initialized Drupal !version root directory at !drupal_root", array("!version" => $version, '!drupal_root' => $drupal_root)), LogLevel::BOOTSTRAP);
+    $this->logger->log(LogLevel::BOOTSTRAP, dt("Initialized Drupal !version root directory at !drupal_root", array("!version" => $version, '!drupal_root' => $drupal_root)));
   }
 
   /**
@@ -408,7 +409,7 @@ abstract class DrupalBoot extends BaseBoot {
     $site = drush_set_context('DRUSH_DRUPAL_SITE', drush_bootstrap_value('site'));
     $conf_path = drush_set_context('DRUSH_DRUPAL_SITE_ROOT', drush_bootstrap_value('conf_path'));
 
-    drush_log(dt("Initialized Drupal site !site at !site_root", array('!site' => $site, '!site_root' => $conf_path)), LogLevel::BOOTSTRAP);
+    $this->logger->log(LogLevel::BOOTSTRAP, dt("Initialized Drupal site !site at !site_root", array('!site' => $site, '!site_root' => $conf_path)));
 
     _drush_preflight_global_options();
   }
@@ -520,7 +521,7 @@ abstract class DrupalBoot extends BaseBoot {
   function bootstrap_drupal_database() {
     // We presume that our derived classes will connect and then
     // either fail, or call us via parent::
-    drush_log(dt("Successfully connected to the Drupal database."), LogLevel::BOOTSTRAP);
+    $this->logger->log(LogLevel::BOOTSTRAP, dt("Successfully connected to the Drupal database."));
   }
 
   /**

--- a/lib/Drush/Boot/DrupalBoot6.php
+++ b/lib/Drush/Boot/DrupalBoot6.php
@@ -2,6 +2,8 @@
 
 namespace Drush\Boot;
 
+use Psr\Log\LoggerInterface;
+
 class DrupalBoot6 extends DrupalBoot {
 
   public function __construct(LoggerInterface $logger) {

--- a/lib/Drush/Boot/DrupalBoot6.php
+++ b/lib/Drush/Boot/DrupalBoot6.php
@@ -4,6 +4,10 @@ namespace Drush\Boot;
 
 class DrupalBoot6 extends DrupalBoot {
 
+  public function __construct(LoggerInterface $logger) {
+    parent::__construct($logger);
+  }
+
   function valid_root($path) {
     if (!empty($path) && is_dir($path) && file_exists($path . '/index.php')) {
       // Drupal 6 root.

--- a/lib/Drush/Boot/DrupalBoot7.php
+++ b/lib/Drush/Boot/DrupalBoot7.php
@@ -2,6 +2,8 @@
 
 namespace Drush\Boot;
 
+use Psr\Log\LoggerInterface;
+
 class DrupalBoot7 extends DrupalBoot {
 
   public function __construct(LoggerInterface $logger) {

--- a/lib/Drush/Boot/DrupalBoot7.php
+++ b/lib/Drush/Boot/DrupalBoot7.php
@@ -4,6 +4,10 @@ namespace Drush\Boot;
 
 class DrupalBoot7 extends DrupalBoot {
 
+  public function __construct(LoggerInterface $logger) {
+    parent::__construct($logger);
+  }
+
   function valid_root($path) {
     if (!empty($path) && is_dir($path) && file_exists($path . '/index.php')) {
       // Drupal 7 root.

--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -70,7 +70,10 @@ class DrupalBoot8 extends DrupalBoot {
     // channel.
     $container = \Drupal::getContainer();
     $parser = $container->get('logger.log_message_parser');
-    $drushLogger = drush_get_context('DRUSH_LOG_CALLBACK');
+
+    $drushContainer = drush_get_dependency_injection_container();
+    $drushLogger = $drushContainer->get('logger');
+
     $logger = new \Drush\Log\DrushLog($parser, $drushLogger);
     $container->get('logger.factory')->addLogger($logger);
   }

--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -71,9 +71,7 @@ class DrupalBoot8 extends DrupalBoot {
     $container = \Drupal::getContainer();
     $parser = $container->get('logger.log_message_parser');
 
-    $drushContainer = drush_get_dependency_injection_container();
-    $drushLogger = $drushContainer->get('logger');
-
+    $drushLogger = \Drush::logger();
     $logger = new \Drush\Log\DrushLog($parser, $drushLogger);
     $container->get('logger.factory')->addLogger($logger);
   }

--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -4,6 +4,7 @@ namespace Drush\Boot;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Psr\Log\LoggerInterface;
 use Drupal\Core\DrupalKernel;
 
 class DrupalBoot8 extends DrupalBoot {
@@ -17,6 +18,10 @@ class DrupalBoot8 extends DrupalBoot {
    * @var \Symfony\Component\HttpFoundation\Request
    */
   protected $request;
+
+  public function __construct(LoggerInterface $logger) {
+    parent::__construct($logger);
+  }
 
   function valid_root($path) {
     if (!empty($path) && is_dir($path) && file_exists($path . '/index.php')) {

--- a/lib/Drush/Boot/EmptyBoot.php
+++ b/lib/Drush/Boot/EmptyBoot.php
@@ -2,6 +2,8 @@
 
 namespace Drush\Boot;
 
+use Psr\Log\LoggerInterface;
+
 /**
  * This is a do-nothing 'Boot' class that is used when there
  * is no site at --root, or when no root is specified.

--- a/lib/Drush/Boot/EmptyBoot.php
+++ b/lib/Drush/Boot/EmptyBoot.php
@@ -12,7 +12,8 @@ namespace Drush\Boot;
  */
 class EmptyBoot extends BaseBoot {
 
-  function __construct() {
+  public function __construct(LoggerInterface $logger) {
+    parent::__construct($logger);
   }
 
   function valid_root($path) {

--- a/lib/Drush/Log/Logger.php
+++ b/lib/Drush/Log/Logger.php
@@ -32,9 +32,12 @@ class Logger extends AbstractLogger {
 
     public function log($level, $message, array $context = array()) {
       // Convert to old $entry array for b/c calls
-      $entry = $context;
-      $entry['type'] = $level;
-      $entry['message'] = $message;
+      $entry = $context + [
+        'type' => $level,
+        'message' => $message,
+        'timestamp' => microtime(TRUE),
+        'memory' => memory_get_usage(),
+      ];
 
       // Drush\Log\Logger should take over all of the responsibilities
       // of drush_log, including caching the log messages and sending

--- a/lib/Drush/Symfony/BootstrapCompilerPass.php
+++ b/lib/Drush/Symfony/BootstrapCompilerPass.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drush\Symfony;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+class BootstrapCompilerPass implements CompilerPassInterface
+{
+  public function process(ContainerBuilder $container)
+  {
+    if (!$container->has('bootstrap.manager')) {
+      return;
+    }
+
+    $definition = $container->findDefinition(
+      'bootstrap.manager'
+    );
+
+    $taggedServices = $container->findTaggedServiceIds(
+      'bootstrap.boot'
+    );
+    foreach ($taggedServices as $id => $tags) {
+      $definition->addMethodCall(
+        'add',
+        array(new Reference($id))
+      );
+    }
+  }
+}


### PR DESCRIPTION
**Motivation:**

We'd like to be able to factor out key parts of Drush into libraries; key among these are the alias / backend invoke handling. We also want to move away from `drush_get_context()` for fetching important Drush service object references.

**First step:**

This PR initializes a DI container that has only the logger in it.  This will allow us to also initialize Alias and Backend Invoke classes from an external library, and use DI to give them a logger.

**Next steps:**

We could use DI to construct all of the bootstrap objects. If some external plugin provided a bootstrap object, it could also initialize it with its own foo-services.yml, and make references to 'logger' et. al. as needed to construct its objects, since the DI container will already be initialized with all of the standard Drush instances.  It would then need to make one more explicit call to add its bootstrap object to our bootstrap object manager.

We could use this technique for our bootstrap objects as well, so each DrushBootN had its own set of services, which instantiated the correct Rules8 vs Rules7 object, and gave them the same tag (e.g. 'rules').  This would make it way easier to provide platform-independent helper classes, or even use DI to provide the implementation for a group of Drush commands associated with a platform.