### PR TITLE
Fix the site list when a site is symlinked.

### DIFF
--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1441,7 +1441,7 @@ function _drush_find_local_sites_in_sites_folder($a_drupal_root) {
       // First we'll resolve the realpath of the settings.php file,
       // so that we get the correct drupal root when symlinks are in use.
       $real_sitedir = dirname(realpath($filename));
-      $real_root = drush_locate_root($filename);
+      $real_root = drush_locate_root($real_sitedir);
       if ($real_root !== FALSE) {
         $a_drupal_site = $real_root . '#' . basename($real_sitedir);
       }


### PR DESCRIPTION
- `$real_root= drush_locate_root($filename)` always return true even if the site directory is symlinked to a directory outside drupal root. This fixes cases where some sites are symlinked.
- For example: a site that is symlinked in the following manner `ls -l DRUPAL_ROOT/sites`  `vanilla -> ../../vanilla/src` where the target is a directory outside the drupal root, the function drush_locate_root return true we end up with a wrong alias.
- I think we should be using the real site directory (`$realsite_dir`) instead of the filename to properly build the `$site_list` for sites that are symlinked.  