### PR TITLE
Update sql-connect to include Fish example.

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -77,7 +77,8 @@ function sql_drush_command() {
         ),
       ),
     'examples' => array(
-      '`drush sql-connect` < example.sql' => 'Import sql statements from a file into the current database.',
+      '`drush sql-connect` < example.sql' => 'Bash: Import SQL statements from a file into the current database.',
+      'eval (drush sql-connect) < example.sql' => 'Fish: Import SQL statements from a file into the current database.',
     ),
   );
   $items['sql-create'] = array(


### PR DESCRIPTION
When using Fish `drush sql-connect` doesn't work because Fish doesn't support command substitution as the command itself.

@see
https://github.com/fish-shell/fish-shell/issues/2669#issuecomment-171494288