### PR TITLE
'Sanitize query failed' with 'sqlsan --sanitize-password=no' on D8

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -619,7 +619,7 @@ function drush_sql_get_version() {
 function sql_drush_sql_sync_sanitize($site) {
   $site_settings = drush_sitealias_get_record($site);
   $databases = sitealias_get_databases_from_record($site_settings);
-  $major_version = drush_drupal_major_version($site_settings['root']);
+  $major_version = drush_drupal_major_version();
   $wrap_table_name = (bool) drush_get_option('db-prefix');
   $user_table_updates = array();
   $message_list = array();

--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -619,6 +619,7 @@ function drush_sql_get_version() {
 function sql_drush_sql_sync_sanitize($site) {
   $site_settings = drush_sitealias_get_record($site);
   $databases = sitealias_get_databases_from_record($site_settings);
+  $major_version = drush_drupal_major_version($site_settings['root']);
   $wrap_table_name = (bool) drush_get_option('db-prefix');
   $user_table_updates = array();
   $message_list = array();
@@ -626,7 +627,6 @@ function sql_drush_sql_sync_sanitize($site) {
   // Sanitize passwords.
   $newpassword = drush_get_option(array('sanitize-password', 'destination-sanitize-password'), 'password');
   if ($newpassword != 'no' && $newpassword !== 0) {
-    $major_version = drush_drupal_major_version();
     $pw_op = "";
 
     // In Drupal 6, passwords are hashed via the MD5 algorithm.


### PR DESCRIPTION
With the `$major_version` variable defined within [the TRUE check for password sanitization](https://github.com/drush-ops/drush/pull/2251/commits/3cc07768b7d3a81ff7425706350fe7d2b363c8da#diff-31ada6b624724696f3cbb93fb59fdde8L629), `sqlsan --sanitize-password=no` on Drupal 8 is unable to determine the proper user table to UPDATE and the command will fail with `[error] Sanitize query failed.`

This 2-line PR simply moves the `$major_version` variable to [the top of the function](https://github.com/drush-ops/drush/pull/2251/commits/3cc07768b7d3a81ff7425706350fe7d2b363c8da#diff-31ada6b624724696f3cbb93fb59fdde8R622) so that even when passwords are not sanitized, the correct user table can be determined and the query will succeed.