### PR TITLE
Fixed method signature in DrupalKernel.

### DIFF
--- a/lib/Drush/Drupal/DrupalKernel.php
+++ b/lib/Drush/Drupal/DrupalKernel.php
@@ -13,7 +13,7 @@ class DrupalKernel extends DrupalDrupalKernel {
   /**
    * @inheritdoc
    */
-  public static function createFromRequest(Request $request, $class_loader, $environment, $allow_dumping = TRUE) {
+  public static function createFromRequest(Request $request, $class_loader, $environment, $allow_dumping = TRUE, $app_root = NULL) {
     drush_log(dt("Create from request"), LogLevel::DEBUG);
     $kernel = new static($environment, $class_loader, $allow_dumping);
     static::bootEnvironment();


### PR DESCRIPTION
`\Drush\Drupal\DrupalKernel::createFromRequest()` seems broken  #after https://www.drupal.org/node/2631362. Fixed it here.