### PR TITLE
Use mtime instead of ctime for cache validity

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -768,7 +768,7 @@ function drush_download_file($url, $destination = FALSE, $cache_duration = 0) {
 
   if ($cache_duration !== 0 && $cache_file = drush_download_file_name($url)) {
     // Check for cached, unexpired file.
-    if (file_exists($cache_file) && filectime($cache_file) > ($_SERVER['REQUEST_TIME']-$cache_duration)) {
+    if (file_exists($cache_file) && filemtime($cache_file) > ($_SERVER['REQUEST_TIME']-$cache_duration)) {
       drush_log(dt('!name retrieved from cache.', array('!name' => $cache_file)));
     }
     else {

--- a/lib/Drush/UpdateService/StatusInfoDrush.php
+++ b/lib/Drush/UpdateService/StatusInfoDrush.php
@@ -33,8 +33,8 @@ class StatusInfoDrush implements StatusInfoInterface {
       $url = Project::buildFetchUrl($request);
       $cache_file = drush_download_file_name($url);
       if (file_exists($cache_file)) {
-        $ctime = filectime($cache_file);
-        $older = (!$older) ? $ctime : min($ctime, $older);
+        $mtime = filemtime($cache_file);
+        $older = (!$older) ? $mtime : min($mtime, $older);
       }
     }
 


### PR DESCRIPTION
The mtime tracks the time the file was last modified.

The ctime tracks the time the file was created _or_ when its inode metadata changed. The ctime is thus vulnerable to being reset via things like `chmod` / `chown`.

Motivation here: https://github.com/drush-ops/drush/pull/2274#issuecomment-235212433

This is intended as the simplest possible fix. A more ideal solution might be something akin to the Doctrine [FilesystemCache](https://github.com/doctrine/cache/blob/master/lib/Doctrine/Common/Cache/FilesystemCache.php), which adds a timestamp to the first line of each cache file.