### PR TITLE
Fix fatal error when using --db-prefix

### DIFF
--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -200,7 +200,7 @@ class SqlBase {
       // Enable prefix processing which can be dangerous so off by default. See http://drupal.org/node/1219850.
       if (drush_get_option('db-prefix')) {
         if (drush_drupal_major_version() >= 7) {
-          $query = Database::getConnection()->prefixTables($query);
+          $query = \Database::getConnection()->prefixTables($query);
         }
         else {
           $query = db_prefix_tables($query);


### PR DESCRIPTION
When running `drush sqlsan --db-prefix="xxx"` there was an issue with namespacing that caused the following error.

`Fatal error: Class 'Drush\Sql\Database' not found in /Users/tactica_david/.composer/vendor/drush/drush/lib/Drush/Sql/SqlBase.php on line 203`