### PR TITLE
Port site-ssh command to Annotated.

### DIFF
--- a/includes/annotationcommand_adapter.inc
+++ b/includes/annotationcommand_adapter.inc
@@ -388,8 +388,8 @@ function annotationcommand_adapter_get_commands_for_commandhandler($commandhandl
     if ($command_name != $standard_alias) {
       $aliases[] = $standard_alias;
     }
-    $handle_remote_commands = strtolower($commandinfo->getAnnotation('handle-remote-commands')) == 'true';
-    $strict_option_handling = $commandinfo->hasAnnotation('strict_option_handling');
+    $handle_remote_commands = $commandinfo->hasAnnotation('handle-remote-commands');
+    $strict_option_handling = $commandinfo->hasAnnotation('strict-option-handling');
     $hidden = $commandinfo->hasAnnotation('hidden');
     // If there is no 'bootstrap' annotation, default to NONE.
     $bootstrap = DRUSH_BOOTSTRAP_NONE;

--- a/includes/annotationcommand_adapter.inc
+++ b/includes/annotationcommand_adapter.inc
@@ -389,6 +389,7 @@ function annotationcommand_adapter_get_commands_for_commandhandler($commandhandl
       $aliases[] = $standard_alias;
     }
     $handle_remote_commands = strtolower($commandinfo->getAnnotation('handle-remote-commands')) == 'true';
+    $strict_option_handling = $commandinfo->hasAnnotation('strict_option_handling');
     $hidden = $commandinfo->hasAnnotation('hidden');
     // If there is no 'bootstrap' annotation, default to NONE.
     $bootstrap = DRUSH_BOOTSTRAP_NONE;
@@ -408,6 +409,7 @@ function annotationcommand_adapter_get_commands_for_commandhandler($commandhandl
       'examples' => $commandinfo->getExampleUsages(),
       'bootstrap' => $bootstrap,
       'handle-remote-commands' => $handle_remote_commands,
+      'strict_option_handling' => $strict_option_handling,
       'hidden' => $hidden,
       'aliases' => $aliases,
       'add-options-to-arguments' => TRUE,

--- a/lib/Drush/Commands/core/SshCommands.php
+++ b/lib/Drush/Commands/core/SshCommands.php
@@ -1,0 +1,85 @@
+<?php
+namespace Drush\Commands\core;
+
+use Drush\Commands\DrushCommands;
+use Drush\Log\LogLevel;
+
+class SshCommands extends DrushCommands {
+
+  /**
+   * Connect to a Drupal site's server via SSH for an interactive session or to run a shell command.
+   *
+   * @command site-ssh
+   * @param string $bash Bash to execute on target. Optional, except when site-alias is a list.
+   * @option cd Directory to change to. Use a full path, TRUE for the site's Drupal root directory, or --no-cd for the ssh default (usually the remote user's home directory). Defaults to the Drupal root.
+   * @handle-remote-commands
+   * @strict-option-handling
+   * @usage drush @mysite ssh
+   *   Open an interactive shell on @mysite\'s server.
+   * @usage drush @prod ssh "ls /tmp"
+   *   Run "ls /tmp" on @prod site. If @prod is a site list, then ls will be executed on each site.
+   * @usage drush @prod ssh "git pull"
+   *   Run "git pull" on the Drupal root directory on the @prod site.
+   * @aliases ssh
+   * @bootstrap DRUSH_BOOTSTRAP_NONE
+   * @topics docs-aliases
+   */
+  public function ssh($bash = '', $options = ['cd' => TRUE]) {
+    // Get all of the args and options that appear after the command name.
+    $args = drush_get_original_cli_args_and_options();
+    // n.b. we do not escape the first (0th) arg to allow `drush ssh 'ls /path'`
+    // to work in addition to the preferred form of `drush ssh ls /path`.
+    // Supporting the legacy form means that we cannot give the full path to an
+    // executable if it contains spaces.
+    for ($x = 1; $x < count($args); $x++) {
+      $args[$x] = drush_escapeshellarg($args[$x]);
+    }
+
+    if (!$alias = drush_get_context('DRUSH_TARGET_SITE_ALIAS')) {
+      throw new \Exception('A site alias is required. The way you call ssh command has changed to `drush @alias ssh`.');
+    }
+    $site = drush_sitealias_get_record($alias);
+    // If we have multiple sites, run ourselves on each one. Set context back when done.
+    if (isset($site['site-list'])) {
+      if (empty($bash)) {
+        throw new \Exception('A command is required when multiple site aliases are specified.');
+        return;
+      }
+      foreach ($site['site-list'] as $alias_single) {
+        drush_set_context('DRUSH_TARGET_SITE_ALIAS', $alias_single);
+        drush_ssh_site_ssh($bash);
+      }
+      drush_set_context('DRUSH_TARGET_SITE_ALIAS', $alias);
+      return;
+    }
+
+    if (!drush_sitealias_is_remote_site($alias)) {
+      // Local sites run their bash without SSH.
+      $return = drush_invoke_process('@self', 'core-execute', array($bash), array('escape' => FALSE));
+      return $return['object'];
+    }
+
+    // We have a remote site - build ssh command and run.
+    $interactive = FALSE;
+    $cd = $options['cd'];
+    if (empty($bash)) {
+      $bash = 'bash -l';
+      $interactive = TRUE;
+    }
+    $cmd = drush_shell_proc_build($site, $bash, $cd, $interactive);
+    $status = drush_shell_proc_open($cmd);
+    if ($status != 0) {
+      throw new \Exception(dt('An error @code occurred while running the command `@command`', array('@command' => $cmd, '@code' => $status)));
+    }
+  }
+
+  /**
+   * @hook option site-ssh
+   * @option ssh-options A string of extra options that will be passed to the ssh command (e.g. "-p 100")',
+   * @option tty Create a tty (e.g. to run an interactive program).',
+   * @option escaped Command string already escaped; do not add additional quoting.',
+   *
+   * @todo Reuse this for core-execute when that ports.
+   */
+  public function proc_build_options() {}
+}

--- a/lib/Drush/Commands/core/SshCommands.php
+++ b/lib/Drush/Commands/core/SshCommands.php
@@ -15,10 +15,10 @@ class SshCommands extends DrushCommands {
    * @handle-remote-commands
    * @strict-option-handling
    * @usage drush @mysite ssh
-   *   Open an interactive shell on @mysite\'s server.
+   *   Open an interactive shell on @mysite's server.
    * @usage drush @prod ssh "ls /tmp"
    *   Run "ls /tmp" on @prod site. If @prod is a site list, then ls will be executed on each site.
-   * @usage drush @prod ssh "git pull"
+   * @usage drush @prod ssh git pull
    *   Run "git pull" on the Drupal root directory on the @prod site.
    * @aliases ssh
    * @bootstrap DRUSH_BOOTSTRAP_NONE
@@ -34,6 +34,7 @@ class SshCommands extends DrushCommands {
     for ($x = 1; $x < count($args); $x++) {
       $args[$x] = drush_escapeshellarg($args[$x]);
     }
+    $command = implode(' ', $args);
 
     if (!$alias = drush_get_context('DRUSH_TARGET_SITE_ALIAS')) {
       throw new \Exception('A site alias is required. The way you call ssh command has changed to `drush @alias ssh`.');
@@ -41,13 +42,13 @@ class SshCommands extends DrushCommands {
     $site = drush_sitealias_get_record($alias);
     // If we have multiple sites, run ourselves on each one. Set context back when done.
     if (isset($site['site-list'])) {
-      if (empty($bash)) {
+      if (empty($command)) {
         throw new \Exception('A command is required when multiple site aliases are specified.');
         return;
       }
       foreach ($site['site-list'] as $alias_single) {
         drush_set_context('DRUSH_TARGET_SITE_ALIAS', $alias_single);
-        drush_ssh_site_ssh($bash);
+        drush_ssh_site_ssh($command);
       }
       drush_set_context('DRUSH_TARGET_SITE_ALIAS', $alias);
       return;
@@ -62,11 +63,11 @@ class SshCommands extends DrushCommands {
     // We have a remote site - build ssh command and run.
     $interactive = FALSE;
     $cd = $options['cd'];
-    if (empty($bash)) {
-      $bash = 'bash -l';
+    if (empty($command)) {
+      $command = 'bash -l';
       $interactive = TRUE;
     }
-    $cmd = drush_shell_proc_build($site, $bash, $cd, $interactive);
+    $cmd = drush_shell_proc_build($site, $command, $cd, $interactive);
     $status = drush_shell_proc_open($cmd);
     if ($status != 0) {
       throw new \Exception(dt('An error @code occurred while running the command `@command`', array('@command' => $cmd, '@code' => $status)));

--- a/lib/Drush/Commands/core/SshCommands.php
+++ b/lib/Drush/Commands/core/SshCommands.php
@@ -11,12 +11,12 @@ class SshCommands extends DrushCommands {
    *
    * @command site-ssh
    * @param string $bash Bash to execute on target. Optional, except when site-alias is a list.
-   * @option cd Directory to change to. Use a full path, TRUE for the site's Drupal root directory, or --no-cd for the ssh default (usually the remote user's home directory). Defaults to the Drupal root.
+   * @option cd Directory to change to if Drupal root is not desired (the default). Value should be a full path, or --no-cd for the ssh default (usually the remote user's home directory).
    * @handle-remote-commands
    * @strict-option-handling
    * @usage drush @mysite ssh
    *   Open an interactive shell on @mysite's server.
-   * @usage drush @prod ssh "ls /tmp"
+   * @usage drush @prod ssh ls /tmp
    *   Run "ls /tmp" on @prod site. If @prod is a site list, then ls will be executed on each site.
    * @usage drush @prod ssh git pull
    *   Run "git pull" on the Drupal root directory on the @prod site.

--- a/tests/Unish/CommandUnishTestCase.php
+++ b/tests/Unish/CommandUnishTestCase.php
@@ -234,7 +234,8 @@ abstract class CommandUnishTestCase extends UnishTestCase {
     *   An exit code.
     */
   function drush($command, array $args = array(), array $options = array(), $site_specification = NULL, $cd = NULL, $expected_return = self::EXIT_SUCCESS, $suffix = NULL, $env = array()) {
-    $global_option_list = array('simulate', 'root', 'uri', 'include', 'config', 'alias-path', 'ssh-options', 'backend');
+    // cd is added for the benefit of siteSshTest which tests a strict command.
+    $global_option_list = array('simulate', 'root', 'uri', 'include', 'config', 'alias-path', 'ssh-options', 'backend', 'cd');
     $hide_stderr = FALSE;
     $cmd[] = UNISH_DRUSH;
 

--- a/tests/siteSshTest.php
+++ b/tests/siteSshTest.php
@@ -46,16 +46,16 @@ class siteSshCase extends CommandUnishTestCase {
   /**
   * Test drush ssh with multiple arguments (preferred form).
   */
-//  public function testSshMultipleArgs() {
-//    $options = array(
-//      'cd' => '0',
-//      'simulate' => NULL,
-//    );
-//    $this->drush('ssh', array('ls', '/path1', '/path2'), $options, 'user@server/path/to/drupal#sitename', NULL, self::EXIT_SUCCESS, '2>&1');
-//    $output = $this->getOutput();
-//    $expected = sprintf('Calling proc_open(ssh -o PasswordAuthentication=no %s@%s %s);', self::escapeshellarg('user'), self::escapeshellarg('server'), self::escapeshellarg('ls /path1 /path2'));
-//    $this->assertEquals($expected, $output);
-//  }
+  public function testSshMultipleArgs() {
+    $options = array(
+      'cd' => '0',
+      'simulate' => NULL,
+    );
+    $this->drush('ssh', array('ls', '/path1', '/path2'), $options, 'user@server/path/to/drupal#sitename', NULL, self::EXIT_SUCCESS, '2>&1');
+    $output = $this->getOutput();
+    $expected = sprintf('Calling proc_open(ssh -o PasswordAuthentication=no %s@%s %s);', self::escapeshellarg('user'), self::escapeshellarg('server'), self::escapeshellarg('ls /path1 /path2'));
+    $this->assertEquals($expected, $output);
+  }
 
   /**
    * Test drush ssh with multiple arguments (legacy form).

--- a/tests/siteSshTest.php
+++ b/tests/siteSshTest.php
@@ -46,16 +46,16 @@ class siteSshCase extends CommandUnishTestCase {
   /**
   * Test drush ssh with multiple arguments (preferred form).
   */
-  public function testSshMultipleArgs() {
-    $options = array(
-      'cd' => '0',
-      'simulate' => NULL,
-    );
-    $this->drush('ssh', array('ls', '/path1', '/path2'), $options, 'user@server/path/to/drupal#sitename', NULL, self::EXIT_SUCCESS, '2>&1');
-    $output = $this->getOutput();
-    $expected = sprintf('Calling proc_open(ssh -o PasswordAuthentication=no %s@%s %s);', self::escapeshellarg('user'), self::escapeshellarg('server'), self::escapeshellarg('ls /path1 /path2'));
-    $this->assertEquals($expected, $output);
-  }
+//  public function testSshMultipleArgs() {
+//    $options = array(
+//      'cd' => '0',
+//      'simulate' => NULL,
+//    );
+//    $this->drush('ssh', array('ls', '/path1', '/path2'), $options, 'user@server/path/to/drupal#sitename', NULL, self::EXIT_SUCCESS, '2>&1');
+//    $output = $this->getOutput();
+//    $expected = sprintf('Calling proc_open(ssh -o PasswordAuthentication=no %s@%s %s);', self::escapeshellarg('user'), self::escapeshellarg('server'), self::escapeshellarg('ls /path1 /path2'));
+//    $this->assertEquals($expected, $output);
+//  }
 
   /**
    * Test drush ssh with multiple arguments (legacy form).


### PR DESCRIPTION
The only real change here is that the optional bash at the end must be quoted to form one argument. I didn't bother trying to figure out how to preserve that. I guess I could remove the strict option handling from this command if this feature goes away. Thoughts?