### PR TITLE
Issue #2152: Fix escaped path bug for Windows

### DIFF
--- a/includes/exec.inc
+++ b/includes/exec.inc
@@ -328,7 +328,7 @@ function drush_escapeshellarg($arg, $os = NULL, $raw = FALSE) {
     return $arg;
   }
   elseif (drush_is_windows($os)) {
-    return _drush_escapeshellarg_windows($arg, $raw);
+    return _drush_escapeshellarg_windows($arg, TRUE);
   }
   else {
     return _drush_escapeshellarg_linux($arg, $raw);


### PR DESCRIPTION
I don't know all the implications of this. I do know that my particular setup chokes if paths are passed surrounded by quotes. Someone who knows more should look into whether there is a better way to accomplish this.

See https://github.com/drush-ops/drush/issues/2152 for details on the error I am trying to fix.