### PR TITLE
Prevent drush_scan_directory from following symlinks.

### DIFF
--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -684,7 +684,7 @@ function drush_scan_directory($dir, $mask, $nomask = array('.', '..', 'CVS'), $c
 
   if (is_string($dir) && is_dir($dir) && $handle = opendir($dir)) {
     while (FALSE !== ($file = readdir($handle))) {
-      if (!in_array($file, $nomask) && (($include_dot_files && (!preg_match("/\.\+/",$file))) || ($file[0] != '.'))) {
+      if (!is_link("$dir/$file") && !in_array($file, $nomask) && (($include_dot_files && (!preg_match("/\.\+/",$file))) || ($file[0] != '.'))) {
         if (is_dir("$dir/$file") && (($recurse_max_depth === TRUE) || ($depth < $recurse_max_depth))) {
           // Give priority to files in this folder by merging them in after any subdirectory files.
           $files = array_merge(drush_scan_directory("$dir/$file", $mask, $nomask, $callback, $recurse_max_depth, $key, $min_depth, $include_dot_files, $depth + 1), $files);


### PR DESCRIPTION
Drush gets stuck in an infinite loop when scanning the filesystem of a Drupal installation that has subsites configured using symlinks.

I'm fairly sure that this has been suggested before and rejected for some reason, but the simplest fix for this is to stop the drush_scan_directory() function stop recursing through symlinks.
