### PR TITLE
Fix undesirable redispatch

### DIFF
--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -571,7 +571,10 @@ function drush_preflight_command_dispatch() {
   $root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
   $local_drush = drush_get_option('drush-script');
   if (empty($local_drush) && !empty($root)) {
-    $local_drush = find_wrapper_or_launcher($root);
+    $local_wrapper_or_launcher = find_wrapper_or_launcher($root);
+    if (!getenv('DRUSH_FINDER_SCRIPT')) {
+      $local_drush = $local_wrapper_or_launcher;
+    }
   }
   $is_local = drush_get_option('local');
   $values = NULL;


### PR DESCRIPTION
drush_preflight_command_dispatch would redispatch even if the DRUSH_FINDER_SCRIPT environment variable was set; that is not desirable, so check for that explicitly.