### PR TITLE
Add global and site (Drupal root) locations for Drush extensions.

### DIFF
--- a/includes/annotationcommand_adapter.inc
+++ b/includes/annotationcommand_adapter.inc
@@ -29,6 +29,10 @@ function annotationcommand_adapter_get_discovery() {
   static $discovery;
   if (!isset($discovery)) {
     $discovery = new CommandFileDiscovery();
+    $discovery
+      ->addSearchLocation('Commands')
+      ->addSearchLocation('CommandFiles')
+      ->setSearchPattern('#.*(Commands|CommandFile).php$#');
   }
   return $discovery;
 }
@@ -370,7 +374,9 @@ function annotationcommand_adapter_get_commands_for_commandhandler($commandhandl
   $commandinfo_list = $factory->getCommandInfoListFromClass($commandhandler);
 
   foreach ($commandinfo_list as $commandinfo) {
-    $factory->registerCommandHook($commandinfo, $commandhandler);
+    // Hooks are automatically registered when the commandhandler is
+    // created via registerCommandClass(), so we don't need to do it again here.
+    // $factory->registerCommandHook($commandinfo, $commandhandler);
     // Skip anything that is not a command
     if (!AnnotatedCommandFactory::isCommandMethod($commandinfo, false)) {
       continue;

--- a/includes/annotationcommand_adapter.inc
+++ b/includes/annotationcommand_adapter.inc
@@ -30,9 +30,9 @@ function annotationcommand_adapter_get_discovery() {
   if (!isset($discovery)) {
     $discovery = new CommandFileDiscovery();
     $discovery
-      ->addSearchLocation('Commands')
-      ->addSearchLocation('CommandFiles')
-      ->setSearchPattern('#.*(Commands|CommandFile).php$#');
+      ->setIncludeFilesAtBase(false)
+      ->setSearchLocations(['Commands'])
+      ->setSearchPattern('#.*Commands.php$#');
   }
   return $discovery;
 }

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -773,6 +773,15 @@ function _drush_find_commandfiles_drush() {
   $annotation_commandfiles = $discovery->discover(DRUSH_BASE_PATH . '/lib/Drush', '\Drush');
 
   // And, finally, search for commandfiles in the $searchpath
+  $searchpath = array_map(
+    function ($item) {
+      if (strtolower(basename($item)) == 'commands') {
+        return dirname($item);
+      }
+      return $item;
+    },
+    $searchpath
+  );
   $global_drush_extensions = $discovery->discover($searchpath, '\Drush');
   $annotation_commandfiles += $global_drush_extensions;
 

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -739,6 +739,9 @@ function _drush_preflight_uri() {
 }
 
 function _drush_find_commandfiles_drush() {
+  // Core commands shipping with Drush
+  $searchpath[] = dirname(__FILE__) . '/../commands/';
+
   // User commands, specified by 'include' option
   $include = drush_get_context('DRUSH_INCLUDE', array());
   foreach ($include as $path) {
@@ -762,14 +765,8 @@ function _drush_find_commandfiles_drush() {
     }
   }
 
-  // Core commands shipping with Drush
-  $drushCoreSearchpath[] = dirname(__DIR__) . '/commands/';
-
-  // Make sure search path is unique
-  $searchpath = array_unique($searchpath);
-
   // @todo the zero parameter is a bit weird here. It's $phase.
-  _drush_add_commandfiles($drushCoreSearchpath + $searchpath, 0);
+  _drush_add_commandfiles($searchpath, 0);
 
   // Also discover Drush's own annotation commands.
   $discovery = annotationcommand_adapter_get_discovery();

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -561,6 +561,18 @@ function drush_preflight_root() {
   // Load the config options from Drupal's /drush, ../drush, and sites/all/drush directories,
   // even prior to bootstrapping the root.
   drush_load_config('drupal');
+
+  // Search for commandfiles in the root locations
+  $discovery = annotationcommand_adapter_get_discovery();
+  $searchpath = [dirname($root) . '/drush', "$root/drush", "$root/sites/all/drush"];
+  $drush_root_extensions = $discovery->discover($searchpath, '\Drush');
+  drush_set_context(
+    'DRUSH_ANNOTATED_COMMANDFILES',
+    array_merge(
+      drush_get_context('DRUSH_ANNOTATED_COMMANDFILES'),
+      $drush_root_extensions
+    )
+  );
 }
 
 function drush_preflight_site() {
@@ -727,9 +739,6 @@ function _drush_preflight_uri() {
 }
 
 function _drush_find_commandfiles_drush() {
-  // Core commands shipping with Drush
-  $searchpath[] = dirname(__FILE__) . '/../commands/';
-
   // User commands, specified by 'include' option
   $include = drush_get_context('DRUSH_INCLUDE', array());
   foreach ($include as $path) {
@@ -753,13 +762,23 @@ function _drush_find_commandfiles_drush() {
     }
   }
 
+  // Core commands shipping with Drush
+  $drushCoreSearchpath[] = dirname(__DIR__) . '/commands/';
+
+  // Make sure search path is unique
+  $searchpath = array_unique($searchpath);
+
   // @todo the zero parameter is a bit weird here. It's $phase.
-  _drush_add_commandfiles($searchpath, 0);
+  _drush_add_commandfiles($drushCoreSearchpath + $searchpath, 0);
 
   // Also discover Drush's own annotation commands.
   $discovery = annotationcommand_adapter_get_discovery();
-  $discovery->addSearchLocation('CommandFiles')->setSearchPattern('#.*(Commands|CommandFile).php$#');
   $annotation_commandfiles = $discovery->discover(DRUSH_BASE_PATH . '/lib/Drush', '\Drush');
+
+  // And, finally, search for commandfiles in the $searchpath
+  $global_drush_extensions = $discovery->discover($searchpath, '\Drush');
+  $annotation_commandfiles += $global_drush_extensions;
+
   drush_set_context('DRUSH_ANNOTATED_COMMANDFILES', $annotation_commandfiles);
 }
 

--- a/lib/Drush/Commands/DrushCommands.php
+++ b/lib/Drush/Commands/DrushCommands.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drush\CommandFiles;
+namespace Drush\Commands;
 
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;

--- a/lib/Drush/Commands/ExampleCommands.php
+++ b/lib/Drush/Commands/ExampleCommands.php
@@ -1,5 +1,5 @@
 <?php
-namespace Drush\CommandFiles;
+namespace Drush\Commands;
 
 /**
  * @file

--- a/lib/Drush/Commands/core/BrowseCommands.php
+++ b/lib/Drush/Commands/core/BrowseCommands.php
@@ -1,7 +1,7 @@
 <?php
-namespace Drush\CommandFiles\core;
+namespace Drush\Commands\core;
 
-use Drush\CommandFiles\DrushCommands;
+use Drush\Commands\DrushCommands;
 
 class BrowseCommands extends DrushCommands {
 
@@ -21,7 +21,7 @@ class BrowseCommands extends DrushCommands {
    *   Open a browser to the web site specified in a site alias.
    * @usage drush browse --browser=firefox admin
    *   Open Firefox web browser to the path 'admin'.
-   * @complete \Drush\CommandFiles\core\BrowseCommands::complete
+   * @complete \Drush\Commands\core\BrowseCommands::complete
    * @handle-remote-commands true
    */
   public function browse($path = '', $options = ['browser' => NULL]) {

--- a/lib/Drush/Commands/core/DrupliconCommands.php
+++ b/lib/Drush/Commands/core/DrupliconCommands.php
@@ -1,8 +1,8 @@
 <?php
-namespace Drush\CommandFiles\core;
+namespace Drush\Commands\core;
 
 use Consolidation\AnnotatedCommand\CommandData;
-use Drush\CommandFiles\DrushCommands;
+use Drush\Commands\DrushCommands;
 
 class DrupliconCommands extends DrushCommands {
   protected $printed = false;

--- a/lib/Drush/Commands/core/EvalCommandFile.php
+++ b/lib/Drush/Commands/core/EvalCommandFile.php
@@ -1,5 +1,5 @@
 <?php
-namespace Drush\CommandFiles\core;
+namespace Drush\Commands\core;
 
 /**
  * @file

--- a/lib/Drush/Commands/core/EvalCommands.php
+++ b/lib/Drush/Commands/core/EvalCommands.php
@@ -6,7 +6,7 @@ namespace Drush\Commands\core;
  *   Evaluate PHP code.
  */
 
-class EvalCommandFile
+class EvalCommands
 {
   /**
    * Evaluate arbitrary php code after bootstrapping Drupal (if available).

--- a/lib/Drush/Commands/core/InitCommandFile.php
+++ b/lib/Drush/Commands/core/InitCommandFile.php
@@ -1,5 +1,5 @@
 <?php
-namespace Drush\CommandFiles\core;
+namespace Drush\Commands\core;
 
 use Drush\Log\LogLevel;
 

--- a/lib/Drush/Commands/core/InitCommands.php
+++ b/lib/Drush/Commands/core/InitCommands.php
@@ -3,7 +3,7 @@ namespace Drush\Commands\core;
 
 use Drush\Log\LogLevel;
 
-class InitCommandFile extends \Robo\Tasks
+class InitCommands extends \Robo\Tasks
 {
   /**
    * Initialize local Drush configuration

--- a/lib/Drush/Commands/core/ShellAliasCommands.php
+++ b/lib/Drush/Commands/core/ShellAliasCommands.php
@@ -1,5 +1,5 @@
 <?php
-namespace Drush\CommandFiles\core;
+namespace Drush\Commands\core;
 
 use Consolidation\OutputFormatters\StructuredData\AssociativeList;
 
@@ -21,7 +21,7 @@ class ShellAliasCommands {
    *   Print the value of the shell alias 'pull'.
    * @aliases sha
    * @todo completion not yet working for Annotated commands.
-   * @complete \Drush\CommandFiles\core\ShellAliasCommands::complete
+   * @complete \Drush\Commands\core\ShellAliasCommands::complete
    *
    * @return \Consolidation\OutputFormatters\StructuredData\AssociativeList
    */

--- a/lib/Drush/Commands/core/StateCommands.php
+++ b/lib/Drush/Commands/core/StateCommands.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drush\CommandFiles\core;
+namespace Drush\Commands\core;
 
 use Consolidation\OutputFormatters\StructuredData\AssociativeList;
 

--- a/lib/Drush/Commands/core/ViewsCommands.php
+++ b/lib/Drush/Commands/core/ViewsCommands.php
@@ -1,10 +1,10 @@
 <?php
-namespace Drush\CommandFiles\core;
+namespace Drush\Commands\core;
 
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\CommandError;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
-use Drush\CommandFiles\DrushCommands;
+use Drush\Commands\DrushCommands;
 use Drush\Log\LogLevel;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -173,7 +173,7 @@ class ViewsCommands extends DrushCommands {
    * @usage drush views-execute my_view page_1 3,foo
    *   Show the rendered HTML of my_view:page_1 where the first two contextual filter values are 3 and 'foo' respectively.
    * @bootstrap DRUSH_BOOTSTRAP_DRUPAL_FULL
-   * @complete \Drush\CommandFiles\core\ViewsCommands::complete
+   * @complete \Drush\Commands\core\ViewsCommands::complete
    * @validate-entity-load view views
    * @aliases vex
    *
@@ -252,7 +252,7 @@ class ViewsCommands extends DrushCommands {
    * @validate-entity-load view views
    * @usage drush ven frontpage,taxonomy_term
    *   Enable the frontpage and taxonomy_term views.
-   * @complete \Drush\CommandFiles\core\ViewsCommands::complete
+   * @complete \Drush\Commands\core\ViewsCommands::complete
    * @bootstrap DRUSH_BOOTSTRAP_DRUPAL_FULL
    * @aliases ven
    */
@@ -275,7 +275,7 @@ class ViewsCommands extends DrushCommands {
    * @param string $views A comma delimited list of view names.
    * @usage drush vdis frontpage taxonomy_term
    *   Disable the frontpage and taxonomy_term views.
-   * @complete \Drush\CommandFiles\core\ViewsCommands::complete
+   * @complete \Drush\Commands\core\ViewsCommands::complete
    * @bootstrap DRUSH_BOOTSTRAP_DRUPAL_FULL
    * @aliases vdis
    */

--- a/lib/Drush/Drupal/DrushServiceModfier.php
+++ b/lib/Drush/Drupal/DrushServiceModfier.php
@@ -15,7 +15,7 @@ class DrushServiceModfier implements ServiceModifierInterface
         drush_log(dt("service modifier alter"), LogLevel::DEBUG);
         // http://symfony.com/doc/2.7/components/dependency_injection/tags.html#register-the-pass-with-the-container
         $container->register('drush.service.consolecommands', 'Drush\Command\ServiceCommandlist');
-        $container->addCompilerPass(new FindCommandsCompilerPass('drush.service.consolecommands', 'console.command'));
+        $container->addCompilerPass(new FindCommandsCompilerPass('drush.service.consolecommands', 'drush.command'));
         $container->register('drush.service.consolidationcommands', 'Drush\Command\ServiceCommandlist');
         $container->addCompilerPass(new FindCommandsCompilerPass('drush.service.consolidationcommands', 'consolidation.commandhandler'));
     }

--- a/tests/annotatedCommandTest.php
+++ b/tests/annotatedCommandTest.php
@@ -6,6 +6,23 @@ namespace Unish;
  * @group base
  */
 class annotatedCommandCase extends CommandUnishTestCase {
+
+  public function testGlobal() {
+    $globalExtensions = $this->setupGlobalExtensionsForTests();
+
+    $options = array(
+      'include' => $globalExtensions,
+    );
+
+    // We modified the set of available Drush commands; we need to clear the Drush command cache
+    $this->drush('cc', array('drush'), $options);
+
+    // drush woot
+    $this->drush('foobar', array(), $options);
+    $output = $this->getOutput();
+    $this->assertEquals('baz', $output);
+  }
+
   public function testExecute() {
     $sites = $this->setUpDrupal(1, TRUE);
     $uri = key($sites);
@@ -146,6 +163,14 @@ EOT;
 
     // Clear the Drush cache so that our 'woot' command is not cached.
     $this->drush('cache-clear', array('drush'), $options, NULL, NULL, self::EXIT_SUCCESS);
+  }
+
+  public function setupGlobalExtensionsForTests() {
+    $globalExtension = __DIR__ . '/resources/global-includes';
+    $targetDir = UNISH_SANDBOX . DIRECTORY_SEPARATOR . 'global-includes';
+    $this->mkdir($targetDir);
+    $this->recursive_copy($globalExtension, $targetDir);
+    return $targetDir;
   }
 
   public function setupModulesForTests($root) {

--- a/tests/annotatedCommandTest.php
+++ b/tests/annotatedCommandTest.php
@@ -10,14 +10,22 @@ class annotatedCommandCase extends CommandUnishTestCase {
   public function testGlobal() {
     $globalExtensions = $this->setupGlobalExtensionsForTests();
 
-    $options = array(
-      'include' => $globalExtensions,
-    );
+    $options = [];
 
     // We modified the set of available Drush commands; we need to clear the Drush command cache
     $this->drush('cc', array('drush'), $options);
 
-    // drush woot
+    // drush foobar
+    $options['include'] = "$globalExtensions";
+    $this->drush('foobar', array(), $options);
+    $output = $this->getOutput();
+    $this->assertEquals('baz', $output);
+
+    // Clear the Drush command cache again and test again with new includes
+    $this->drush('cc', array('drush'), $options);
+
+    // drush foobar again, except include the 'Commands' folder when passing --include
+    $options['include'] = "$globalExtensions/Commands";
     $this->drush('foobar', array(), $options);
     $output = $this->getOutput();
     $this->assertEquals('baz', $output);

--- a/tests/annotatedCommandTest.php
+++ b/tests/annotatedCommandTest.php
@@ -22,9 +22,9 @@ class annotatedCommandCase extends CommandUnishTestCase {
     // These are not good asserts, but for the purposes of isolation....
     $targetDir = $root . DIRECTORY_SEPARATOR . $this->drupalSitewideDirectory() . '/modules/woot';
     if (UNISH_DRUPAL_MAJOR_VERSION == 8) {
-        $commandFile = $targetDir . "/src/Command/WootCommands.php";
+        $commandFile = $targetDir . "/src/Commands/WootCommands.php";
     } else {
-        $commandFile = $targetDir . "/Command/WootCommands.php";
+        $commandFile = $targetDir . "/Commands/WootCommands.php";
     }
     $this->assertFileExists(dirname(dirname(dirname($commandFile))));
     $this->assertFileExists(dirname(dirname($commandFile)));

--- a/tests/resources/global-includes/Commands/FoobarCommands.php
+++ b/tests/resources/global-includes/Commands/FoobarCommands.php
@@ -1,0 +1,21 @@
+<?php
+namespace Drush\Commands;
+
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+
+/**
+ * For commands that are 'global', Drush expects to find them inside
+ * the 'Commands' folder of a location specified via --include.
+ */
+class FoobarCommands
+{
+    /**
+     * Do nearly nothing.
+     *
+     * @command foobar
+     */
+    public function foobar()
+    {
+        return 'baz';
+    }
+}

--- a/tests/resources/modules/d6/woot/Commands/WootCommands.php
+++ b/tests/resources/modules/d6/woot/Commands/WootCommands.php
@@ -1,5 +1,5 @@
 <?php
-namespace Drupal\woot\Command;
+namespace Drupal\woot\Commands;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 

--- a/tests/resources/modules/d7/woot/Commands/WootCommands.php
+++ b/tests/resources/modules/d7/woot/Commands/WootCommands.php
@@ -1,5 +1,5 @@
 <?php
-namespace Drupal\woot\Command;
+namespace Drupal\woot\Commands;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 

--- a/tests/resources/modules/d8/woot/src/Commands/AnnotatedGreetCommand.php
+++ b/tests/resources/modules/d8/woot/src/Commands/AnnotatedGreetCommand.php
@@ -1,6 +1,7 @@
 <?php
-namespace Drupal\woot\Command;
+namespace Drupal\woot\Commands;
 
+use Consolidation\AnnotatedCommand\AnnotatedCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -8,32 +9,20 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * This is a literal copy of the example Symfony Console command
+ * This is an annotated version of the example Symfony Console command
  * from the documentation.
  *
  * See: http://symfony.com/doc/2.7/components/console/introduction.html#creating-a-basic-command
  */
-class GreetCommand extends Command
+class AnnotatedGreetCommand extends AnnotatedCommand
 {
-    protected function configure()
-    {
-        $this
-            ->setName('demo:greet')
-            ->setDescription('Greet someone')
-            ->addArgument(
-                'name',
-                InputArgument::OPTIONAL,
-                'Who do you want to greet?'
-            )
-            ->addOption(
-               'yell',
-               null,
-               InputOption::VALUE_NONE,
-               'If set, the task will yell in uppercase letters'
-            )
-        ;
-    }
-
+    /**
+     * Greet someone
+     *
+     * @command annotated:greet
+     * @arg string $name Who do you want to greet?
+     * @option boolean $yell If set, the task will yell in uppercase letters
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $name = $input->getArgument('name');

--- a/tests/resources/modules/d8/woot/src/Commands/GreetCommand.php
+++ b/tests/resources/modules/d8/woot/src/Commands/GreetCommand.php
@@ -1,7 +1,6 @@
 <?php
-namespace Drupal\woot\Command;
+namespace Drupal\woot\Commands;
 
-use Consolidation\AnnotatedCommand\AnnotatedCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -9,20 +8,32 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * This is an annotated version of the example Symfony Console command
+ * This is a literal copy of the example Symfony Console command
  * from the documentation.
  *
  * See: http://symfony.com/doc/2.7/components/console/introduction.html#creating-a-basic-command
  */
-class AnnotatedGreetCommand extends AnnotatedCommand
+class GreetCommand extends Command
 {
-    /**
-     * Greet someone
-     *
-     * @command annotated:greet
-     * @arg string $name Who do you want to greet?
-     * @option boolean $yell If set, the task will yell in uppercase letters
-     */
+    protected function configure()
+    {
+        $this
+            ->setName('demo:greet')
+            ->setDescription('Greet someone')
+            ->addArgument(
+                'name',
+                InputArgument::OPTIONAL,
+                'Who do you want to greet?'
+            )
+            ->addOption(
+               'yell',
+               null,
+               InputOption::VALUE_NONE,
+               'If set, the task will yell in uppercase letters'
+            )
+        ;
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $name = $input->getArgument('name');

--- a/tests/resources/modules/d8/woot/src/Commands/WootCommands.php
+++ b/tests/resources/modules/d8/woot/src/Commands/WootCommands.php
@@ -1,5 +1,5 @@
 <?php
-namespace Drupal\woot\Command;
+namespace Drupal\woot\Commands;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 

--- a/tests/resources/modules/d8/woot/woot.services.yml
+++ b/tests/resources/modules/d8/woot/woot.services.yml
@@ -5,14 +5,14 @@ services:
     tags:
       -  { name: consolidation.commandhandler }
   woot.command:
-    class: Drupal\woot\Command\WootCommands
+    class: Drupal\woot\Commands\WootCommands
     tags:
       -  { name: consolidation.commandhandler }
   greet.command:
-    class: Drupal\woot\Command\GreetCommand
+    class: Drupal\woot\Commands\GreetCommand
     tags:
       -  { name: console.command }
   annotated_greet.command:
-    class: Drupal\woot\Command\AnnotatedGreetCommand
+    class: Drupal\woot\Commands\AnnotatedGreetCommand
     tags:
       -  { name: console.command }

--- a/tests/resources/modules/d8/woot/woot.services.yml
+++ b/tests/resources/modules/d8/woot/woot.services.yml
@@ -11,8 +11,8 @@ services:
   greet.command:
     class: Drupal\woot\Commands\GreetCommand
     tags:
-      -  { name: console.command }
+      -  { name: drush.command }
   annotated_greet.command:
     class: Drupal\woot\Commands\AnnotatedGreetCommand
     tags:
-      -  { name: console.command }
+      -  { name: drush.command }


### PR DESCRIPTION
This allows Drush extensions with commands and hooks to be declared in global (e.g. ~/.drush) and site (e.g. __DRUPAL_ROOT__/drush) locations.

For each potential search location, the actual commandfiles may be located at `.`, `./Commands`, or `./CommandFiles`.  The namespace calculation is not necessarily correct, though.  For example, a commandfile named `ExampleCommand.php` located in ~/.drush should have a namespace of `Drush`, whereas a commandfile with the same name located in ~/.drush/Commands should have a namespace of `Drush/Commands`. This is an ambiguity, because if the file is distributed as a standalone .php file, its namespace should not have to be modified based on where the end user chooses to install it.

This is not necessarily rational.  Potential improvements:

- Only allow commandfiles to be installed via Composer.
- Restrict global commandfiles to a single directory in each search location (e.g. ~/.drush/Commandfiles) so there is no ambiguity about namespaces. (No deep searching ever.)
- Assume the namespace of every global / site commandfile is `Drush`, regardless of location.
- Prohibit global commandfiles from using namespaces at all.
- Read in the first few lines of each global commandfile and search for the `namespace` line. Allow commandfiles to be namespaced to anything.
