### PR TITLE
Issue #1581: Warn about 'no-backup' side effects.

### DIFF
--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -1823,7 +1823,7 @@ function pm_drush_engine_version_control() {
       'description' => 'Backup all project files before updates.',
       'options' => array(
         'no-backup' => 'Do not perform backups.',
-        'backup-dir' => 'Specify a directory to backup projects into. Defaults to drush-backups within the home directory of the user running the command. It is forbidden to specify a directory inside your drupal root.',
+        'backup-dir' => 'Specify a directory to backup projects into. Defaults to drush-backups within the home directory of the user running the command. It is forbidden to specify a directory inside your drupal root. WARNING: Will result in non-core files being deleted, e.g. ".git", etc.',
       ),
     ),
     'bzr' => array(


### PR DESCRIPTION
Provide a warning that using the "no-backup" option for pm-updatecode will result in possible deletion of files.
