### PR TITLE
Do not add default extra options to pg_dump

### DIFF
--- a/lib/Drush/Sql/Sqlpgsql.php
+++ b/lib/Drush/Sql/Sqlpgsql.php
@@ -121,7 +121,7 @@ class Sqlpgsql extends SqlBase {
     if (isset($data_only)) {
       $extra .= ' --data-only';
     }
-    if ($option = drush_get_option('extra', $this->query_extra)) {
+    if ($option = drush_get_option('extra')) {
       $extra .= " $option";
     }
     $exec .= $extra;


### PR DESCRIPTION
Current options which are valid for psql do not work for pg_dump:
- no-align
- field-separator
- pset
- tuples_only

See http://www.postgresql.org/docs/9.5/static/app-pgdump.html

Adding them causes the command to fail.
