### PR TITLE
Database names containing dashes silently break sql-create.

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -255,7 +255,7 @@ function drush_sql_create() {
     }
   }
 
-  return $sql->createdb();
+  return $sql->createdb(TRUE);
 }
 
 

--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -254,7 +254,7 @@ class SqlBase {
    */
   public function createdb($quoted = FALSE) {
     $dbname = $this->db_spec['database'];
-    $sql = $this->createdb_sql($dbname);
+    $sql = $this->createdb_sql($dbname, $quoted);
     // Adjust connection to allow for superuser creds if provided.
     $this->su();
     return $this->query($sql);


### PR DESCRIPTION
I just ran into an issue with a database name containing dashes, like "project-site". drush sql-create silently failed, but drush sql-create --debug showed errors during database creation. Problem: MySQL requires quotes around database names with dashes, at least with MySQL 5.5 (tested with default ubuntu 14.04 versions).

The fix adds quoting what seems to work fine. Also, it makes the quote option of  \Drush\Sql\SqlBase::createdb() actually work. 

createDB has that docu:

> 
>    * @param boolean $quoted
>    *   Quote the database name. Mysql uses backticks to quote which can cause problems
>    *   in a Windows shell. Set TRUE if the CREATE is not running on the bash command line.

I do not know about windows compatibility, but as the quoted database name is part of the SQL connection I do not see how that can be influenced by a windows shell? Imho, it should be safe to quote the db name + is the right thing todo. PR fixes that and the mentioned issues for me.

I did not find any test coverage for sql-creation, so there is no test-coverage added it here. Also, the PR does not address the problem of drush silently ignoring errors during database creation. That qualifies as a separate issue imho.

