### PR TITLE
Fixed missing version info from git_deploy.

### DIFF
--- a/commands/core/drupal/update_7.inc
+++ b/commands/core/drupal/update_7.inc
@@ -167,9 +167,10 @@ function update_main_prepare() {
 
   // Load module basics.
   include_once $core . '/includes/module.inc';
-  $module_list['system']['filename'] = 'modules/system/system.module';
-  module_list(TRUE, FALSE, FALSE, $module_list);
-  drupal_load('module', 'system');
+  $GLOBALS['module_list']['system']['filename'] = 'modules/system/system.module';
+  foreach (module_list(TRUE, FALSE, FALSE, $GLOBALS['module_list']) as $module) {
+    drupal_load('module', $module);
+  }
 
   // Reset the module_implements() cache so that any new hook implementations
   // in updated code are picked up.


### PR DESCRIPTION
The updatedb command is unable to load version info from git_deploy. This causes every module that has a version dependency to generate errors. I have added support for the workaround that is waiting to be committed to Drupal 7 core: https://www.drupal.org/node/2062763
