### PR TITLE
fix [warning] apcu_clear_cache() expects exactly 0 parameters, 1 given

### DIFF
--- a/commands/core/cache.drush.inc
+++ b/commands/core/cache.drush.inc
@@ -277,7 +277,7 @@ function drush_cache_rebuild() {
     'wincache_ucache_clear',
     'xcache_clear_cache',
   ];
-  array_walk(array_filter($user_caches, 'is_callable'), 'call_user_func');
+  array_map('call_user_func', array_filter($user_caches, 'is_callable'));
 
   $autoloader = drush_drupal_load_autoloader(DRUPAL_ROOT);
   require_once DRUSH_DRUPAL_CORE . '/includes/utility.inc';


### PR DESCRIPTION
After #2450 with PHP 7
The following error is caused by execution of `drush cr`
[warning] apcu_clear_cache() expects exactly 0 parameters, 1 given cache.drush.inc:280