### PR TITLE
drush_sitealiase_get_record does not exist

### DIFF
--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -2283,10 +2283,10 @@ function drush_sitealias_get_root($alias_record) {
  */
 function drush_get_runner($source, $destination, $runner = FALSE) {
   if (is_string($source)) {
-    $source = drush_sitealiase_get_record($site);
+    $source = drush_sitealias_get_record($site);
   }
   if (is_string($destination)) {
-    $source = drush_sitealiase_get_record($destination);
+    $source = drush_sitealias_get_record($destination);
   }
 
   // If both sites are remote, and --runner=auto, then we'll use the destination site.


### PR DESCRIPTION
with https://github.com/drush-ops/drush/pull/1937 we introduced a typo:
`drush_sitealiase_get_record` is called `drush_sitealias_get_record` :)