### PR TITLE
Fixes #2110: Drush site-install fails when empty database exists.

### DIFF
--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -266,7 +266,8 @@ class SqlBase {
    */
   public function drop_or_create() {
     if ($this->db_exists()) {
-      return $this->drop($this->listTables());
+      $this->drop($this->listTables());
+      return TRUE;
     }
     else {
       return $this->createdb();


### PR DESCRIPTION
Caused by `DROP TABLE` command error checking from https://github.com/drush-ops/drush/commit/92fa9a439fc5ec26cff3fb68a9e7cfd0d4076d2d

See #2110 for more info.