### PR TITLE
Use "classmap" for Composer autoloading of Drush.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "psr-0": {
       "Drush":        "lib/"
     },
-    "files": [
+    "classmap": [
       "lib/Drush.php"
     ]
   },


### PR DESCRIPTION
The [`classmap` parameter](https://getcomposer.org/doc/04-schema.md#classmap) in `composer.json` is used to enable autoloading files that have PHP classes in them. [`lib/Drush.php`](https://github.com/drush-ops/drush/blob/master/lib/Drush.php) is such an example. Move from "files" to "classmap" to have it autoload the class properly.

Uploaded a [similar issue to Drupal.org](https://www.drupal.org/node/2703487).