### PR TITLE
Document install alternative for all users via composer

### DIFF
--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -75,8 +75,12 @@ Windows
 ------------
 Drush on Windows is not recommended, since Drush's test suite is not running there ([help wanted](https://github.com/drush-ops/drush/issues/1612)).
 
-* [Acquia Dev Desktop](https://www.acquia.com/downloads) is excellent, and includes Drush. See the terminal icon after setting up a web site.
-* Or consider running Linux/OSX via Virtualbox. [Drupal VM](http://www.drupalvm.com/) and [Vlad](https://github.com/hashbangcode/vlad) are popular.* These Windows packages include Drush and its dependencies (including MSys).     * [7.0.0 (stable)](https://github.com/drush-ops/drush/releases/download/7.0.0/windows-7.0.0.zip).    * [6.6.0](https://github.com/drush-ops/drush/releases/download/6.6.0/windows-6.6.0.zip).    * [6.0](https://github.com/drush-ops/drush/releases/download/6.0.0/Drush-6.0-2013-08-28-Installer-v1.0.21.msi).
-* Or install LAMP on your own, and run Drush via [Git's shell](https://git-for-windows.github.io/), in order to insure that [all depedencies](https://github.com/acquia/DevDesktopCommon/tree/master/bintools-win/msys/bin) are available.   
-* Whenever the documentation or the help text refers to `drush [option] <command>` or something similar, 'drush' may need to be replaced by 'drush.bat'.
-* When creating site aliases for Windows remote machines, pay particular attention to information presented in the example.aliases.drushrc.php file, especially when setting values for 'remote-host' and 'os', as these are very important when running Drush rsync and Drush sql-sync commands.
+- [Acquia Dev Desktop](https://www.acquia.com/downloads) is excellent, and includes Drush. See the terminal icon after setting up a web site.
+- Or consider running Linux/OSX via Virtualbox. [Drupal VM](http://www.drupalvm.com/) and [Vlad](https://github.com/hashbangcode/vlad) are popular.
+- These Windows packages include Drush and its dependencies (including MSys).
+    - [7.0.0 (stable)](https://github.com/drush-ops/drush/releases/download/7.0.0/windows-7.0.0.zip).
+    - [6.6.0](https://github.com/drush-ops/drush/releases/download/6.6.0/windows-6.6.0.zip).
+    - [6.0](https://github.com/drush-ops/drush/releases/download/6.0.0/Drush-6.0-2013-08-28-Installer-v1.0.21.msi).
+- Or install LAMP on your own, and run Drush via [Git's shell](https://git-for-windows.github.io/), in order to insure that [all depedencies](https://github.com/acquia/DevDesktopCommon/tree/master/bintools-win/msys/bin) are available.
+- Whenever the documentation or the help text refers to `drush [option] <command>` or something similar, `drush` may need to be replaced by `drush.bat`.
+- When creating site aliases for Windows remote machines, pay particular attention to information presented in the `example.aliases.drushrc.php` file, especially when setting values for `'remote-host'` and `'os'`, as these are very important when running `drush rsync` and `drush sql-sync` commands.

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -25,16 +25,16 @@ Install Drush for all users via Composer
 If you need a common Drush install available for all users on a system, follow the composer install steps below.
 
 1. [Install Composer globally][composer install global].
-1. Create and/or navigate to a directory path for the single composer drush install. In this example we are going to install drush version 7.x
+1. Create and/or navigate to a directory path for the single composer Drush install. In this example we are going to install Drush version 7.x
 
         sudo mkdir --parents /opt/drush/7.x
         cd /opt/drush/7.x
 
-1. Initialise a new composer project that requires drush. Here you may also specify the drush [package version][composer package version] you wish composer to install. In this example we specify drush version 7.x with the [package version][composer package version] string `7.*`
+1. Initialise a new composer project that requires Drush. Here you may also specify the Drush [package version][composer package version] you wish composer to install. In this example we specify Drush version 7.x with the [package version][composer package version] string `7.*`
 
         sudo composer init --require=drush/drush:7.* -n
 
-1. Configure the path composer should use for the drush package's [vendor binaries][composer vendor binaries] or command-line scripts. Choose a directory path that is used in the `$PATH` configuration for all users, for example `/usr/local/bin`:
+1. Configure the path composer should use for the Drush package's [vendor binaries][composer vendor binaries] or command-line scripts. Choose a directory path that is used in the `$PATH` configuration for all users, for example `/usr/local/bin`:
 
         sudo composer config bin-dir /usr/local/bin
 
@@ -42,21 +42,21 @@ If you need a common Drush install available for all users on a system, follow t
 
         sudo composer install
 
-    The `composer.json` file tells composer to install (or update) drush at the [package version][composer package version] we specified and to put the [vendor binaries][composer vendor binaries] where all users can access them.
+    The `composer.json` file tells composer to install (or update) Drush at the [package version][composer package version] we specified and to put the [vendor binaries][composer vendor binaries] where all users can access them.
 
-1. Lastly, if you are using bash with command completion you can enable drush completion for all users by simply symlinking the `drush.complete.sh` shell script into the correct location.
+1. Lastly, if you are using bash with command completion you can enable Drush completion for all users by simply symlinking the `drush.complete.sh` shell script into the correct location.
 
         sudo ln -s /usr/local/bin/drush.complete.sh \
           /etc/bash_completion.d/drush
 
-**Important Tip:** When installing *drush 6.x* there are *dependencies not managed by composer* that will require download on first run. You
-should execute drush as a privelged user once after install (run `sudo drush --version`) to allow download of those libraries.
+**Important Tip:** When installing *Drush 6.x* there are *dependencies not managed by composer* that will require download on first run. You
+should execute Drush as a privelged user once after install (run `sudo drush --version`) to allow download of those libraries.
 
 ### Getting Updates
 
-Use composer to update the drush library just as you would with any other composer managed project.
+Use composer to update the Drush library just as you would with any other composer managed project.
 
-1. Navigate to the drush install directory path. This is the path where your `composer.json` file for the drush install was created.
+1. Navigate to the Drush install directory path. This is the path where your `composer.json` file for the Drush install was created.
 
         cd /opt/drush/7.x
 
@@ -70,7 +70,7 @@ After composer update completes, the binaries and library will be updated for al
 
 If upgrading to a new major version the steps are the same, with one addition:
 
-1. Remove the existing symlinks to drush [vendor binaries][composer vendor binaries]. From our example above these would be located in the `bin-dir` path `/usr/local/bin`:
+1. Remove the existing symlinks to Drush [vendor binaries][composer vendor binaries]. From our example above these would be located in the `bin-dir` path `/usr/local/bin`:
 
         sudo rm -i /usr/local/bin/drush*
 

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -2,7 +2,7 @@ Install a global Drush via Composer
 ------------------
 To install Drush globally for a single user follow the instructions below, or [watch a video by Drupalize.me](https://youtu.be/eAtDaD8xz0Q).
 
-1. [Install Composer globally][composer install global].
+1. [Install Composer globally][].
 1. Add composer's `bin` directory to the system path by placing `export PATH="$HOME/.composer/vendor/bin:$PATH"` into your ~/.bash_profile (Mac OS users) or into your ~/.bashrc (Linux users).
 1. Install latest stable Drush: `composer global require drush/drush`.
 1. Verify that Drush works: `drush status`
@@ -17,12 +17,12 @@ To install Drush globally for a single user follow the instructions below, or [w
         # Install master branch as a git clone. Great for contributing back to Drush project.
         composer global require drush/drush:dev-master --prefer-source
 
-* [Documentation for composer's require command.](http://getcomposer.org/doc/03-cli.md#require)
+* [Documentation for composer's require command](http://getcomposer.org/doc/03-cli.md#require).
 * Uninstall with : `composer global remove drush/drush`
 
 Install Drush for all users via Composer
 ------------
-If you need Drush installed for all users on a system using composer, follow the install steps below.
+If you need Drush installed for all users on a system using Composer, [install Composer globally][] then follow the steps below.
 
 **Important:** Run these shell commands as a privelged user with write access to `/opt` and `/usr/local/bin` or prefix with `sudo`.
 
@@ -63,7 +63,7 @@ cd /opt/drush-9.x
 
 **Important:** At the time of writing composer will warn you if it cannot create [vendor binaries][] due to a name conflict with an existing file. 
 
-[composer install global]: https://getcomposer.org/doc/00-intro.md#globally
+[Install Composer globally]: https://getcomposer.org/doc/00-intro.md#globally
 [vendor binaries]: https://getcomposer.org/doc/articles/vendor-binaries.md
 
 Windows

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -2,7 +2,7 @@ Install a global Drush via Composer
 ------------------
 To install Drush globally for a single user follow the instructions below, or [watch a video by Drupalize.me](https://youtu.be/eAtDaD8xz0Q).
 
-1. [Install Composer globally](https://getcomposer.org/doc/00-intro.md#globally).
+1. [Install Composer globally][composer install global].
 1. Add composer's `bin` directory to the system path by placing `export PATH="$HOME/.composer/vendor/bin:$PATH"` into your ~/.bash_profile (Mac OS users) or into your ~/.bashrc (Linux users).
 1. Install latest stable Drush: `composer global require drush/drush`.
 1. Verify that Drush works: `drush status`
@@ -24,25 +24,27 @@ Install Drush for all users via Composer
 ------------
 If you need a common Drush install available for all users on a system, follow the composer install steps below.
 
-1. [Install Composer globally](https://getcomposer.org/doc/00-intro.md#globally).
+1. [Install Composer globally][composer install global].
 1. Create and/or navigate to a directory path for the single composer drush install. In this example we are going to install drush version 7.x
 
         sudo mkdir --parents /opt/drush/7.x
         cd /opt/drush/7.x
 
-1. Initialise a new composer project that requires drush. Here you may also specify the version of drush you wish to use for all users. In this example we specify drush version 6.x
+1. Initialise a new composer project that requires drush. Here you may also specify the drush [package version][composer package version] you wish composer to install. In this example we specify drush version 7.x with the [package version][composer package version] string `7.*`
 
         sudo composer init --require=drush/drush:7.* -n
 
-1. Configure the path composer should use for the drush library's executables or its 'bin' directory. Choose a directory path that is used in the `$PATH` configuration for all users, for example `/usr/local/bin`
+1. Configure the path composer should use for the drush package's [vendor binaries][composer vendor binaries] or command-line scripts. Choose a directory path that is used in the `$PATH` configuration for all users, for example `/usr/local/bin`:
 
         sudo composer config bin-dir /usr/local/bin
 
-1. Now run the composer install command. A `composer.json` file containing each of the configurations we just did will be used to install drush at the version and location we just specified.
+1. Now run the `composer install` command. A `composer.json` file containing each of the configurations we just did has been created.
 
         sudo composer install
 
-1. Finally, if you are using bash you can enable bash command completion for all users by simply symlinking the `drush.complete.sh` shell script into the correct location.
+    The `composer.json` file tells composer to install (or update) drush at the [package version][composer package version] we specified and to put the [vendor binaries][composer vendor binaries] where all users can access them.
+
+1. Lastly, if you are using bash with command completion you can enable drush completion for all users by simply symlinking the `drush.complete.sh` shell script into the correct location.
 
         sudo ln -s /usr/local/bin/drush.complete.sh \
           /etc/bash_completion.d/drush
@@ -50,7 +52,7 @@ If you need a common Drush install available for all users on a system, follow t
 **Important Tip:** When installing *drush 6.x* there are *dependencies not managed by composer* that will require download on first run. You
 should execute drush as a privelged user once after install (run `sudo drush --version`) to allow download of those libraries.
 
-### Updates
+### Getting Updates
 
 Use composer to update the drush library just as you would with any other composer managed project.
 
@@ -70,6 +72,9 @@ If upgrading to a new major version, simply create a new directory path for the 
 
 In this way you can even switch forward or back between major versions if required.
 
+[composer package version]: https://getcomposer.org/doc/articles/versions.md
+[composer install global]: https://getcomposer.org/doc/00-intro.md#globally
+[composer vendor binaries]: https://getcomposer.org/doc/articles/vendor-binaries.md
 
 Windows
 ------------

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -49,11 +49,11 @@ composer install
 
 1. Configure the path composer should use for the Drush package's [vendor binaries][composer vendor binaries] or command-line scripts. Choose a directory path that is used in the `$PATH` configuration for all users, for example `/usr/local/bin`:
 
-        sudo composer config bin-dir /usr/local/bin
+        composer config bin-dir /usr/local/bin
 
 1. Now run the `composer install` command. A `composer.json` file containing each of the configurations we just did has been created.
 
-        sudo composer install
+        composer install
 
     The `composer.json` file tells composer to install (or update) Drush at the [package version][composer package version] we specified and to put the [vendor binaries][composer vendor binaries] where all users can access them.
 
@@ -71,7 +71,7 @@ Enable Drush completion for all users by symlinking the `drush.complete.sh` shel
 
 Use composer to update the Drush library just as you would with any other composer managed project.
 
-1. Navigate to the Drush install directory path. This is the path where your `composer.json` file for the Drush install was created.
+1. Navigate to the Drush install directory path. This is the path where your `composer.json` file for the Drush composer install was created.
 
         cd /opt/drush-8.x
 
@@ -85,9 +85,9 @@ After composer update completes, the binaries and library will be updated for al
 
 If upgrading to a new major version the steps are the same, with one addition:
 
-1. Remove the existing symlinks to Drush [vendor binaries][composer vendor binaries]. From our example above these would be located in the `bin-dir` path `/usr/local/bin`:
+1. Remove the existing symlinks to Drush [vendor binaries][composer vendor binaries]. From our example above these would be located in the `bin-dir` path `/usr/local/bin` and point to a path starting with `/opt/drush*`:
 
-        sudo rm -i /usr/local/bin/drush*
+        find /usr/local/bin -lname '/opt/drush*' -exec unlink \{\} \;
 
 1. Follow the steps shown above, starting with creation of a new directory path for the new major version number.
 

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -1,6 +1,6 @@
 Install a global Drush via Composer
 ------------------
-Follow the instructions below, or [watch a video by Drupalize.me](https://youtu.be/eAtDaD8xz0Q).
+To install Drush globally for a single user follow the instructions below, or [watch a video by Drupalize.me](https://youtu.be/eAtDaD8xz0Q). 
 
 1. [Install Composer globally](https://getcomposer.org/doc/00-intro.md#globally).
 1. Add composer's `bin` directory to the system path by placing `export PATH="$HOME/.composer/vendor/bin:$PATH"` into your ~/.bash_profile (Mac OS users) or into your ~/.bashrc (Linux users).		
@@ -17,12 +17,59 @@ Follow the instructions below, or [watch a video by Drupalize.me](https://youtu.
         # Install master branch as a git clone. Great for contributing back to Drush project.
         composer global require drush/drush:dev-master --prefer-source
 
-* Alternate way to install for all users via Composer:
-
-        COMPOSER_HOME=/opt/drush COMPOSER_BIN_DIR=/usr/local/bin COMPOSER_VENDOR_DIR=/opt/drush/7 composer require drush/drush:7
-
 * [Documentation for composer's require command.](http://getcomposer.org/doc/03-cli.md#require)
 * Uninstall with : `composer global remove drush/drush`
+
+Install Drush for all users via Composer
+------------
+If you need a common Drush install available for all users on a system, follow the composer install steps below.
+
+1. [Install Composer globally](https://getcomposer.org/doc/00-intro.md#globally).
+1. Create and/or navigate to a directory path for the single composer drush install. In this example we are going to install drush version 7.x
+
+        sudo mkdir --parents /opt/drush/7.x
+        cd /opt/drush/7.x
+
+1. Initialise a new composer project that requires drush. Here you may also specify the version of drush you wish to use for all users. In this example we specify drush version 6.x
+
+        sudo composer init --require=drush/drush:7.* -n
+
+1. Configure the path composer should use for the drush library's executables or its 'bin' directory. Choose a directory path that is used in the `$PATH` configuration for all users, for example `/usr/local/bin`
+
+        sudo composer config bin-dir /usr/local/bin
+
+1. Now run the composer install command. A `composer.json` file containing each of the configurations we just did will be used to install drush at the version and location we just specified.
+
+        sudo composer install
+
+1. Finally, if you are using bash you can enable bash command completion for all users by simply symlinking the `drush.complete.sh` shell script into the correct location.
+
+        sudo ln -s /usr/local/bin/drush.complete.sh \
+          /etc/bash_completion.d/drush
+
+**Important Tip:** When installing *drush 6.x* there are *dependencies not managed by composer* that will require download on first run. You
+should execute drush as a privelged user once after install (run `sudo drush --version`) to allow download of those libraries.
+
+### Updates
+
+Use composer to update the drush library just as you would with any other composer managed project.
+
+1. Navigate to the drush install directory path. This is the path where your `composer.json` file for the drush install was created.
+
+        cd /opt/drush/7.x
+
+1. Run composer update
+
+        sudo composer update
+
+After composer update completes, the binaries and library will be updated for all users.
+
+### Major Version Upgrade
+
+If upgrading to a new major version, simply create a new directory path for the new major version number and follow the same steps shown above. The binaries for drush will be overwritten with the new major version.
+
+In this way you can even switch forward or back between major versions if required.
+
 
 Windows
 ------------

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -24,81 +24,47 @@ Install Drush for all users via Composer
 ------------
 If you need Drush installed for all users on a system using composer, follow the install steps below.
 
-### Commands Only
-
-Just want the commands? Here you go then. Run these shell commands as a privelged user with write access to `/opt` and `/usr/local/bin` or prefix with `sudo`.
+**Important:** Run these shell commands as a privelged user with write access to `/opt` and `/usr/local/bin` or prefix with `sudo`.
 
 ```sh
+# Create and/or navigate to a path for the single Composer Drush install.
+mkdir --parents /opt/drush-8.x
 cd /opt/drush-8.x
+# Initialise a new Composer project that requires Drush.
 composer init --require=drush/drush:8.* -n
+# Configure the path Composer should use for the Drush vendor binaries.
 composer config bin-dir /usr/local/bin
+# Install Drush. 
 composer install
 ```
 
-### Steps Explained
-
-1. [Install Composer globally][composer install global].
-1. Create and/or navigate to a directory path for the single composer Drush install. In this example we are going to install Drush version 8.x
-
-        mkdir --parents /opt/drush-8.x
-        cd /opt/drush-8.x
-
-1. Initialise a new composer project that requires Drush. Here you may also specify the Drush [package version][composer package version] you wish composer to install. In this example we specify Drush version 8.x with the [package version][composer package version] string `8.*`
-
-        composer init --require=drush/drush:8.* -n
-
-1. Configure the path composer should use for the Drush package's [vendor binaries][composer vendor binaries] or command-line scripts. Choose a directory path that is used in the `$PATH` configuration for all users, for example `/usr/local/bin`:
-
-        composer config bin-dir /usr/local/bin
-
-1. Now run the `composer install` command. A `composer.json` file containing each of the configurations we just did has been created.
-
-        composer install
-
-    The `composer.json` file tells composer to install (or update) Drush at the [package version][composer package version] we specified and to put the [vendor binaries][composer vendor binaries] where all users can access them.
-
-
-### Command Completion
-
-Drush provides the `drush init` command to add command completion and shell prompt scripts into a users bash configuration. You can enable this though for all users immediately, without requiring them to run `drush init`.
-
-Enable Drush completion for all users by symlinking the `drush.complete.sh` shell script into the correct location.
-
-    sudo ln -s /usr/local/bin/drush.complete.sh \
-      /etc/bash_completion.d/drush
-
 ### Getting Updates
 
-Use composer to update the Drush library just as you would with any other composer managed project.
+Use composer to update Drush just as you would with any other composer managed project. The [vendor binaries][] will be updated for all users.
 
-1. Navigate to the Drush install directory path. This is the path where your `composer.json` file for the Drush composer install was created.
-
-        cd /opt/drush-8.x
-
-1. Run composer update
-
-        sudo composer update
-
-After composer update completes, the binaries and library will be updated for all users.
+```sh
+# Navigate to the Drush install path.
+cd /opt/drush-8.x
+# Run composer update
+composer update
+```
 
 ### Major Version Upgrade
 
 If upgrading to a new major version the steps are the same, with one addition:
 
-1. Remove the existing symlinks to Drush [vendor binaries][composer vendor binaries]. From our example above these would be located in the `bin-dir` path `/usr/local/bin` and point to a path starting with `/opt/drush*`:
+```sh
+# Remove the existing symlinks to Drush vendor binaries. 
+find /usr/local/bin -lname '/opt/drush*' -exec unlink \{\} \;
+# Follow the steps shown above, starting with creation of a new path.
+mkdir --parents /opt/drush-9.x
+cd /opt/drush-9.x
+```
 
-        find /usr/local/bin -lname '/opt/drush*' -exec unlink \{\} \;
+**Important:** At the time of writing composer will warn you if it cannot create [vendor binaries][] due to a name conflict with an existing file. 
 
-1. Follow the steps shown above, starting with creation of a new directory path for the new major version number.
-
-        mkdir --parents /opt/drush-9.x
-        cd /opt/drush-9.x
-
-**Important Tip:** At the time of writing composer will warn you if it cannot create vendor binaries due to a name conflict with an existing file. Community contributions to composer coming soon will allow you to force the overwrite of existing vendor binaries during an install or update.
-
-[composer package version]: https://getcomposer.org/doc/articles/versions.md
 [composer install global]: https://getcomposer.org/doc/00-intro.md#globally
-[composer vendor binaries]: https://getcomposer.org/doc/articles/vendor-binaries.md
+[vendor binaries]: https://getcomposer.org/doc/articles/vendor-binaries.md
 
 Windows
 ------------

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -57,13 +57,15 @@ composer install
 
     The `composer.json` file tells composer to install (or update) Drush at the [package version][composer package version] we specified and to put the [vendor binaries][composer vendor binaries] where all users can access them.
 
-1. Lastly, if you are using bash with command completion you can enable Drush completion for all users by simply symlinking the `drush.complete.sh` shell script into the correct location.
 
-        sudo ln -s /usr/local/bin/drush.complete.sh \
-          /etc/bash_completion.d/drush
+### Command Completion
 
-**Important Tip:** When installing *Drush 6.x* there are *dependencies not managed by composer* that will require download on first run. You
-should execute Drush as a privelged user once after install (run `sudo drush --version`) to allow download of those libraries.
+Drush provides the `drush init` command to add command completion and shell prompt scripts into a users bash configuration. You can enable this though for all users immediately, without requiring them to run `drush init`.
+
+Enable Drush completion for all users by symlinking the `drush.complete.sh` shell script into the correct location.
+
+    sudo ln -s /usr/local/bin/drush.complete.sh \
+      /etc/bash_completion.d/drush
 
 ### Getting Updates
 

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -38,14 +38,14 @@ composer install
 ### Steps Explained
 
 1. [Install Composer globally][composer install global].
-1. Create and/or navigate to a directory path for the single composer Drush install. In this example we are going to install Drush version 7.x
+1. Create and/or navigate to a directory path for the single composer Drush install. In this example we are going to install Drush version 8.x
 
-        sudo mkdir --parents /opt/drush/7.x
-        cd /opt/drush/7.x
+        mkdir --parents /opt/drush-8.x
+        cd /opt/drush-8.x
 
-1. Initialise a new composer project that requires Drush. Here you may also specify the Drush [package version][composer package version] you wish composer to install. In this example we specify Drush version 7.x with the [package version][composer package version] string `7.*`
+1. Initialise a new composer project that requires Drush. Here you may also specify the Drush [package version][composer package version] you wish composer to install. In this example we specify Drush version 8.x with the [package version][composer package version] string `8.*`
 
-        sudo composer init --require=drush/drush:7.* -n
+        composer init --require=drush/drush:8.* -n
 
 1. Configure the path composer should use for the Drush package's [vendor binaries][composer vendor binaries] or command-line scripts. Choose a directory path that is used in the `$PATH` configuration for all users, for example `/usr/local/bin`:
 
@@ -73,7 +73,7 @@ Use composer to update the Drush library just as you would with any other compos
 
 1. Navigate to the Drush install directory path. This is the path where your `composer.json` file for the Drush install was created.
 
-        cd /opt/drush/7.x
+        cd /opt/drush-8.x
 
 1. Run composer update
 
@@ -90,6 +90,9 @@ If upgrading to a new major version the steps are the same, with one addition:
         sudo rm -i /usr/local/bin/drush*
 
 1. Follow the steps shown above, starting with creation of a new directory path for the new major version number.
+
+        mkdir --parents /opt/drush-9.x
+        cd /opt/drush-9.x
 
 **Important Tip:** At the time of writing composer will warn you if it cannot create vendor binaries due to a name conflict with an existing file. Community contributions to composer coming soon will allow you to force the overwrite of existing vendor binaries during an install or update.
 

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -68,9 +68,15 @@ After composer update completes, the binaries and library will be updated for al
 
 ### Major Version Upgrade
 
-If upgrading to a new major version, simply create a new directory path for the new major version number and follow the same steps shown above. The binaries for drush will be overwritten with the new major version.
+If upgrading to a new major version the steps are the same, with one addition:
 
-In this way you can even switch forward or back between major versions if required.
+1. Remove the existing symlinks to drush [vendor binaries][composer vendor binaries]. From our example above these would be located in the `bin-dir` path `/usr/local/bin`:
+
+        sudo rm -i /usr/local/bin/drush*
+
+1. Follow the steps shown above, starting with creation of a new directory path for the new major version number.
+
+**Important Tip:** At the time of writing composer will warn you if it cannot create vendor binaries due to a name conflict with an existing file. Community contributions to composer coming soon will allow you to force the overwrite of existing vendor binaries during an install or update.
 
 [composer package version]: https://getcomposer.org/doc/articles/versions.md
 [composer install global]: https://getcomposer.org/doc/00-intro.md#globally

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -22,7 +22,20 @@ To install Drush globally for a single user follow the instructions below, or [w
 
 Install Drush for all users via Composer
 ------------
-If you need a common Drush install available for all users on a system, follow the composer install steps below.
+If you need Drush installed for all users on a system using composer, follow the install steps below.
+
+### Commands Only
+
+Just want the commands? Here you go then. Run these shell commands as a privelged user with write access to `/opt` and `/usr/local/bin` or prefix with `sudo`.
+
+```sh
+cd /opt/drush-8.x
+composer init --require=drush/drush:8.* -n
+composer config bin-dir /usr/local/bin
+composer install
+```
+
+### Steps Explained
 
 1. [Install Composer globally][composer install global].
 1. Create and/or navigate to a directory path for the single composer Drush install. In this example we are going to install Drush version 7.x

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -1,15 +1,15 @@
 Install a global Drush via Composer
 ------------------
-To install Drush globally for a single user follow the instructions below, or [watch a video by Drupalize.me](https://youtu.be/eAtDaD8xz0Q). 
+To install Drush globally for a single user follow the instructions below, or [watch a video by Drupalize.me](https://youtu.be/eAtDaD8xz0Q).
 
 1. [Install Composer globally](https://getcomposer.org/doc/00-intro.md#globally).
-1. Add composer's `bin` directory to the system path by placing `export PATH="$HOME/.composer/vendor/bin:$PATH"` into your ~/.bash_profile (Mac OS users) or into your ~/.bashrc (Linux users).		
-1. Install latest stable Drush: `composer global require drush/drush`.		
-1. Verify that Drush works: `drush status`				
+1. Add composer's `bin` directory to the system path by placing `export PATH="$HOME/.composer/vendor/bin:$PATH"` into your ~/.bash_profile (Mac OS users) or into your ~/.bashrc (Linux users).
+1. Install latest stable Drush: `composer global require drush/drush`.
+1. Verify that Drush works: `drush status`
 
-#### Notes		
+#### Notes
 * Update to latest release (per your specification in ~/.composer/composer.json): `composer global update`
-* Install a specific version of Drush:		
+* Install a specific version of Drush:
 
         # Install a specific version of Drush, e.g. Drush 7.1.0
         composer global require drush/drush:7.1.0


### PR DESCRIPTION
This change explains how to do a single, common drush install for all users and all projects on a system using composer. I believe this documentation better explains how that works and gives a repeatable, simple set of steps that are robust and could be followed by anyone.

Also included is a fix for the Windows dot-points which had become munged due to end-of-line characters being lost at some point.