### PR TITLE
Exclude node_modules and bower_components from directory scans

### DIFF
--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -678,6 +678,9 @@ function drush_scan_directory($dir, $mask, $nomask = array('.', '..', 'CVS'), $c
   $key = (in_array($key, array('filename', 'basename', 'name')) ? $key : 'filename');
   $files = array();
 
+  // Exclude Bower and Node directories.
+  $nomask = array_merge($nomask, array('node_modules', 'bower_components'));
+
   if (is_string($dir) && is_dir($dir) && $handle = opendir($dir)) {
     while (FALSE !== ($file = readdir($handle))) {
       if (!in_array($file, $nomask) && (($include_dot_files && (!preg_match("/\.\+/",$file))) || ($file[0] != '.'))) {


### PR DESCRIPTION
Quick workaround to #1347 