### PR TITLE
Fixed sneaky fallback on mysql when mysqli is enabled and configured

### DIFF
--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1641,7 +1641,7 @@ function drush_convert_db_from_db_url($db_url) {
       );
       $url = (object)array_map('urldecode', $url);
       $db_spec = array(
-        'driver'   => $url->scheme == 'mysqli' ? 'mysql' : $url->scheme,
+        'driver'   => $url->scheme,
         'username' => $url->user,
         'password' => $url->pass,
         'host' => $url->host,

--- a/lib/Drush/Sql/Sqlmysqli.php
+++ b/lib/Drush/Sql/Sqlmysqli.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drush\Sql;
+
+class Sqlmysqli extends Sqlmysql {
+
+}


### PR DESCRIPTION
## What

This removes the sneaky switching from the mysqli driver to the [deprecated](http://php.net/manual/en/migration55.deprecated.php) mysql driver in Drush, even though the mysqli extension is configured and loaded, and working and the Drupal project we use Drush on uses the mysqli driver.

## Why

We are currently relocating a legacy Drupal 6 project from an old server which runs PHP 5.3, to a newer infrastructure that runs PHP 5.6. We run on Ubuntu 14.04 TLS, but since the default PHP version in Ubuntu 14.04 is 5.5, we make use of the widely used [PPA of Ondřej Surý](https://launchpad.net/~ondrej/+archive/ubuntu/php5-5.6).

In these builds of PHP 5.6, the legacy mysql driver / extension has not been compiled and packaged, and is thus not available. Debating whether this is wise and should be included by Ondřej Surý is beyond the point, since it the extension is deprecated as of PHP 5.5 and will be removed completely in PHP7, so if we do not deal with it now, we have to later.

Since Drupal 6 does not support support PDO but relies only on mysql and mysqli, it is not an option to switch to PDO instead. It is however important that Drush follows what has been configured in Drupal and should not wander of on it's own, deciding it is probably a good idea to instead opt for the legacy mysql extension even though the Drupal project is using mysqli.

## Drush output before my patch

```
$ drush up admin_menu
Command pm-update needs a higher bootstrap level to run - you will need to invoke drush[error]
from a more functional Drupal environment to run this command.
The drush command 'up admin_menu' could not be executed.                        [error]
Drush was not able to start (bootstrap) the Drupal database.                           [error]
Hint: This may occur when Drush is trying to:
 * bootstrap a site that has not been installed or does not have a configured database.
In this case you can select another site with a working database setup by specifying
the URI to use with the --uri parameter on the command line. See `drush topic
docs-aliases` for details.
 * connect the database through a socket. The socket file may be wrong or the php-cli
may have no access to it in a jailed shell. See http://drupal.org/node/1428638 for
details.

Drush was attempting to connect to: 
 Drupal version         :  6.37                                          
 Site URI               :  http://default                                
 Database driver        :  mysql                                         
 Database hostname      :  127.0.0.1                                     
 Database port          :                                                
 Database username      :  dev
 Database name          :  dev
 PHP executable         :  /usr/bin/php                                  
 PHP configuration      :  /etc/php/5.6/cli/php.ini                      
 PHP OS                 :  Linux                                         
 Drush script           :  /vagrant/drush-8/vendor/drush/drush/drush.php 
 Drush version          :  8.0.3                                         
 Drush temp directory   :  /tmp                                          
 Drush configuration    :                                                
 Drush alias files      :                                                
 Drupal root            :  /vagrant/test-project
 Drupal Settings File   :  sites/default/settings.php                    
 Site path              :  sites/default
```

## Output after my fix has been applied

```
$ drush up admin_menu
Update information last refreshed: wo, 02/17/2016 - 14:38
 Name                              Installed Version  Proposed version  Message                   
 Administration menu (admin_menu)  6.x-1.8            6.x-1.9           Nieuwe versie beschikbaar 

Code updates will be made to the following projects: Administration menu [admin_menu-6.x-1.9]

Note: A backup of your project will be stored to backups directory if it is not managed by a supported version control system.
Note: If you have made any modifications to any file that belongs to one of these projects, you will have to migrate those modifications after updating.
Do you really want to continue with the update process? (y/n): y
Project admin_menu was updated successfully. Installed version is now 6.x-1.9.
Backups were saved into the directory                                                  [ok]
/home/vagrant/drush-backups/test-project/20160217133810/modules/admin_menu.
No database updates required                                                           [success]
'all' cache was cleared.                                                               [success]
Finished performing updates.                                                           [ok]
```
Also, when checking `drush status`, the Database driver has been switched from `mysql` to `mysqli` after applying my patch.

## How to test

1. Grab the latest Drush, and on a PHP installation **without the legacy mysql extension**, configure a Drupal project to use mysqli as the driver, and see that Drupal will work but Drush will fail because it decides to use legacy mysql driver instead.
1. Now grab my patch, and see that Drush will work because it no longer switches from the mysqli driver to the mysql driver on it's own.
1. Rejoice, for all was good again.