### PR TITLE
Fix drush_backend_invoke_concurrent() thinks @self is a different site

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -829,7 +829,10 @@ function drush_backend_invoke_concurrent($invocations, $common_options = array()
     $drush_global_options = $item['drush-global-options'];
     $backend_options = $item['backend-options'];
     $is_remote = array_key_exists('remote-host', $site_record);
-    $is_different_site = $is_remote || (isset($site_record['root']) && ($site_record['root'] != drush_get_context('DRUSH_DRUPAL_SITE_ROOT')));
+    $is_different_site =
+      $is_remote ||
+      (isset($site_record['root']) && ($site_record['root'] != drush_get_context('DRUSH_DRUPAL_ROOT'))) ||
+      (isset($site_record['uri']) && ($site_record['uri'] != drush_get_context('DRUSH_SELECTED_URI')));
     $os = drush_os($site_record);
     // If the caller did not pass in a specific path to drush, then we will
     // use a default value.  For commands that are being executed on the same


### PR DESCRIPTION
It was comparing a site record's 'root' entry (e.g. /path/to/drupal) to
drush_get_context('DRUSH_DRUPAL_SITE_ROOT) (e.g. sites/default) instead of
drush_get_context('DRUSH_DRUPAL_ROOT'), This fixes that and detects whether we
are dispatching to a different multi-site in the same Drupal root using the
site record's 'uri' entry and drush_get_context('DRUSH_SELECTED_URI')

I found this when trying to debug a problem with my update path (i.e. `drush updb`) with Xdebug. I was never hitting the breakpoint in the update function because Drush was dispatching to the "other" site using the drush.launcher, which does not work with Xdebug. With this fix Drush calls out to `php /path/to/drush/drush.php` directly, so that Xdebug starts working.