### PR TITLE
Conflicting UUIDs in shortcut.set.default when using --config-dir

### DIFF
--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -251,6 +251,7 @@ function drush_core_site_install($profile = NULL) {
     // Set the destination site UUID to match the source UUID, to bypass a core fail-safe.
     $source_storage = new FileStorage($config);
     drush_op('drush_config_set', 'system.site', 'uuid', $source_storage->read('system.site')['uuid']);
+    drush_op('drush_config_set', 'shortcut.set.default', 'uuid', $source_storage->read('shortcut.set.default')['uuid']);
     // Run a full configuration import.
     drush_invoke_process('@self', 'config-import', array(), array('source' => $config));
   }


### PR DESCRIPTION
When using the config-dir option on site-install I was receiving the following error:

`Import the listed configuration changes? (y/n): y
Drupal\Core\Config\ConfigImporterException: There were errors validating the config synchronization. in 
Drupal\Core\Config\ConfigImporter->validate() (line 730 of /var/www/SITENAME/core/lib/Drupal/Core/Config/ConfigImporter.php).
The import failed due for the following reasons:
Entities exist of type <em class="placeholder">Shortcut link</em> and <em class="placeholder"></em> <em class="placeholder">Default</em>. These entities need to be deleted before importing.`

Setting the destination site shortcut.set.default UUID to that of the imported config resolved the issue for me.