### PR TITLE
Strange problem with double-include of make.utilities.inc

### DIFF
--- a/tests/makeTest.php
+++ b/tests/makeTest.php
@@ -763,7 +763,7 @@ class makeMakefileCase extends CommandUnishTestCase {
    * Test that files without a core attribute are correctly identified.
    */
   public function testNoCoreMakefileParsing() {
-    require __DIR__ . '/../commands/make/make.utilities.inc';
+    require_once __DIR__ . '/../commands/make/make.utilities.inc';
 
     // INI.
     $data = file_get_contents(__DIR__ . '/makefiles/no-core.make');


### PR DESCRIPTION
Does not seem to be happening on Travis, but let's see if this at least does no harm. Just creating this to force the tests to run.