### PR TITLE
Fix condition for hidden modules

### DIFF
--- a/commands/core/drupal/environment.inc
+++ b/commands/core/drupal/environment.inc
@@ -25,7 +25,7 @@ function drush_get_modules($include_hidden = TRUE) {
   $modules = system_rebuild_module_data();
 
   foreach ($modules as $key => $module) {
-    if ((!$include_hidden) && (isset($module->info['hidden']))) {
+    if ((!$include_hidden) && (!empty($module->info['hidden']))) {
       unset($modules[$key]);
     }
     else {


### PR DESCRIPTION
Raised from this issue https://www.drupal.org/node/2771855.
drush_get_modules() doesn't check a value of hidden property.