### PR TITLE
Allow --root to be specified with a relative path

### DIFF
--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -257,9 +257,6 @@ function drush_startup($argv) {
   // we will look for a "launcher" script in vendor/bin.
   if (empty($found_script) && !empty($ROOT)) {
     $found_script = find_wrapper_or_launcher($ROOT);
-    if (!empty($found_script)) {
-      chdir($ROOT);
-    }
   }
 
   // If there is a .drush-use file, then its contents will


### PR DESCRIPTION
**Problem**
Specifying a `--root` with a relative path fails. This seems to be a regression since version 8.0.0-rc1.

Reproduce with:
```bash
cd path/to/drupal/..
drush --root=drupal status
```

**Cause**
`drush_preflight_root()` finds the root specified in `--root` and does a `realpath($root)`. This fails for relative paths, because the CWD has already been changed to the `--root` much earlier in the Drush startup.

**Proposed solution:**
Remove an unnecessary `chdir()` from `drush_startup()`.