### PR TITLE
Change single quotes to double quotes in field-separator extra parameter for psql command-line queries

### DIFF
--- a/lib/Drush/Sql/Sqlpgsql.php
+++ b/lib/Drush/Sql/Sqlpgsql.php
@@ -6,7 +6,7 @@ define('PSQL_SHOW_TABLES', "SELECT tablename FROM pg_tables WHERE schemaname='pu
 
 class Sqlpgsql extends SqlBase {
 
-  public $query_extra = "--no-align --field-separator='\t' --pset tuples_only=on";
+  public $query_extra = "--no-align --field-separator=\"\t\" --pset tuples_only=on";
 
   public $query_file = "--file";
 


### PR DESCRIPTION
When calling `psql.exe` under Windows, the value of the extra `--field-separator` command-line argument is quoted incorrectly (single quotes are used). The command interpreter of windows (cmd.exe) doesn't accept this type of quoting and thus this results in hangs during the execution of various drush commands (e.g. `drush cc all`).

The patch changes the single quotes to double quotes that should be interpreted correctly under windows-based and non-windows-based systems.