### PR TITLE
Add a queue-delete command

### DIFF
--- a/commands/core/queue.drush.inc
+++ b/commands/core/queue.drush.inc
@@ -43,6 +43,13 @@ function queue_drush_command() {
       'output-data-type' => 'format-table',
     ),
   );
+  $items['queue-delete'] = array(
+    'description' => 'Delete all items in a specific queue',
+    'arguments' => array(
+      'queue_name' => 'The name of the queue to get a count for, as defined in either hook_queue_info or hook_cron_queue_info.',
+    ),
+    'required-arguments' => TRUE,
+  );
 
   return $items;
 }
@@ -93,3 +100,31 @@ function drush_queue_list() {
   return $queue->listQueues();
 }
 
+/**
+ * Validation callback for drush queue-delete.
+ */
+function drush_queue_delete_validate($queue_name) {
+  try {
+    $queue = drush_queue_get_class();
+    $queue->getInfo($queue_name);
+  }
+  catch (\Drush\Queue\QueueException $exception) {
+    return drush_set_error('DRUSH_QUEUE_DELETE_VALIDATION_ERROR', $exception->getMessage());
+  }
+}
+
+/**
+ * Command callback for drush queue-delete.
+ *
+ * @param $queue_name
+ *   Arbitrary string. The name of the queue to work with.
+ *
+ * @return int
+ */
+function drush_queue_delete($queue_name) {
+  $drush_queue = drush_queue_get_class();
+  $queue = $drush_queue->getQueue($queue_name);
+  $queue->deleteQueue();
+
+  drush_log(dt('All items in @name queue deleted.', array('@name' => $queue_name)), LogLevel::OK);
+}

--- a/commands/core/queue.drush.inc
+++ b/commands/core/queue.drush.inc
@@ -46,7 +46,7 @@ function queue_drush_command() {
   $items['queue-delete'] = array(
     'description' => 'Delete all items in a specific queue',
     'arguments' => array(
-      'queue_name' => 'The name of the queue to get a count for, as defined in either hook_queue_info or hook_cron_queue_info.',
+      'queue_name' => 'The name of the queue to delete all items for, as defined in either hook_queue_info or hook_cron_queue_info.',
     ),
     'required-arguments' => TRUE,
   );

--- a/tests/queueTest.php
+++ b/tests/queueTest.php
@@ -45,6 +45,32 @@ class QueueCase extends CommandUnishTestCase {
     $output = trim($this->getOutput());
     $parts = explode(",", $output);
     $this->assertEquals(str_replace('%items', 0, $expected), $output, 'Queue item processed.');
+  }
+
+  /**
+   * Tests the queue-delete command.
+   */
+  public function testQueueDelete() {
+    if (UNISH_DRUPAL_MAJOR_VERSION == 6) {
+      $this->markTestSkipped("Queue API not available in Drupal 6.");
+    }
+
+    if (UNISH_DRUPAL_MAJOR_VERSION == 7) {
+      $expected = 'aggregator_feeds,%items,SystemQueue';
+    }
+    else {
+      $expected = 'aggregator_feeds,%items,Drupal\Core\Queue\DatabaseQueue';
+    }
+
+    $sites = $this->setUpDrupal(1, TRUE);
+    $options = array(
+      'yes' => NULL,
+      'root' => $this->webroot(),
+      'uri' => key($sites),
+    );
+
+    // Enable aggregator since it declares a queue.
+    $this->drush('pm-enable', array('aggregator'), $options);
 
     // Add another item to the queue and make sure it was deleted.
     $this->drush('php-script', array('queue_script-D' . UNISH_DRUPAL_MAJOR_VERSION), $options + array('script-path' => dirname(__FILE__) . '/resources'));
@@ -58,4 +84,5 @@ class QueueCase extends CommandUnishTestCase {
     $output = trim($this->getOutput());
     $this->assertEquals(str_replace('%items', 0, $expected), $output, 'Queue was successfully deleted.');
   }
+
 }

--- a/tests/queueTest.php
+++ b/tests/queueTest.php
@@ -45,5 +45,17 @@ class QueueCase extends CommandUnishTestCase {
     $output = trim($this->getOutput());
     $parts = explode(",", $output);
     $this->assertEquals(str_replace('%items', 0, $expected), $output, 'Queue item processed.');
+
+    // Add another item to the queue and make sure it was deleted.
+    $this->drush('php-script', array('queue_script-D' . UNISH_DRUPAL_MAJOR_VERSION), $options + array('script-path' => dirname(__FILE__) . '/resources'));
+    $this->drush('queue-list', array(), $options + array('pipe' => TRUE));
+    $output = trim($this->getOutput());
+    $this->assertEquals(str_replace('%items', 1, $expected), $output, 'Item was successfully added to the queue.');
+
+    $this->drush('queue-delete', array('aggregator_feeds'), $options);
+
+    $this->drush('queue-list', array(), $options + array('pipe' => TRUE));
+    $output = trim($this->getOutput());
+    $this->assertEquals(str_replace('%items', 0, $expected), $output, 'Queue was successfully deleted.');
   }
 }


### PR DESCRIPTION
Working on something at the moment where we want to remove all items in the queue on some deployments, as items are easy to regenerate. I think it makes sense for drush to have this functionality too. Seems pretty useful to me.