### PR TITLE
Handle RequeueException in queue workers

### DIFF
--- a/lib/Drush/Queue/Queue8.php
+++ b/lib/Drush/Queue/Queue8.php
@@ -4,6 +4,7 @@ namespace Drush\Queue;
 
 use Drush\Log\LogLevel;
 use Drupal\Core\Queue\QueueWorkerManager;
+use Drupal\Core\Queue\RequeueException;
 use Drupal\Core\Queue\SuspendQueueException;
 
 class Queue8 extends QueueBase {
@@ -57,6 +58,10 @@ class Queue8 extends QueueBase {
         $worker->processItem($item->data);
         $queue->deleteItem($item);
         $count++;
+      }
+      catch (RequeueException $e) {
+        // The worker requested the task to be immediately requeued.
+        $queue->releaseItem($item);
       }
       catch (SuspendQueueException $e) {
         // If the worker indicates there is a problem with the whole queue,

--- a/tests/queueTest.php
+++ b/tests/queueTest.php
@@ -120,6 +120,16 @@ class QueueCase extends CommandUnishTestCase {
     $this->drush('queue-run', array('woot_requeue_exception'), $options);
 
     // Check that the item was processed after being requeued once.
+    // Here is the detailed workflow of what the above command did.
+    // 1. Drush calls drush queue-run woot_requeue_exception.
+    // 2. Drush claims the item. The worker sets a state variable (see below)
+    // and throws the RequeueException.
+    // 3. Drush catches the exception and puts it back in the queue.
+    // 4. Drush claims the next item, which is the one that we just requeued.
+    // 5. The worker finds the state variable, so it does not throw the
+    // RequeueException this time (see below).
+    // 6. Drush removes the item from the queue.
+    // 7. Command finishes. The queue is empty.
     $this->drush('queue-list', array(), $options + array('pipe' => TRUE));
     $output = trim($this->getOutput());
     $this->assertEquals(str_replace('%items', 0, $expected), $output, 'Queue item processed after being requeued.');

--- a/tests/resources/modules/d8/woot/src/Plugin/QueueWorker/WootRequeueException.php
+++ b/tests/resources/modules/d8/woot/src/Plugin/QueueWorker/WootRequeueException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\woot\Plugin\QueueWorker;
+
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\Queue\RequeueException;
+
+/**
+ * Queue worker used to test RequeueException.
+ *
+ * @QueueWorker(
+ *   id = "woot_requeue_exception",
+ *   title = @Translation("RequeueException test"),
+ *   cron = {"time" = 60}
+ * )
+ */
+class WootRequeueException extends QueueWorkerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    $state = \Drupal::state();
+    if (!$state->get('woot_requeue_exception')) {
+      $state->set('woot_requeue_exception', 1);
+      throw new RequeueException('I am not done yet!');
+    }
+    else {
+      $state->set('woot_requeue_exception', 2);
+    }
+  }
+
+}

--- a/tests/resources/requeue_script.php
+++ b/tests/resources/requeue_script.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @file
+ * Creates the woot_requeue_exception queue and adds an item to it.
+ *
+ * @see WootRequeueException
+ */
+
+$queue_factory = \Drupal::service('queue');
+$queue = $queue_factory->get('woot_requeue_exception', TRUE);
+$queue->createItem(['foo' => 'bar']);


### PR DESCRIPTION
Drupal 8 added the [RequeueException](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Queue!RequeueException.php/class/RequeueException/8.2.x) to allow workers to mark an item to be re-queued.

[Core's Cron.php handles it](http://cgit.drupalcode.org/drupal/tree/core/lib/Drupal/Core/Cron.php#n168), but Drush's queue processor doesn't. This pull request fixes it.