### PR TITLE
Do not populate the "q" query.

### DIFF
--- a/commands/runserver/d8-rs-router.php
+++ b/commands/runserver/d8-rs-router.php
@@ -17,9 +17,6 @@ if (file_exists('.' . $url['path'])) {
   return FALSE;
 }
 
-// Populate the "q" query key with the path, skip the leading slash.
-$_GET['q'] = $_REQUEST['q'] = substr($url['path'], 1);
-
 // We set the base_url so that Drupal generates correct URLs for runserver
 // (e.g. http://127.0.0.1:8888/...), but can still select and serve a specific
 // site in a multisite configuration (e.g. http://mysite.com/...).


### PR DESCRIPTION
Populating the "q" query in the d8-rs-router produces failures of assertUrl()
when executing SimpleTests within 'drush rs'.

Example of failed assertion:
`
Fail 
Expected
    'http://localhost:8888/search-api-test-fulltext?f%5B0%5D=ab_facet%3Aitem'
    matches current URL
    'http://localhost:8888/search-api-test-fulltext?q=search-api-test-fulltext&f[0]=ab_facet%3Aitem'.
`