### PR TITLE
Check for 'config_readonly' setting when writing config

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -10,6 +10,7 @@ use Drupal\Core\Config\StorageComparer;
 use Drupal\Core\Config\ConfigImporter;
 use Drupal\Core\Config\ConfigException;
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Site\Settings;
 use Drush\Config\StorageWrapper;
 use Drush\Config\CoreExtensionFilter;
 use Symfony\Component\Yaml\Parser;
@@ -257,6 +258,11 @@ function drush_config_set($config_name, $key = NULL, $data = NULL) {
 
   if (!isset($data)) {
     return drush_set_error('DRUSH_CONFIG_ERROR', dt('No config value specified.'));
+  }
+
+  // If configuration is in read-only mode, bail with a useful error message.
+  if (Settings::get('config_readonly', FALSE)) {
+    return drush_set_error(dt("Config edit is not allowed while \$settings['config_readonly'] is enabled."));
   }
 
   $config = Drupal::configFactory()->getEditable($config_name);
@@ -698,6 +704,11 @@ function drush_config_edit($config_name = '') {
   if (empty($config_name) && $file) {
     // If not provided, assume config name from the given file.
     $config_name = basename($file, '.yml');
+  }
+
+  // If configuration is in read-only mode, bail with a useful error message.
+  if (Settings::get('config_readonly', FALSE)) {
+    return drush_set_error(dt("Config edit is not allowed while \$settings['config_readonly'] is enabled."));
   }
 
   // Identify and validate input.


### PR DESCRIPTION
Bail with a useful error in config edit and config set commands, fixes #1934.