### PR TITLE
Fixed site-install --config-dir option

### DIFF
--- a/commands/core/site_install.drush.inc
+++ b/commands/core/site_install.drush.inc
@@ -230,7 +230,7 @@ function drush_core_site_install($profile = NULL) {
     // Set the destination site UUID to match the source UUID, to bypass a core fail-safe.
     $source_storage = new FileStorage($config);
     $options = ['yes' => TRUE];
-    drush_invoke_process('@self', 'config_set', array('system.site', 'uuid', $source_storage->read('system.site')['uuid']), $options);
+    drush_invoke_process('@self', 'config-set', array('system.site', 'uuid', $source_storage->read('system.site')['uuid']), $options);
     // Run a full configuration import.
     drush_invoke_process('@self', 'config-import', array(), array('source' => $config) + $options);
   }


### PR DESCRIPTION
Typo in `config-set` invocation.