### PR TITLE
#2183 Fixed .my.cnf messing up mysql connection + minor credential-leak fix

### DIFF
--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -412,10 +412,12 @@ function drush_program_exists($program) {
  * @param string $suffix
  *   Append string to filename. use of this parameter if is discouraged. @see
  *   drush_tempnam().
+ * @param int $mode
+ *   Optional filemode to set upon creation.
  * @return string
  *   A path to the file.
  */
-function drush_save_data_to_temp_file($data, $suffix = NULL) {
+function drush_save_data_to_temp_file($data, $suffix = NULL, $mode = NULL) {
   static $fp;
 
   $file = drush_tempnam('drush_', NULL, $suffix);
@@ -424,6 +426,11 @@ function drush_save_data_to_temp_file($data, $suffix = NULL) {
   $meta_data = stream_get_meta_data($fp);
   $file = $meta_data['uri'];
   fclose($fp);
+
+  // Set filemode.
+  if ($mode) {
+    @chmod($file, $mode);
+  }
 
   return $file;
 }

--- a/lib/Drush/Sql/Sqlmysql.php
+++ b/lib/Drush/Sql/Sqlmysql.php
@@ -20,8 +20,8 @@ user="{$this->db_spec['username']}"
 password="{$this->db_spec['password']}"
 EOT;
 
-      $file = drush_save_data_to_temp_file($contents);
-      $parameters['defaults-extra-file'] = $file;
+      $file = drush_save_data_to_temp_file($contents, NULL, 0700);
+      $parameters['defaults-file'] = $file;
     }
     else {
       // User is required. Drupal calls it 'username'. MySQL calls it 'user'.

--- a/lib/Drush/Sql/Sqlmysql.php
+++ b/lib/Drush/Sql/Sqlmysql.php
@@ -20,7 +20,7 @@ user="{$this->db_spec['username']}"
 password="{$this->db_spec['password']}"
 EOT;
 
-      $file = drush_save_data_to_temp_file($contents, NULL, 0700);
+      $file = drush_save_data_to_temp_file($contents, NULL, 0600);
       $parameters['defaults-file'] = $file;
     }
     else {

--- a/lib/Drush/Sql/Sqlpgsql.php
+++ b/lib/Drush/Sql/Sqlpgsql.php
@@ -30,8 +30,7 @@ class Sqlpgsql extends SqlBase {
         $part = str_replace(array('\\', ':'), array('\\\\', '\:'), $part);
       });
       $pgpass_contents = implode(':', $pgpass_parts);
-      $password_file = drush_save_data_to_temp_file($pgpass_contents);
-      chmod($password_file, 0600);
+      $password_file = drush_save_data_to_temp_file($pgpass_contents, NULL, 0600);
     }
     return $password_file;
   }


### PR DESCRIPTION
Please merge this PR, it fixes the problem where .my.cnf is used to connect to mysql.
Furthermore, the filemode-option in drush_save_data_to_temp_file() provides a way to prevent credential leakage, since that seemed to be the whole point of using the --defaults-extra-file param.
Prior to this commit the sql credentials were exposed in the open-to-anyone /tmp folder.

Created this on the 8.x branch, but maybe it's just possible to merge this 1:1 to the master branch (didn't check).
