### PR TITLE
Pick the most recent release when there's no recommended major

### DIFF
--- a/lib/Drush/UpdateService/Project.php
+++ b/lib/Drush/UpdateService/Project.php
@@ -235,6 +235,12 @@ class Project {
       $releases[$release_info['version']] = $release_info;
     }
 
+    // If there's no "Recommended major version", we want to recommend
+    // the most recent release.
+    if (!$recommended_major) {
+      $latest_version = key($releases);
+    }
+
     // If there is no -stable- release in the recommended major,
     // then take the latest version in the recommended major to be
     // the recommended release.
@@ -387,10 +393,12 @@ class Project {
     if ($recommended_major != 0) {
       $majors[] = $this->parsed['recommended_major'];
     }
-    $supported = explode(',', $this->parsed['supported_majors']);
-    foreach ($supported as $v) {
-      if ($v != $recommended_major) {
-        $majors[] = $v;
+    if (!empty($this->parsed['supported_majors'])) {
+      $supported = explode(',', $this->parsed['supported_majors']);
+      foreach ($supported as $v) {
+        if ($v != $recommended_major) {
+          $majors[] = $v;
+        }
       }
     }
     $releases = array();

--- a/tests/makeTest.php
+++ b/tests/makeTest.php
@@ -511,6 +511,7 @@ class makeMakefileCase extends CommandUnishTestCase {
       'default-major' => 6, // The makefile used below is core = "6.x".
       'destination' => UNISH_SANDBOX . '/sites/all/modules/contrib',
       'yes' => NULL,
+      'dev' => NULL,
     );
     $this->drush('pm-download', array('cck_signup'), $options);
 


### PR DESCRIPTION
Fixes #2024

This PR addresses a long standing issue with projects with no recommended major version. This has resurged recently when drupal.org marked all 6.x branches of projects as unsupported, and removed the supported and recommended branches settings.
