### PR TITLE
Adds sub-options for xhprof_enable() flags.

### DIFF
--- a/commands/xh.drush.inc
+++ b/commands/xh.drush.inc
@@ -6,6 +6,12 @@
 
 use Drush\Log\LogLevel;
 
+define('XH_PROFILE_MEMORY', FALSE);
+
+define('XH_PROFILE_CPU', FALSE);
+
+define('XH_PROFILE_BUILTINS', TRUE);
+
 /**
  * Implements hook_drush_help_alter().
  */
@@ -18,6 +24,9 @@ function xh_drush_help_alter(&$command) {
       );
       $command['sub-options']['xh']['xh-link'] = 'URL to your XHProf report site.';
       $command['sub-options']['xh']['xh-path'] = 'Absolute path to the xhprof project.';
+      $command['sub-options']['xh']['xh-profile-builtins'] = 'Profile built-in PHP functions (defaults to TRUE).';
+      $command['sub-options']['xh']['xh-profile-cpu'] = 'Profile CPU (defaults to FALSE).';
+      $command['sub-options']['xh']['xh-profile-memory'] = 'Profile Memory (defaults to FALSE).';
     }
   }
 }
@@ -35,6 +44,23 @@ function xh_enabled() {
 }
 
 /**
+ * Determines flags for xhprof_enable based on drush options.
+ */
+function xh_flags() {
+  $flags = 0;
+  if (!drush_get_option('xh-profile-builtins', XH_PROFILE_BUILTINS)) {
+    $flags |= XHPROF_FLAGS_NO_BUILTINS;
+  }
+  if (drush_get_option('xh-profile-cpu', XH_PROFILE_CPU)) {
+    $flags |= XHPROF_FLAGS_CPU;
+  }
+  if (drush_get_option('xh-profile-memory', XH_PROFILE_MEMORY)) {
+    $flags |= XHPROF_FLAGS_MEMORY;
+  }
+  return $flags;
+}
+
+/**
  * Implements hook_drush_init().
  */
 function xh_drush_init() {
@@ -42,7 +68,7 @@ function xh_drush_init() {
     if ($path = drush_get_option('xh-path', '')) {
       include_once $path . '/xhprof_lib/utils/xhprof_lib.php';
       include_once $path . '/xhprof_lib/utils/xhprof_runs.php';
-      xhprof_enable(); // @todo support custom flags
+      xhprof_enable(xh_flags());
     }
   }
 }

--- a/tests/xhUnitTest.php
+++ b/tests/xhUnitTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Unish;
+
+/**
+ * Unit tests for xh.drush.inc.
+ *
+ * @group base
+ */
+class xhUnitCase extends UnitUnishTestCase {
+
+  /**
+   * Test various combinations of XHProf flag options.
+   *
+   * @dataProvider xhOptionProvider
+   */
+  public function testFlags($name, $options, $expected) {
+    drush_preflight();
+    foreach ($options as $option_name => $option_value) {
+      drush_set_option($option_name, $option_value);
+    }
+    $this->assertEquals($expected, xh_flags(), $name);
+  }
+
+  /**
+   * Provides drush XHProf options and the results we expect from xh_flags().
+   */
+  public function xhOptionProvider() {
+
+    if (!defined('XHPROF_FLAGS_NO_BUILTINS')) {
+      define('XHPROF_FLAGS_NO_BUILTINS', 1);
+      define('XHPROF_FLAGS_CPU', 2);
+      define('XHPROF_FLAGS_MEMORY', 3);
+    }
+
+    return array(
+      array(
+        'name' => 'No flag options provided (default)',
+        'options' => array(),
+        'expected' => 0,
+      ),
+      array(
+        'name' => 'Default flag options explicitly provided',
+        'options' => array(
+          'xh-profile-builtins' => TRUE,
+          'xh-profile-cpu' => FALSE,
+          'xh-profile-memory' => FALSE,
+        ),
+        'expected' => 0,
+      ),
+      array(
+        'name' => 'Disable profiling of built-ins',
+        'options' => array(
+          'xh-profile-builtins' => FALSE,
+          'xh-profile-cpu' => FALSE,
+          'xh-profile-memory' => FALSE,
+        ),
+        'expected' => XHPROF_FLAGS_NO_BUILTINS,
+      ),
+      array(
+        'name' => 'Enable profiling of CPU',
+        'options' => array(
+          'xh-profile-builtins' => TRUE,
+          'xh-profile-cpu' => TRUE,
+          'xh-profile-memory' => FALSE,
+        ),
+        'expected' => XHPROF_FLAGS_CPU,
+      ),
+      array(
+        'name' => 'Enable profiling of CPU, without builtins',
+        'options' => array(
+          'xh-profile-builtins' => FALSE,
+          'xh-profile-cpu' => TRUE,
+          'xh-profile-memory' => FALSE,
+        ),
+        'expected' => XHPROF_FLAGS_NO_BUILTINS | XHPROF_FLAGS_CPU,
+      ),
+      array(
+        'name' => 'Enable profiling of Memory',
+        'options' => array(
+          'xh-profile-builtins' => TRUE,
+          'xh-profile-cpu' => FALSE,
+          'xh-profile-memory' => TRUE,
+        ),
+        'expected' => XHPROF_FLAGS_MEMORY,
+      ),
+      array(
+        'name' => 'Enable profiling of Memory, without builtins',
+        'options' => array(
+          'xh-profile-builtins' => FALSE,
+          'xh-profile-cpu' => FALSE,
+          'xh-profile-memory' => TRUE,
+        ),
+        'expected' => XHPROF_FLAGS_NO_BUILTINS | XHPROF_FLAGS_MEMORY,
+      ),
+      array(
+        'name' => 'Enable profiling of CPU & Memory',
+        'options' => array(
+          'xh-profile-builtins' => TRUE,
+          'xh-profile-cpu' => TRUE,
+          'xh-profile-memory' => TRUE,
+        ),
+        'expected' => XHPROF_FLAGS_CPU | XHPROF_FLAGS_MEMORY,
+      ),
+    );
+  }
+
+}


### PR DESCRIPTION
The function `xhprof_enable()` takes flags to control the profiling of CPU, memory, and PHP built-ins. This change would add a drush sub-option for each of the flags.

Related to how sub-options appear to work currently, see #2173.
