### PR TITLE
Pass the $app_root to the kernel during boot

### DIFF
--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -123,10 +123,10 @@ class DrupalBoot8 extends DrupalBoot {
     // @todo - use Request::create() and then no need to set PHP superglobals
     $kernelClass = new \ReflectionClass('\Drupal\Core\DrupalKernel');
     if ($kernelClass->hasMethod('addServiceModifier')) {
-      $this->kernel = DrupalKernel::createFromRequest($this->request, $classloader, 'prod');
+      $this->kernel = DrupalKernel::createFromRequest($this->request, $classloader, 'prod', DRUPAL_ROOT);
     }
     else {
-      $this->kernel = DrushDrupalKernel::createFromRequest($this->request, $classloader, 'prod');
+      $this->kernel = DrushDrupalKernel::createFromRequest($this->request, $classloader, 'prod', DRUPAL_ROOT);
     }
     // @see Drush\Drupal\DrupalKernel::addServiceModifier()
     $this->kernel->addServiceModifier(new DrushServiceModfier());


### PR DESCRIPTION
This is a follow-up to #2202 (and #2280)

Seems innocent enough, but I'm not very knowledgeable about the Drush boot process, so could use some eyes.

Note that passing the `$app_root` explicitly is considered a best practice. It's only optional for backwards-compatibility.