### PR TITLE
Recommend install over https

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@ Install/Upgrade a global Drush
 ---------------
 ```sh
 # Download latest stable release using the code below or browse to github.com/drush-ops/drush/releases.
-php -r "readfile('http://files.drush.org/drush.phar');" > drush
+php -r "readfile('https://files.drush.org/drush.phar');" > drush
 # Or use our upcoming release: php -r "readfile('http://files.drush.org/drush-unstable.phar');" > drush
 
 # Test your install.


### PR DESCRIPTION
We shouldn't be advocating fetching executables from the internet over http.

Actual URL will probably need to reference the full s3 address because the certificate isn't valid for files.drush.org