### PR TITLE
Added bypass_shell option to proc_open()

### DIFF
--- a/includes/exec.inc
+++ b/includes/exec.inc
@@ -242,7 +242,7 @@ function drush_shell_proc_open($cmd) {
     drush_print("Calling proc_open($cmd);", 0, STDERR);
   }
   if (!drush_get_context('DRUSH_SIMULATE')) {
-    $process = proc_open($cmd, array(0 => STDIN, 1 => STDOUT, 2 => STDERR), $pipes);
+    $process = proc_open($cmd, array(0 => STDIN, 1 => STDOUT, 2 => STDERR), $pipes, NULL, NULL, array('bypass_shell' => TRUE));
     $proc_status = proc_get_status($process);
     $exit_code = proc_close($process);
     return ($proc_status["running"] ? $exit_code : $proc_status["exitcode"] );


### PR DESCRIPTION
Fixes drush ssh on Win. See https://github.com/drush-ops/drush/issues/2443