### PR TITLE
Backport Composer support into make-convert command

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -679,6 +679,32 @@ function drush_make_convert_project_to_composer($original_project, $core_major_v
 }
 
 /**
+ * Converts a drush info array to a YAML array.
+ *
+ * @param array $info
+ *   A drush make info array.
+ *
+ * @return string
+ *   A yaml encoded info array.
+ */
+function drush_make_convert_make_to_yml($info) {
+  // Remove incorrect value.
+  unset($info['format']);
+
+  // Replace "*" with "~" for project versions.
+  foreach ($info['projects'] as $key => $project) {
+    if ($project['version'] == '*') {
+      $info['projects'][$key]['version'] = '~';
+    }
+  }
+
+  $dumper = drush_load_engine('outputformat', 'yaml');
+  $output = $dumper->format($info, array());
+
+  return $output;
+}
+
+/**
  * Drush callback: hidden file to process an individual project.
  *
  * @param string $directory

--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -150,7 +150,7 @@ function make_drush_command() {
 
   $items['make-convert'] = array(
     'bootstrap' => DRUSH_BOOTSTRAP_NONE,
-    'description' => 'Convert a legacy makefile into YAML format.',
+    'description' => 'Convert a legacy makefile into another format. Defaults to converting .make => .make.yml.',
     'arguments' => array(
       'makefile' => 'Filename of the makefile to convert.',
     ),
@@ -158,10 +158,13 @@ function make_drush_command() {
       'projects' => $projects,
       'libraries' => $libraries,
       'includes' => 'A list of makefiles to include at build-time.',
+      'format' => 'The format to which the make file should be converted. Accepted values include make, composer, and yml.',
     ),
     'required-arguments' => TRUE,
     'examples' => array(
-      'drush make-convert example.make' => 'Convert example.make to example.make.yml',
+      'drush make-convert example.make --format=yml' => 'Convert example.make to example.make.yml',
+      'drush make-convert example.make --format=composer' => 'Convert example.make to composer.json',
+      'drush make-convert composer.lock --format=make' => 'Convert composer.lock example.make',
     ),
   );
 
@@ -379,25 +382,300 @@ function drush_make($makefile = NULL, $build_path = NULL) {
 /**
  * Command callback; convert ini makefile to YAML.
  */
-function drush_make_convert($makefile) {
+function drush_make_convert($source) {
+  $dest_format = drush_get_option('format', 'yml');
 
-  drush_log(dt('Beginning to convert !makefile.', array('!makefile' => $makefile)), LogLevel::OK);
+  // Load source data.
+  $source_format = pathinfo($source, PATHINFO_EXTENSION);
 
-  $file = $makefile . '.yml';
-  $info = make_parse_info_file($makefile);
-  // Remove incorrect value.
-  unset($info['format']);
-
-  $dumper = drush_load_engine('outputformat', 'yaml');
-  $yaml = $dumper->format($info, array());
-
-  if (file_put_contents($file, $yaml)) {
-    drush_log(dt("Wrote make file @file", array('@file' => $file)), LogLevel::OK);
-    return $file;
+  if ($source_format == $dest_format || $source_format == 'lock' && $dest_format == 'composer') {
+    drush_print('The source format cannot be the same as the destination format.');
   }
-  else {
-    make_error('FILE_ERROR', dt("Unable to write file !file", array('!file' => $file)));
+
+  // Obtain drush make $info array, converting if necessary.
+  switch ($source_format) {
+    case 'make':
+    case 'yml':
+    case 'yaml':
+      $info = make_parse_info_file($source);
+      break;
+    case 'lock':
+      $composer_json_file = str_replace('lock', 'json', $source);
+      if (!file_exists($composer_json_file)) {
+        drush_print('Please ensure that a composer.json file is in the same directory as the specified composer.lock file.');
+        return FALSE;
+      }
+      $composer_json = json_decode(make_get_data($composer_json_file), TRUE);
+      $composer_lock = json_decode(make_get_data($source), TRUE);
+      $info = drush_make_convert_composer_to_make($composer_lock, $composer_json);
+      break;
+    case 'json':
+      drush_print('Please use composer.lock instead of composer.json as source for conversion.');
+      return FALSE;
+      break;
   }
+
+  // Output into destination formation.
+  switch ($dest_format) {
+    case 'yml':
+    case 'yaml':
+      $output = drush_make_convert_make_to_yml($info);
+      break;
+
+    case 'make':
+      foreach ($info['projects'] as $key => $project) {
+        $info['projects'][$key]['_type'] = $info['projects'][$key]['type'];
+      }
+      foreach ($info['libraries'] as $key => $library) {
+        $info['libraries'][$key]['_type'] = 'librarie';
+      }
+      $output = _drush_make_generate_makefile_contents($info['projects'], $info['libraries'], $info['core'], $info['defaults']);
+
+      break;
+
+    case 'composer':
+      $output = drush_make_convert_make_to_composer($info);
+      break;
+  }
+
+  drush_print($output);
+}
+
+/**
+ * Converts a composer.lock array into a traditional drush make array.
+ *
+ * @param array $composer_lock
+ *   An array of composer.lock data.
+ *
+ * @param array $composer_json
+ *   An array of composer.json data.
+ *
+ * @return array A traditional drush make info array.
+ * A traditional drush make info array.
+ */
+function drush_make_convert_composer_to_make($composer_lock, $composer_json) {
+  $info = array(
+    'core' => array(),
+    'api' => 2,
+    'defaults' => array(
+      'projects' => array(
+        'subdir' => 'contrib',
+      ),
+    ),
+    'projects' => array(),
+    'libraries' => array(),
+  );
+
+  // The make generation function requires that projects be grouped by type,
+  // or else duplicative project groups will be created.
+  $core = array();
+  $modules = array();
+  $themes = array();
+  $profiles = array();
+  $libraries = array();
+  foreach ($composer_lock['packages'] as $key => $package) {
+    if (strpos($package['name'], 'drupal/') === 0 && in_array($package['type'], array('drupal-core', 'drupal-theme', 'drupal-module', 'drupal-profile'))) {
+      $project_name = str_replace('drupal/', '', $package['name']);
+
+      switch ($package['type']) {
+        case 'drupal-core':
+          $project_name = 'drupal';
+          $group =& $core;
+          $group[$project_name]['type'] = 'core';
+          $info['core'] = substr($package['version'], 0, 1) . '.x';
+          break;
+        case 'drupal-theme':
+          $group =& $themes;
+          $group[$project_name]['type'] = 'theme';
+          break;
+        case 'drupal-module':
+          $group =& $modules;
+          $group[$project_name]['type'] = 'module';
+          break;
+        case 'drupal-profile':
+          $group =& $profiles;
+          $group[$project_name]['type'] = 'profile';
+          break;
+      }
+
+      $group[$project_name]['download']['type'] = 'git';
+      $group[$project_name]['download']['url'] = $package['source']['url'];
+      // Dev versions should use git branch + revision, otherwise a tag is used.
+      if (strstr($package['version'], 'dev')) {
+        // Change 'dev-' prefix to '-dev' suffix.
+        if (strpos($package['version'], 'dev-') === 0) {
+          $group[$project_name]['download']['branch'] = str_replace('dev-', '', $package['version']) . '-dev';
+        }
+        // Otherwise, leave as is. Version may already use '-dev' suffix.
+        else {
+          $group[$project_name]['download']['branch'] = $package['version'];
+        }
+        $group[$project_name]['download']['revision'] = $package['source']['reference'];
+      }
+      elseif ($package['type'] == 'drupal-core') {
+        // For 7.x tags, replace 7.xx.0 with 7.xx.
+        if ($info['core'] == '7.x') {
+          $group[$project_name]['download']['tag']= substr($package['version'], 0, 4);
+        }
+        else {
+          $group[$project_name]['download']['tag'] = $package['version'];
+        }
+      }
+      else {
+        // Make tag versioning drupal-friendly. 8.1.0-alpha1 => 8.x-1.0-alpha1.
+        $major_version = substr($package['version'], 0 ,1);
+        $the_rest = substr($package['version'], 2, strlen($package['version']));
+        $group[$project_name]['download']['tag'] = "$major_version.x-$the_rest";
+      }
+
+      if (!empty($package['extra']['patches_applied'])) {
+        foreach ($package['extra']['patches_applied'] as $desc => $url) {
+          $group[$project_name]['patch'][] = $url;
+        }
+      }
+    }
+    // Include any non-drupal libraries that exist in both .lock and .json.
+    elseif (!in_array($package['type'], array('composer-plugin', 'metapackage'))
+      && array_key_exists($package['name'], $composer_json['require'])) {
+      $project_name = $package['name'];
+      $libraries[$project_name]['type'] = 'library';
+      $libraries[$project_name]['download']['type'] = 'git';
+      $libraries[$project_name]['download']['url'] = $package['source']['url'];
+      $libraries[$project_name]['download']['branch'] = $package['version'];
+      $libraries[$project_name]['download']['revision'] = $package['source']['reference'];
+    }
+  }
+
+  $info['projects'] = $core + $modules + $themes;
+  $info['libraries'] = $libraries;
+
+  return $info;
+}
+
+/**
+ * Converts a drush info array to a composer.json array.
+ *
+ * @param array $info
+ *   A drush make info array.
+ *
+ * @return string
+ *   A json encoded composer.json schema object.
+ */
+function drush_make_convert_make_to_composer($info) {
+  $core_major_version = substr($info['core'], 0, 1);
+  $core_project_name = $core_major_version == 7 ? 'drupal/drupal' : 'drupal/core';
+
+  // Add default projects.
+  $projects = array(
+    'composer/installers' => '^1.0.20',
+    'cweagans/composer-patches' => '~1.0',
+    $core_project_name => str_replace('x', '*', $info['core']),
+  );
+
+  $patches = array();
+
+  // Iterate over projects, populating composer-friendly array.
+  foreach ($info['projects'] as $project_name => $project) {
+    switch ($project['type']) {
+      case 'core':
+        $project['name'] = 'drupal/core';
+        $projects[$project['name']] = str_replace('x', '*', $project['version']);
+        break;
+
+      default:
+        $project['name'] = "drupal/$project_name";
+        $projects[$project['name']] = drush_make_convert_project_to_composer($project, $core_major_version);
+        break;
+    }
+
+    // Add project patches.
+    if (!empty($project['patch'])) {
+      foreach($project['patch'] as $key => $patch) {
+        $patch_description = "Enter {$project['name']} patch #$key description here";
+        $patches[$project['name']][$patch_description] = $patch;
+      }
+    }
+  }
+
+  // Iterate over libraries, populating composer-friendly array.
+  if (!empty($info['libraries'])) {
+    foreach ($info['libraries'] as $library_name => $library) {
+      $library_name = 'Verify project name: ' . $library_name;
+      $projects[$library_name] = drush_make_convert_project_to_composer($library, $core_major_version);
+    }
+  }
+
+  $output = array(
+    'name' => 'Enter project name here',
+    'description' => 'Enter project description here',
+    'type' => 'project',
+    'repositories' => array(
+      array('type' => 'composer', 'url' => 'https://packagist.drupal-composer.org'),
+    ),
+    'require' => $projects,
+    'minimum-stability' => 'dev',
+    'prefer-stable' => TRUE,
+    'extra' => array(
+      'installer-paths' => array(
+        'core' => array('type:drupal-core'),
+        'docroot/modules/contrib/{$name}' => array('type:drupal-module'),
+        'docroot/profiles/contrib/{$name}' => array('type:drupal-profile'),
+        'docroot/themes/contrib/{$name}' => array('type:drupal-theme'),
+        'drush/contrib/{$name}' => array('type:drupal-drush'),
+      ),
+      'patches' => $patches,
+    ),
+  );
+
+  $output = json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+  return $output;
+}
+
+/**
+ * Converts a make file project array into a composer project version string.
+ *
+ * @param array $original_project
+ *   A project dependency, as defined in a make file.
+ *
+ * @param string $core_major_version
+ *   The major core version. E.g., 6, 7, 8, etc.
+ *
+ * @return string
+ *   The project version, in composer syntax.
+ *
+ */
+function drush_make_convert_project_to_composer($original_project, $core_major_version) {
+  // Typical specified version with major version "x" removed.
+  if (!empty($original_project['version'])) {
+    $version = str_replace('x', '0', $original_project['version']);
+  }
+  // Git branch or revision.
+  elseif (!empty($original_project['download'])) {
+    switch ($original_project['download']['type']) {
+      case 'git':
+        if (!empty($original_project['download']['branch'])) {
+          // @todo Determine if '0' will always be correct.
+          $version = str_replace('x', '0', $original_project['download']['branch']);
+        }
+        if (!empty($original_project['download']['tag'])) {
+          // @todo Determine if '0' will always be correct.
+          $version = str_replace('x', '0', $original_project['download']['tag']);
+        }
+        if (!empty($project['download']['revision'])) {
+          $version .= '#' . $original_project['download']['revision'];
+        }
+        break;
+
+      default:
+        $version = 'Enter correct project name and version number';
+        break;
+    }
+  }
+
+  $version = "$core_major_version." . $version;
+
+  return $version;
 }
 
 /**

--- a/tests/makeConvertTest.php
+++ b/tests/makeConvertTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Unish;
+
+/**
+ * Make makefile tests.
+ * @group make
+ * @group slow
+ */
+class makeConvertCase extends CommandUnishTestCase {
+
+  /**
+   * Tests the conversion of make file to various formats.
+   *
+   * @param string $source_filename
+   *   The source file to be converted.
+   *
+   * @param $options
+   *   Options to be passed to the make-convert command. E.g., --format=yml.
+   *
+   * @param $expected_lines
+   *   An array of lines expected to be present in the command output.
+   *
+   * @dataProvider providerTestMakeConvert
+   */
+  public function testMakeConvert($source_filename, $options, $expected_lines) {
+    $makefile_dir =  dirname(__FILE__) . DIRECTORY_SEPARATOR . 'makefiles';
+    $source_file = $makefile_dir . DIRECTORY_SEPARATOR . $source_filename;
+    $return = $this->drush('make-convert', array($source_file), $options);
+    $output = $this->getOutput();
+    foreach ($expected_lines as $expected_line) {
+      $this->assertContains($expected_line, $output);
+    }
+  }
+
+  /**
+   * Data provider for testMakeConvert().
+   *
+   * @return array
+   *   An array of test case data. See testMakeConvert() signature.
+   */
+  public function providerTestMakeConvert() {
+    return array(
+      array(
+        // Source filename in makefiles directory.
+        'patches.make',
+        // Command pptions.
+        array('format' => 'yml'),
+        // Expected output lines.
+        array(
+          'core: 7.x',
+          'features:',
+          'version: 1.0-beta4',
+          'patch:',
+          "- 'http://drupal.org/files/issues/features-drush-backend-invoke-25.patch'",
+        ),
+      ),
+      array(
+        'patches.make',
+        array('format' => 'composer'),
+        array(
+          '"drupal/drupal": "7.*",',
+          '"drupal/features": "7.1.0-beta4",',
+          '"patches": {',
+          '"drupal/features": {',
+          '"Enter drupal/features patch #0 description here": "http://drupal.org/files/issues/features-drush-backend-invoke-25.patch"',
+        ),
+      ),
+      array(
+        'patches.make.yml',
+        array('format' => 'composer'),
+        array(
+          '"drupal/drupal": "7.*",',
+          '"drupal/features": "7.1.0-beta4",',
+          '"patches": {',
+          '"drupal/features": {',
+          '"Enter drupal/features patch #0 description here": "http://drupal.org/files/issues/features-drush-backend-invoke-25.patch"',
+        ),
+      ),
+      array(
+        'composer.lock',
+        array('format' => 'make'),
+        array(
+          'core = 7.x',
+          'api = 2',
+          // Ensure Drupal core tag is set correctly.
+          'projects[drupal][download][tag] = "7.43"',
+          'projects[features][download][type] = "git"',
+          'projects[features][download][url] = "https://git.drupal.org/project/features"',
+          'projects[features][download][tag] = "7.x-1.0-beta4"',
+          'projects[features][patch][0] = "http://drupal.org/files/issues/features-drush-backend-invoke-25.patch"'),
+      ),
+      array(
+        'composer.lock',
+        array('format' => 'yml'),
+        array(
+          'core: 7.x',
+          'api: 2',
+          // Ensure Drupal core tag is set correctly.
+          "tag: '7.43'",
+          'features:',
+          'tag: 7.x-1.0-beta4',
+          'patch:',
+          "- 'http://drupal.org/files/issues/features-drush-backend-invoke-25.patch'",
+        ),
+      ),
+    );
+  }
+
+}

--- a/tests/makefiles/composer.json
+++ b/tests/makefiles/composer.json
@@ -1,0 +1,53 @@
+{
+    "name": "Enter project name here",
+    "description": "Enter project description here",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://packagist.drupal-composer.org"
+        }
+    ],
+    "require": {
+        "composer/installers": "^1.0.20",
+        "cweagans/composer-patches": "~1.0",
+        "drupal/drupal": "7.*",
+        "drupal/wysiwyg": "7.2.1",
+        "drupal/features": "7.1.0-beta4",
+        "drupal/context": "7.3.0-beta2"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "extra": {
+        "installer-paths": {
+            "core": [
+                "type:drupal-core"
+            ],
+            "docroot/modules/contrib/{$name}": [
+                "type:drupal-module"
+            ],
+            "docroot/profiles/contrib/{$name}": [
+                "type:drupal-profile"
+            ],
+            "docroot/themes/contrib/{$name}": [
+                "type:drupal-theme"
+            ],
+            "drush/contrib/{$name}": [
+                "type:drupal-drush"
+            ]
+        },
+        "patches": {
+            "drupal/wysiwyg": {
+                "Enter drupal/wysiwyg patch #0 description here": "http://drupal.org/files/0001-feature.inc-from-624018-211.patch",
+                "Enter drupal/wysiwyg patch #1 description here": "patches-local-test-wysiwyg.patch"
+            },
+            "drupal/features": {
+                "Enter drupal/features patch #0 description here": "http://drupal.org/files/issues/features-drush-backend-invoke-25.patch"
+            },
+            "drupal/context": {
+                "Enter drupal/context patch #0 description here": "http://drupal.org/files/issues/custom_blocks_arent_editable-make.patch",
+                "Enter drupal/context patch #1 description here": "http://drupal.org/files/issues/661094-context-permissions.patch"
+            }
+        }
+    }
+}

--- a/tests/makefiles/composer.lock
+++ b/tests/makefiles/composer.lock
@@ -1,0 +1,406 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "ded042990efb1c573ef284e73156d835",
+    "content-hash": "e03033724e81829af4933cd3370a66d9",
+    "packages": [
+        {
+            "name": "composer/installers",
+            "version": "v1.0.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/installers.git",
+                "reference": "6213d900e92647831f7a406d5c530ea1f3d4360e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/installers/zipball/6213d900e92647831f7a406d5c530ea1f3d4360e",
+                "reference": "6213d900e92647831f7a406d5c530ea1f3d4360e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0"
+            },
+            "replace": {
+                "roundcube/plugin-installer": "*",
+                "shama/baton": "*"
+            },
+            "require-dev": {
+                "composer/composer": "1.0.*@dev",
+                "phpunit/phpunit": "4.1.*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Composer\\Installers\\Plugin",
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Composer\\Installers\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle Robinson Young",
+                    "email": "kyle@dontkry.com",
+                    "homepage": "https://github.com/shama"
+                }
+            ],
+            "description": "A multi-framework Composer library installer",
+            "homepage": "http://composer.github.com/installers/",
+            "keywords": [
+                "Craft",
+                "Dolibarr",
+                "Hurad",
+                "MODX Evo",
+                "OXID",
+                "SMF",
+                "Thelia",
+                "WolfCMS",
+                "agl",
+                "aimeos",
+                "annotatecms",
+                "bitrix",
+                "cakephp",
+                "chef",
+                "codeigniter",
+                "concrete5",
+                "croogo",
+                "dokuwiki",
+                "drupal",
+                "elgg",
+                "fuelphp",
+                "grav",
+                "installer",
+                "joomla",
+                "kohana",
+                "laravel",
+                "lithium",
+                "magento",
+                "mako",
+                "mediawiki",
+                "modulework",
+                "moodle",
+                "phpbb",
+                "piwik",
+                "ppi",
+                "puppet",
+                "roundcube",
+                "shopware",
+                "silverstripe",
+                "symfony",
+                "typo3",
+                "wordpress",
+                "zend",
+                "zikula"
+            ],
+            "time": "2016-01-27 12:54:22"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "0d75c63b6de66144517a1da9084422b78c2ff251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/0d75c63b6de66144517a1da9084422b78c2ff251",
+                "reference": "0d75c63b6de66144517a1da9084422b78c2ff251",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "~1.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "time": "2016-02-29 03:45:02"
+        },
+        {
+            "name": "drupal/context",
+            "version": "7.3.0-beta2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/context",
+                "reference": "289025b16464ecf8d1832ff49db3866f5aa40e1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/context-7.x-3.0-beta2.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "drupal/ctools": "7.*",
+                "drupal/drupal": "7.*"
+            },
+            "replace": {
+                "drupal/context_layouts": "self.version",
+                "drupal/context_ui": "self.version"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-7.x-3.x": "7.3.x-dev"
+                },
+                "patches_applied": {
+                    "Enter drupal/context patch #0 description here": "http://drupal.org/files/issues/custom_blocks_arent_editable-make.patch",
+                    "Enter drupal/context patch #1 description here": "http://drupal.org/files/issues/661094-context-permissions.patch"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "description": "Provide modules with a cache that lasts for a single page request.",
+            "homepage": "https://www.drupal.org/project/context"
+        },
+        {
+            "name": "drupal/ctools",
+            "version": "7.1.9",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/ctools",
+                "reference": "1bf2f388cd7371ae16639349ae3b344732faafae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/ctools-7.x-1.9.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "drupal/drupal": "7.*"
+            },
+            "replace": {
+                "drupal/bulk_export": "self.version",
+                "drupal/ctools_access_ruleset": "self.version",
+                "drupal/ctools_ajax_sample": "self.version",
+                "drupal/ctools_custom_content": "self.version",
+                "drupal/ctools_plugin_example": "self.version",
+                "drupal/page_manager": "self.version",
+                "drupal/stylizer": "self.version",
+                "drupal/term_depth": "self.version",
+                "drupal/views_content": "self.version"
+            },
+            "suggest": {
+                "drupal/advanced_help": "Required by drupal/ctools_plugin_example",
+                "drupal/color": "Required by drupal/stylizer",
+                "drupal/page_manager": "Required by drupal/ctools_plugin_example",
+                "drupal/panels": "Required by drupal/ctools_plugin_example",
+                "drupal/views": "Required by drupal/views_content"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-7.x-1.x": "7.1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "description": "A library of helpful tools by Merlin of Chaos.",
+            "homepage": "https://www.drupal.org/project/ctools"
+        },
+        {
+            "name": "drupal/drupal",
+            "version": "7.43.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/drupal",
+                "reference": "c136d1347b9b92145590cb1f84cc02a695d721fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/drupal-7.43.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "replace": {
+                "drupal/aggregator": "self.version",
+                "drupal/bartik": "self.version",
+                "drupal/block": "self.version",
+                "drupal/blog": "self.version",
+                "drupal/book": "self.version",
+                "drupal/color": "self.version",
+                "drupal/comment": "self.version",
+                "drupal/contact": "self.version",
+                "drupal/contextual": "self.version",
+                "drupal/dashboard": "self.version",
+                "drupal/dblog": "self.version",
+                "drupal/field": "self.version",
+                "drupal/field_sql_storage": "self.version",
+                "drupal/field_ui": "self.version",
+                "drupal/file": "self.version",
+                "drupal/filter": "self.version",
+                "drupal/forum": "self.version",
+                "drupal/garland": "self.version",
+                "drupal/help": "self.version",
+                "drupal/image": "self.version",
+                "drupal/list": "self.version",
+                "drupal/locale": "self.version",
+                "drupal/menu": "self.version",
+                "drupal/minimal": "self.version",
+                "drupal/node": "self.version",
+                "drupal/number": "self.version",
+                "drupal/openid": "self.version",
+                "drupal/options": "self.version",
+                "drupal/overlay": "self.version",
+                "drupal/path": "self.version",
+                "drupal/php": "self.version",
+                "drupal/poll": "self.version",
+                "drupal/profile": "self.version",
+                "drupal/rdf": "self.version",
+                "drupal/search": "self.version",
+                "drupal/seven": "self.version",
+                "drupal/shortcut": "self.version",
+                "drupal/standard": "self.version",
+                "drupal/stark": "self.version",
+                "drupal/statistics": "self.version",
+                "drupal/syslog": "self.version",
+                "drupal/system": "self.version",
+                "drupal/taxonomy": "self.version",
+                "drupal/text": "self.version",
+                "drupal/toolbar": "self.version",
+                "drupal/tracker": "self.version",
+                "drupal/translation": "self.version",
+                "drupal/trigger": "self.version",
+                "drupal/update": "self.version",
+                "drupal/user": "self.version"
+            },
+            "suggest": {
+                "drupal/block": "Required by drupal/dashboard, drupal/minimal, drupal/standard",
+                "drupal/color": "Required by drupal/standard",
+                "drupal/comment": "Required by drupal/forum, drupal/tracker, drupal/standard",
+                "drupal/contextual": "Required by drupal/standard",
+                "drupal/dashboard": "Required by drupal/standard",
+                "drupal/dblog": "Required by drupal/minimal, drupal/standard",
+                "drupal/field": "Required by drupal/field_sql_storage, drupal/list, drupal/number, drupal/options, drupal/text, drupal/field_ui, drupal/file",
+                "drupal/field_sql_storage": "Required by drupal/field",
+                "drupal/field_ui": "Required by drupal/standard",
+                "drupal/file": "Required by drupal/image, drupal/standard",
+                "drupal/help": "Required by drupal/standard",
+                "drupal/image": "Required by drupal/standard",
+                "drupal/list": "Required by drupal/standard",
+                "drupal/locale": "Required by drupal/translation",
+                "drupal/menu": "Required by drupal/standard",
+                "drupal/number": "Required by drupal/standard",
+                "drupal/options": "Required by drupal/list, drupal/taxonomy, drupal/standard",
+                "drupal/overlay": "Required by drupal/standard",
+                "drupal/path": "Required by drupal/standard",
+                "drupal/rdf": "Required by drupal/standard",
+                "drupal/search": "Required by drupal/standard",
+                "drupal/shortcut": "Required by drupal/standard",
+                "drupal/taxonomy": "Required by drupal/forum, drupal/standard",
+                "drupal/text": "Required by drupal/comment",
+                "drupal/toolbar": "Required by drupal/standard"
+            },
+            "type": "drupal-core",
+            "extra": {
+                "branch-alias": {
+                    "dev-7.x-": "7.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "description": "Handles general site configuration for administrators.",
+            "homepage": "https://www.drupal.org/project/drupal"
+        },
+        {
+            "name": "drupal/features",
+            "version": "7.1.0-beta4",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/features",
+                "reference": "dc3297e5f4141f40f46635c1bbf05913d0ae662d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/features-7.x-1.0-beta4.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "drupal/drupal": "7.*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-7.x-1.x": "7.1.x-dev"
+                },
+                "patches_applied": {
+                    "Enter drupal/features patch #0 description here": "http://drupal.org/files/issues/features-drush-backend-invoke-25.patch"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "description": "Provides feature management for Drupal.",
+            "homepage": "https://www.drupal.org/project/features"
+        },
+        {
+            "name": "drupal/wysiwyg",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/wysiwyg",
+                "reference": "2602159043586a5878a08a48f6faa665a62b726a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/wysiwyg-7.x-2.1.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "drupal/drupal": "7.*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-7.x-2.x": "7.2.x-dev"
+                },
+                "patches_applied": {
+                    "Enter drupal/wysiwyg patch #0 description here": "http://drupal.org/files/0001-feature.inc-from-624018-211.patch",
+                    "Enter drupal/wysiwyg patch #1 description here": "patches-local-test-wysiwyg.patch"
+                }
+            },
+            "notification-url": "https://packagist.drupal-composer.org/downloads/",
+            "description": "Allows to edit content with client-side editors.",
+            "homepage": "https://www.drupal.org/project/wysiwyg"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/tests/makefiles/patches.make.yml
+++ b/tests/makefiles/patches.make.yml
@@ -1,0 +1,18 @@
+core: 7.x
+api: '2'
+projects:
+  wysiwyg:
+    version: '2.1'
+    patch:
+      - 'http://drupal.org/files/0001-feature.inc-from-624018-211.patch'
+      - patches-local-test-wysiwyg.patch
+  features:
+    version: 1.0-beta4
+    patch:
+      - 'http://drupal.org/files/issues/features-drush-backend-invoke-25.patch'
+  context:
+    version: 3.0-beta2
+    patch:
+      - 'http://drupal.org/files/issues/custom_blocks_arent_editable-make.patch'
+      - 'http://drupal.org/files/issues/661094-context-permissions.patch'
+


### PR DESCRIPTION
This functionality is present in Drush 9.x, but not in Drush 8.x. It'd be really useful to have it here, so this PR backports (actually just copy-and-pastes) it back into the 8.x branch.