### PR TITLE
PR: rsync between two remote directories fails

### DIFF
--- a/commands/core/rsync.core.inc
+++ b/commands/core/rsync.core.inc
@@ -267,12 +267,20 @@ function _drush_core_rsync_both_remote($source, $destination, $additional_option
   // in the destination (i.e. there is no 'tmpdir' in the destination).
   //
   // All three of these cases need to be handled correctly in order
-  // to ensure the correct results.  In all cases, though, the first
-  // rsync always copies to $tmpDir, and the second rsync always
-  // copies from $tmpDir/basename($source_path).  So, the actual logic
-  // comes out to be much simpler than the analysis.
+  // to ensure the correct results.  In all cases the first
+  // rsync always copies to $tmpDir, however the second rsync has
+  // two cases that depend on the source path.  If the source path ends
+  // in /, the contents of a directory have been copied to $tmpDir, and
+  // the contents of $tmpDir must be copied to the destination.  Otherwise,
+  // a specific file or directory has been copied to $tmpDir and that
+  // specific item, identified by basename($source_path) must be copied to
+  // the destination.
+
   $putInTmpPath = drush_tempdir();
-  $getFromTmpPath = "$putInTmpPath/" . basename($source_path);
+  $getFromTmpPath = "$putInTmpPath/";
+  if (substr($source_path, -1) !== '/') {
+    $getFromTmpPath .= basename($source_path);
+  }
 
   // Copy from the source to the temporary location. Exit on failure.
   $values = drush_invoke_process('@self', 'core-rsync', array($source, $putInTmpPath), $options);


### PR DESCRIPTION
Modification to correct comments and append the basename of the source path to the intermediate directory only when the source is a specific file or directory.