### PR TITLE
Add Drush::call or re-use taskExec for calling other commands.

### DIFF
--- a/lib/Drush.php
+++ b/lib/Drush.php
@@ -212,6 +212,15 @@ class Drush {
   }
 
   /**
+   * Run a Drush command in a new process.
+   *
+   * @see drush_invoke_process() for much more detail.
+   */
+  public static function call($site_alias_record, $command_name, $commandline_args = array(), $commandline_options = array(), $backend_options = TRUE) {
+    return drush_invoke_process($site_alias_record, $command_name, $commandline_args, $commandline_options, $backend_options);
+  }
+
+  /**
    * Read the drush info file.
    */
   private static function drush_read_drush_info() {

--- a/lib/Drush/Commands/core/BrowseCommands.php
+++ b/lib/Drush/Commands/core/BrowseCommands.php
@@ -30,7 +30,7 @@ class BrowseCommands extends DrushCommands {
     $alias = drush_get_context('DRUSH_TARGET_SITE_ALIAS');
     if (drush_sitealias_is_remote_site($alias)) {
       $site_record = drush_sitealias_get_record($alias);
-      $return = drush_invoke_process($site_record, 'browse', [$path], drush_redispatch_get_options(), array('integrate' => TRUE));
+      $return = \Drush::call($site_record, 'browse', [$path], drush_redispatch_get_options(), array('integrate' => TRUE));
       if ($return['error_status']) {
         throw new \Exception('Unable to execute browse command on remote alias.');
       }

--- a/lib/Drush/Commands/core/BrowseCommands.php
+++ b/lib/Drush/Commands/core/BrowseCommands.php
@@ -2,8 +2,13 @@
 namespace Drush\Commands\core;
 
 use Drush\Commands\DrushCommands;
+use Robo\Contract\BuilderAwareInterface;
+use Robo\LoadAllTasks;
+use Symfony\Component\Console\Application;
 
-class BrowseCommands extends DrushCommands {
+class BrowseCommands extends DrushCommands implements BuilderAwareInterface {
+
+  use LoadAllTasks;
 
   /**
    * Display a link to a given path or open link in a browser.
@@ -30,7 +35,19 @@ class BrowseCommands extends DrushCommands {
     $alias = drush_get_context('DRUSH_TARGET_SITE_ALIAS');
     if (drush_sitealias_is_remote_site($alias)) {
       $site_record = drush_sitealias_get_record($alias);
+
+      // Experiment 1a.
+      $ret = $this->taskExec('drush browse')->run();
+      // Experiment 1b.
+      $container = \Drush::getContainer();
+      /** @var Application $app */
+      $app = $container->get('application');
+      $command = $app->get('browse');
+      $ret = $this->taskExec($command)->site($site_record)->run();
+
+      // Experiment 2.
       $return = \Drush::call($site_record, 'browse', [$path], drush_redispatch_get_options(), array('integrate' => TRUE));
+
       if ($return['error_status']) {
         throw new \Exception('Unable to execute browse command on remote alias.');
       }

--- a/lib/Drush/Commands/core/SshCommands.php
+++ b/lib/Drush/Commands/core/SshCommands.php
@@ -57,7 +57,7 @@ class SshCommands extends DrushCommands {
 
     if (!drush_sitealias_is_remote_site($alias)) {
       // Local sites run their bash without SSH.
-      $return = drush_invoke_process('@self', 'core-execute', array($bash), array('escape' => FALSE));
+      $return = \Drush::call('@self', 'core-execute', array($bash), array('escape' => FALSE));
       return $return['object'];
     }
 

--- a/lib/Drush/Commands/core/UserCommands.php
+++ b/lib/Drush/Commands/core/UserCommands.php
@@ -350,7 +350,7 @@ class UserCommands extends DrushCommands {
     // the *local* machine.
     $alias = drush_get_context('DRUSH_TARGET_SITE_ALIAS');
     if (drush_sitealias_is_remote_site($alias)) {
-      $return = drush_invoke_process($alias, 'user-login', $name, drush_redispatch_get_options(), array('integrate' => FALSE));
+      $return = \Drush::call($alias, 'user-login', $options['name'], drush_redispatch_get_options(), array('integrate' => FALSE));
       if ($return['error_status']) {
         throw new \Exception('Unable to execute user login.');
       }


### PR DESCRIPTION
For now it wraps drush_invoke_process(). Should we change its signature? 

Inspired by https://laravel.com/docs/5.3/artisan#programmatically-executing-commands. That example doesn't require forking a new process - maybe we shouldn't either? How can we achieve same as Artisan::call(). Maybe the method in this PR should be `Drush::process()` and `Drush::call` comes later.