### PR TITLE
Add a new log level, DEBUG_NOTIFY. 

### DIFF
--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -355,9 +355,12 @@ function drush_preflight_site() {
 
 function _drush_preflight_global_options() {
   // Debug implies verbose
-  drush_set_context('DRUSH_VERBOSE',     drush_get_option(array('verbose', LogLevel::DEBUG), FALSE));
-  drush_set_context('DRUSH_DEBUG', drush_get_option(LogLevel::DEBUG));
-  drush_set_context('DRUSH_SIMULATE',    drush_get_option('simulate', FALSE));
+  $verbose = drush_get_option('verbose', FALSE);
+  $debug = drush_get_option('debug', FALSE);
+  drush_set_context('DRUSH_VERBOSE',      $verbose || $debug);
+  drush_set_context('DRUSH_DEBUG',        $debug);
+  drush_set_context('DRUSH_DEBUG_NOTIFY', $verbose && $debug);
+  drush_set_context('DRUSH_SIMULATE',     drush_get_option('simulate', FALSE));
 
   // Backend implies affirmative unless negative is explicitly specified
   drush_set_context('DRUSH_NEGATIVE',    drush_get_option('no', FALSE));

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -632,7 +632,7 @@ function _drush_sitealias_find_alias_files($aliasname = NULL, $alias_path_contex
   foreach ($alias_path as $path) {
     // Find all of the matching files in this location
     foreach ($alias_files as $file_pattern_to_search_for) {
-      drush_log(dt('Scanning into @path for @pattern', array('@path' => $path, '@pattern' => $file_pattern_to_search_for)), LogLevel::DEBUG);
+      drush_log(dt('Scanning into @path for @pattern', array('@path' => $path, '@pattern' => $file_pattern_to_search_for)), LogLevel::DEBUG_NOTIFY);
       $alias_files_to_consider = array_merge($alias_files_to_consider, array_keys(drush_scan_directory($path, $file_pattern_to_search_for, $blacklist, 0, TRUE)));
     }
   }

--- a/lib/Drush/Log/LogLevel.php
+++ b/lib/Drush/Log/LogLevel.php
@@ -18,6 +18,10 @@ class LogLevel extends \Psr\Log\LogLevel
     // Various 'success' messages.  Like 'notice'
     const OK = 'ok';
 
+    // Highly verbose messages that are not always interesting.
+    // Displayed only when --debug and --verbose specified together.
+    const DEBUG_NOTIFY = 'debugnotify';
+
     // Means the command was successful. Should appear at most once
     // per command (perhaps more if subcommands are executed, though).
     // Like 'notice'.

--- a/lib/Drush/Log/Logger.php
+++ b/lib/Drush/Log/Logger.php
@@ -42,7 +42,9 @@ class Logger extends AbstractLogger {
       // TODO: move these implementations inside this class.
       $log =& drush_get_context('DRUSH_LOG', array());
       $log[] = $entry;
-      drush_backend_packet('log', $entry);
+      if ($level != LogLevel::DEBUG_NOTIFY) {
+        drush_backend_packet('log', $entry);
+      }
 
       if (drush_get_context('DRUSH_NOCOLOR')) {
         $red = "[%s]";
@@ -57,19 +59,22 @@ class Logger extends AbstractLogger {
 
       $verbose = drush_get_context('DRUSH_VERBOSE');
       $debug = drush_get_context('DRUSH_DEBUG');
+      $debugnotify = drush_get_context('DRUSH_DEBUG_NOTIFY');
 
       switch ($level) {
         case LogLevel::WARNING :
-        case 'cancel' :
+        case LogLevel::CANCEL :
           $type_msg = sprintf($yellow, $level);
           break;
         case 'failed' : // Obsolete; only here in case contrib is using it.
-        case 'error' :
+        case LogLevel::EMERGENCY : // Not used by Drush
+        case LogLevel::ALERT : // Not used by Drush
+        case LogLevel::ERROR :
           $type_msg = sprintf($red, $level);
           break;
-        case 'ok' :
+        case LogLevel::OK :
         case 'completed' : // Obsolete; only here in case contrib is using it.
-        case 'success' :
+        case LogLevel::SUCCESS :
         case 'status': // Obsolete; only here in case contrib is using it.
           // In quiet mode, suppress progress messages
           if (drush_get_context('DRUSH_QUIET')) {
@@ -77,15 +82,26 @@ class Logger extends AbstractLogger {
           }
           $type_msg = sprintf($green, $level);
           break;
-        case 'notice' :
+        case LogLevel::NOTICE :
         case 'message' : // Obsolete; only here in case contrib is using it.
-        case 'info' :
+        case LogLevel::INFO :
           if (!$verbose) {
             // print nothing. exit cleanly.
             return TRUE;
           }
           $type_msg = sprintf("[%s]", $level);
           break;
+        case LogLevel::DEBUG_NOTIFY :
+          $level = LogLevel::DEBUG; // Report 'debug', handle like 'preflight'
+        case LogLevel::PREFLIGHT :
+          if (!$debugnotify) {
+            // print nothing unless --debug AND --verbose. exit cleanly.
+            return TRUE;
+          }
+          $type_msg = sprintf("[%s]", $level);
+          break;
+        case LogLevel::BOOTSTRAP :
+        case LogLevel::DEBUG :
         default :
           if (!$debug) {
             // print nothing. exit cleanly.


### PR DESCRIPTION
Messages logged at this level are only displayed when --debug and --verbose are used together.

--verbose:  Prints verbose log messages (e.g. 'notice'), but not debug.

--debug:  Prints verbose AND debug log messages (e.g. 'notice' and 'debug'), but does not print LogLevel::DEBUG_NOTIFY messages.

--debug --verbose:  Like --debug, but also prints new LogLevel::DEBUG_NOTIFY messages.

With this PR, only 'preflight' and the site-alias 'Scanning into' messages are moved to LogLevel::DEBUG_NOTIFY. Even with this small change, I like --debug output much better, as a lot of noise that is usually not interesting is removed.

We will have a minimal impact of occasionally having to ask folks to run with `-dv` for extra debugging info, but this should be very rare. It's unlikely that we'll ever need the 'preflight' messages, and the alias-scanning stuff is only useful when debugging site alias usage.  In general, I think it will be very helpful to have this extra logging level, as we can start to add in info that is useful only in edge cases, without making ordinary debug logs arduously long.

Note that I also remove DEBUG_NOTIFY (but not PREFLIGHT) log message from inclusion in the backend invoke packet log.