### PR TITLE
Fix PHP 5.3 test on PHP 7 in Drush 7 startup script

### DIFF
--- a/drush
+++ b/drush
@@ -125,8 +125,7 @@ if [ -n "$PHP_OPTIONS" ] ; then
 fi
 
 # If on PHP 5.3, disable magic_quotes_gpc and friends
-PHP_MINOR_VERSION="`\"$php\" -r 'print PHP_MINOR_VERSION;'`"
-if [ $PHP_MINOR_VERSION -le 3 ] ; then
+if [ -n "`php --version | grep '^PHP 5\.3'`" ] ; then
   php_options="$php_options -d magic_quotes_gpc=Off -d magic_quotes_runtime=Off -d magic_quotes_sybase=Off"
 fi
 

--- a/tests/makeTest.php
+++ b/tests/makeTest.php
@@ -70,7 +70,7 @@ class makeMakefileCase extends CommandUnishTestCase {
         'name'     => 'bzip2 single file',
         'makefile' => 'bz2-singlefile.make',
         'build'    => TRUE,
-        'md5'      => '4f9d57f6caaf6ece0526d867327621cc',
+        'md5'      => '05a0ecad1ecc3de4845f06ca6272c6f4',
         'options'  => array('no-core' => NULL),
       ),
       'contrib-destination' => array(

--- a/tests/makefiles/bz2-singlefile.make
+++ b/tests/makefiles/bz2-singlefile.make
@@ -5,4 +5,4 @@ core = 6.x
 ; This should move that single file to sites/all/libraries/wkhtmltopdf .
 libraries[wkhtmltopdf][destination] = libraries
 libraries[wkhtmltopdf][download][type] = get
-libraries[wkhtmltopdf][download][url] = http://wkhtmltopdf.googlecode.com/files/wkhtmltopdf-0.11.0_rc1-static-amd64.tar.bz2
+libraries[wkhtmltopdf][download][url] = http://download.gna.org/wkhtmltopdf/0.12/0.12.2.1/wkhtmltox-0.12.2.1.tar.bz2

--- a/tests/makefiles/file-extract.make
+++ b/tests/makefiles/file-extract.make
@@ -13,5 +13,5 @@ libraries[vegas][download][type] = "get"
 libraries[vegas][download][url] = "https://github.com/jaysalvat/vegas/zipball/v1.2"
 
 libraries[autopager][download][type] = "get"
-libraries[autopager][download][url] = "https://jquery-autopager.googlecode.com/files/jquery.autopager-1.0.0.js"
+libraries[autopager][download][url] = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/jquery-autopager/jquery.autopager-1.0.0.js"
 libraries[autopager][directory_name] = "autopager"


### PR DESCRIPTION
The drush script (which is now drush.laundher in Drush 8 or later) uses PHP_MIN_VERSION to determine if the php release is PHP 5.3. This causes the test to spuriously pass on PHP 7. Adding the extra -d options is innocuous, but noisy.

Running php -r has a bad side-effect on Pantheon, though, which doesn't like it if you run php without the php options we've told Drush to use. This recently became an actual operational problem with some APC changes we made; breaks Kalabox when running Drupal 7 + Drush 7 + PHP 7.

This PR fixes all of these problems.