### PR TITLE
Allow setting a different terminal environment for an interactive SSH tty

### DIFF
--- a/commands/core/sitealias.drush.inc
+++ b/commands/core/sitealias.drush.inc
@@ -37,7 +37,7 @@ function sitealias_drush_command() {
       'variable-name' => 'aliases',
       'hide-empty-fields' => TRUE,
       'private-fields' => 'password',
-      'field-labels' => array('#name' => 'Name', 'root' => 'Root', 'uri' => 'URI', 'remote-host' => 'Host', 'remote-user' => 'User', 'remote-port' => 'Port', 'os' => 'OS', 'ssh-options' => 'SSH options', 'php' => 'PHP'),
+      'field-labels' => array('#name' => 'Name', 'root' => 'Root', 'uri' => 'URI', 'remote-host' => 'Host', 'remote-user' => 'User', 'remote-port' => 'Port', 'os' => 'OS', 'ssh-options' => 'SSH options', 'ssh-term' => 'SSH tty terminal type', 'php' => 'PHP'),
       'fields-default' => array('#name', 'root', 'uri', 'remote-host', 'remote-user'),
       'field-mappings' => array('name' => '#name'),
       'output-data-type' => 'format-table',

--- a/examples/example.aliases.drushrc.php
+++ b/examples/example.aliases.drushrc.php
@@ -210,6 +210,11 @@
  *   standard port, alternative identity file, or alternative
  *   authentication method, ssh-options can contain a string of extra
  *   options that are used with the ssh command, eg "-p 100"
+ * - 'ssh-term': Set the terminal environment to request for an interactive SSH 
+ *   tty. This can be useful if the target machine does not recognise your
+ *   current local terminal environment type. This can be recognised by a
+ *   disconnect with the hint 'Try requesting a different terminal environment'.
+ *   In case of an error some options to try are: 'xterm' or 'vt220'.
  * - 'parent': Deprecated.  See "altering aliases", below.
  * - 'path-aliases': An array of aliases for common rsync targets.
  *   Relative aliases are always taken from the Drupal root.

--- a/examples/example.drushrc.php
+++ b/examples/example.drushrc.php
@@ -174,6 +174,15 @@
  */
 # $options['ssh-options'] = '-o PasswordAuthentication=no';
 
+/**
+ * Set a different terminal environment for the interactive SSH tty. 
+ * This can by handy in case a target machine does not accept your local 
+ * terminal environment. This problem can be recognised by a disconnect and the
+ * hint: 'Try requesting a different terminal environment'.
+ * Good options to try are 'xterm' and 'vt220'.
+ */
+# $options['ssh-term'] = 'xterm';
+
 // Set 'remote-os' to 'Windows' to make Drush use Windows shell escape rules
 // for remote sites that do not have an 'os' item set.
 # $options['remote-os'] = 'Linux';

--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1068,6 +1068,7 @@ function drush_backend_generate_sitealias($backend_options) {
     'remote-host' => NULL,
     'remote-user' => NULL,
     'ssh-options' => NULL,
+    'ssh-term' => NULL,
     'drush-script' => NULL,
     'env-vars' => NULL
   );
@@ -1075,6 +1076,7 @@ function drush_backend_generate_sitealias($backend_options) {
     'remote-host' => $backend_options['remote-host'],
     'remote-user' => $backend_options['remote-user'],
     'ssh-options' => $backend_options['ssh-options'],
+    'ssh-term' => $backend_options['ssh-term'],
     '#env-vars' => $backend_options['env-vars'],
     'path-aliases' => array(
       '%drush-script' => $backend_options['drush-script'],
@@ -1093,6 +1095,8 @@ function drush_backend_generate_sitealias($backend_options) {
  *      Optional. Defaults to the current user. If you specify this, you can choose which module to send.
  *   'ssh-options'
  *      Optional.  Defaults to "-o PasswordAuthentication=no"
+ *   'ssh-term'
+ *      Optional. Default is empty and thus your local terminal environment will be requested.
  *   '#env-vars'
  *      Optional. An associative array of environmental variables to prefix the Drush command with.
  *   'path-aliases'
@@ -1126,6 +1130,7 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
     'remote-host' => NULL,
     'remote-user' => NULL,
     'ssh-options' => NULL,
+    'ssh-term' => NULL,
     'path-aliases' => array(),
   );
   $backend_options += array(
@@ -1135,6 +1140,8 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
   $hostname = $site_record['remote-host'];
   $username = $site_record['remote-user'];
   $ssh_options = $site_record['ssh-options'];
+  $ssh_term = $site_record['ssh-term'];
+
   $os = drush_os($site_record);
 
   if (drush_is_local_host($hostname)) {
@@ -1162,6 +1169,9 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
     $ssh_options = $site_record['ssh-options'];
     $ssh_options = (isset($ssh_options)) ? $ssh_options : drush_get_option('ssh-options', "-o PasswordAuthentication=no");
 
+    if ($backend_options['#tty'] && $ssh_term) {
+      $ssh_cmd[] = "env TERM=" . $ssh_term;
+    }
     $ssh_cmd[] = "ssh";
     $ssh_cmd[] = $ssh_options;
     if ($backend_options['#tty']) {

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -321,6 +321,7 @@ function drush_get_global_options($brief = FALSE) {
     $options['shell-aliases']       = array('hidden' => TRUE, 'merge' => TRUE, 'never-propagate' => TRUE, 'description' => 'List of shell aliases.');
     $options['path-aliases']        = array('hidden' => TRUE, 'never-propagate' => TRUE, 'description' => 'Path aliases from site alias.');
     $options['ssh-options']         = array('never-propagate' => TRUE, 'description' => 'A string of extra options that will be passed to the ssh command', 'example-value' => '-p 100');
+    $options['ssh-term']            = array('never-propagate' => TRUE, 'description' => 'The terminal environment to request for an interactive ssh tty', 'example-value' => 'xterm');
     $options['editor']              = array('never-propagate' => TRUE, 'description' => 'A string of bash which launches user\'s preferred text editor. Defaults to ${VISUAL-${EDITOR-vi}}.', 'example-value' => 'vi');
     $options['bg']                  = array('never-propagate' => TRUE, 'description' => 'Run editor in the background. Does not work with editors such as `vi` that run in the terminal. Supresses config-import at the end.');
     $options['db-url']              = array('hidden' => TRUE, 'description' => 'A Drupal 6 style database URL. Used by various commands.', 'example-value' => 'mysql://root:pass@127.0.0.1/db');

--- a/includes/exec.inc
+++ b/includes/exec.inc
@@ -197,12 +197,16 @@ function drush_shell_proc_build($site, $command = '', $cd = NULL, $interactive =
   // Build up the command. TODO: We maybe refactor this soon.
   $hostname = drush_remote_host($site);
   $ssh_options = drush_sitealias_get_option($site, 'ssh-options', "-o PasswordAuthentication=no");
+  $ssh_term = drush_sitealias_get_option($site, 'ssh-term', '');
+  if (!empty($ssh_term)) {
+    $ssh_term = 'env TERM=' . $ssh_term . ' ';
+  }
   $os = drush_os($site);
   if (drush_sitealias_get_option($site, 'tty') || $interactive) {
     $ssh_options .= ' -t';
   }
 
-  $cmd = "ssh " . $ssh_options . " " . $hostname;
+  $cmd = $ssh_term . "ssh " . $ssh_options . " " . $hostname;
 
   if ($cd === TRUE) {
     if (array_key_exists('root', $site)) {
@@ -257,6 +261,7 @@ function drush_shell_proc_open($cmd) {
 function drush_shell_exec_proc_build_options() {
   return array(
    'ssh-options' => 'A string of extra options that will be passed to the ssh command (e.g. "-p 100")',
+    'ssh-term' => 'The terminal environment type to request for an interactive ssh tty (e.g. "xterm").',
     'tty' => 'Create a tty (e.g. to run an interactive program).',
     'escaped' => 'Command string already escaped; do not add additional quoting.',
   );

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -2114,7 +2114,7 @@ function drush_sitealias_evaluate_path($path, &$additional_options, $local_only 
  * Option keys used for site selection.
  */
 function drush_sitealias_site_selection_keys() {
-  return array('remote-host', 'remote-user', 'ssh-options', '#name', 'os');
+  return array('remote-host', 'remote-user', 'ssh-options', 'ssh-term', '#name', 'os');
 }
 
 


### PR DESCRIPTION
Sometimes it is necessary to set a different terminal environment type for an interactive SSH tty. This is the case if the terminal emulator type you use locally is not recognised on the remote machine.

If so, the interactive ssh connection will be closed immediately with a hint: "Try requesting a different terminal environment."

This pull request adds an option to request a different type so we can happily use Drush in any terminal emulator we like (in my case urxvt).