### PR TITLE
Support all three file methods on drush_move_dir and properly use it on drush make

### DIFF
--- a/commands/core/archive.drush.inc
+++ b/commands/core/archive.drush.inc
@@ -153,7 +153,7 @@ function drush_archive_dump($sites_subdirs = '@self') {
   // (unless --overwrite) in a writable directory (and a writable file if
   // it exists). We check all this up front to avoid failing after a long
   // dump process.
-  $overwrite = drush_get_option('overwrite');
+  $overwrite = drush_get_option('overwrite') ? FILE_EXISTS_OVERWRITE : FILE_EXISTS_ABORT;
   $dest_dir = dirname($final_destination);
   $dt_args = array('!file' => $final_destination, '!dir' => $dest_dir);
   if (is_dir($final_destination)) {
@@ -342,10 +342,11 @@ function drush_archive_restore($file, $site_id = NULL) {
   $first = array_shift($ini_tmp);
   $docroot = basename($first['docroot']);
   $destination = drush_get_option('destination', realpath('.') . "/$docroot");
+  $overwrite = drush_get_option('overwrite') ? FILE_EXISTS_OVERWRITE : FILE_EXISTS_ABORT;
 
   if ($ini['Global']['archiveformat'] == 'platform') {
     // Move the whole platform in-place at once.
-    if (!drush_move_dir("$tmp/$docroot", $destination, drush_get_option('overwrite'))) {
+    if (!drush_move_dir("$tmp/$docroot", $destination, $overwrite)) {
       return drush_set_error('DRUSH_ARCHIVE_UNABLE_TO_RESTORE_FILES', dt('Unable to restore platform to !dest', array('!dest' => $destination)));
     }
   }
@@ -359,7 +360,7 @@ function drush_archive_restore($file, $site_id = NULL) {
       $site_destination = $destination . '/' . $site['sitedir'];
       // Restore site, in case not already done above.
       if ($ini['Global']['archiveformat'] == 'site') {
-        if (!drush_move_dir("$tmp/$docroot/" . $site['sitedir'], $site_destination, drush_get_option('overwrite'))) {
+        if (!drush_move_dir("$tmp/$docroot/" . $site['sitedir'], $site_destination, $overwrite)) {
           return drush_set_error('DRUSH_ARCHIVE_UNABLE_TO_RESTORE_FILES', dt('Unable to restore site to !dest', array('!dest' => $site_destination)));
         }
       }

--- a/commands/make/make.download.inc
+++ b/commands/make/make.download.inc
@@ -134,7 +134,7 @@ function make_download_file_unpack($filename, $download_location, $name, $subtre
       }
     }
 
-    $success = drush_move_dir($tmp_location, $download_location, TRUE);
+    $success = drush_move_dir($tmp_location, $download_location, FILE_EXISTS_MERGE);
 
     // Remove the tarball.
     if (file_exists($filename)) {
@@ -151,7 +151,7 @@ function make_download_file_unpack($filename, $download_location, $name, $subtre
     // The destination directory has already been created by
     // findDownloadLocation().
     $destination = $download_location . ($name ? '/' . $name : '');
-    $success = drush_move_dir($filename, $destination, TRUE);
+    $success = drush_move_dir($filename, $destination, FILE_EXISTS_MERGE);
   }
   return $success ? $download_location : FALSE;
 }
@@ -165,14 +165,14 @@ function _make_download_file_move($tmp_path, $filename, $download_location, $sub
   if (count($lines) == 1) {
     $directory = array_shift($lines);
     if ($directory->basename != $main_directory) {
-      drush_move_dir($directory->filename, $tmp_path . DIRECTORY_SEPARATOR . $main_directory, TRUE);
+      drush_move_dir($directory->filename, $tmp_path . DIRECTORY_SEPARATOR . $main_directory, FILE_EXISTS_OVERWRITE);
     }
     drush_copy_dir($tmp_path . DIRECTORY_SEPARATOR . $main_directory . DIRECTORY_SEPARATOR . $subtree, $download_location, FILE_EXISTS_OVERWRITE);
     drush_delete_dir($tmp_path, TRUE);
   }
   elseif (count($lines) > 1) {
     drush_delete_dir($download_location, TRUE);
-    drush_move_dir($tmp_path . DIRECTORY_SEPARATOR . $subtree, $download_location, TRUE);
+    drush_move_dir($tmp_path . DIRECTORY_SEPARATOR . $subtree, $download_location, FILE_EXISTS_OVERWRITE);
   }
 
   // Remove the tarball.

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -1066,7 +1066,7 @@ function make_move_build($build_path) {
   }
   else {
     drush_mkdir(dirname($build_path));
-    $ret = drush_move_dir($tmp_path . DIRECTORY_SEPARATOR . '__build__', $tmp_path . DIRECTORY_SEPARATOR . basename($build_path), TRUE);
+    $ret = drush_move_dir($tmp_path . DIRECTORY_SEPARATOR . '__build__', $tmp_path . DIRECTORY_SEPARATOR . basename($build_path), FILE_EXISTS_OVERWRITE);
     $ret = $ret && drush_copy_dir($tmp_path . DIRECTORY_SEPARATOR . basename($build_path), $build_path);
   }
 

--- a/commands/pm/version_control/backup.inc
+++ b/commands/pm/version_control/backup.inc
@@ -50,7 +50,7 @@ class drush_version_control_backup implements drush_version_control {
     if (drush_get_option('no-backup', FALSE)) {
       return;
     }
-    if (drush_move_dir($project['backup_target'], $project['full_project_path'], TRUE)) {
+    if (drush_move_dir($project['backup_target'], $project['full_project_path'], FILE_EXISTS_OVERWRITE)) {
       return drush_log(dt("Backups were restored successfully."), LogLevel::OK);
     }
     return drush_set_error('DRUSH_PM_BACKUP_ROLLBACK_FAILED', dt('Could not restore backup and rollback from failed upgrade. You will need to resolve manually.'));

--- a/examples/sync_via_http.drush.inc
+++ b/examples/sync_via_http.drush.inc
@@ -86,7 +86,7 @@ function drush_sync_via_http_pre_sql_sync($source = NULL, $destination = NULL) {
  *
  * Optionaly uses user authentication, using either wget or curl, as available.
  */
-function _drush_sync_via_http_download_file($url, $user = FALSE, $password = FALSE, $destination = FALSE, $overwrite = TRUE) {
+function _drush_sync_via_http_download_file($url, $user = FALSE, $password = FALSE, $destination = FALSE, $overwrite = FILE_EXISTS_OVERWRITE) {
   static $use_wget;
   if ($use_wget === NULL) {
     $use_wget = drush_shell_exec('which wget');

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -772,7 +772,7 @@ function drush_download_file($url, $destination = FALSE, $cache_duration = 0) {
       drush_log(dt('!name retrieved from cache.', array('!name' => $cache_file)));
     }
     else {
-      if (_drush_download_file($url, $cache_file, TRUE)) {
+      if (_drush_download_file($url, $cache_file, FILE_EXISTS_OVERWRITE)) {
         // Cache was set just by downloading file to right location.
       }
       elseif (file_exists($cache_file)) {
@@ -834,7 +834,7 @@ function _drush_is_url($url) {
  *   The path to the downloaded file, or FALSE if the file could not be
  *   downloaded.
  */
-function _drush_download_file($url, $destination, $overwrite = TRUE) {
+function _drush_download_file($url, $destination, $overwrite = FILE_EXISTS_OVERWRITE) {
   static $use_wget;
   if ($use_wget === NULL) {
     $use_wget = drush_shell_exec('wget --version');

--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -299,17 +299,20 @@ function _drush_recursive_copy($src, $dest) {
  *   $src = "/b/a" and $dest = "/c/a".  To move "a" to "/c" and rename
  *   it to "d", then $dest = "/c/d" (just like php rename function).
  * @param $overwrite
- *   If TRUE, the destination will be deleted if it exists.
+ *   Action to take if destination already exists.
+ *     - FILE_EXISTS_OVERWRITE - completely removes existing directory.
+ *     - FILE_EXISTS_ABORT - aborts the operation.
+ *     - FILE_EXISTS_MERGE - Leaves existing files and directories in place.
  * @return
  *   TRUE on success, FALSE on failure.
  */
-function drush_move_dir($src, $dest, $overwrite = FALSE) {
+function drush_move_dir($src, $dest, $overwrite = FILE_EXISTS_ABORT) {
   // Preflight based on $overwrite if $dest exists.
   if (file_exists($dest)) {
-    if ($overwrite) {
+    if ($overwrite == FILE_EXISTS_OVERWRITE) {
       drush_op('drush_delete_dir', $dest, TRUE);
     }
-    else {
+    else if ($overwrite == FILE_EXISTS_ABORT) {
       return drush_set_error('DRUSH_DESTINATION_EXISTS', dt('Destination directory !dest already exists.', array('!dest' => $dest)));
     }
   }
@@ -333,7 +336,7 @@ function drush_move_dir($src, $dest, $overwrite = FALSE) {
 
   // If 'rename' fails, then we will use copy followed
   // by a delete of the source.
-  if (drush_copy_dir($src, $dest)) {
+  if (drush_copy_dir($src, $dest, $overwrite)) {
     drush_op('drush_delete_dir', $src, TRUE);
     return TRUE;
   }


### PR DESCRIPTION
I have the following on my makefile:

```
  fpdf_tpl:
    download:
      type: file
      url: 'https://www.setasign.com/downloads/63411/FPDF_TPL-1.2.3.tgz'
    directory_name: 'fpdi'
  fpdi:
    download:
      type: file
      url: 'https://www.setasign.com/downloads/60111/FPDI-1.4.4.zip'
```

Notice that fpdf_tpl needs to go inside fpdi. It's odd, I know, but still, I would have expected this to work.

So I noticed that `make_download_file_unpack` was always overwriting, and I thought, when building, that was better suited a merge, I don't see any issues.

For this I simply extended drush_move_dir() to support the same overwrite methods as drush_copy_dir(), replace it everywhere to keep current behaviour and changed OVERWRITE to MERGE **ONLY** on `make_download_file_unpack`