### PR TITLE
fixing drush-ops/drush/issues/1971

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -10,6 +10,7 @@ use Drupal\Core\Config\StorageComparer;
 use Drupal\Core\Config\ConfigImporter;
 use Drupal\Core\Config\ConfigException;
 use Drupal\Core\Config\FileStorage;
+use Drupal\Component\Utility\NestedArray;
 use Drush\Config\StorageWrapper;
 use Drush\Config\CoreExtensionFilter;
 use Symfony\Component\Yaml\Parser;
@@ -862,11 +863,16 @@ function drush_config_get_object($config_name) {
  *   The config key.
  */
 function drush_config_get_value($config_name, $key) {
-  $config = Drupal::config($config_name);
-  if ($config->isNew()) {
-    return drush_set_error(dt('Config !name does not exist', array('!name' => $config_name)));
+  $data = drush_config_get_object($config_name);
+  $parts = explode('.', $key);
+  if (count($parts) == 1) {
+    $value =  isset($data[$key]) ? $data[$key] : NULL;
   }
-  $value = $config->get($key);
+  else {
+    $value = NestedArray::getValue($data, $parts, $key_exists);
+    $value = $key_exists ? $value : NULL;
+  }
+
   $returns[$config_name . ':' . $key] = $value;
 
   if ($value === NULL) {


### PR DESCRIPTION
this fixes drush-ops/drush/issues/1971

loading drush_config_get_object within drush_config_get_value allows us to work with include-overridden

proof:

```
$ drush cget system.site
uuid: 772b5957-0cfb-4660-933b-59a1c55a9416
name: 'Site-Install Change7'
mail: admin@example.com
slogan: ''
page:
  403: ''
  404: ''
  front: /node
admin_compact_mode: false
weight_select_max: 100
langcode: en
default_langcode: en
_core:
  default_config_hash: yXadRE77Va-G6dxhd2kPYapAvbnSvTF6hO4oXiOEynI

$ drush cget system.site --include-overridden
uuid: 772b5957-0cfb-4660-933b-59a1c55a9416
name: 'overwritten sitename'
mail: admin@example.com
slogan: ''
page:
  403: asdf
  404: ''
  front: /node
admin_compact_mode: false
weight_select_max: 100
langcode: en
default_langcode: en
_core:
  default_config_hash: yXadRE77Va-G6dxhd2kPYapAvbnSvTF6hO4oXiOEynI

$ drush cget system.site page.403
'system.site:page.403': ''

$ drush cget system.site page.403 --include-overridden
'system.site:page.403': asdf
```