### PR TITLE
Support color tags in drush_print

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "psy/psysh": "~0.6",
     "symfony/yaml": "2.7.*",
     "symfony/var-dumper": "^2.6.3",
-    "pear/console_table": "~1.2.0"
+    "pear/console_table": "~1.2.0",
+    "symfony/console": "^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "160e694a860dd8b012104bae69cd2d75",
-    "content-hash": "345215a79dc35e20c5858b0a05b0aba6",
+    "hash": "d557ad433577cb9b616f7cd53f36ac42",
+    "content-hash": "c57583e132585d5c78949dd37ccaa682",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -1,6 +1,7 @@
 <?php
 
 use Drush\Log\LogLevel;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 /**
  * @defgroup outputfunctions Process output text.
@@ -37,7 +38,7 @@ function drush_print($message = '', $indent = 0, $handle = NULL, $newline = TRUE
     fwrite($handle, $msg);
   }
   else {
-    print $msg;
+    (new ConsoleOutput)->writeln($msg);
   }
 }
 


### PR DESCRIPTION
Since #88 does not seem to happen, I propose we leverage some _Symfony/Console_ subsystems individually. Colorful output may improve developer experience significantly.

Usage: `drush_print('<info>This will be green.</info>');`