### PR TITLE
Get SVN back working again

### DIFF
--- a/commands/pm/download.pm.inc
+++ b/commands/pm/download.pm.inc
@@ -198,37 +198,18 @@ function drush_pm_download() {
     if ($version_control->engine == 'backup') {
       // Check if install location already exists.
       if (is_dir($request['project_install_location'])) {
-        if (drush_confirm(dt('Install location !location already exists. Do you want to overwrite it?', array('!location' => $request['project_install_location'])))) {
-          drush_delete_dir($request['project_install_location'], TRUE);
-        }
-        else {
+        if (!drush_confirm(dt('Install location !location already exists. Do you want to overwrite it?', array('!location' => $request['project_install_location'])))) {
           drush_log(dt("Skip installation of !project to !dest.", array('!project' => $request['name'], '!dest' => $request['project_install_location'])), LogLevel::WARNING);
           continue;
         }
       }
     }
-    else {
-      // Find and unlink all files but the ones in the vcs control directories.
-      $skip_list = array('.', '..');
-      $skip_list = array_merge($skip_list, drush_version_control_reserved_files());
-      drush_scan_directory($request['project_install_location'], '/.*/', $skip_list, 'unlink', TRUE, 'filename', 0, TRUE);
-    }
 
     // Copy the project to the install location.
-    if (drush_op('_drush_recursive_copy', $request['full_project_path'], $request['project_install_location'])) {
+    if (drush_copy_dir($request['full_project_path'], $request['project_install_location'], FILE_EXISTS_OVERWRITE)) {
       drush_log(dt("Project !project (!version) downloaded to !dest.", array('!project' => $request['name'], '!version' => $release['version'], '!dest' => $request['project_install_location'])), LogLevel::SUCCESS);
       // Adjust full_project_path to the final project location.
       $request['full_project_path'] = $request['project_install_location'];
-
-      // If the version control engine is a proper vcs we also need to remove
-      // orphan directories.
-      if ($version_control->engine != 'backup') {
-        $empty_dirs = drush_find_empty_directories($request['full_project_path'], $version_control->reserved_files());
-        foreach ($empty_dirs as $empty_dir) {
-          // Some VCS files are read-only on Windows (e.g., .svn/entries).
-          drush_delete_dir($empty_dir, TRUE);
-        }
-      }
 
       // Post download actions.
       package_handler_post_download($request, $release);

--- a/commands/pm/package_handler/wget.inc
+++ b/commands/pm/package_handler/wget.inc
@@ -100,7 +100,7 @@ function package_handler_download_project(&$request, $release) {
 function package_handler_update_project(&$request, $release) {
   $download_path = package_handler_download_project($request, $release);
   if ($download_path) {
-    return drush_move_dir($download_path, $request['full_project_path']);
+    return drush_move_dir($download_path, $request['full_project_path'], TRUE);
   }
   else {
     return FALSE;

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -2148,52 +2148,6 @@ function drush_pm_extensions_in_project($project) {
 }
 
 /**
- * Return an array of empty directories.
- *
- * Walk a directory and return an array of subdirectories that are empty. Will
- * return the given directory if it's empty.
- * If a list of items to exclude is provided, subdirectories will be condidered
- * empty even if they include any of the items in the list.
- *
- * @param string $dir
- *   Path to the directory to work in.
- * @param array $exclude
- *   Array of files or directory to exclude in the check.
- *
- * @return array
- *   A list of directory paths that are empty. A directory is deemed to be empty
- *   if it only contains excluded files or directories.
- */
-function drush_find_empty_directories($dir, $exclude = array()) {
-  // Skip files.
-  if (!is_dir($dir)) {
-    return array();
-  }
-  $to_exclude = array_merge(array('.', '..'), $exclude);
-  $empty_dirs = array();
-  $dir_is_empty = TRUE;
-  foreach (scandir($dir) as $file) {
-    // Skip excluded directories.
-    if (in_array($file, $to_exclude)) {
-      continue;
-    }
-    // Recurse into sub-directories to find potentially empty ones.
-    $subdir = $dir . '/' . $file;
-    $empty_dirs += drush_find_empty_directories($subdir, $exclude);
-    // $empty_dir will not contain $subdir, if it is a file or if the
-    // sub-directory is not empty. $subdir is only set if it is empty.
-    if (!isset($empty_dirs[$subdir])) {
-      $dir_is_empty = FALSE;
-    }
-  }
-
-  if ($dir_is_empty) {
-    $empty_dirs[$dir] = $dir;
-  }
-  return $empty_dirs;
-}
-
-/**
  * Inject metadata into all .info files for a given project.
  *
  * @param string $project_dir

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -676,19 +676,14 @@ function drush_get_projects(&$extensions = NULL) {
 
     // Obtain the project name. It is not available in this cases:
     //   1. the extension is part of drupal core.
-    //   2. the project was checked out from CVS/git and cvs_deploy/git_deploy
-    //      is not installed.
+    //   2. the project was checked out from git and git_deploy is not installed.
     //   3. it is not a project hosted in drupal.org.
     if (empty($extension->info['project'])) {
       if (isset($extension->info['version']) && ($extension->info['version'] == drush_drupal_version())) {
         $project = 'drupal';
       }
       else {
-        if (is_dir($extension_path . '/CVS') && (!drush_module_exists('cvs_deploy'))) {
-          $extension->vcs = 'cvs';
-          drush_log(dt('Extension !extension is fetched from cvs. Ignoring.', array('!extension' => $extension_name)), LogLevel::DEBUG);
-        }
-        elseif (is_dir($extension_path . '/.git') && (!drush_module_exists('git_deploy'))) {
+        if (is_dir($extension_path . '/.git') && (!drush_module_exists('git_deploy'))) {
           $extension->vcs = 'git';
           drush_log(dt('Extension !extension is fetched from git. Ignoring.', array('!extension' => $extension_name)), LogLevel::DEBUG);
         }

--- a/commands/pm/updatecode.pm.inc
+++ b/commands/pm/updatecode.pm.inc
@@ -161,13 +161,14 @@ function _pm_update_core(&$project, $tmpfile) {
   }
 
   // Create a list of directories to exclude from the update process.
+  $skip_list = array('sites', $project['path']);
+  $skip_list = array_merge($skip_list, drush_version_control_reserved_files());
+
   // On Drupal >=8 skip also directories in the document root.
   if (drush_drupal_major_version() >= 8) {
-    $skip_list = array('sites', $project['path'], 'modules', 'profiles', 'themes');
+    array_push($skip_list, 'modules', 'profiles', 'themes');
   }
-  else {
-    $skip_list = array('sites', $project['path']);
-  }
+
   // Add non-writable directories: we can't move them around.
   // We will also use $items_to_test later for $version_control check.
   $items_to_test = drush_scan_directory($drupal_root, '/.*/', array_merge(array('.', '..'), $skip_list), 0, FALSE, 'basename', 0, TRUE);
@@ -340,21 +341,6 @@ function pm_update_packages($update_info, $tmpfile) {
  *   Success or failure. An error message will be logged.
  */
 function pm_update_project($project, $version_control) {
-  // 1. If the version control engine is a proper vcs we need to remove project
-  // files in order to not have orphan files after update.
-  // 2. If the package-handler is cvs or git, it will remove upstream removed
-  // files and no orphans will exist after update.
-  // So, we must remove all files previous update if the directory is not a
-  // working copy of cvs or git but we don't need to remove them if the version
-  // control engine is backup, as it did already move the project out to the
-  // backup directory.
-  if (($version_control->engine != 'backup') && (drush_get_option('package-handler', 'wget') == 'wget')) {
-    // Find and unlink all files but the ones in the vcs control directories.
-    $skip_list = array('.', '..');
-    $skip_list = array_merge($skip_list, drush_version_control_reserved_files());
-    drush_scan_directory($project['full_project_path'], '/.*/', $skip_list, 'unlink', TRUE, 'filename', 0, TRUE);
-  }
-
   // Add the project to a context so we can roll back if needed.
   $updated = drush_get_context('DRUSH_PM_UPDATED');
   $updated[] = $project;
@@ -362,13 +348,6 @@ function pm_update_project($project, $version_control) {
 
   if (!package_handler_update_project($project, $project['releases'][$project['candidate_version']])) {
     return drush_set_error('DRUSH_PM_UPDATING_FAILED', dt('Updating project !project failed. Attempting to roll back to previously installed version.', array('!project' => $project['name'])));
-  }
-
-  // If the version control engine is a proper vcs we also need to remove
-  // orphan directories.
-  if (($version_control->engine != 'backup') && (drush_get_option('package-handler', 'wget') == 'wget')) {
-    $files = drush_find_empty_directories($project['full_project_path'], $version_control->reserved_files());
-    array_map('drush_delete_dir', $files);
   }
 
   return TRUE;

--- a/commands/pm/updatestatus.pm.inc
+++ b/commands/pm/updatestatus.pm.inc
@@ -39,8 +39,7 @@ function drush_pm_updatestatus() {
 
   foreach ($extensions as $name => $extension) {
     // Add an item to $update_info for each enabled extension which was obtained
-    // from cvs or git and its project is unknown (because of cvs_deploy or
-    // git_deploy is not enabled).
+    // from git and its project is unknown (because git_deploy is not enabled).
     if (!isset($extension->info['project'])) {
       if ((isset($extension->vcs)) && ($extension->status)) {
         $update_info[$name] = array(

--- a/commands/pm/version_control/backup.inc
+++ b/commands/pm/version_control/backup.inc
@@ -14,10 +14,6 @@ class drush_version_control_backup implements drush_version_control {
    */
   public function pre_update(&$project, $items_to_test = array()) {
     if (drush_get_option('no-backup', FALSE)) {
-      // Delete the project path to clean up files that should be removed
-      if (!drush_delete_dir($project['full_project_path'])) {
-        return FALSE;
-      }
       return TRUE;
     }
     if ($backup_target = $this->prepare_backup_dir()) {

--- a/commands/pm/version_control/backup.inc
+++ b/commands/pm/version_control/backup.inc
@@ -35,7 +35,7 @@ class drush_version_control_backup implements drush_version_control {
           return TRUE;
         }
       }
-      // cvs or git.
+      // git.
       elseif (drush_copy_dir($project['full_project_path'], $backup_target)) {
         return TRUE;
       }

--- a/commands/pm/version_control/svn.inc
+++ b/commands/pm/version_control/svn.inc
@@ -48,7 +48,7 @@ class drush_version_control_svn implements drush_version_control {
    * Implementation of rollback().
    */
   public function rollback($project) {
-    if (drush_shell_exec('svn revert '. drush_get_option('svnrevertparams') .' '. $project['full_project_path'])) {
+    if (drush_shell_exec('svn revert -R'. drush_get_option('svnrevertparams') .' '. $project['full_project_path'])) {
       $output = drush_shell_exec_output();
       if (!empty($output)) {
         return drush_set_error('DRUSH_PM_SVN_LOCAL_CHANGES', dt("The SVN working copy at !path appears to have uncommitted changes (see below). Please commit or revert these changes before continuing:\n!output", array('!path' => $project['full_project_path'], '!output' => implode("\n", $output))));


### PR DESCRIPTION
OK, I'm not an expert on drush, nor github.  However not many people are using SVN, so I guess if I want it to work, I'm going to have to give it a try.  Sorry for any mistakes.  I would appreciate some sort of comment even if it's "thanks I'll look in a few weeks when I have time" or "thanks, but you've done it all wrong because..."

1) Main SVN fix in #1056:
- I noted the new wget package update code simply overwrites the whole old package with the new, with no fancy recursive preserving of control files, orphan dir handling etc.
- Actually that's not a big problem as in modern SVN (and I think BZR as best I could tell from a search) the control files are only at the root.
- So firstly a quick extra call to skip control files when updating drupal core.
- Secondly, set the option to drupal_move_dir to make sure we actually do overwrite.

2) The rollback part #2015 should be simple and clear.

3) #2020 is not essential to make SVN work, but will help stop it breaking in future.  I've removed various hard-coded if tests on VCS system, so there is much greater commonality of code.  I can take this one out of the pull request if needs be.

4) In passing I removed some old code/comments relating to CVS.
