### PR TITLE
Remove unrecognized options used by postgresql in archive-dump.

### DIFF
--- a/lib/Drush/Sql/Sqlpgsql.php
+++ b/lib/Drush/Sql/Sqlpgsql.php
@@ -121,7 +121,7 @@ class Sqlpgsql extends SqlBase {
     if (isset($data_only)) {
       $extra .= ' --data-only';
     }
-    if ($option = drush_get_option('extra', $this->query_extra)) {
+    if ($option = drush_get_option('extra')) {
       $extra .= " $option";
     }
     $exec .= $extra;


### PR DESCRIPTION
archive-dump on postgresql does not works correctly because it refer unrecognized options.

```
$ drush ard
pg_dump: unrecognized option '--no-align'
Try "pg_dump --help" for more information.
Database dump failed
...
```
