### PR TITLE
Follow correct update procedure for drupal core #2022

### DIFF
--- a/commands/pm/download.pm.inc
+++ b/commands/pm/download.pm.inc
@@ -198,37 +198,18 @@ function drush_pm_download() {
     if ($version_control->engine == 'backup') {
       // Check if install location already exists.
       if (is_dir($request['project_install_location'])) {
-        if (drush_confirm(dt('Install location !location already exists. Do you want to overwrite it?', array('!location' => $request['project_install_location'])))) {
-          drush_delete_dir($request['project_install_location'], TRUE);
-        }
-        else {
+        if (!drush_confirm(dt('Install location !location already exists. Do you want to overwrite it?', array('!location' => $request['project_install_location'])))) {
           drush_log(dt("Skip installation of !project to !dest.", array('!project' => $request['name'], '!dest' => $request['project_install_location'])), LogLevel::WARNING);
           continue;
         }
       }
     }
-    else {
-      // Find and unlink all files but the ones in the vcs control directories.
-      $skip_list = array('.', '..');
-      $skip_list = array_merge($skip_list, drush_version_control_reserved_files());
-      drush_scan_directory($request['project_install_location'], '/.*/', $skip_list, 'unlink', TRUE, 'filename', 0, TRUE);
-    }
 
     // Copy the project to the install location.
-    if (drush_op('_drush_recursive_copy', $request['full_project_path'], $request['project_install_location'])) {
+    if (drush_copy_dir($request['full_project_path'], $request['project_install_location'], FILE_EXISTS_OVERWRITE)) {
       drush_log(dt("Project !project (!version) downloaded to !dest.", array('!project' => $request['name'], '!version' => $release['version'], '!dest' => $request['project_install_location'])), LogLevel::SUCCESS);
       // Adjust full_project_path to the final project location.
       $request['full_project_path'] = $request['project_install_location'];
-
-      // If the version control engine is a proper vcs we also need to remove
-      // orphan directories.
-      if ($version_control->engine != 'backup') {
-        $empty_dirs = drush_find_empty_directories($request['full_project_path'], $version_control->reserved_files());
-        foreach ($empty_dirs as $empty_dir) {
-          // Some VCS files are read-only on Windows (e.g., .svn/entries).
-          drush_delete_dir($empty_dir, TRUE);
-        }
-      }
 
       // Post download actions.
       package_handler_post_download($request, $release);

--- a/commands/pm/package_handler/wget.inc
+++ b/commands/pm/package_handler/wget.inc
@@ -99,11 +99,15 @@ function package_handler_download_project(&$request, $release) {
  */
 function package_handler_update_project(&$request, $release) {
   $download_path = package_handler_download_project($request, $release);
-  if ($download_path) {
-    return drush_move_dir($download_path, $request['full_project_path'], TRUE);
+  if (!$download_path) {
+    return FALSE;
+  }
+
+  if ($request['name'] == 'drupal') {
+    return drush_copy_dir($download_path, $request['full_project_path'], FILE_EXISTS_MERGE);
   }
   else {
-    return FALSE;
+    return drush_move_dir($download_path, $request['full_project_path'], TRUE);
   }
 }
 

--- a/commands/pm/package_handler/wget.inc
+++ b/commands/pm/package_handler/wget.inc
@@ -100,7 +100,7 @@ function package_handler_download_project(&$request, $release) {
 function package_handler_update_project(&$request, $release) {
   $download_path = package_handler_download_project($request, $release);
   if ($download_path) {
-    return drush_move_dir($download_path, $request['full_project_path']);
+    return drush_move_dir($download_path, $request['full_project_path'], TRUE);
   }
   else {
     return FALSE;

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -2148,52 +2148,6 @@ function drush_pm_extensions_in_project($project) {
 }
 
 /**
- * Return an array of empty directories.
- *
- * Walk a directory and return an array of subdirectories that are empty. Will
- * return the given directory if it's empty.
- * If a list of items to exclude is provided, subdirectories will be condidered
- * empty even if they include any of the items in the list.
- *
- * @param string $dir
- *   Path to the directory to work in.
- * @param array $exclude
- *   Array of files or directory to exclude in the check.
- *
- * @return array
- *   A list of directory paths that are empty. A directory is deemed to be empty
- *   if it only contains excluded files or directories.
- */
-function drush_find_empty_directories($dir, $exclude = array()) {
-  // Skip files.
-  if (!is_dir($dir)) {
-    return array();
-  }
-  $to_exclude = array_merge(array('.', '..'), $exclude);
-  $empty_dirs = array();
-  $dir_is_empty = TRUE;
-  foreach (scandir($dir) as $file) {
-    // Skip excluded directories.
-    if (in_array($file, $to_exclude)) {
-      continue;
-    }
-    // Recurse into sub-directories to find potentially empty ones.
-    $subdir = $dir . '/' . $file;
-    $empty_dirs += drush_find_empty_directories($subdir, $exclude);
-    // $empty_dir will not contain $subdir, if it is a file or if the
-    // sub-directory is not empty. $subdir is only set if it is empty.
-    if (!isset($empty_dirs[$subdir])) {
-      $dir_is_empty = FALSE;
-    }
-  }
-
-  if ($dir_is_empty) {
-    $empty_dirs[$dir] = $dir;
-  }
-  return $empty_dirs;
-}
-
-/**
  * Inject metadata into all .info files for a given project.
  *
  * @param string $project_dir

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -676,19 +676,14 @@ function drush_get_projects(&$extensions = NULL) {
 
     // Obtain the project name. It is not available in this cases:
     //   1. the extension is part of drupal core.
-    //   2. the project was checked out from CVS/git and cvs_deploy/git_deploy
-    //      is not installed.
+    //   2. the project was checked out from git and git_deploy is not installed.
     //   3. it is not a project hosted in drupal.org.
     if (empty($extension->info['project'])) {
       if (isset($extension->info['version']) && ($extension->info['version'] == drush_drupal_version())) {
         $project = 'drupal';
       }
       else {
-        if (is_dir($extension_path . '/CVS') && (!drush_module_exists('cvs_deploy'))) {
-          $extension->vcs = 'cvs';
-          drush_log(dt('Extension !extension is fetched from cvs. Ignoring.', array('!extension' => $extension_name)), LogLevel::DEBUG);
-        }
-        elseif (is_dir($extension_path . '/.git') && (!drush_module_exists('git_deploy'))) {
+        if (is_dir($extension_path . '/.git') && (!drush_module_exists('git_deploy'))) {
           $extension->vcs = 'git';
           drush_log(dt('Extension !extension is fetched from git. Ignoring.', array('!extension' => $extension_name)), LogLevel::DEBUG);
         }

--- a/commands/pm/updatecode.pm.inc
+++ b/commands/pm/updatecode.pm.inc
@@ -147,50 +147,35 @@ function _pm_update_core(&$project, $tmpfile) {
   }
 
   $drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT');
+  $project['full_project_path'] = $drupal_root;
 
   // We need write permission on $drupal_root.
   if (!is_writable($drupal_root)) {
     return drush_set_error('DRUSH_PATH_NO_WRITABLE', dt('Drupal root path is not writable.'));
   }
 
-  // Create a directory 'core' if it does not already exist.
-  $project['path'] = 'drupal-' . $project['candidate_version'];
-  $project['full_project_path'] = $drupal_root . '/' . $project['path'];
-  if (!is_dir($project['full_project_path'])) {
-    drush_mkdir($project['full_project_path']);
-  }
+  // The upgrade process for core requires to remove files from the old core first, but not removing any site-local files.
+  // Drupal documentation specifies a set of directories that comprise the core, but isn't specific about the exact list of files in the root.
+  // The code below takes a safe approach.
+  // - Check and back-up all files in the root.
+  // - Don't delete any files in the root.  Instead allow the new files to overwrite them.  This does mean that if a file is removed from
+  //   core, it will stay around locally.  However this is likely to be rare, and seems hard to avoid.
 
-  // Create a list of directories to exclude from the update process.
-  $skip_list = array('sites', $project['path']);
-  $skip_list = array_merge($skip_list, drush_version_control_reserved_files());
-
-  // On Drupal >=8 skip also directories in the document root.
   if (drush_drupal_major_version() >= 8) {
-    array_push($skip_list, 'modules', 'profiles', 'themes');
+    // See https://api.drupal.org/api/drupal/core!UPGRADE.txt/8
+    $items_to_delete = array('core', 'vendor');
+  }
+  else {
+    // See https://api.drupal.org/api/drupal/UPGRADE.txt/7
+    $items_to_delete = array('includes', 'misc', 'modules', 'scripts', 'themes', 'profiles/minimal', 'profiles/standard', 'profiles/testing');
   }
 
-  // Add non-writable directories: we can't move them around.
-  // We will also use $items_to_test later for $version_control check.
-  $items_to_test = drush_scan_directory($drupal_root, '/.*/', array_merge(array('.', '..'), $skip_list), 0, FALSE, 'basename', 0, TRUE);
-  foreach (array_keys($items_to_test) as $item) {
-    if (is_dir($item) && !is_writable($item)) {
-      $skip_list[] = $item;
-      unset($items_to_test[$item]);
-    }
-    elseif (is_link($item)) {
-      $skip_list[] = $item;
-      unset($items_to_test[$item]);
+  $items_to_test = array_flip($items_to_delete);
+  foreach (scandir($drupal_root) as $file) {
+    if (is_file("$drupal_root/$file")) {
+      $items_to_test[$file] = 1;
     }
   }
-  $project['skip_list'] = $skip_list;
-
-  // Move all files and folders in $drupal_root to the new 'core' directory
-  // except for the items in the skip list
-  _pm_update_move_files($drupal_root, $project['full_project_path'], $project['skip_list']);
-
-  // Set a context variable to indicate that rollback should reverse
-  // the _pm_update_move_files above.
-  drush_set_context('DRUSH_PM_DRUPAL_CORE', $project);
 
   if (!$version_control = drush_pm_include_version_control($project['full_project_path'])) {
     return FALSE;
@@ -201,44 +186,19 @@ function _pm_update_core(&$project, $tmpfile) {
     return FALSE;
   }
 
+  foreach ($items_to_delete as $dir) {
+    if (!drush_delete_dir($dir)) {
+      return FALSE;
+    }
+  }
+
   // Update core.
   if (pm_update_project($project, $version_control) === FALSE) {
     return FALSE;
   }
 
-  // Take the updated files in the 'core' directory that have been updated,
-  // and move all except for the items in the skip list back to
-  // the drupal root.
-  _pm_update_move_files($project['full_project_path'], $drupal_root, $project['skip_list']);
-  drush_delete_dir($project['full_project_path']);
-  $project['full_project_path'] = $drupal_root;
-
-  // If there is a backup target, then find items
-  // in the backup target that do not exist at the
-  // drupal root.  These are to be moved back.
-  if (array_key_exists('backup_target', $project)) {
-    _pm_update_move_files($project['backup_target'], $drupal_root, $project['skip_list'], FALSE);
-    _pm_update_move_files($project['backup_target'] . '/profiles', $drupal_root . '/profiles', array('default'), FALSE);
-  }
-
   pm_update_finish($project, $version_control);
 
-  return TRUE;
-}
-
-/**
- * Move some files from one location to another.
- */
-function _pm_update_move_files($src_dir, $dest_dir, $skip_list, $remove_conflicts = TRUE) {
-  $items_to_move = drush_scan_directory($src_dir, '/.*/', array_merge(array('.', '..'), $skip_list), 0, FALSE, 'filename', 0, TRUE);
-  foreach ($items_to_move as $filename => $info) {
-    if ($remove_conflicts) {
-      drush_delete_dir($dest_dir . '/' . basename($filename));
-    }
-    if (!file_exists($dest_dir . '/' . basename($filename))) {
-      $move_result = drush_move_dir($filename,  $dest_dir . '/' . basename($filename));
-    }
-  }
   return TRUE;
 }
 
@@ -375,14 +335,6 @@ function drush_pm_updatecode_rollback() {
       return FALSE;
     }
     $version_control->rollback($project);
-  }
-
-  // Post rollback, we will do additional repair if the project is drupal core.
-  $drupal_core = drush_get_context('DRUSH_PM_DRUPAL_CORE', FALSE);
-  if ($drupal_core) {
-    $drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT');
-    _pm_update_move_files($drupal_core['full_project_path'], $drupal_root, $drupal_core['skip_list']);
-    drush_delete_dir($drupal_core['full_project_path']);
   }
 }
 

--- a/commands/pm/updatecode.pm.inc
+++ b/commands/pm/updatecode.pm.inc
@@ -161,13 +161,14 @@ function _pm_update_core(&$project, $tmpfile) {
   }
 
   // Create a list of directories to exclude from the update process.
+  $skip_list = array('sites', $project['path']);
+  $skip_list = array_merge($skip_list, drush_version_control_reserved_files());
+
   // On Drupal >=8 skip also directories in the document root.
   if (drush_drupal_major_version() >= 8) {
-    $skip_list = array('sites', $project['path'], 'modules', 'profiles', 'themes');
+    array_push($skip_list, 'modules', 'profiles', 'themes');
   }
-  else {
-    $skip_list = array('sites', $project['path']);
-  }
+
   // Add non-writable directories: we can't move them around.
   // We will also use $items_to_test later for $version_control check.
   $items_to_test = drush_scan_directory($drupal_root, '/.*/', array_merge(array('.', '..'), $skip_list), 0, FALSE, 'basename', 0, TRUE);
@@ -340,21 +341,6 @@ function pm_update_packages($update_info, $tmpfile) {
  *   Success or failure. An error message will be logged.
  */
 function pm_update_project($project, $version_control) {
-  // 1. If the version control engine is a proper vcs we need to remove project
-  // files in order to not have orphan files after update.
-  // 2. If the package-handler is cvs or git, it will remove upstream removed
-  // files and no orphans will exist after update.
-  // So, we must remove all files previous update if the directory is not a
-  // working copy of cvs or git but we don't need to remove them if the version
-  // control engine is backup, as it did already move the project out to the
-  // backup directory.
-  if (($version_control->engine != 'backup') && (drush_get_option('package-handler', 'wget') == 'wget')) {
-    // Find and unlink all files but the ones in the vcs control directories.
-    $skip_list = array('.', '..');
-    $skip_list = array_merge($skip_list, drush_version_control_reserved_files());
-    drush_scan_directory($project['full_project_path'], '/.*/', $skip_list, 'unlink', TRUE, 'filename', 0, TRUE);
-  }
-
   // Add the project to a context so we can roll back if needed.
   $updated = drush_get_context('DRUSH_PM_UPDATED');
   $updated[] = $project;
@@ -362,13 +348,6 @@ function pm_update_project($project, $version_control) {
 
   if (!package_handler_update_project($project, $project['releases'][$project['candidate_version']])) {
     return drush_set_error('DRUSH_PM_UPDATING_FAILED', dt('Updating project !project failed. Attempting to roll back to previously installed version.', array('!project' => $project['name'])));
-  }
-
-  // If the version control engine is a proper vcs we also need to remove
-  // orphan directories.
-  if (($version_control->engine != 'backup') && (drush_get_option('package-handler', 'wget') == 'wget')) {
-    $files = drush_find_empty_directories($project['full_project_path'], $version_control->reserved_files());
-    array_map('drush_delete_dir', $files);
   }
 
   return TRUE;

--- a/commands/pm/updatestatus.pm.inc
+++ b/commands/pm/updatestatus.pm.inc
@@ -39,8 +39,7 @@ function drush_pm_updatestatus() {
 
   foreach ($extensions as $name => $extension) {
     // Add an item to $update_info for each enabled extension which was obtained
-    // from cvs or git and its project is unknown (because of cvs_deploy or
-    // git_deploy is not enabled).
+    // from git and its project is unknown (because git_deploy is not enabled).
     if (!isset($extension->info['project'])) {
       if ((isset($extension->vcs)) && ($extension->status)) {
         $update_info[$name] = array(

--- a/commands/pm/version_control/backup.inc
+++ b/commands/pm/version_control/backup.inc
@@ -12,30 +12,36 @@ class drush_version_control_backup implements drush_version_control {
   /**
    * Implementation of pre_update().
    */
-  public function pre_update(&$project, $items_to_test = array()) {
+  public function pre_update(&$project, $items_to_test = array('' => 1)) {
     if (drush_get_option('no-backup', FALSE)) {
       return TRUE;
     }
     if ($backup_target = $this->prepare_backup_dir()) {
       if ($project['project_type'] != 'core') {
         $backup_target .= '/' . $project['project_type'] . 's';
-        drush_mkdir($backup_target);
       }
       $backup_target .= '/'. $project['name'];
+      $backup_source = $project['full_project_path'];
       // Save for rollback or notifications.
       $project['backup_target'] = $backup_target;
+      $ok = TRUE;
 
-      // Move or copy to backup target based in package-handler.
-      if (drush_get_option('package-handler', 'wget') == 'wget') {
-        if (drush_move_dir($project['full_project_path'], $backup_target)) {
-          return TRUE;
+      foreach (array_keys($items_to_test) as $file) {
+        drush_mkdir(dirname("$backup_target/$file"));
+        // Move or copy to backup target based on package-handler.
+        if (drush_get_option('package-handler', 'wget') == 'wget') {
+          $ok = $ok && drush_move_dir("$backup_source/$file", "$backup_target/$file");
+        }
+        // git.
+        else {
+          $ok = $ok && drush_copy_dir("$backup_source/$file", "$backup_target/$file");
         }
       }
-      // git.
-      elseif (drush_copy_dir($project['full_project_path'], $backup_target)) {
-        return TRUE;
+
+      if (!$ok) {
+        return drush_set_error('DRUSH_PM_BACKUP_FAILED', dt('Failed to backup project directory !project to !backup_target', array('!project' => $backup_source, '!backup_target' => $backup_target)));
       }
-      return drush_set_error('DRUSH_PM_BACKUP_FAILED', dt('Failed to backup project directory !project to !backup_target', array('!project' => $project['full_project_path'], '!backup_target' => $backup_target)));
+      return TRUE;
     }
   }
 

--- a/commands/pm/version_control/backup.inc
+++ b/commands/pm/version_control/backup.inc
@@ -14,10 +14,6 @@ class drush_version_control_backup implements drush_version_control {
    */
   public function pre_update(&$project, $items_to_test = array()) {
     if (drush_get_option('no-backup', FALSE)) {
-      // Delete the project path to clean up files that should be removed
-      if (!drush_delete_dir($project['full_project_path'])) {
-        return FALSE;
-      }
       return TRUE;
     }
     if ($backup_target = $this->prepare_backup_dir()) {

--- a/commands/pm/version_control/backup.inc
+++ b/commands/pm/version_control/backup.inc
@@ -35,7 +35,7 @@ class drush_version_control_backup implements drush_version_control {
           return TRUE;
         }
       }
-      // cvs or git.
+      // git.
       elseif (drush_copy_dir($project['full_project_path'], $backup_target)) {
         return TRUE;
       }

--- a/commands/pm/version_control/svn.inc
+++ b/commands/pm/version_control/svn.inc
@@ -48,7 +48,7 @@ class drush_version_control_svn implements drush_version_control {
    * Implementation of rollback().
    */
   public function rollback($project) {
-    if (drush_shell_exec('svn revert '. drush_get_option('svnrevertparams') .' '. $project['full_project_path'])) {
+    if (drush_shell_exec('svn revert -R'. drush_get_option('svnrevertparams') .' '. $project['full_project_path'])) {
       $output = drush_shell_exec_output();
       if (!empty($output)) {
         return drush_set_error('DRUSH_PM_SVN_LOCAL_CHANGES', dt("The SVN working copy at !path appears to have uncommitted changes (see below). Please commit or revert these changes before continuing:\n!output", array('!path' => $project['full_project_path'], '!output' => implode("\n", $output))));


### PR DESCRIPTION
Also solves
- #614 completely (currently it is fixed in some common cases, but not always).
- #4 Update Drupal core without moving core files out of the way.

See a more detailed list of benefits in the comments for #2022.  This PR solves several long open issues and simplifies code so it would be great to get it committed.

Note this PR is cumulative on top of #2021 because both affect the same areas of code, and it would be a mess of merging to consider them separately.  It would be sufficient to pull this PR then reject the other one.
