### PR TITLE
Maintain compatibility with Drush extensions that use DRUSH_LOG_CALLBACK

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -1271,13 +1271,7 @@ function _drush_log($entry) {
     $callback = \Drush::logger();
   }
   if ($callback instanceof LoggerInterface) {
-    $context = $entry;
-    $log_level = $entry['type'];
-    $message = $entry['message'];
-    unset($entry['type']);
-    unset($entry['message']);
-
-    $callback->log($log_level, $message, $context);
+    _drush_log_to_logger($callback, $entry);
   }
   elseif ($callback) {
     $log =& drush_get_context('DRUSH_LOG', array());
@@ -1285,6 +1279,25 @@ function _drush_log($entry) {
     drush_backend_packet('log', $entry);
     return $callback($entry);
   }
+}
+
+// Maintain compatibility with extensions that hook into
+// DRUSH_LOG_CALLBACK (e.g. drush_ctex_bonus)
+function _drush_print_log($entry) {
+  $drush_logger = \Drush::logger();
+  if ($drush_logger) {
+    _drush_log_to_logger($drush_logger, $entry);
+  }
+}
+
+function _drush_log_to_logger($logger, $entry) {
+    $context = $entry;
+    $log_level = $entry['type'];
+    $message = $entry['message'];
+    unset($entry['type']);
+    unset($entry['message']);
+
+    $logger->log($log_level, $message, $context);
 }
 
 function drush_log_has_errors($types = array(LogLevel::WARNING, LogLevel::ERROR, LogLevel::FAILED)) {


### PR DESCRIPTION
For the master branch, we could just take out the compatibility layer, and force folks to add a PSR-3 logger.  Let's keep this for a little while, though.