### PR TITLE
Prevent locale-update from executing same operation multiple times

### DIFF
--- a/commands/core/locale.d8.drush.inc
+++ b/commands/core/locale.d8.drush.inc
@@ -78,7 +78,7 @@ function drush_locale_update() {
   $langcodes = [];
   foreach (locale_translation_get_status() as $project_id => $project) {
     foreach ($project as $langcode => $project_info) {
-      if (!empty($project_info->type)) {
+      if (!empty($project_info->type) && !in_array($langcode, $langcodes)) {
         $langcodes[] = $langcode;
       }
     }


### PR DESCRIPTION
Currently each project returned from `locale_translation_get_status()` results in a new entry in `$langcodes`.  When `$langcodes` is used to determine the batch operations, an operation is added for each module and each duplicate value in `$langcodes`.  For 11 translatable modules and one language on a site this means over 300 mostly duplicate operations instead of the 33 required.