### PR TITLE
Fix typo in router rebuild call

### DIFF
--- a/commands/core/drupal/cache_8.inc
+++ b/commands/core/drupal/cache_8.inc
@@ -62,7 +62,7 @@ function drush_cache_clear_theme_registry() {
 function drush_cache_clear_router() {
   /** @var \Drupal\Core\Routing\RouteBuilderInterface $router_builder */
   $router_builder = \Drupal::service('router.builder');
-  $router_builder->rebuild;
+  $router_builder->rebuild();
 }
 
 function drush_cache_clear_css_js() {


### PR DESCRIPTION
To rebuild the route tables the [RouteBuilder service](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Routing!RouteBuilder.php/class/RouteBuilder/8.2.x) needs to run the [`rebuild`](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Routing%21RouteBuilder.php/function/RouteBuilder%3A%3Arebuild/8.2.x) method, but this isn't correctly flagged to execute the method during cache clear. This results in the router tables not being rebuilt correctly since the method is never run.