### PR TITLE
Fix so drush make acts more like drush pm-updatecode for contrib projects

### DIFF
--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -211,7 +211,7 @@ class DrushMakeProject {
    * Determine the location to download project to.
    */
   function findDownloadLocation() {
-    $this->path = $this->generatePath();
+    $this->path = $this->generatePath(FALSE);
     $this->project_directory = !empty($this->directory_name) ? $this->directory_name : $this->name;
     $this->download_location = $this->path . '/' . $this->project_directory;
     // This directory shouldn't exist yet -- if it does, stop,


### PR DESCRIPTION
When Drupal contrib projects are updated, the current project directory should be cleared out and replaced by the new code; not leaving residue behind.