### PR TITLE
Allow drush rsync to operate on two remote aliases.

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -195,6 +195,7 @@ function config_drush_command() {
     'options' => array(
       'safe' => 'Validate that there are no git uncommitted changes before proceeding',
       'label' => "A config directory label (i.e. a key in \$config_directories array in settings.php). Defaults to 'sync'",
+      'runner' => 'Where to run the rsync command; defaults to the local site. Can also be "source" or "destination".',
     ),
     'topics' => array('docs-aliases', 'docs-config-exporting'),
   );
@@ -805,7 +806,7 @@ function drush_config_pull($source, $destination) {
     'delete' => TRUE,
   );
   $label = drush_get_option('label', 'sync');
-  $runner = drush_get_runner($source, $destination);
+  $runner = drush_get_runner($source, $destination, drush_get_option('runner', FALSE));
   drush_log(dt('Starting to rsync configuration files from !source to !dest.', array('!source' => $source, '!dest' => $destination)), LogLevel::OK);
   $return = drush_invoke_process($runner, 'core-rsync', array("$source:$export_path", "$destination:%config-$label"), $rsync_options, $backend_options);
   if ($return['error_status']) {

--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -290,7 +290,7 @@ function core_drush_command() {
     ),
     'strict-option-handling' => TRUE,
     'examples' => array(
-      'drush rsync @dev @stage' => 'Rsync Drupal root from Drush alias dev to the alias stage (one of which must be local).',
+      'drush rsync @dev @stage' => 'Rsync Drupal root from Drush alias dev to the alias stage. Either or both may be remote.',
       'drush rsync ./ @stage:%files/img' => 'Rsync all files in the current directory to the \'img\' directory in the file storage folder on the Drush alias stage.',
       'drush -s rsync @dev @stage --exclude=*.sql --delete' => "Simulate Rsync Drupal root from the Drush alias dev to the alias stage (one of which must be local), excluding all files that match the filter '*.sql' and delete all files on the destination that are no longer on the source.",
     ),

--- a/commands/core/rsync.core.inc
+++ b/commands/core/rsync.core.inc
@@ -58,6 +58,13 @@ function drush_core_rsync($source, $destination, $additional_options = array()) 
     }
   }
 
+  // Next, check to see if both the source and the destination are remote.
+  // If so, then we'll process this as an rsync from source to local,
+  // followed by an rsync from local to the destination.
+  if (drush_sitealias_is_remote_site($source_settings) && drush_sitealias_is_remote_site($destination_settings)) {
+    return _drush_core_rsync_both_remote($source, $destination, $additional_options, $source_path);
+  }
+
   // Exclude settings is the default only when both the source and
   // the destination are aliases or site names.  Therefore, include
   // settings will be the default whenever either the source or the
@@ -212,4 +219,69 @@ function _drush_rsync_option_exists($option, $additional_options) {
   else {
     return drush_get_option($option, FALSE);
   }
+}
+
+/**
+ * Handle an rsync operation from a remote site to a remote
+ * site by first rsync'ing to a local location, and then
+ * copying that location to its final destination.
+ */
+function _drush_core_rsync_both_remote($source, $destination, $additional_options, $source_path) {
+  $options = $additional_options + drush_redispatch_get_options();
+
+  // Make a temporary directory to copy to.  There are three
+  // cases to consider:
+  //
+  // 1. rsync @src:file.txt @dest:location
+  // 2. rsync @src:dir @dest:location
+  // 3. rsync @src:dir/ @dest:location
+  //
+  // We will explain each of these in turn.
+  //
+  // 1. Copy a single file.  We'll split this up like so:
+  //
+  //    rsync @src:file.txt /tmp/tmpdir
+  //    rsync /tmp/tmpdir/file.txt @dest:location
+  //
+  // Since /tmp/tmpdir is empty, we could also rsync from
+  // '/tmp/tmpdir/' if we wished.
+  //
+  // 2. Copy a directory. A directory with the same name
+  // is copied to the destination.  We'll split this up like so:
+  //
+  //    rsync @src:dir /tmp/tmpdir
+  //    rsync /tmp/tmpdir/dir @dest:location
+  //
+  // The result is that everything in 'dir' is copied to @dest,
+  // and ends up in 'location/dir'.
+  //
+  // 3. Copy the contents of a directory.  We will split this
+  // up as follows:
+  //
+  //    rsync @src:dir/ /tmp/tmpdir
+  //    rsync /tmp/tmpdir/ @dest:location
+  //
+  // After the first rsync, everything in 'dir' will end up in
+  // tmpdir.  The second rsync copies everything in tmpdir to
+  // @dest:location without creating an encapsulating folder
+  // in the destination (i.e. there is no 'tmpdir' in the destination).
+  //
+  // All three of these cases need to be handled correctly in order
+  // to ensure the correct results.  In all cases, though, the first
+  // rsync always copies to $tmpDir, and the second rsync always
+  // copies from $tmpDir/basename($source_path).  So, the actual logic
+  // comes out to be much simpler than the analysis.
+  $putInTmpPath = drush_tempdir();
+  $getFromTmpPath = "$putInTmpPath/" . basename($source_path);
+
+  // Copy from the source to the temporary location. Exit on failure.
+  $values = drush_invoke_process('@self', 'core-rsync', array($source, $putInTmpPath), $options);
+  if ($values['error'] != 0) {
+    return FALSE;
+  }
+
+  // Copy from the temporary location to the final destination.
+  $values = drush_invoke_process('@self', 'core-rsync', array($getFromTmpPath, $destination), $options);
+
+  return $values['error'] == 0;
 }

--- a/commands/sql/sqlsync.drush.inc
+++ b/commands/sql/sqlsync.drush.inc
@@ -263,7 +263,7 @@ function drush_sqlsync_sql_sync($source, $destination) {
       // Cleanup if this command created the dump file.
       $rsync_options['remove-source-files'] = TRUE;
     }
-    $runner = drush_get_runner($source, $destination);
+    $runner = drush_get_runner($source_settings, $destination_settings);
     // Since core-rsync is a strict-handling command and drush_invoke_process() puts options at end, we can't send along cli options to rsync.
     // Alternatively, add options like --ssh-options to a site alias (usually on the machine that initiates the sql-sync).
     $return = drush_invoke_process($runner, 'core-rsync', array("$source:$source_dump_path", "$destination:$destination_dump_path"), $rsync_options);

--- a/commands/sql/sqlsync.drush.inc
+++ b/commands/sql/sqlsync.drush.inc
@@ -44,6 +44,7 @@ function sqlsync_drush_command() {
       // 'no-cache' => 'Do not cache the sql-dump file.',
       'no-dump' => 'Do not dump the sql database; always use an existing dump file.',
       'no-sync' => 'Do not rsync the database dump file from source to target.',
+      'runner' => 'Where to run the rsync command; defaults to the local site. Can also be "source" or "destination".',
       'source-db-url' => 'Database specification for source system to dump from.',
       'source-remote-port' => 'Override sql database port number in source-db-url. Optional.',
       'source-remote-host' => 'Remote machine to run sql-dump file on. Optional; default is local machine.',
@@ -263,7 +264,7 @@ function drush_sqlsync_sql_sync($source, $destination) {
       // Cleanup if this command created the dump file.
       $rsync_options['remove-source-files'] = TRUE;
     }
-    $runner = drush_get_runner($source_settings, $destination_settings);
+    $runner = drush_get_runner($source_settings, $destination_settings, drush_get_option('runner', FALSE));
     // Since core-rsync is a strict-handling command and drush_invoke_process() puts options at end, we can't send along cli options to rsync.
     // Alternatively, add options like --ssh-options to a site alias (usually on the machine that initiates the sql-sync).
     $return = drush_invoke_process($runner, 'core-rsync', array("$source:$source_dump_path", "$destination:$destination_dump_path"), $rsync_options);

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1115,7 +1115,7 @@ function drush_sitealias_resolve_path_references(&$alias_record, $test_string = 
   }
   $project_list = implode(',', $project_array);
 
-  if (!empty($project_array)) {
+  if (!empty($project_array) || !isset($alias_record['root'])) {
     // Optimization:  if we're already bootstrapped to the
     // site specified by $alias_record, then we can just
     // call _core_site_status_table() rather than use backend invoke.
@@ -1934,7 +1934,7 @@ function drush_sitealias_evaluate_path($path, &$additional_options, $local_only 
     drush_sitealias_set_alias_context($site_alias_settings);
 
     // Use 'remote-host' from settings if available; otherwise site is local
-    if (array_key_exists('remote-host', $site_alias_settings) && !drush_is_local_host($site_alias_settings['remote-host'])) {
+    if (drush_sitealias_is_remote_site($site_alias_settings)) {
       $machine = drush_remote_host($site_alias_settings);
     }
     else {
@@ -2027,7 +2027,7 @@ function drush_sitealias_evaluate_path($path, &$additional_options, $local_only 
   if (array_key_exists('root', $site_alias_settings)) {
     $drupal_root = $site_alias_settings['root'];
   }
-  else {
+  elseif (!drush_sitealias_is_remote_site($site_alias_settings)) {
     drush_bootstrap_max(DRUSH_BOOTSTRAP_DRUPAL_SITE);
     $drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT');
   }
@@ -2280,18 +2280,26 @@ function drush_sitealias_get_root($alias_record) {
  * @return mixed
  */
 function drush_get_runner($source, $destination) {
+  if (is_string($source)) {
+    $source = drush_sitealiase_get_record($site);
+  }
+  if (is_string($destination)) {
+    $source = drush_sitealiase_get_record($destination);
+  }
 // Try run to rsync locally so that aliases always resolve. https://github.com/drush-ops/drush/issues/668
 // Return @self when possible instead of $source or $destination so that @self in a core-rsync argument resolves properly.
-  if (drush_sitealias_is_remote_site($source) === FALSE) {
-    $runner = '@self';
+  if (drush_sitealias_is_remote_site($source) && drush_sitealias_is_remote_site($destination)) {
+    // Both are remote. Now that rsync can handle both aliases being
+    // remote sites, only do the optimized remote execution when the
+    // alias explitily allows it.
+    if (array_key_exists('#remote-rsync', $destination)) {
+      return "@" . $destination['#name'];
+    }
+    if (array_key_exists('#remote-rsync', $source)) {
+      return "@" . $source['#name'];
+    }
   }
-  elseif (drush_sitealias_is_remote_site($destination) === FALSE) {
-    $runner = '@self';
-  }
-  else {
-    // Both are remote. Arbitrarily run rsync on destination. Aliases must be defined there (for now).
-    // @todo Add an option for choosing runner? Resolve aliases before rsync?
-    $runner = $destination;
-  }
-  return $runner;
+  // Default to running rsync locally. When in doubt, local is best, because
+  // we can always resolve aliases here.
+  return '@self';
 }

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -2279,26 +2279,29 @@ function drush_sitealias_get_root($alias_record) {
  * @param $destination
  * @return mixed
  */
-function drush_get_runner($source, $destination) {
+function drush_get_runner($source, $destination, $runner = FALSE) {
   if (is_string($source)) {
     $source = drush_sitealiase_get_record($site);
   }
   if (is_string($destination)) {
     $source = drush_sitealiase_get_record($destination);
   }
-// Try run to rsync locally so that aliases always resolve. https://github.com/drush-ops/drush/issues/668
-// Return @self when possible instead of $source or $destination so that @self in a core-rsync argument resolves properly.
+
+  // If both sites are remote, and --runner=auto, then we'll use the destination site.
   if (drush_sitealias_is_remote_site($source) && drush_sitealias_is_remote_site($destination)) {
-    // Both are remote. Now that rsync can handle both aliases being
-    // remote sites, only do the optimized remote execution when the
-    // alias explitily allows it.
-    if (array_key_exists('#remote-rsync', $destination)) {
-      return "@" . $destination['#name'];
-    }
-    if (array_key_exists('#remote-rsync', $source)) {
-      return "@" . $source['#name'];
+    if ($runner == 'auto') {
+      $runner = 'destination';
     }
   }
+
+  // If the user explicitly requests a remote site, then return the selected one.
+  if ($runner == 'destination') {
+    return "@" . $destination['#name'];
+  }
+  if ($runner == 'source') {
+    return "@" . $source['#name'];
+  }
+
   // Default to running rsync locally. When in doubt, local is best, because
   // we can always resolve aliases here.
   return '@self';

--- a/tests/siteAliasTest.php
+++ b/tests/siteAliasTest.php
@@ -83,6 +83,55 @@ EOD;
     $this->assertEquals( "WORKING CASE = TRUE", $output);
   }
 
+
+  /**
+   * Test to see if rsync @site:%files calculates the %files path correctly.
+   * This tests the non-optimized code path in drush_sitealias_resolve_path_references.
+   */
+  function testRsyncBothRemote() {
+    $aliasPath = UNISH_SANDBOX . '/site-alias-directory';
+    file_exists($aliasPath) ?: mkdir($aliasPath);
+    $aliasFile = $aliasPath . '/remote.aliases.drushrc.php';
+    $aliasContents = <<<EOD
+  <?php
+  // Written by Unish. This file is safe to delete.
+  \$aliases['one'] = array(
+    'remote-host' => 'fake.remote-host.com',
+    'remote-user' => 'www-admin',
+    'root' => '/fake/path/to/root',
+    'uri' => 'default',
+  );
+  \$aliases['two'] = array(
+    'remote-host' => 'other-fake.remote-host.com',
+    'remote-user' => 'www-admin',
+    'root' => '/other-fake/path/to/root',
+    'uri' => 'default',
+  );
+EOD;
+    file_put_contents($aliasFile, $aliasContents);
+    $options = array(
+      'alias-path' => $aliasPath,
+      'simulate' => TRUE,
+      'yes' => NULL,
+    );
+    $this->drush('core-rsync', array("@remote.one:files", "@remote.two:tmp"), $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1;');
+    $output = $this->getOutput();
+    $level = $this->log_level();
+    $pattern = in_array($level, array('verbose', 'debug')) ? "Calling system(rsync -e 'ssh ' -akzv --stats --progress --yes %s /tmp);" : "Calling system(rsync -e 'ssh ' -akz --yes %s /tmp);";
+    $expected = sprintf($pattern, UNISH_SANDBOX . "/web/sites/$site/files");
+
+
+    // Expected ouput:
+    //   Simulating backend invoke: /path/to/php  -d sendmail_path='true' /path/to/drush.php --php=/path/to/php --php-options=' -d sendmail_path='\''true'\'''  --backend=2 --alias-path=/path/to/site-alias-directory --nocolor --root=/fake/path/to/root --uri=default  core-rsync '@remote.one:files' /path/to/tmpdir 2>&1
+    //   Simulating backend invoke: /path/to/php  -d sendmail_path='true' /path/to/drush.php --php=/path/to/php --php-options=' -d sendmail_path='\''true'\'''  --backend=2 --alias-path=/path/to/site-alias-directory --nocolor --root=/fake/path/to/root --uri=default  core-rsync /path/to/tmpdir/files '@remote.two:tmp' 2>&1'
+    // Since there are a lot of variable items in the output (e.g. path
+    // to a temporary folder), so we will use 'assertContains' to
+    // assert on portions of the output that does not vary.
+    $this->assertContains('Simulating backend invoke', $output);
+    $this->assertContains("core-rsync '@remote.one:files' /", $output);
+    $this->assertContains("/files '@remote.two:tmp'", $output);
+  }
+
   /**
    * Assure that site lists work as expected.
    * @todo Use --backend for structured return data. Depends on http://drupal.org/node/1043922


### PR DESCRIPTION
An oft-requested feature. Handy for migrations.