### PR TITLE
Fix "Could not open input file" error under Windows

### DIFF
--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -128,7 +128,12 @@ function find_wrapper_or_launcher_at_location($location) {
 /**
  * Determine whether current OS is a Windows variant.
  */
-function drush_is_windows($os = PHP_OS) {
+function drush_is_windows($os = NULL) {
+  if (!$os) {
+    // cannot use PHP_OS as default value
+    $os = PHP_OS;
+  }
+  
   return strtoupper(substr($os, 0, 3)) === 'WIN';
 }
 


### PR DESCRIPTION
I installed Drush on Windows using ``composer global require drush/drush:8.*``; however, calling ``drush afterwards yielded this error: 

``Could not open input file: 'C:\Users\Blaeul\AppData\Roaming\Composer\vendor\drush\drush\drush.php'``

The error comes on cmd.exe as well as on MINGW64.

After some digging in the code, I could make Drush work perfectly normal by changing ``drush_is_windows`` in the following way:

````
function drush_is_windows($os = PHP_OS) {
  if (!$os) {
    $os = PHP_OS;
  }
  return strtoupper(substr($os, 0, 3)) === 'WIN';
}
````

Thus it seems like my PHP doesn't like the default value for the $os parameter. I am using 
````
PHP 5.6.8 (cli) (built: Apr 15 2015 15:07:09)
    Zend Engine v2.6.0, 
    with Zend OPcache v7.0.4-dev
````