### PR TITLE
Filter out placeholders that can not be cast to strings

### DIFF
--- a/lib/Drush/Log/DrushLog.php
+++ b/lib/Drush/Log/DrushLog.php
@@ -95,6 +95,12 @@ class DrushLog implements LoggerInterface {
 
     // Populate the message placeholders and then replace them in the message.
     $message_placeholders = $this->parser->parseMessagePlaceholders($message, $context);
+
+    // Filter out any placeholders that can not be cast to strings.
+    $message_placeholders = array_filter($message_placeholders, function ($element) {
+      return is_scalar($element) || is_callable([$element, '__toString']);
+    });
+
     $message = empty($message_placeholders) ? $message : strtr($message, $message_placeholders);
 
     $this->logger->log($error_type, $message, $context);


### PR DESCRIPTION
When I run a migration with `drush migrate-drush-run` I'm getting the following error:

> Object of class Drupal\Core\Session\AccountProxy could not be converted to string in DrushLog.php

This is caused by the `user` element in the `$message_placeholders` array being an `AccountProxy` object instead of a string. This message placeholders are retrieved from the `$context` which is populated in `LoggerChannel::log()`:

```
      try {
        if ($this->currentUser) {
          $context['user'] = $this->currentUser;  // <<< here
          $context['uid'] = $this->currentUser->id();
        }
      }
```

Our loggers are adhering to `LoggerInterface` from [`psr/log`](https://github.com/php-fig/log). According to their [documentation](https://github.com/php-fig/log/blob/master/Psr/Log/LoggerInterface.php#L13):

> The context array can contain arbitrary data. The only assumption that can be made by implementors is that if an Exception instance is given to produce a stack trace, it MUST be in a key named "exception".

The reason for this is presumably to allow custom loggers to have access to arbitrary data to provide rich log messages.

For our use case, we do not have intimate knowledge about the event which is being logged. In order to display any log message we need to filter out anything that can not be cast to a string.