### PR TITLE
--Uri on CLI overrides alias. Fixes #1883.

### DIFF
--- a/includes/command.inc
+++ b/includes/command.inc
@@ -718,9 +718,9 @@ function drush_redispatch_get_options() {
   unset($cli_context['php']);
   unset($cli_context['php-options']);
   // cli overrides and command specific
-  $options = $cli_context + drush_get_context('specific');
+  $options_soup = $cli_context + drush_get_context('specific') + drush_get_context('alias');
   $global_option_list = drush_get_global_options(FALSE);
-  foreach (drush_get_context('alias') as $key => $value) {
+  foreach ($options_soup as $key => $value) {
     if (array_key_exists($key, $global_option_list)) {
       $options[$key] = $value;
     }

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -88,15 +88,15 @@ function drush_sitealias_check_site_env() {
  * Check to see if a '@self' record was created during bootstrap.
  * If not, make one now.
  */
-function drush_sitealias_create_self_alias() {
-  $self_record = drush_sitealias_get_record('@self');
-  if (!array_key_exists('root', $self_record) && !array_key_exists('remote-host', $self_record)) {
-    $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
-    $uri = drush_get_context('DRUSH_SELECTED_URI');
-    if (!empty($drupal_root) && !empty($uri)) {
-      // Create an alias '@self'
-      _drush_sitealias_cache_alias('@self', array('root' => $drupal_root, 'uri' => $uri));
-    }
+function drush_sitealias_create_self_alias($fallback_site_record = array()) {
+  $drupal_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+  $uri = drush_get_context('DRUSH_SELECTED_URI');
+  // Create an alias '@self'
+  if (!empty($drupal_root) && !empty($uri)) {
+    _drush_sitealias_cache_alias('@self', array('root' => $drupal_root, 'uri' => $uri));
+  }
+  elseif (!empty($fallback_site_record['root']) && !empty($fallback_site_record['uri'])) {
+    _drush_sitealias_cache_alias('@self', $fallback_site_record);
   }
 }
 
@@ -226,6 +226,8 @@ function drush_sitealias_get_record($alias, $alias_context = NULL) {
         $path = drush_sitealias_local_site_path($alias_record);
         if ($path) {
           $cached_alias_record = drush_sitealias_lookup_alias_by_path($path);
+          // Don't overrite keys which have already been negotiated.
+          unset($cached_alias_record['#name'], $cached_alias_record['root'], $cached_alias_record['uri']);
           $alias_record = array_merge($alias_record, $cached_alias_record);
         }
       }
@@ -1705,8 +1707,8 @@ function _drush_sitealias_set_context_by_name($alias, $prefix = '') {
       drush_sitealias_cache_alias_by_path($site_alias_settings);
       if (empty($prefix)) {
         // Create an alias '@self'
-        _drush_sitealias_cache_alias('@self', $site_alias_settings);
-        // change the selected site to match the new --root and --uri, if any were set
+        drush_sitealias_create_self_alias($site_alias_settings);
+        // Change the selected site to match the new --root and --uri, if any were set.
         _drush_preflight_root_uri();
       }
       return $site_alias_settings;

--- a/tests/Unish/UnishTestCase.php
+++ b/tests/Unish/UnishTestCase.php
@@ -283,10 +283,6 @@ abstract class UnishTestCase extends \PHPUnit_Framework_TestCase {
       foreach ($sites_subdirs as $subdir) {
         $this->fetchInstallDrupal($subdir, $install, $version_string, $profile);
       }
-      // Write an empty sites.php if we are on D8+. Needed for multi-site.
-      if ($major_version >= 8 && !file_exists($root . '/sites/sites.php')) {
-        copy($root . '/sites/example.sites.php', $root . '/sites/sites.php');
-      }
       $options = array(
         'destination' => $source,
         'root' => $root,
@@ -296,6 +292,11 @@ abstract class UnishTestCase extends \PHPUnit_Framework_TestCase {
       if ($install) {
         $this->drush('archive-dump', array('@sites'), $options);
       }
+    }
+    // Write an empty sites.php if we are on D7+. Needed for multi-site on D8 and
+    // used on D7 in \Unish\saCase::testBackendHonorsAliasOverride.
+    if ($major_version >= 7 && !file_exists($root . '/sites/sites.php')) {
+      copy($root . '/sites/example.sites.php', $root . '/sites/sites.php');
     }
 
     // Stash details about each site.

--- a/tests/sqlSyncTest.php
+++ b/tests/sqlSyncTest.php
@@ -97,7 +97,7 @@ class sqlSyncTest extends CommandUnishTestCase {
       'sanitize' => NULL,
       'yes' => NULL,
       'sanitize-email' => 'user@mysite.org',
-      // Test wildcards expansion from within sql-sync. Also avoid D8 persisten entity cache.
+      // Test wildcards expansion from within sql-sync. Also avoid D8 persistent entity cache.
       'structure-tables-list' => 'cache,cache*',
     );
     $this->drush('sql-sync', array('@stage', '@dev'), $sync_options);


### PR DESCRIPTION
Allow cli overrides in drush_redispatch_get_options() and in @self. This replaces the PR #1924.