### PR TITLE
Add option 'no-data' to sql-dump command

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -116,6 +116,7 @@ function sql_drush_command() {
       'tables-list' => 'A comma-separated list of tables to transfer. Optional.',
       'create-db' => array('hidden' => TRUE, 'description' => 'Omit DROP TABLE statements. Postgres and Oracle only.  Used by sql-sync, since including the DROP TABLE statements interfere with the import when the database is created.'),
       'data-only' => 'Dump data without statements to create any of the schema.',
+      'no-data' => 'Dump statements to create scheme without any data. Mysql only.',
       'ordered-dump' => 'Order by primary key and add line breaks for efficient diff in revision control. Slows down the dump. Mysql only.',
       'gzip' => 'Compress the dump using the gzip program which must be in your $PATH.',
     ) + $options + $db_url,

--- a/lib/Drush/Sql/Sqlmysql.php
+++ b/lib/Drush/Sql/Sqlmysql.php
@@ -100,6 +100,7 @@ EOT;
     $ignores = array();
     $skip_tables  = array_merge($structure_tables, $skip_tables);
     $data_only = drush_get_option('data-only');
+    $no_data = drush_get_option('no-data');
     // The ordered-dump option is only supported by MySQL for now.
     // @todo add documention once a hook for drush_get_option_help() is available.
     // @see drush_get_option_help() in drush.inc
@@ -115,6 +116,9 @@ EOT;
     $extra = ' --no-autocommit --single-transaction --opt -Q';
     if (isset($data_only)) {
       $extra .= ' --no-create-info';
+    }
+    elseif (isset($no_data)) {
+      $extra .= ' --no-data';
     }
     if (isset($ordered_dump)) {
       $extra .= ' --skip-extended-insert --order-by-primary';


### PR DESCRIPTION
The --skip-tables-key option is handy to exclude temporary tables such as caches when doing sql-dump.

However when you come to restore a site from such a dump, you need to create the schema for these skipped tables.  mysql has such a feature, and this PR exposes it through drush with a new "--no-data" option.

Typical use case:
```
drush sql-dump --data-only --skip-tables-key=XX
drush sql-dump --no-data
```

I marked this as mysql only because that is the only platform I can test or know about.