### PR TITLE
Append /login to the user password reset URL also in 8.X

### DIFF
--- a/lib/Drush/User/UserSingle7.php
+++ b/lib/Drush/User/UserSingle7.php
@@ -32,15 +32,6 @@ class UserSingle7 extends UserSingleBase {
     return $userinfo;
   }
 
-  public function passResetUrl($path = '') {
-    $options = array();
-    if ($path) {
-      $options['query']['destination'] = $path;
-    }
-    // D6,D7 append a /login. Otherwise identical to D8+.
-    return drush_url(user_pass_reset_url($this->account) . '/login', $options);
-  }
-
   function password($pass) {
     user_save($this->account, array('pass' => $pass));
   }

--- a/lib/Drush/User/UserSingleBase.php
+++ b/lib/Drush/User/UserSingleBase.php
@@ -108,7 +108,7 @@ abstract class UserSingleBase {
    * @return string
    */
   public function passResetUrl($path = '') {
-    $url = user_pass_reset_url($this->account);
+    $url = user_pass_reset_url($this->account) . '/login';
     if ($path) {
       $url .= '?destination=' . $path;
     }


### PR DESCRIPTION
Drupal 8 supports this again since 8.1.9 or so, as part of a security improvement.

Not sure if we want some kind of version check.