### PR TITLE
Use Request::create() to create the request for drush cr so that the request method is set

### DIFF
--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -275,7 +275,7 @@ function drush_cache_rebuild() {
   $autoloader = drush_drupal_load_autoloader(DRUPAL_ROOT);
   require_once DRUSH_DRUPAL_CORE . '/includes/utility.inc';
 
-  $request = Request::createFromGlobals();
+  $request = Request::create('/');
   // Manually resemble early bootstrap of DrupalKernel::boot().
   require_once DRUSH_DRUPAL_CORE . '/includes/bootstrap.inc';
   DrupalKernel::bootEnvironment();

--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -275,6 +275,8 @@ function drush_cache_rebuild() {
   $autoloader = drush_drupal_load_autoloader(DRUPAL_ROOT);
   require_once DRUSH_DRUPAL_CORE . '/includes/utility.inc';
 
+  // Any path would be sufficient here. We must assure that an HTTP Method is set. 
+  // This does not happen with createFromGlobals()
   $request = Request::create('/');
   // Manually resemble early bootstrap of DrupalKernel::boot().
   require_once DRUSH_DRUPAL_CORE . '/includes/bootstrap.inc';

--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -275,9 +275,9 @@ function drush_cache_rebuild() {
   $autoloader = drush_drupal_load_autoloader(DRUPAL_ROOT);
   require_once DRUSH_DRUPAL_CORE . '/includes/utility.inc';
 
-  // Any path would be sufficient here. We must assure that an HTTP Method is set. 
-  // This does not happen with createFromGlobals()
-  $request = Request::create('/');
+  $request = Request::createFromGlobals();
+  // Ensure that the HTTP method is set, which does not happen with Request::createFromGlobals().
+  $request->setMethod('GET');
   // Manually resemble early bootstrap of DrupalKernel::boot().
   require_once DRUSH_DRUPAL_CORE . '/includes/bootstrap.inc';
   DrupalKernel::bootEnvironment();


### PR DESCRIPTION
To reproduce:

1. Create a menu link pointing to /user/logout in the UI
2. Run drush cr, then access the page as anonymous user. The Logout link is visible
3. Clear cache in the UI, the logout link is not visible as anonymous user.

See also https://www.drupal.org/node/2817911 and possibly other duplicate bug reports caused by this.

Interesting site note: This only behaves like this in 8.2, in 8.1 it worked fine but I think this change makes sense anyway.

There is at least another createFromGlobals() but that's only a fallback that might not actually be used anmyore.
