### PR TITLE
Revert "Add workarounds to pm-download / pm-enable tests for Drupal 6"

### DIFF
--- a/tests/commandTest.php
+++ b/tests/commandTest.php
@@ -90,12 +90,6 @@ class commandCase extends CommandUnishTestCase {
       'uri' => $uri,
       'cache' => NULL,
     );
-    // All 6.x contrib modules are 'unsupported', so just download the
-    // second presented option (the first being the 'dev' version).
-    if (UNISH_DRUPAL_MAJOR_VERSION == 6) {
-      $options['select'] = NULL;
-      $options['choice'] = 2;
-    }
     $this->drush('pm-download', array('devel'), $options);
     $options += array(
       'backend' => NULL, // To obtain and parse the error log.

--- a/tests/pmDownloadTest.php
+++ b/tests/pmDownloadTest.php
@@ -72,21 +72,21 @@ class pmDownloadCase extends CommandUnishTestCase {
       'select' => NULL,
       'choice' => 0, // Cancel.
     );
-    // --select. Specify 5.x since that is frozen and not subjected to "unsupported" hyjinx on drupal.org
-    $this->drush('pm-download', array('devel-5.x'), $options, NULL, NULL, CommandUnishTestCase::UNISH_EXITCODE_USER_ABORT);
+    // --select. Specify 6.x since that has so many releases.
+    $this->drush('pm-download', array('devel-6.x'), $options, NULL, NULL, CommandUnishTestCase::UNISH_EXITCODE_USER_ABORT);
     $items = $this->getOutputAsList();
     $output = $this->getOutput();
      // 6 items are: Select message + Cancel + 3 versions.
     $this->assertEquals(5, count($items), '--select offerred 3 options.');
-    $this->assertContains('5.x-1.x-dev', $output, 'Dev release was shown by --select.');
+    $this->assertContains('6.x-1.x-dev', $output, 'Dev release was shown by --select.');
 
     // --select --dev. Specify 6.x since that has so many releases.
-    $this->drush('pm-download', array('devel-5.x'), $options + array('dev' => NULL), NULL, NULL, CommandUnishTestCase::UNISH_EXITCODE_USER_ABORT);
+    $this->drush('pm-download', array('devel-6.x'), $options + array('dev' => NULL), NULL, NULL, CommandUnishTestCase::UNISH_EXITCODE_USER_ABORT);
     $items = $this->getOutputAsList();
     $output = $this->getOutput();
     // 12 items are: Select message + Cancel + 1 option.
     $this->assertEquals(3, count($items), '--select --dev expected to offer only one option.');
-    $this->assertContains('5.x-1.x-dev', $output, 'Assure that --dev lists the only dev release.');
+    $this->assertContains('6.x-1.x-dev', $output, 'Assure that --dev lists the only dev release.');
 
     // --select --all. Specify 5.x since this is frozen.
     $this->drush('pm-download', array('devel-5.x'), $options + array('all' => NULL), NULL, NULL, CommandUnishTestCase::UNISH_EXITCODE_USER_ABORT);

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -102,7 +102,8 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
 
     // Test pm-enable is able to download dependencies.
     // @todo pathauto has no usable D8 release yet.
-    if (UNISH_DRUPAL_MAJOR_VERSION <=7) {
+    // Also, Drupal 6 has no stable releases any longer, so resolve-dependencies are inconvenient to test.
+    if (UNISH_DRUPAL_MAJOR_VERSION ==7) {
       $this->drush('pm-download', array('pathauto'), $options);
       $this->drush('pm-enable', array('pathauto'), $options + array('resolve-dependencies' => TRUE));
       $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
@@ -110,11 +111,13 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
       $this->assertTrue(in_array('token', $list));
     }
 
-    // Test that pm-enable downloads missing projects and dependencies.
-    $this->drush('pm-enable', array('panels'), $options + array('resolve-dependencies' => TRUE));
-    $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
-    $list = $this->getOutputAsList();
-    $this->assertTrue(in_array('ctools', $list));
+    if (UNISH_DRUPAL_MAJOR_VERSION !=6) {
+      // Test that pm-enable downloads missing projects and dependencies.
+      $this->drush('pm-enable', array('panels'), $options + array('resolve-dependencies' => TRUE));
+      $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
+      $list = $this->getOutputAsList();
+      $this->assertTrue(in_array('ctools', $list));
+    }
 
     // Test that pm-enable downloads missing projects
     // and dependencies with project namespace (date:date_popup).

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -26,17 +26,9 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
     $options = $options_no_pipe + array(
       'pipe' => NULL,
     );
-    $extra_dl_options = array();
-    // All 6.x contrib modules are 'unsupported', so just download the
-    // second presented option (the first being the 'dev' version).
-    if (UNISH_DRUPAL_MAJOR_VERSION == 6) {
-      $extra_dl_options['select'] = NULL;
-      $extra_dl_options['choice'] = 2;
-    }
-
 
     // Test pm-download downloads a module and pm-list lists it.
-    $this->drush('pm-download', array('devel'), $options + $extra_dl_options);
+    $this->drush('pm-download', array('devel'), $options);
     $this->drush('pm-list', array(), $options + array('no-core' => NULL, 'status' => 'disabled,not installed'));
     $out = $this->getOutput();
     $list = $this->getOutputAsList();
@@ -110,22 +102,19 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
 
     // Test pm-enable is able to download dependencies.
     // @todo pathauto has no usable D8 release yet.
-    // Drupal 6 has no stable releases any longer, so resolve-dependencies are inconvenient to test.
-    if (UNISH_DRUPAL_MAJOR_VERSION ==7) {
-      $this->drush('pm-download', array('pathauto'), $options + $extra_dl_options);
+    if (UNISH_DRUPAL_MAJOR_VERSION <=7) {
+      $this->drush('pm-download', array('pathauto'), $options);
       $this->drush('pm-enable', array('pathauto'), $options + array('resolve-dependencies' => TRUE));
       $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
       $list = $this->getOutputAsList();
       $this->assertTrue(in_array('token', $list));
     }
 
-    if (UNISH_DRUPAL_MAJOR_VERSION !=6) {
-      // Test that pm-enable downloads missing projects and dependencies.
-      $this->drush('pm-enable', array('panels'), $options + array('resolve-dependencies' => TRUE));
-      $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
-      $list = $this->getOutputAsList();
-      $this->assertTrue(in_array('ctools', $list));
-    }
+    // Test that pm-enable downloads missing projects and dependencies.
+    $this->drush('pm-enable', array('panels'), $options + array('resolve-dependencies' => TRUE));
+    $this->drush('pm-list', array(), $options + array('status' => 'enabled'));
+    $list = $this->getOutputAsList();
+    $this->assertTrue(in_array('ctools', $list));
 
     // Test that pm-enable downloads missing projects
     // and dependencies with project namespace (date:date_popup).


### PR DESCRIPTION
Test to see if these are even necessary.

This reverts commit 37081e6ec9a7a61c79935a77799b01bd092440f1.