### PR TITLE
Fatal error when calling drush cpull with no additional arguments

### DIFF
--- a/includes/command.inc
+++ b/includes/command.inc
@@ -711,6 +711,7 @@ function _drush_flatten_options($options) {
  *   An associative array of option key => value pairs.
  */
 function drush_redispatch_get_options() {
+  $options = array();
   // Start off by taking everything from the site alias and command line
   // ('cli' context)
   $cli_context = drush_get_context('cli');


### PR DESCRIPTION
with https://github.com/drush-ops/drush/pull/1952 we changed the behavior of `drush_redispatch_get_options()` which ends up in the function having array function errors when there are no arguments at all.
I saw it failing then on `drush cpull` but there are probably also other places.

the full error:

```
drupal8@drupalhostingdev1:~/public_html (dev)$ drush cpull @dev default
array_diff_key(): Argument #1 is not an array command.inc:729                                       
PHP Fatal error:  Unsupported operand types in /opt/drush/master/vendor/drush/drush/commands/core/config.drush.inc on line 782

Fatal error: Unsupported operand types in /opt/drush/master/vendor/drush/drush/commands/core/config.drush.inc on line 782
Drush command terminated abnormally due to an unrecoverable error.                                  
Error: Unsupported operand types in
/opt/drush/master/vendor/drush/drush/commands/core/config.drush.inc, line 782
```

with just starting with an empty array for `$options` everything is fixed :)