### PR TITLE
Add a caster for MarkupInterface

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -139,6 +139,7 @@ function _drush_core_cli_get_casters() {
     'Drupal\Core\Config\Entity\ConfigEntityInterface' => 'Drush\Psysh\Caster::castConfigEntity',
     'Drupal\Core\Config\ConfigBase' => 'Drush\Psysh\Caster::castConfig',
     'Drupal\Component\DependencyInjection\Container' => 'Drush\Psysh\Caster::castContainer',
+    'Drupal\Component\Render\MarkupInterface' => 'Drush\Psysh\Caster::castMarkup',
   ];
 }
 

--- a/lib/Drush/Psysh/Caster.php
+++ b/lib/Drush/Psysh/Caster.php
@@ -93,4 +93,15 @@ class Caster {
     return $array;
   }
 
+  /**
+   * Casts \Drupal\Component\Render\MarkupInterface classes.
+   */
+  public static function castMarkup($markup, $array, $stub, $isNested) {
+    if (!$isNested) {
+      $array[BaseCaster::PREFIX_VIRTUAL . 'markup'] = (string) $markup;
+    }
+
+    return $array;
+  }
+
 }


### PR DESCRIPTION
I'm bored of casting `MarkupInterface` objects (like `TranslatableMarkup`) to a string every time... Let's add a caster for it!

<img width="467" alt="1__fish_____sites_tag1_updates_docroot__fish_" src="https://cloud.githubusercontent.com/assets/1053891/16143757/baf5a1c6-3466-11e6-814c-d14d9ae6488b.png">
