### PR TITLE
Remove check for root in alias record 

### DIFF
--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1115,7 +1115,7 @@ function drush_sitealias_resolve_path_references(&$alias_record, $test_string = 
   }
   $project_list = implode(',', $project_array);
 
-  if (!empty($project_array) || !isset($alias_record['root'])) {
+  if (!empty($project_array)) {
     // Optimization:  if we're already bootstrapped to the
     // site specified by $alias_record, then we can just
     // call _core_site_status_table() rather than use backend invoke.


### PR DESCRIPTION
It caused lots of entries into the drush_invoke_process() branch for alias records containing site lists and also aliases that were used as @parent records. This led to backend calls out to remote-hosts like pantheon.com and acquia.com for me (I have a lot of aliases).

The line I'm editing reverts an edit by "rsync on two remotes". See https://github.com/drush-ops/drush/commit/33fa3d24004d5db1f4118a430b3663f18364e06f#diff-7fa60dcfe6be9c85f3682fccc9d87899L1118

Lets see what fails (i.e. new rsync test).