### PR TITLE
moved 'chmod +x' to come before executing drush

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,11 +5,13 @@ Install/Upgrade a global Drush
 php -r "readfile('https://s3.amazonaws.com/files.drush.org/drush.phar');" > drush
 # Or use our upcoming release: php -r "readfile('https://s3.amazonaws.com/files.drush.org/drush.phar');" > drush
 
+# Make the file executable
+chmod +x drush
+
 # Test your install.
 php drush core-status
 
 # Make `drush` executable as a command from anywhere. Destination can be anywhere on $PATH.
-chmod +x drush
 sudo mv drush /usr/local/bin
 
 # Optional. Enrich the bash startup file with completion and aliases.


### PR DESCRIPTION
The step 'chmod +x drush' needs to come before the step where the user executes drush. This is just a simple fix to the order of instructions.
