### PR TITLE
GH-2143: Include cache.inc during site-install.

### DIFF
--- a/commands/core/drupal/site_install_7.inc
+++ b/commands/core/drupal/site_install_7.inc
@@ -9,10 +9,14 @@ function drush_core_site_install_version($profile, array $additional_form_option
   require_once DRUSH_DRUPAL_CORE . '/includes/install.core.inc';
 
   if (!isset($profile)) {
+    global $conf;
     require_once DRUSH_DRUPAL_CORE . '/includes/file.inc';
     require_once DRUSH_DRUPAL_CORE . '/includes/install.inc';
     require_once DRUSH_DRUPAL_CORE . '/includes/common.inc';
     require_once DRUSH_DRUPAL_CORE . '/includes/module.inc';
+    require_once DRUSH_DRUPAL_CORE . '/includes/cache.inc';
+    require_once DRUSH_DRUPAL_CORE . '/includes/cache-install.inc';
+    $conf['cache_default_class'] = 'DrupalFakeCache';
 
     // If there is an installation profile that is marked as exclusive, use that
     // one.


### PR DESCRIPTION
See: GH-2143

This is attempt to fix the issues reproducible by the following steps:

```
$ drush -y dl drupal-7 --dev && cd drupal-7.x-dev
$ patch -p1 < <(curl -s https://www.drupal.org/files/issues/file_scan_directory-caching-2710289.patch)
$ drush -y si --db-url="sqlite://db.s"
PHP Fatal error:  Call to undefined function cache_get() in ~/temp/drupal7/drupal-7.x-dev/includes/common.inc on line 5522
```