### PR TITLE
Fix drush runserver issues when dot is in URL.

### DIFF
--- a/commands/runserver/d8-rs-router.php
+++ b/commands/runserver/d8-rs-router.php
@@ -20,10 +20,7 @@ if (file_exists('.' . $url['path'])) {
 // Populate the "q" query key with the path, skip the leading slash.
 $_GET['q'] = $_REQUEST['q'] = substr($url['path'], 1);
 
-// We set the base_url so that Drupal generates correct URLs for runserver
-// (e.g. http://127.0.0.1:8888/...), but can still select and serve a specific
-// site in a multisite configuration (e.g. http://mysite.com/...).
-$base_url = runserver_env('RUNSERVER_BASE_URL');
+$_SERVER['SCRIPT_NAME'] = '/index.php';
 
 // Include the main index.php and let core take over.
 // n.b. Drush sets the cwd to the Drupal root during bootstrap.


### PR DESCRIPTION
If you are using `drush runserver`, and a URL is loaded in with a dot, such as _/admin/structure/types/manage/page/fields/node.page.body/storage_, then the following two issues are exposed:

- Linked HTML resources such as Javascript and CSS, have an incorrect base URL calculated for them. Resulting in 404sresulting in 404's.
- If a URL with a dot is POST-ed to, and the form has a redirect to an internal route, then the following exception is thrown.
  > Redirects to external URLs are not allowed by default, use \Drupal\Core\Routing\TrustedRedirectResponse for it.

These issues arose since https://www.drupal.org/node/2528988 was committed in October.

You can see some examples of Travis failures for RNG: https://travis-ci.org/dpi/rng/jobs/107258656

# Resolution

[commands/runserver/d8-rs-router.php](https://github.com/drush-ops/drush/blob/master/commands/runserver/d8-rs-router.php) includes a line for `$base_url`, this is no longer required since [Drupal does not use it](https://www.drupal.org/node/2528988).

The above two symptoms can be fixed by adding the following line before Drupal is included in **d8-rs-router.php**:

```php
$_SERVER['SCRIPT_NAME'] = '/index.php'
```

PHP internal web server "incorrectly" calculates `$_SERVER['SCRIPT_NAME']` [if a dot is in the URL](https://bugs.php.net/bug.php?id=61286)