### PR TITLE
Accept 'local-host' in site alias configuration to specify the host to consider "local"

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1091,6 +1091,8 @@ function drush_backend_generate_sitealias($backend_options) {
  *      Optional. A remote host to execute the drush command on.
  *   'remote-user'
  *      Optional. Defaults to the current user. If you specify this, you can choose which module to send.
+ *   'local-host'
+ *      Optional. If == gethostname(), then force local operation of command.
  *   'ssh-options'
  *      Optional.  Defaults to "-o PasswordAuthentication=no"
  *   '#env-vars'
@@ -1125,6 +1127,7 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
   $site_record += array(
     'remote-host' => NULL,
     'remote-user' => NULL,
+    'local-host' => NULL,
     'ssh-options' => NULL,
     'path-aliases' => array(),
   );
@@ -1137,7 +1140,7 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
   $ssh_options = $site_record['ssh-options'];
   $os = drush_os($site_record);
 
-  if (drush_is_local_host($hostname)) {
+  if (isset($site_record['local-host']) ? $site_record['local-host'] === gethostname() : drush_is_local_host($hostname)) {
     $hostname = null;
   }
 

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1782,10 +1782,11 @@ function drush_sitealias_set_alias_context($site_alias_settings, $prefix = '') {
     }
   }
   // If 'php-options' are not set in the alias, then skip 'remote-host'
-  // and 'remote-user' if 'remote-host' is actually the local machine.
+  // and 'remote-user' if 'remote-host' is actually the local machine,
+  // unless 'ssh-options' is set, forcing SSH.
   // This prevents drush from using the remote dispatch mechanism (the command
   // is just run directly on the local machine, bootstrapping to the specified alias)
-  elseif (array_key_exists('remote-host', $site_alias_settings) && drush_is_local_host($site_alias_settings['remote-host'])) {
+  elseif (array_key_exists('local-host', $site_alias_settings) ? $site_alias_settings['local-host'] === gethostname() : array_key_exists('remote-host', $site_alias_settings) && drush_is_local_host($site_alias_settings['remote-host'])) {
     $skip_list[] = 'remote-host';
     $skip_list[] = 'remote-user';
   }


### PR DESCRIPTION
This addresses an issue with Vagrant setups that use port-forwarding on `localhost`, which is detected as a "local" due to `drush_is_local_host()`.

This was discussed in https://github.com/drush-ops/drush/commit/5fd7351, which seems to revert the `#check-local` flag that was added in https://github.com/drush-ops/drush/commit/00d1f4e055ce9218416a2bc41f060661a5ff385f and was made necessary to force drush to check for local.

This PR creates a new acceptable key on the aliases configuration array, `'local-host'`, which when set, will cause drush to treat the target host as local only when the value specified is equal to the value of `gethostname()`.

For my Vagrant environment, this change allows me to set `'local-host' => 'mymachine.dev'` in the alias configuration, and when I invoke the alias from my host machine (NOT mymachine.dev,) drush will correctly connect via ssh. However when I leverage the same alias when using the virtual machine `mymachine.dev`, it will recognize it as the local host.

Before this change, the host machine would be considered local because the IP for the `remote-host` is `127.0.0.1`. 

This change is backwards-compatible in that it only affects behavior if `local-host` is part of the site alias configuration array.
