### PR TITLE
Perform assignment after validating the return value

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1034,8 +1034,8 @@ function _drush_backend_invoke($cmds, $common_backend_options = array(), $contex
 
       if ($proc['output']) {
         $values = drush_backend_parse_output($proc['output'], $proc['backend-options'], $proc['outputted']);
-        $values['site'] = $site;
         if (is_array($values)) {
+          $values['site'] = $site;
           if (empty($ret)) {
             $ret = $values;
           }


### PR DESCRIPTION
The return value of `drush_backend_parse_output` is not guaranteed to be an array, in such cases, the assignment `$values['site'] = $site;` fails with an `Illegal string offset` error.

![illegal offset](https://cloud.githubusercontent.com/assets/17079617/12848030/93715b2a-cc17-11e5-86e7-dd6c8a9c8da7.png)

