### PR TITLE
Fix yaml makefile generation - reading looks for patch, not patches.

### DIFF
--- a/commands/make/generate.make.inc
+++ b/commands/make/generate.make.inc
@@ -160,7 +160,7 @@ function _drush_make_generate_add_patch_files(&$project, $location) {
   if (is_file($patchfile)) {
     foreach (file($patchfile) as $line) {
       if (substr($line, 0, 2) == '- ') {
-        $project['patches'][] = trim(substr($line, 2));
+        $project['patch'][] = trim(substr($line, 2));
       }
     }
   }


### PR DESCRIPTION
This patch modifies the output of generate-makefile so that the key matches that sought when reading a drush makefile.

Signed-off-by: Nigel Cunningham <nigel@salsadigital.com.au>