### PR TITLE
Quote database name

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -249,7 +249,7 @@ function drush_sql_create() {
     }
   }
 
-  return $sql->createdb();
+  return $sql->createdb(TRUE);
 }
 
 

--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -254,7 +254,7 @@ class SqlBase {
    */
   public function createdb($quoted = FALSE) {
     $dbname = $this->db_spec['database'];
-    $sql = $this->createdb_sql($dbname);
+    $sql = $this->createdb_sql($dbname, $quoted);
     // Adjust connection to allow for superuser creds if provided.
     $this->su();
     return $this->query($sql);


### PR DESCRIPTION
I ran into the problem that Databases weren't created with sql-create when the database name has a dash in it. So 'example-db' wouldn't work, where 'example_db' would work.
Therefore I did some research. It turned out this is fixed in the Master branch, but not yet for Drush 8.1.x (currently running v8.1.3).

The changes that are the solution to this issue are found here:
https://github.com/drush-ops/drush/commit/483149e0716991e8ab742ea7ab21d3280088eb8f

As this is my very first pull request, I'm not sure this is the correct way to go. However, I duplicated these changes on a branche of 8.x. 

I hope these lines can be a part of the next update.