### PR TITLE
Issue #2285: Fix detecting sites other than default when a site-local drush is installed.

### DIFF
--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -282,7 +282,6 @@ function drush_startup($argv) {
     while (!empty($c) && ($c != $last)) {
       $found_script = find_wrapper_or_launcher($c);
       if ($found_script) {
-        chdir($c);
         break;
       }
       $last = $c;


### PR DESCRIPTION
See issue #2285 for details.
