### PR TITLE
#178 Allow extra arguments in sql-dump command

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -71,11 +71,11 @@ function sql_drush_command() {
     'description' => 'A string for connecting to the DB.',
     'bootstrap' => DRUSH_BOOTSTRAP_NONE,
     'options' => $options + $db_url + array(
-        'extra' => array(
-          'description' => 'Add custom options to the mysql command.',
-          'example-value' => '--skip-column-names',
-        ),
+      'extra' => array(
+        'description' => 'Add custom options to the SQL command.',
+        'example-value' => '--skip-column-names',
       ),
+    ),
     'examples' => array(
       '`drush sql-connect` < example.sql' => 'Bash: Import SQL statements from a file into the current database.',
       'eval (drush sql-connect) < example.sql' => 'Fish: Import SQL statements from a file into the current database.',
@@ -118,6 +118,7 @@ function sql_drush_command() {
       'data-only' => 'Dump data without statements to create any of the schema.',
       'ordered-dump' => 'Order by primary key and add line breaks for efficient diff in revision control. Slows down the dump. Mysql only.',
       'gzip' => 'Compress the dump using the gzip program which must be in your $PATH.',
+      'extra' => 'Add custom options to the SQL command.',
     ) + $options + $db_url,
   );
   $items['sql-query'] = array(
@@ -139,7 +140,7 @@ function sql_drush_command() {
       ),
       'file' => 'Path to a file containing the SQL to be run. Gzip files are accepted.',
       'extra' => array(
-        'description' => 'Add custom options to the mysql command.',
+        'description' => 'Add custom options to the SQL command.',
         'example-value' => '--skip-column-names',
       ),
       'db-prefix' => 'Enable replacement of braces in your query.',

--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -72,7 +72,7 @@ function sql_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_NONE,
     'options' => $options + $db_url + array(
       'extra' => array(
-        'description' => 'Add custom options to the SQL command.',
+        'description' => 'Add custom options to the connect string.',
         'example-value' => '--skip-column-names',
       ),
     ),
@@ -101,7 +101,7 @@ function sql_drush_command() {
     'examples' => array(
       'drush sql-dump --result-file=../18.sql' => 'Save SQL dump to the directory above Drupal root.',
       'drush sql-dump --skip-tables-key=common' => 'Skip standard tables. @see example.drushrc.php',
-      'drush sql-dump --extra=--no-data' => 'Pass extra option to SQL dump command.',
+      'drush sql-dump --extra=--no-data' => 'Pass extra option to dump command.',
     ),
     'options' => array(
       'result-file' => array(
@@ -119,7 +119,7 @@ function sql_drush_command() {
       'data-only' => 'Dump data without statements to create any of the schema.',
       'ordered-dump' => 'Order by primary key and add line breaks for efficient diff in revision control. Slows down the dump. Mysql only.',
       'gzip' => 'Compress the dump using the gzip program which must be in your $PATH.',
-      'extra' => 'Add custom options to the SQL command.',
+      'extra' => 'Add custom options to the dump command.',
     ) + $options + $db_url,
   );
   $items['sql-query'] = array(
@@ -141,7 +141,7 @@ function sql_drush_command() {
       ),
       'file' => 'Path to a file containing the SQL to be run. Gzip files are accepted.',
       'extra' => array(
-        'description' => 'Add custom options to the SQL command.',
+        'description' => 'Add custom options to the database connection command.',
         'example-value' => '--skip-column-names',
       ),
       'db-prefix' => 'Enable replacement of braces in your query.',

--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -101,6 +101,7 @@ function sql_drush_command() {
     'examples' => array(
       'drush sql-dump --result-file=../18.sql' => 'Save SQL dump to the directory above Drupal root.',
       'drush sql-dump --skip-tables-key=common' => 'Skip standard tables. @see example.drushrc.php',
+      'drush sql-dump --extra=--no-data' => 'Pass extra option to SQL dump command.',
     ),
     'options' => array(
       'result-file' => array(

--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -61,6 +61,9 @@ class SqlBase {
     $table_selection = $this->get_expanded_table_selection();
     $file = $this->dumpFile($file);
     $cmd = $this->dumpCmd($table_selection);
+    if ($extra = drush_get_option('extra', $this->query_extra)) {
+      $cmd .= " $extra";
+    }
     // Gzip the output from dump command(s) if requested.
     if (drush_get_option('gzip')) {
       $cmd .= ' | gzip -f';

--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -61,9 +61,6 @@ class SqlBase {
     $table_selection = $this->get_expanded_table_selection();
     $file = $this->dumpFile($file);
     $cmd = $this->dumpCmd($table_selection);
-    if ($extra = drush_get_option('extra', $this->query_extra)) {
-      $cmd .= " $extra";
-    }
     // Gzip the output from dump command(s) if requested.
     if (drush_get_option('gzip')) {
       $cmd .= ' | gzip -f';

--- a/lib/Drush/Sql/Sqlmysql.php
+++ b/lib/Drush/Sql/Sqlmysql.php
@@ -119,6 +119,9 @@ EOT;
     if (isset($ordered_dump)) {
       $extra .= ' --skip-extended-insert --order-by-primary';
     }
+    if ($option = drush_get_option('extra', $this->query_extra)) {
+      $extra .= " $option";
+    }
     $exec .= $extra;
 
     if (!empty($tables)) {

--- a/lib/Drush/Sql/Sqloracle.php
+++ b/lib/Drush/Sql/Sqloracle.php
@@ -84,6 +84,9 @@ class Sqloracle extends SqlBase {
       $exec .= ' tables="(' . implode(',', $tables) . ')"';
     }
     $exec .= ' owner=' . $this->db_spec['username'];
+    if ($option = drush_get_option('extra', $this->query_extra)) {
+      $exec .= " $option";
+    }
     return array($exec, $file);
   }
 }

--- a/lib/Drush/Sql/Sqlpgsql.php
+++ b/lib/Drush/Sql/Sqlpgsql.php
@@ -121,6 +121,9 @@ class Sqlpgsql extends SqlBase {
     if (isset($data_only)) {
       $extra .= ' --data-only';
     }
+    if ($option = drush_get_option('extra', $this->query_extra)) {
+      $extra .= " $option";
+    }
     $exec .= $extra;
     $exec .= (!isset($create_db) && !isset($data_only) ? ' --clean' : '');
 

--- a/lib/Drush/Sql/Sqlsqlite.php
+++ b/lib/Drush/Sql/Sqlsqlite.php
@@ -87,6 +87,9 @@ class Sqlsqlite extends SqlBase {
     // Postgres or MySQL equivalents. We may be able to fake some in the
     // future, but for now, let's just support simple dumps.
     $exec .= ' ".dump"';
+    if ($option = drush_get_option('extra', $this->query_extra)) {
+      $exec .= " $option";
+    }
     return $exec;
   }
 

--- a/lib/Drush/Sql/Sqlsqlsrv.php
+++ b/lib/Drush/Sql/Sqlsqlsrv.php
@@ -21,7 +21,7 @@ class Sqlsqlsrv extends SqlBase {
       return ' -S ' . $host . ' -d ' . $database;
     }
     else {
-      return ' -S ' . $host . ' -d ' . $database . ' -U ' . $this->db_spec['username'] . ' -P ' . $this->db_spec['password'];    
+      return ' -S ' . $host . ' -d ' . $database . ' -U ' . $this->db_spec['username'] . ' -P ' . $this->db_spec['password'];
     }
   }
 
@@ -55,6 +55,9 @@ class Sqlsqlsrv extends SqlBase {
       $file = $this->db_spec['database'] . '_' . date('Ymd_His') . '.bak';
     }
     $exec = "sqlcmd -U \"" . $this->db_spec['username'] . "\" -P \"" . $this->db_spec['password'] . "\" -S \"" . $this->db_spec['host'] . "\" -Q \"BACKUP DATABASE [" . $this->db_spec['database'] . "] TO DISK='" . $file . "'\"";
+    if ($option = drush_get_option('extra', $this->query_extra)) {
+      $exec .= " $option";
+    }
     return array($exec, $file);
   }
 


### PR DESCRIPTION
The --extra option is already present on other SQL commands, so all it needs is to reuse that on sql-dump.  As far as I can see, --extra should work for any back-end, so I've changed some description references from mysql to SQL.

Note the the original https://www.drupal.org/node/518184 additionally allowed removing of the default options (--no-autocommit --single-transaction --opt -Q) by removing them from the code and adding them back in to example.drushrc.php.  However I'm not clear how existing users would get their actual drushrc.php modified.  Anyway I've _not_ done this extra bit as I don't need it, and it's not part of the title of #178.  I suggest that if anyone cares about it they can create a new task.