### PR TITLE
Support for updating code (both upc and make-udpate) for unsupported modules

### DIFF
--- a/commands/make/update.make.inc
+++ b/commands/make/update.make.inc
@@ -15,6 +15,8 @@ function drush_make_update($makefile = NULL) {
   make_prepare_projects(FALSE, $info);
   $make_projects = drush_get_option('DRUSH_MAKE_PROJECTS', FALSE);
 
+  drush_set_option('check-unsupported', TRUE);
+
   // Pick projects coming from drupal.org and adjust its structure
   // to feed update_status engine.
   // We provide here some heuristics to determine if a git clone comes

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -1718,6 +1718,7 @@ function pm_drush_engine_type_info() {
       'options' => array(
         'update-backend' => 'Backend to obtain available updates.',
         'check-disabled' => 'Check for updates of disabled modules and themes.',
+        'check-unsupported' => 'Check for updates of unsupported modules and themes.',
         'security-only'  => 'Only update modules that have security updates available.',
       ),
       'combine-help' => TRUE,

--- a/commands/pm/updatecode.pm.inc
+++ b/commands/pm/updatecode.pm.inc
@@ -31,7 +31,7 @@ function drush_pm_updatecode() {
   // Print report of modules to update, and record
   // result of that function in $update_info.
   $updatestatus_options = array();
-  foreach (array('lock', 'unlock', 'lock-message', 'update-backend', 'check-disabled', 'security-only') as $option) {
+  foreach (array('lock', 'unlock', 'lock-message', 'update-backend', 'check-disabled', 'check-unsupported', 'security-only') as $option) {
     $value = drush_get_option($option, FALSE);
     if ($value) {
       $updatestatus_options[$option] = $value;


### PR DESCRIPTION
I still maintain D6 sites (and D5 and D46 but that's just anecdotical) and it's still very useful to be able to update module versions to the last supported version regardless of the unsupported status.

With #2241, this allows for a nice way to update old D6 sites to the last supported-versions.

This also includes a very small fix with a leftover 't()' to 'dt()'
