### PR TITLE
Implement @hook interact and @hook init.

### DIFF
--- a/includes/annotationcommand_adapter.inc
+++ b/includes/annotationcommand_adapter.inc
@@ -212,6 +212,7 @@ function annotationcommand_adapter_process_command() {
     $args[$key] = $value;
   }
 
+  // TODO: Need to determine if $input is interactive, and ensure that $input->isInteractive() returns the correct result.
   $input = new DrushInputAdapter($args, annotationcommand_adapter_get_options($command), $command['command']);
   $output = new ConsoleOutput();
   $annotationData = $command['annotations'];
@@ -223,7 +224,16 @@ function annotationcommand_adapter_process_command() {
   $commandData->setIncludeOptionsInArgs($command['add-options-to-arguments']);
   $names = annotationcommand_adapter_command_names($command);
 
-  // n.b.: backend result is set by a post-alter hook.
+  // Run any `@hook init` for this command. c.f. AnnotatedCommand::initialize()
+  $commandprocessor->initializeHook($input, $names, $annotationData);
+
+  // Run any `@hook interact` for this command. c.f. AnnotatedCommand::interact()
+  if ($input->isInteractive()) {
+    $commandprocessor->interact($input, $output, $names, $annotationData);
+  }
+
+  // Run any validate, command, process, alter or handle results hooks. c.f. AnnotatedCommand::execute()
+  // n.b.: backend result is set by a global post-alter hook.
   $result = $commandprocessor->process(
     $output,
     $names,

--- a/lib/Drush/Commands/ValidatorsCommands.php
+++ b/lib/Drush/Commands/ValidatorsCommands.php
@@ -29,7 +29,7 @@ class ValidatorsCommands {
 
   /**
    * Validate that the file path exists.
-
+   *
    * @hook validate @validate-file-exists
    * @param \Consolidation\AnnotatedCommand\CommandData $commandData
    * @return \Consolidation\AnnotatedCommand\CommandError|null
@@ -38,7 +38,7 @@ class ValidatorsCommands {
     $arg_names = _convert_csv_to_array($commandData->annotationData()->get('validate-file-exists', NULL));
     foreach ($arg_names as $arg_name) {
       $path = $commandData->input()->getArgument($arg_name);
-      if (!file_exists($path)) {
+      if (!empty($path) && !file_exists($path)) {
         $missing[] = $path;
       }
     }

--- a/lib/Drush/Commands/core/ImageCommands.php
+++ b/lib/Drush/Commands/core/ImageCommands.php
@@ -43,6 +43,7 @@ class ImageCommands extends DrushCommands {
       $choices = array_merge(array('all' => 'all'), $choices);
       $style_names = drush_choice($choices, dt("Choose a style to flush."));
       if ($style_names === FALSE) {
+        // TODO: This will need to `throw`
         return drush_user_abort();
       }
     }

--- a/lib/Drush/Commands/core/ImageCommands.php
+++ b/lib/Drush/Commands/core/ImageCommands.php
@@ -37,9 +37,12 @@ class ImageCommands extends DrushCommands {
   public function interactFlush($input, $output) {
     $styles = ImageStyle::loadMultiple();
     $style_names = $input->getArgument('style_names');
+    if ($input->hasOption('all')) {
+      $style_names = 'all';
+    }
 
-    if (empty($input->getOption('all') && empty($style_names))) {
-      $choices = array_combine($styles, $styles);
+    if (empty($style_names)) {
+      $choices = array_combine(array_keys($styles), array_keys($styles));
       $choices = array_merge(array('all' => 'all'), $choices);
       $style_names = drush_choice($choices, dt("Choose a style to flush."));
       if ($style_names === FALSE) {

--- a/lib/Drush/Commands/core/WatchdogCommands.php
+++ b/lib/Drush/Commands/core/WatchdogCommands.php
@@ -59,14 +59,38 @@ class WatchdogCommands extends DrushCommands {
   }
 
   /**
-   * @hook interact watchdog-show
+   * Show watchdog messages.
+   *
+   * @command watchdog-list
+   * @drupal-dependencies dblog
+   * @param $substring A substring to look search in error messages.
+   * @option count The number of messages to show. Defaults to 10.
+   * @option extended Return extended information about each message.
+   * @bootstrap DRUSH_BOOTSTRAP_DRUPAL_FULL
+   * @usage  drush watchdog-list
+   *   Prompt for message type or severity, then run watchdog-show.
+   * @aliases wd-list
+   * @field-labels
+   *   wid: ID
+   *   type: Type
+   *   message: Message
+   *   severity: Severity
+   *   location: Location
+   *   hostname: Hostname
+   *   date: Date
+   *   username: Username
+   * @default-fields wid,date,type,severity,message
+   * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+   */
+  function watchdogList($substring = '', $options = ['format' => 'table', 'count' => 10, 'extended' => FALSE]) {
+    return $this->show($substring, $options);
+  }
+
+  /**
+   * @hook interact watchdog-list
    */
   public function interactShow($input, $output) {
     drush_include_engine('drupal', 'environment');
-
-    if ($this->hasSeverityOrTypeOption($input)) {
-      return;
-    }
 
     $choices['-- types --'] = dt('== message types ==');
     $types = drush_watchdog_message_types();
@@ -90,13 +114,6 @@ class WatchdogCommands extends DrushCommands {
     else {
       $input->setOption('severity', $severities[$option]);
     }
-  }
-
-  protected function hasSeverityOrTypeOption($input) {
-    if ($input->getOption('type', false) || $input->getOption('severity', false)) {
-      return true;
-    }
-    return false;
   }
 
   /**

--- a/lib/Drush/Commands/core/WatchdogCommands.php
+++ b/lib/Drush/Commands/core/WatchdogCommands.php
@@ -64,6 +64,10 @@ class WatchdogCommands extends DrushCommands {
   public function interactShow($input, $output) {
     drush_include_engine('drupal', 'environment');
 
+    if ($this->hasSeverityOrTypeOption($input)) {
+      return;
+    }
+
     $choices['-- types --'] = dt('== message types ==');
     $types = drush_watchdog_message_types();
     foreach ($types as $key => $type) {
@@ -76,6 +80,8 @@ class WatchdogCommands extends DrushCommands {
     }
     $option = drush_choice($choices, dt('Select a message type or severity level.'));
     if ($option === FALSE) {
+      // TODO: We need to throw an exception to abort from an interact hook.
+      // Need to define an abort type and catch it.
       return drush_user_abort();
     }
     if (isset($types[$option])) {
@@ -84,6 +90,13 @@ class WatchdogCommands extends DrushCommands {
     else {
       $input->setOption('severity', $severities[$option]);
     }
+  }
+
+  protected function hasSeverityOrTypeOption($input) {
+    if ($input->getOption('type', false) || $input->getOption('severity', false)) {
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/tests/imageTest.php
+++ b/tests/imageTest.php
@@ -27,7 +27,7 @@ class ImageCase extends CommandUnishTestCase {
     $this->assertFileExists($thumbnail);
 
     // Test that "drush image-flush thumbnail" deletes derivatives created by the thumbnail image style.
-    $this->drush('image-flush', array($style_name), $options);
+    $this->drush('image-flush', array($style_name), $options + ['all' => NULL]);
     $this->assertFileNotExists($thumbnail);
 
     // Check that "drush image-flush --all" deletes all image styles by creating two different ones and testing its


### PR DESCRIPTION
This is a start. c.f. #2524; we don't have an implementation for --no-interaction yet.  Also, we will need to throw an exception to abort from an interact hook.

Ideally, hook interact should only be used to ask the user to provide values for arguments or options not provided on the commandline. If something is queried in the interact hook, then it should be skipped if the user already provided a usable value. The image commands follow this pattern, but in the case of `watchdog-list`, the interact hook is not necessary -- the interaction could be done as part of the command, before it calls through to `watchdog-show`.  I left this as an interact hook for illustrative purposes, though.

n.b. The interact hook conforms to the interface provided by Symfony Console. If the annotated-command project had supplied CommandData here, then we could make `watchdog-list` an alias of `watchdog-show`, and have @hook interact exit if the command was anything other than `watchdog-list` or `wd-list`.