### PR TITLE
Console_Table throws deprecated warnings on PHP 7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "psy/psysh": "~0.6",
     "symfony/yaml": "2.7.*",
     "symfony/var-dumper": "^2.6.3",
-    "pear/console_table": "dev-master#95607d141c"
+    "pear/console_table": "~1.3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",
@@ -44,13 +44,6 @@
       "ext-pcntl": "*",
       "drush/config-extra": "Provides configuration workflow commands, such as config-merge."
   },
-  "repositories": [
-      {
-          "_comment": "Packagist currently links to a fork of Console_Table rather than the canonical source.",
-          "type": "vcs",
-          "url": "git@github.com:pear/Console_Table"
-      }
-  ],
   "autoload": {
     "psr-0": {
       "Drush":        "lib/"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "psy/psysh": "~0.6",
     "symfony/yaml": "2.7.*",
     "symfony/var-dumper": "^2.6.3",
-    "pear/console_table": "dev-php7-support"
+    "pear/console_table": "dev-master#95607d141c"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",
@@ -46,9 +46,9 @@
   },
   "repositories": [
       {
-          "_comment": "Fork of pear/console_table that provides PHP 7 compatibility. See PR #13.",
+          "_comment": "Packagist currently links to a fork of Console_Table rather than the canonical source.",
           "type": "vcs",
-          "url": "git@github.com:ec-europa/Console_Table"
+          "url": "git@github.com:pear/Console_Table"
       }
   ],
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "psy/psysh": "~0.6",
     "symfony/yaml": "2.7.*",
     "symfony/var-dumper": "^2.6.3",
-    "pear/console_table": "~1.2.0"
+    "pear/console_table": "dev-php7-support"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",
@@ -44,6 +44,13 @@
       "ext-pcntl": "*",
       "drush/config-extra": "Provides configuration workflow commands, such as config-merge."
   },
+  "repositories": [
+      {
+          "_comment": "Fork of pear/console_table that provides PHP 7 compatibility. See PR #13.",
+          "type": "vcs",
+          "url": "git@github.com:ec-europa/Console_Table"
+      }
+  ],
   "autoload": {
     "psr-0": {
       "Drush":        "lib/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "623b1b9885e6668dc70e6a3726212bfb",
-    "content-hash": "b6e8f826a6964fbc5f0045a2b7e587dc",
+    "hash": "92bcde80a40d43f90efba6be244573d6",
+    "content-hash": "0af55007c0a85dc779e0db01c90f40f4",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -180,16 +180,16 @@
         },
         {
             "name": "pear/console_table",
-            "version": "dev-master",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Console_Table.git",
-                "reference": "95607d141c"
+                "reference": "64100b9ee81852f4fa17823e55d0b385a544f976"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Console_Table/zipball/95607d141c909ccebfc5d631652dd1ca4faa8331",
-                "reference": "95607d141c",
+                "url": "https://api.github.com/repos/pear/Console_Table/zipball/64100b9ee81852f4fa17823e55d0b385a544f976",
+                "reference": "64100b9ee81852f4fa17823e55d0b385a544f976",
                 "shasum": ""
             },
             "require": {
@@ -204,6 +204,7 @@
                     "Table.php"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-2-Clause"
             ],
@@ -230,11 +231,7 @@
             "keywords": [
                 "console"
             ],
-            "support": {
-                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Console_Table",
-                "source": "https://github.com/pear/Console_Table"
-            },
-            "time": "2016-01-19 08:32:40"
+            "time": "2016-01-21 16:14:31"
         },
         {
             "name": "psr/log",
@@ -1533,9 +1530,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "pear/console_table": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "160e694a860dd8b012104bae69cd2d75",
-    "content-hash": "345215a79dc35e20c5858b0a05b0aba6",
+    "hash": "c27d3aee74e187e21786fe92e1f3ef90",
+    "content-hash": "09dbbe99f14010908e30e6d7afacd010",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -180,20 +180,20 @@
         },
         {
             "name": "pear/console_table",
-            "version": "1.2.1",
+            "version": "dev-php7-support",
             "source": {
                 "type": "git",
-                "url": "https://github.com/RobLoach/Console_Table.git",
-                "reference": "10d89fbbe533351dcfe5dc1e84de25d9a8395950"
+                "url": "https://github.com/ec-europa/Console_Table.git",
+                "reference": "e9ccefc406362dcafbb188b4e0766ea215f2cfbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RobLoach/Console_Table/zipball/10d89fbbe533351dcfe5dc1e84de25d9a8395950",
-                "reference": "10d89fbbe533351dcfe5dc1e84de25d9a8395950",
+                "url": "https://api.github.com/repos/ec-europa/Console_Table/zipball/e9ccefc406362dcafbb188b4e0766ea215f2cfbe",
+                "reference": "e9ccefc406362dcafbb188b4e0766ea215f2cfbe",
                 "shasum": ""
             },
             "require": {
-                "php": ">=4.3.10"
+                "php": ">=5.1.2"
             },
             "suggest": {
                 "pear/Console_Color2": ">=0.1.2"
@@ -204,7 +204,6 @@
                     "Table.php"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-2-Clause"
             ],
@@ -231,7 +230,11 @@
             "keywords": [
                 "console"
             ],
-            "time": "2014-10-27 10:04:49"
+            "support": {
+                "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Console_Table",
+                "source": "https://github.com/pear/Console_Table"
+            },
+            "time": "2016-01-15 10:24:49"
         },
         {
             "name": "psr/log",
@@ -464,16 +467,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v2.8.1",
+            "version": "v2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "f943f29ae69c42511a2d85adee9d13d835b5c803"
+                "reference": "ab94426d127ad9e95433778a3a451fe9d18f3d6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/f943f29ae69c42511a2d85adee9d13d835b5c803",
-                "reference": "f943f29ae69c42511a2d85adee9d13d835b5c803",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/ab94426d127ad9e95433778a3a451fe9d18f3d6b",
+                "reference": "ab94426d127ad9e95433778a3a451fe9d18f3d6b",
                 "shasum": ""
             },
             "require": {
@@ -523,20 +526,20 @@
                 "debug",
                 "dump"
             ],
-            "time": "2015-12-05 11:09:21"
+            "time": "2016-01-07 13:38:40"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.8",
+            "version": "v2.7.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "1d96518eb7775ba42704652dff32269236c5adb4"
+                "reference": "a91e8af3dcde226e00be2e1c068764eef7b4c153"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/1d96518eb7775ba42704652dff32269236c5adb4",
-                "reference": "1d96518eb7775ba42704652dff32269236c5adb4",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a91e8af3dcde226e00be2e1c068764eef7b4c153",
+                "reference": "a91e8af3dcde226e00be2e1c068764eef7b4c153",
                 "shasum": ""
             },
             "require": {
@@ -572,7 +575,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-26 13:37:43"
+            "time": "2016-01-13 10:26:43"
         }
     ],
     "packages-dev": [
@@ -1480,16 +1483,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.8",
+            "version": "v2.7.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "a3fb8f4c4afc4f1b285de5df07e568602934f525"
+                "reference": "0570b9ca51135ee7da0f19239eaf7b07ffb87034"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/a3fb8f4c4afc4f1b285de5df07e568602934f525",
-                "reference": "a3fb8f4c4afc4f1b285de5df07e568602934f525",
+                "url": "https://api.github.com/repos/symfony/process/zipball/0570b9ca51135ee7da0f19239eaf7b07ffb87034",
+                "reference": "0570b9ca51135ee7da0f19239eaf7b07ffb87034",
                 "shasum": ""
             },
             "require": {
@@ -1525,12 +1528,14 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-23 11:03:39"
+            "time": "2016-01-06 09:57:37"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "pear/console_table": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c27d3aee74e187e21786fe92e1f3ef90",
-    "content-hash": "09dbbe99f14010908e30e6d7afacd010",
+    "hash": "623b1b9885e6668dc70e6a3726212bfb",
+    "content-hash": "b6e8f826a6964fbc5f0045a2b7e587dc",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -180,20 +180,20 @@
         },
         {
             "name": "pear/console_table",
-            "version": "dev-php7-support",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ec-europa/Console_Table.git",
-                "reference": "e9ccefc406362dcafbb188b4e0766ea215f2cfbe"
+                "url": "https://github.com/pear/Console_Table.git",
+                "reference": "95607d141c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ec-europa/Console_Table/zipball/e9ccefc406362dcafbb188b4e0766ea215f2cfbe",
-                "reference": "e9ccefc406362dcafbb188b4e0766ea215f2cfbe",
+                "url": "https://api.github.com/repos/pear/Console_Table/zipball/95607d141c909ccebfc5d631652dd1ca4faa8331",
+                "reference": "95607d141c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.1.2"
+                "php": ">=5.2.0"
             },
             "suggest": {
                 "pear/Console_Color2": ">=0.1.2"
@@ -234,7 +234,7 @@
                 "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Console_Table",
                 "source": "https://github.com/pear/Console_Table"
             },
-            "time": "2016-01-15 10:24:49"
+            "time": "2016-01-19 08:32:40"
         },
         {
             "name": "psr/log",


### PR DESCRIPTION
Whenever I execute a drush command that returns tabular data I get the following notice on PHP 7:

> Methods with the same name as their class will not be constructors in a future version of PHP; Console_Table has a deprecated constructor in Table.php on line 58

Here is the PR that fixes this: [PR #13: Old style constructors are deprecated in PHP 7](https://github.com/pear/Console_Table/pull/13).

We can use this version for the time being until the PR is accepted.