### PR TITLE
Check release information (e.g. versions) strictly

### DIFF
--- a/lib/Drush/UpdateService/Project.php
+++ b/lib/Drush/UpdateService/Project.php
@@ -330,7 +330,7 @@ class Project {
   private function searchReleases($key, $value) {
     $releases = array();
     foreach ($this->parsed['releases'] as $version => $release) {
-      if ($release['status'] == 'published' && isset($release[$key]) && $release[$key] == $value) {
+      if ($release['status'] == 'published' && isset($release[$key]) && $release[$key] === $value) {
         $releases[$version] = $release;
       }
     }


### PR DESCRIPTION
1. Somehow end up with a Drush cache that includes out-of-date release info, _not_ containing Drupal core version `7.50`
2. Run `drush make` on a make file (YAML or ini) which asks for Drupal core `"7.50"`
3. Instead of failing and reporting that the version `7.50` could not be found, Drush will select version `7.5`
4. The result could be a site unexpectedly vulnerable to Drupalgeddon.

The actual fix could probably be improved by contributors more knowledgeable about Make internals: I created the PR to illustrate the problem.