### PR TITLE
Add a base class called DrushCommands

### DIFF
--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\PathUtil\Path;
 
 /**
  * The main Drush function.
@@ -366,6 +367,8 @@ function drush_init_annotation_commands($container) {
   /** @var \Consolidation\AnnotatedCommand\CommandFileDiscovery */
   $discovery = $container->get('commandDiscovery');
   $commandFiles = $discovery->discover(DRUSH_BASE_PATH . '/lib/Drush', '\Drush');
+  $base_class = Path::join(DRUSH_BASE_PATH, 'lib/Drush/CommandFiles/DrushCommands.php');
+  unset($commandFiles[$base_class]);
   drush_init_register_command_files($container, $commandFiles);
 }
 

--- a/lib/Drush/CommandFiles/DrushCommands.php
+++ b/lib/Drush/CommandFiles/DrushCommands.php
@@ -31,13 +31,13 @@ abstract class DrushCommands implements
   }
 
   /**
-   * Override Robo's IO function with our custom style.
+   * @todo Override Robo's IO function with our custom style.
    */
-//  protected function io()
-//  {
+  protected function io()
+  {
 //    if (!$this->io) {
 //      $this->io = new TerminusStyle($this->input(), $this->output());
 //    }
-//    return $this->io;
-//  }
+    return $this->io;
+  }
 }

--- a/lib/Drush/CommandFiles/DrushCommands.php
+++ b/lib/Drush/CommandFiles/DrushCommands.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drush\CommandFiles;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Robo\Contract\IOAwareInterface;
+use Robo\Common\IO;
+
+abstract class DrushCommands implements
+  IOAwareInterface,
+  LoggerAwareInterface
+{
+  use LoggerAwareTrait;
+  use IO {
+    io as roboIo;
+  }
+
+
+  public function __construct() {}
+
+  /**
+   * Returns a logger object.
+   *
+   * @return LoggerInterface
+   */
+  protected function logger()
+  {
+    return $this->logger;
+  }
+
+  /**
+   * Override Robo's IO function with our custom style.
+   */
+//  protected function io()
+//  {
+//    if (!$this->io) {
+//      $this->io = new TerminusStyle($this->input(), $this->output());
+//    }
+//    return $this->io;
+//  }
+}

--- a/lib/Drush/CommandFiles/ExampleCommandsFile.php
+++ b/lib/Drush/CommandFiles/ExampleCommandsFile.php
@@ -12,7 +12,7 @@ use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 
 use Consolidation\AnnotatedCommand\CommandData;
 
-class ExampleCommandFile
+class ExampleCommandsFile extends DrushCommands
 {
     /**
      * Demonstrate output formatters.  Default format is 'table'.

--- a/lib/Drush/CommandFiles/core/BrowseCommands.php
+++ b/lib/Drush/CommandFiles/core/BrowseCommands.php
@@ -1,7 +1,9 @@
 <?php
 namespace Drush\CommandFiles\core;
 
-class BrowseCommands {
+use Drush\CommandFiles\DrushCommands;
+
+class BrowseCommands extends DrushCommands {
 
   /**
    * Display a link to a given path or open link in a browser.

--- a/lib/Drush/CommandFiles/core/DrupliconCommands.php
+++ b/lib/Drush/CommandFiles/core/DrupliconCommands.php
@@ -2,8 +2,9 @@
 namespace Drush\CommandFiles\core;
 
 use Consolidation\AnnotatedCommand\CommandData;
+use Drush\CommandFiles\DrushCommands;
 
-class DrupliconCommands {
+class DrupliconCommands extends DrushCommands {
   protected $printed = false;
 
   /**
@@ -30,7 +31,7 @@ class DrupliconCommands {
       return;
     }
     if ($commandData->input()->getOption('druplicon')) {
-      drush_log(dt('Displaying Druplicon for "!command" command.', array('!command' => $commandName)));
+      $this->logger()->debug(dt('Displaying Druplicon for "!command" command.', array('!command' => $commandName)));
       $misc_dir = DRUSH_BASE_PATH . '/misc';
       if (drush_get_context('DRUSH_NOCOLOR')) {
         $content = file_get_contents($misc_dir . '/druplicon-no_color.txt');

--- a/lib/Drush/CommandFiles/core/ViewsCommands.php
+++ b/lib/Drush/CommandFiles/core/ViewsCommands.php
@@ -4,14 +4,12 @@ namespace Drush\CommandFiles\core;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\CommandError;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Drush\CommandFiles\DrushCommands;
 use Drush\Log\LogLevel;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
-class ViewsCommands implements LoggerAwareInterface {
-
-  use LoggerAwareTrait;
-
+class ViewsCommands extends DrushCommands {
   /**
    * Set several Views settings to more developer-oriented values.
    *


### PR DESCRIPTION
- [ ] Is the unset() in preflight.inc sufficient? Am seeing errors without it.
- [ ] the io() method in DrushCommands currently references a TerminusStyle. Do we want one of these for Drush? I'm especially thinking of of custom table formatting needs.