### PR TITLE
Fixes #1895: Check for autoload.php rather than index.php 

### DIFF
--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -19,7 +19,7 @@ class DrupalBoot8 extends DrupalBoot {
   protected $request;
 
   function valid_root($path) {
-    if (!empty($path) && is_dir($path) && file_exists($path . '/index.php')) {
+    if (!empty($path) && is_dir($path) && file_exists($path . '/autoload.php')) {
       // Additional check for the presence of core/composer.json to
       // grant it is not a Drupal 7 site with a base folder named "core".
       $candidate = 'core/includes/common.inc';


### PR DESCRIPTION
Apparently, some folks use Drupal 8 with a Symfony front-controller.  Not sure why, but autoload.php is a file that definitely must exist in Drupal 8, so this will do as well as index.php for our purposes.

Seems legitimate to me, anyway; let's see what the tests say.