### PR TITLE
Improve help texts on config-export

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -444,10 +444,10 @@ function _drush_config_export($destination, $destination_dir, $branch) {
 
     $config_comparer = new StorageComparer($comparison_source, $target_storage, Drupal::service('config.manager'));
     if (!$config_comparer->createChangelist()->hasChanges()) {
-      return drush_log(dt('There are no changes to export.'), LogLevel::OK);
+      return drush_log(dt('The active config does not differ to the export directory (!target).', array('!target' => $destination_dir)), LogLevel::OK);
     }
 
-    drush_print("The following configuration changes have been made since the last export:\n");
+    drush_print("Differences of the active config to the export directory:\n");
     $change_list = array();
     foreach ($config_comparer->getAllCollectionNames() as $collection) {
       $change_list[$collection] = $config_comparer->getChangelist(NULL, $collection);
@@ -462,7 +462,7 @@ function _drush_config_export($destination, $destination_dir, $branch) {
     }
     $comment .= "\n\n$output";
 
-    if (!$commit && !drush_confirm(dt('The .yml files in your export directory (!target) will be deleted.', array('!target' => $destination_dir)))) {
+    if (!$commit && !drush_confirm(dt('The .yml files in your export directory (!target) will be deleted and overwridden with the active config.', array('!target' => $destination_dir)))) {
       return drush_user_abort();
     }
     // Only delete .yml files, and not .htaccess or .git.


### PR DESCRIPTION
I'm working on documenting and improving the Drupal 8 configuration management experience, it spoke to some developers and they are sometimes confused with the helper-texts that drush shows, so I took some time and checked how we could improve the experience.

Added some inline comments why I think my changes are better