### PR TITLE
Make sure rsync-version handle --remove-source-files all the time

### DIFF
--- a/commands/core/core.drush.inc
+++ b/commands/core/core.drush.inc
@@ -286,7 +286,7 @@ function core_drush_command() {
       'include-paths' => 'List of paths to include, seperated by : (Unix-based systems) or ; (Windows).',
       '{rsync-option-name}' => "Replace {rsync-option-name} with the rsync option (or option='value') that you would like to pass through to rsync. Examples include --delete, --exclude=*.sql, --filter='merge /etc/rsync/default.rules', etc. See the rsync documentation for a complete explanation of all the rsync options and values.",
       'rsync-version' => 'Set to the version of rsync you are using to signal Drush to go into backwards-compatibility mode when using very old versions of rsync. For example, --rsync-version=2.6.8 or earlier will cause Drush to avoid the --remove-source-files flag.',
-
+      'remove-source-files' => 'If possible, rsync removes synchronized files (non-dir) at sender.',
     ),
     'strict-option-handling' => TRUE,
     'examples' => array(

--- a/commands/core/rsync.core.inc
+++ b/commands/core/rsync.core.inc
@@ -184,21 +184,25 @@ function _drush_build_rsync_options($additional_options, $include_settings_is_de
     $options .= ' --stats --progress';
   }
 
-  // Check if the user has set $options['rsync-version'] to enable rsync legacy version support.
-  // Drush was written for rsync 2.6.9 or later, so assume that version if nothing was explicitly set.
-  $rsync_version = drush_get_option(array('rsync-version','source-rsync-version','target-rsync-version'), '2.6.9');
+  if (_drush_rsync_option_exists('remove-source-files', $additional_options)) {
+    // Check if the user has set $options['rsync-version'] to enable rsync legacy version support.
+    // Drush was written for rsync 2.6.9 or later, so assume that version if nothing was explicitly set.
+    $rsync_version = drush_get_option(array('rsync-version','source-rsync-version','target-rsync-version'), '2.6.9');
+
+    // Downgrade some options for older versions of rsync
+    if (version_compare($rsync_version, '2.6.4', '<')) {
+      drush_log('Rsync does not support --remove-sent-files prior to version 2.6.4; some temporary files may remain undeleted.', LogLevel::WARNING);
+    }
+    elseif (version_compare($rsync_version, '2.6.9', '<')) {
+      $options .= '--remove-sent-files';
+    }
+    else {
+      $options .= '--remove-source-files';
+    }
+  }
+
   $options_to_exclude = array('ssh-options');
   foreach ($additional_options as $test_option => $value) {
-    // Downgrade some options for older versions of rsync
-    if ($test_option == 'remove-source-files') {
-      if (version_compare($rsync_version, '2.6.4', '<')) {
-        $test_option = NULL;
-        drush_log('Rsync does not support --remove-sent-files prior to version 2.6.4; some temporary files may remain undeleted.', LogLevel::WARNING);
-      }
-      elseif (version_compare($rsync_version, '2.6.9', '<')) {
-        $test_option = 'remove-sent-files';
-      }
-    }
     if ((isset($test_option)) && !in_array($test_option, $options_to_exclude) && (isset($value)  && !is_array($value))) {
       if (($value === TRUE) || (!isset($value))) {
         $options .= " --$test_option";

--- a/commands/core/rsync.core.inc
+++ b/commands/core/rsync.core.inc
@@ -194,10 +194,10 @@ function _drush_build_rsync_options($additional_options, $include_settings_is_de
       drush_log('Rsync does not support --remove-sent-files prior to version 2.6.4; some temporary files may remain undeleted.', LogLevel::WARNING);
     }
     elseif (version_compare($rsync_version, '2.6.9', '<')) {
-      $options .= '--remove-sent-files';
+      $options .= ' --remove-sent-files';
     }
     else {
-      $options .= '--remove-source-files';
+      $options .= ' --remove-source-files';
     }
   }
 


### PR DESCRIPTION
This is another try for #1975. It was related to #758 and closed thought as not addressing #842.

I believe this is a separate fix that sorts something important on #758 which is not command propagation. I have reverted the commit that adds a command while #842 is being fixed, but the fix for sql-sync is still valid I believe.
