### PR TITLE
download theme engines into the sensible default destination

### DIFF
--- a/commands/pm/download.pm.inc
+++ b/commands/pm/download.pm.inc
@@ -306,16 +306,17 @@ function pm_drush_pm_download_destination_alter(&$request, $release) {
  * @return String the candidate destination if it exists.
  */
 function _pm_download_destination_lookup($type, $drupal_root, $sitepath, $create = FALSE) {
-  if ($type == 'theme engine') {
-    $destination = 'themes/engines';
-  }
   // Profiles in Drupal < 8
-  elseif (($type == 'profile') && (drush_drupal_major_version() < 8)) {
+  if (($type == 'profile') && (drush_drupal_major_version() < 8)) {
     $destination = 'profiles';
   }
   // Type: module, theme or profile.
   else {
-    $destination = $type . 's';
+    if ($type == 'theme engine') {
+      $destination = 'themes/engines';
+    } else {
+      $destination = $type . 's';
+    }
     // Prefer /contrib if it exists.
     if ($sitepath) {
       $destination = $sitepath . '/' . $destination;


### PR DESCRIPTION
At the moment when you download a theme engine, e.g. "drush dl tfd7-7.x-3.0-beta2", it ends up in /public/themes/engines. But the sensible default place for theme engines from "contrib" is 
/public/sites/all/themes/engines.