### PR TITLE
add $app_root to bootEnvironment

### DIFF
--- a/lib/Drush/Drupal/DrupalKernel.php
+++ b/lib/Drush/Drupal/DrupalKernel.php
@@ -16,7 +16,7 @@ class DrupalKernel extends DrupalDrupalKernel {
   public static function createFromRequest(Request $request, $class_loader, $environment, $allow_dumping = TRUE, $app_root = NULL) {
     drush_log(dt("Create from request"), LogLevel::DEBUG);
     $kernel = new static($environment, $class_loader, $allow_dumping);
-    static::bootEnvironment();
+    static::bootEnvironment($app_root);
     $kernel->initializeSettings($request);
     return $kernel;
   }


### PR DESCRIPTION
As stated in the pull request #2202 
We should pass the $app_root to bootEnvironment().