### PR TITLE
Issue #2035: Bail out system_watchdog() unless in Drupal 6/7.

### DIFF
--- a/includes/drupal.inc
+++ b/includes/drupal.inc
@@ -76,9 +76,14 @@ function drush_drupal_major_version($drupal_root = NULL) {
  * A sneaky implementation of hook_watchdog(), for D6/D7.
  */
 function system_watchdog($log_entry) {
+  $version = drush_drupal_major_version();
+  if (!in_array($version, array(6, 7))) {
+    return;
+  }
+
   // Transform non informative severity levels to 'error' for compatibility with _drush_print_log.
   // Other severity levels are coincident with the ones we use in drush.
-  if (drush_drupal_major_version() >= 6 && $log_entry['severity'] <= 2) {
+  if ($log_entry['severity'] <= 2) {
     $severity = 'error';
   }
   else {


### PR DESCRIPTION
Fixes https://github.com/drush-ops/drush/issues/2035.
