### PR TITLE
fix(bootstrap): Do not clear the module_implements() cache on a drush invocation

### DIFF
--- a/lib/Drush/Boot/DrupalBoot7.php
+++ b/lib/Drush/Boot/DrupalBoot7.php
@@ -33,8 +33,14 @@ class DrupalBoot7 extends DrupalBoot {
     // If needed, prod module_implements() to recognize our system_watchdog() implementation.
     $dogs = drush_module_implements('watchdog');
     if (!in_array('system', $dogs)) {
-      // Note that this resets module_implements cache.
-      drush_module_implements('watchdog', FALSE, TRUE);
+      // Note that we must never clear the module_implements() cache because
+      // that would trigger larger cache rebuilds with system_cache_tables on
+      // every drush invocation. Instead we inject our system_watchdog()
+      // implementation direclty into the static cache.
+      $implementations = &drupal_static('module_implements');
+      $implementations['watchdog']['system'] = FALSE;
+      $verified_implementations = &drupal_static('module_implements:verified');
+      $verified_implementations['watchdog'] = TRUE;
     }
   }
 


### PR DESCRIPTION
We run drush cron every 10 minutes on a site and we saw a lot of cache clearing on every cron run. The problem was that the cache entry for system_cache_tables was gone after each drush invocation.

Traced that back to drush bootstrap where the module_implements() cache is reset. Drush should never do that when a random drush command is executed. We can inject the logging into the static module implements cache instead.