### PR TITLE
Use DIRECTORY_SEPARATOR

### DIFF
--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -739,7 +739,7 @@ function drush_file_append_data($file, $data) {
  */
 function drush_is_nested_directory($base_dir, $test_is_nested) {
   // Ensure there is always exactly one '/' at the end of $base_dir
-  $base_dir = rtrim($base_dir, '/') . '/';
+  $base_dir = rtrim($base_dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
   return substr($test_is_nested, 0, strlen($base_dir)) == $base_dir;
 }
 

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -799,7 +799,7 @@ function drush_preflight_command_dispatch() {
   $values = NULL;
   if (!empty($root) && !empty($local_drush) && empty($is_local)) {
     if (!drush_is_absolute_path($local_drush)) {
-      $local_drush = $root . '/' . $local_drush;
+      $local_drush = $root . DIRECTORY_SEPARATOR . $local_drush;
     }
     $local_drush = realpath($local_drush);
     $this_drush = drush_find_drush();


### PR DESCRIPTION
And thereby fix drush_is_nested_directory() and drush_preflight_command_dispatch() on Windows.

Progress on #1674 