### PR TITLE
Fixes #1845: Report bootstrap errors that may arise in bootstrap_max()

### DIFF
--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -140,14 +140,17 @@ function drush_cache_command_clear($type = NULL) {
       return drush_user_abort();
     }
   }
+  // Require a full bootstrap unless we are just clearing the Drush cache.
+  // This will give more consistent error messages when a site cannot be found.
+  if ($type != 'drush') {
+    drush_bootstrap_max(); // bootstrap quietly - drush_bootstrap may fail ungracefully
+    if (!drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_FULL)) {
+      return drush_set_error('DRUSH_CC_COULD_NOT_BOOTSTRAP', dt("The cache could not be cleared, because the Drupal site could not be bootstrapped."));
+    }
+  }
   // Do it.
   drush_op($types[$type]);
-  if ($type == 'all' && !drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_FULL)) {
-    drush_log(dt("No Drupal site found, only 'drush' cache was cleared."), LogLevel::WARNING);
-  }
-  else {
-    drush_log(dt("'!name' cache was cleared.", array('!name' => $type)), LogLevel::SUCCESS);
-  }
+  drush_log(dt("'!name' cache was cleared.", array('!name' => $type)), LogLevel::SUCCESS);
 }
 
 /**

--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -143,7 +143,7 @@ function drush_cache_command_clear($type = NULL) {
   // Require a full bootstrap unless we are just clearing the Drush cache.
   // This will give more consistent error messages when a site cannot be found.
   if ($type != 'drush') {
-    if (!drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_FULL)) {
+    if (!drush_require_bootstrap(DRUSH_BOOTSTRAP_DRUPAL_FULL)) {
       return drush_set_error('DRUSH_CC_COULD_NOT_BOOTSTRAP', dt("The cache could not be cleared, because the Drupal site could not be bootstrapped."));
     }
   }

--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -143,7 +143,6 @@ function drush_cache_command_clear($type = NULL) {
   // Require a full bootstrap unless we are just clearing the Drush cache.
   // This will give more consistent error messages when a site cannot be found.
   if ($type != 'drush') {
-    drush_bootstrap_max(); // bootstrap quietly - drush_bootstrap may fail ungracefully
     if (!drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_FULL)) {
       return drush_set_error('DRUSH_CC_COULD_NOT_BOOTSTRAP', dt("The cache could not be cleared, because the Drupal site could not be bootstrapped."));
     }

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -378,6 +378,8 @@ function drush_bootstrap($phase, $phase_max = FALSE) {
  * fix it. Take a deep breath, and smile. See
  * http://en.wikipedia.org/wiki/HTTP_referer
  *
+ * IMPORTANT: If a command requires a certain bootstrap level in order to
+ * continue, then drush_require_bootstrap() should be used instead.
  *
  * @param int $phase
  *   The bootstrap phase to test
@@ -389,6 +391,26 @@ function drush_has_boostrapped($phase) {
   $phase_index = drush_get_context('DRUSH_BOOTSTRAP_PHASE');
 
   return isset($phase_index) && ($phase_index >= $phase);
+}
+
+/**
+ * Require a certain minimum bootstrap in order to continue.  If the
+ * requested level has not been met, then any bootstrap errors that
+ * prevented us from bootstrapping farther will be displayed.
+ *
+ * Usage:
+ *
+ *    if (!drush_require_bootstrap(DRUSH_BOOTSTRAP_DRUPAL_FULL)) {
+ *      return drush_set_error('DRUSH_SOMETHING_WRONG', dt("I could not do what I was trying to do."));
+ *    }
+ */
+function drush_require_bootstrap($phase) {
+  $result = drush_has_boostrapped($phase);
+  if (!$result) {
+    $bootstrap = drush_get_bootstrap_object();
+    $bootstrap->report_bootstrap_errors();
+  }
+  return $result;
 }
 
 /**

--- a/lib/Drush/Boot/BaseBoot.php
+++ b/lib/Drush/Boot/BaseBoot.php
@@ -36,11 +36,15 @@ abstract class BaseBoot implements Boot {
     elseif (!empty($args)) {
       drush_set_error('DRUSH_COMMAND_NOT_FOUND', dt("The drush command '!args' could not be found.  Run `drush cache-clear drush` to clear the commandfile cache if you have installed new extensions.", array('!args' => $args)));
     }
+  }
+
+  function report_bootstrap_errors() {
     // Set errors that occurred in the bootstrap phases.
     $errors = drush_get_context('DRUSH_BOOTSTRAP_ERRORS', array());
     foreach ($errors as $code => $message) {
       drush_set_error($code, $message);
     }
+    drush_set_context('DRUSH_BOOTSTRAP_ERRORS', array());
   }
 
   function bootstrap_and_dispatch() {
@@ -96,5 +100,10 @@ abstract class BaseBoot implements Boot {
    * {@inheritdoc}
    */
   public function terminate() {
+    // If we exited with an error, then report any bootstrap errors
+    // that may not have been reported before.
+    if (drush_get_error() != DRUSH_SUCCESS) {
+      $this->report_bootstrap_errors();
+    }
   }
 }

--- a/lib/Drush/Boot/BaseBoot.php
+++ b/lib/Drush/Boot/BaseBoot.php
@@ -36,12 +36,17 @@ abstract class BaseBoot implements Boot {
     elseif (!empty($args)) {
       drush_set_error('DRUSH_COMMAND_NOT_FOUND', dt("The drush command '!args' could not be found.  Run `drush cache-clear drush` to clear the commandfile cache if you have installed new extensions.", array('!args' => $args)));
     }
+    $this->report_bootstrap_errors();
   }
 
-  function report_bootstrap_errors() {
+  function report_bootstrap_errors($warning = '') {
     // Set errors that occurred in the bootstrap phases.
     $errors = drush_get_context('DRUSH_BOOTSTRAP_ERRORS', array());
     foreach ($errors as $code => $message) {
+      if (!empty($warning)) {
+        drush_log($warning, LogLevel::WARNING);
+        $warning = '';
+      }
       drush_set_error($code, $message);
     }
     drush_set_context('DRUSH_BOOTSTRAP_ERRORS', array());
@@ -103,7 +108,7 @@ abstract class BaseBoot implements Boot {
     // If we exited with an error, then report any bootstrap errors
     // that may not have been reported before.
     if (drush_get_error() != DRUSH_SUCCESS) {
-      $this->report_bootstrap_errors();
+      $this->report_bootstrap_errors(dt('Unreported bootstrap errors:'));
     }
   }
 }

--- a/lib/Drush/Boot/Boot.php
+++ b/lib/Drush/Boot/Boot.php
@@ -101,6 +101,12 @@ interface Boot {
   function report_command_error($command);
 
   /**
+   * Called from drush_require_bootstrap() if required bootstrap
+   * level is not met.  Also called by report_command_error().
+   */
+  function report_bootstrap_errors();
+
+  /**
    * This method is called during the shutdown of drush.
    *
    * @return void


### PR DESCRIPTION
This PR delays the reporting of bootstrap error until Drush is terminating, instead of reporting bootstrap errors during initialization. This makes it possible to show bootstrap errors if any arise during command execution in a call to `drush_bootstrap_max()`.

It also includes a change to drush cc to ensure that `drush_bootstrap_max()` is called if the user is trying to clear any cache other than just the `drush` cache.
