### PR TITLE
Drush drupal version context for make update

### DIFF
--- a/commands/make/update.make.inc
+++ b/commands/make/update.make.inc
@@ -14,6 +14,7 @@ function drush_make_update($makefile = NULL) {
 
   make_prepare_projects(FALSE, $info);
   $make_projects = drush_get_option('DRUSH_MAKE_PROJECTS', FALSE);
+  $drupal_version = $info['core'];
 
   // Pick projects coming from drupal.org and adjust its structure
   // to feed update_status engine.
@@ -23,6 +24,9 @@ function drush_make_update($makefile = NULL) {
   // git_drupalorg engine.
   $projects = array();
   foreach ($make_projects as $project_name => $project) {
+    if ($project['type'] == 'core' && isset($project['version'])) {
+      $drupal_version = $project['version'];
+    }
     if (($project['download']['type'] == 'git') && !empty($project['download']['url'])) {
       // TODO check that tag or branch are valid version strings (with pm_parse_version()).
       if (!empty($project['download']['tag'])) {
@@ -53,6 +57,8 @@ function drush_make_update($makefile = NULL) {
       );
     }
   }
+
+  drush_set_context('DRUSH_DRUPAL_VERSION', $drupal_version);
 
   // Check for updates.
   $update_status = drush_get_engine('update_status');

--- a/includes/drupal.inc
+++ b/includes/drupal.inc
@@ -36,6 +36,10 @@ function drush_drupal_load_autoloader($drupal_root) {
 function drush_drupal_version($drupal_root = NULL) {
   static $version = FALSE;
 
+  if ($drush_drupal_version = drush_get_context('DRUSH_DRUPAL_VERSION')) {
+    $version = $drush_drupal_version;
+  }
+
   if (!$version) {
     if (($drupal_root != NULL) || ($drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT'))) {
       $bootstrap = \Drush::bootstrapManager()->bootstrapObjectForRoot($drupal_root);
@@ -43,10 +47,6 @@ function drush_drupal_version($drupal_root = NULL) {
         $version = $bootstrap->get_version($drupal_root);
       }
     }
-  }
-
-  if ($drush_version = drush_get_context('DRUSH_DRUPAL_VERSION')) {
-    $version = $drush_version;
   }
 
   return $version;

--- a/includes/drupal.inc
+++ b/includes/drupal.inc
@@ -44,6 +44,11 @@ function drush_drupal_version($drupal_root = NULL) {
       }
     }
   }
+
+  if ($drush_version = drush_get_context('DRUSH_DRUPAL_VERSION')) {
+    $version = $drush_version;
+  }
+
   return $version;
 }
 


### PR DESCRIPTION
This is an addition to a pull request that will follow and will reference this one, but basically because 'make-update' needs no bootstrap but indirectly relies on the update-status engine, and when parsing version numbers it needs a drupal version to properly parse module versions, so this provides a way to set up a drupal version internally as a drush context. It's harmless and eventually useful.