### PR TITLE
Handle requeue exception in 8.x

### DIFF
--- a/lib/Drush/Queue/Queue8.php
+++ b/lib/Drush/Queue/Queue8.php
@@ -4,6 +4,7 @@ namespace Drush\Queue;
 
 use Drush\Log\LogLevel;
 use Drupal\Core\Queue\QueueWorkerManager;
+use Drupal\Core\Queue\RequeueException;
 use Drupal\Core\Queue\SuspendQueueException;
 
 class Queue8 extends QueueBase {
@@ -57,6 +58,10 @@ class Queue8 extends QueueBase {
         $worker->processItem($item->data);
         $queue->deleteItem($item);
         $count++;
+      }
+      catch (RequeueException $e) {
+        // The worker requested the task to be immediately requeued.
+        $queue->releaseItem($item);
       }
       catch (SuspendQueueException $e) {
         // If the worker indicates there is a problem with the whole queue,

--- a/tests/queueTest.php
+++ b/tests/queueTest.php
@@ -46,4 +46,106 @@ class QueueCase extends CommandUnishTestCase {
     $parts = explode(",", $output);
     $this->assertEquals(str_replace('%items', 0, $expected), $output, 'Queue item processed.');
   }
+
+  /**
+   * Tests the queue-delete command.
+   */
+  public function testQueueDelete() {
+    if (UNISH_DRUPAL_MAJOR_VERSION == 6) {
+      $this->markTestSkipped("Queue API not available in Drupal 6.");
+    }
+
+    if (UNISH_DRUPAL_MAJOR_VERSION == 7) {
+      $expected = 'aggregator_feeds,%items,SystemQueue';
+    }
+    else {
+      $expected = 'aggregator_feeds,%items,Drupal\Core\Queue\DatabaseQueue';
+    }
+
+    $sites = $this->setUpDrupal(1, TRUE);
+    $options = array(
+      'yes' => NULL,
+      'root' => $this->webroot(),
+      'uri' => key($sites),
+    );
+
+    // Enable aggregator since it declares a queue.
+    $this->drush('pm-enable', array('aggregator'), $options);
+
+    // Add another item to the queue and make sure it was deleted.
+    $this->drush('php-script', array('queue_script-D' . UNISH_DRUPAL_MAJOR_VERSION), $options + array('script-path' => dirname(__FILE__) . '/resources'));
+    $this->drush('queue-list', array(), $options + array('pipe' => TRUE));
+    $output = trim($this->getOutput());
+    $this->assertEquals(str_replace('%items', 1, $expected), $output, 'Item was successfully added to the queue.');
+
+    $this->drush('queue-delete', array('aggregator_feeds'), $options);
+
+    $this->drush('queue-list', array(), $options + array('pipe' => TRUE));
+    $output = trim($this->getOutput());
+    $this->assertEquals(str_replace('%items', 0, $expected), $output, 'Queue was successfully deleted.');
+  }
+
+  /**
+   * Tests the RequeueException.
+   */
+  public function testRequeueException() {
+    if (UNISH_DRUPAL_MAJOR_VERSION < 8) {
+      $this->markTestSkipped("RequeueException only available in Drupal 8.");
+    }
+
+    $sites = $this->setUpDrupal(1, TRUE);
+    $options = array(
+      'yes' => NULL,
+      'root' => $this->webroot(),
+      'uri' => key($sites),
+    );
+
+    // Copy the 'woot' module over to the Drupal site we just set up.
+    $this->setupModulesForTests($this->webroot());
+
+    // Enable woot module, which contains a queue worker that throws a
+    // RequeueException.
+    $this->drush('pm-enable', array('woot'), $options, NULL, NULL, self::EXIT_SUCCESS);
+
+    // Add an item to the queue.
+    $this->drush('php-script', array('requeue_script'), $options + array('script-path' => dirname(__FILE__) . '/resources'));
+
+    // Check that the queue exists and it has one item in it.
+    $expected = 'woot_requeue_exception,%items,Drupal\Core\Queue\DatabaseQueue';
+    $this->drush('queue-list', array(), $options + array('pipe' => TRUE));
+    $output = trim($this->getOutput());
+    $this->assertEquals(str_replace('%items', 1, $expected), $output, 'Item was successfully added to the queue.');
+
+    // Process the queue.
+    $this->drush('queue-run', array('woot_requeue_exception'), $options);
+
+    // Check that the item was processed after being requeued once.
+    // Here is the detailed workflow of what the above command did.
+    // 1. Drush calls drush queue-run woot_requeue_exception.
+    // 2. Drush claims the item. The worker sets a state variable (see below)
+    // and throws the RequeueException.
+    // 3. Drush catches the exception and puts it back in the queue.
+    // 4. Drush claims the next item, which is the one that we just requeued.
+    // 5. The worker finds the state variable, so it does not throw the
+    // RequeueException this time (see below).
+    // 6. Drush removes the item from the queue.
+    // 7. Command finishes. The queue is empty.
+    $this->drush('queue-list', array(), $options + array('pipe' => TRUE));
+    $output = trim($this->getOutput());
+    $this->assertEquals(str_replace('%items', 0, $expected), $output, 'Queue item processed after being requeued.');
+  }
+
+  /**
+   * Copies the woot module into Drupal.
+   *
+   * @param string $root
+   *   The path to the root directory of Drupal.
+   */
+  public function setupModulesForTests($root) {
+    $wootModule = __DIR__ . '/resources/modules/d' . UNISH_DRUPAL_MAJOR_VERSION . '/woot';
+    $modulesDir = "$root/sites/all/modules";
+    $this->mkdir($modulesDir);
+    \symlink($wootModule, "$modulesDir/woot");
+  }
+
 }

--- a/tests/queueTest.php
+++ b/tests/queueTest.php
@@ -48,44 +48,6 @@ class QueueCase extends CommandUnishTestCase {
   }
 
   /**
-   * Tests the queue-delete command.
-   */
-  public function testQueueDelete() {
-    if (UNISH_DRUPAL_MAJOR_VERSION == 6) {
-      $this->markTestSkipped("Queue API not available in Drupal 6.");
-    }
-
-    if (UNISH_DRUPAL_MAJOR_VERSION == 7) {
-      $expected = 'aggregator_feeds,%items,SystemQueue';
-    }
-    else {
-      $expected = 'aggregator_feeds,%items,Drupal\Core\Queue\DatabaseQueue';
-    }
-
-    $sites = $this->setUpDrupal(1, TRUE);
-    $options = array(
-      'yes' => NULL,
-      'root' => $this->webroot(),
-      'uri' => key($sites),
-    );
-
-    // Enable aggregator since it declares a queue.
-    $this->drush('pm-enable', array('aggregator'), $options);
-
-    // Add another item to the queue and make sure it was deleted.
-    $this->drush('php-script', array('queue_script-D' . UNISH_DRUPAL_MAJOR_VERSION), $options + array('script-path' => dirname(__FILE__) . '/resources'));
-    $this->drush('queue-list', array(), $options + array('pipe' => TRUE));
-    $output = trim($this->getOutput());
-    $this->assertEquals(str_replace('%items', 1, $expected), $output, 'Item was successfully added to the queue.');
-
-    $this->drush('queue-delete', array('aggregator_feeds'), $options);
-
-    $this->drush('queue-list', array(), $options + array('pipe' => TRUE));
-    $output = trim($this->getOutput());
-    $this->assertEquals(str_replace('%items', 0, $expected), $output, 'Queue was successfully deleted.');
-  }
-
-  /**
    * Tests the RequeueException.
    */
   public function testRequeueException() {

--- a/tests/resources/modules/d8/woot/src/Plugin/QueueWorker/WootRequeueException.php
+++ b/tests/resources/modules/d8/woot/src/Plugin/QueueWorker/WootRequeueException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\woot\Plugin\QueueWorker;
+
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\Queue\RequeueException;
+
+/**
+ * Queue worker used to test RequeueException.
+ *
+ * @QueueWorker(
+ *   id = "woot_requeue_exception",
+ *   title = @Translation("RequeueException test"),
+ *   cron = {"time" = 60}
+ * )
+ */
+class WootRequeueException extends QueueWorkerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+    $state = \Drupal::state();
+    if (!$state->get('woot_requeue_exception')) {
+      $state->set('woot_requeue_exception', 1);
+      throw new RequeueException('I am not done yet!');
+    }
+    else {
+      $state->set('woot_requeue_exception', 2);
+    }
+  }
+
+}

--- a/tests/resources/requeue_script.php
+++ b/tests/resources/requeue_script.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @file
+ * Creates the woot_requeue_exception queue and adds an item to it.
+ *
+ * @see WootRequeueException
+ */
+
+$queue_factory = \Drupal::service('queue');
+$queue = $queue_factory->get('woot_requeue_exception', TRUE);
+$queue->createItem(['foo' => 'bar']);


### PR DESCRIPTION
At https://github.com/drush-ops/drush/pull/2264 we added support for RequeueException in `master` branch. This PR backports that pull request for `8.x`.