### PR TITLE
Issue #1854: Allow uninstall of dependent modules.

### DIFF
--- a/commands/core/drupal/pm_8.inc
+++ b/commands/core/drupal/pm_8.inc
@@ -42,18 +42,6 @@ function _drush_pm_uninstall($extensions) {
       unset($extensions[$extension]);
       drush_log(dt('!extension is already uninstalled.', array('!extension' => $extension)), LogLevel::OK);
     }
-    elseif (drush_extension_get_type($extension_info[$extension]) == 'module') {
-      $dependents = array();
-      foreach (drush_module_dependents(array($extension), $extension_info) as $dependent) {
-        if (!in_array($dependent, $required) && ($extension_info[$dependent]->status)) {
-          $dependents[] = $dependent;
-        }
-      }
-      if (count($dependents)) {
-        drush_log(dt('To uninstall !extension, the following extensions must be uninstalled first: !required', array('!extension' => $extension, '!required' => implode(', ', $dependents))), LogLevel::ERROR);
-        unset($extensions[$extension]);
-      }
-    }
   }
 
   // Discard default theme.
@@ -87,4 +75,3 @@ function _drush_pm_uninstall($extensions) {
     drush_log(dt('!extension was successfully uninstalled.', array('!extension' => $extension)), LogLevel::OK);
   }
 }
-

--- a/commands/core/drupal/pm_8.inc
+++ b/commands/core/drupal/pm_8.inc
@@ -42,6 +42,15 @@ function _drush_pm_uninstall($extensions) {
       unset($extensions[$extension]);
       drush_log(dt('!extension is already uninstalled.', array('!extension' => $extension)), LogLevel::OK);
     }
+    elseif (drush_extension_get_type($extension_info[$extension]) == 'module') {
+      // Add installed dependencies to the list of modules to uninstall.
+      foreach (drush_module_dependents(array($extension), $extension_info) as $dependent) {
+        // Check if this dependency is not required, already enabled, and not already already in the list of modules to uninstall.
+        if (!in_array($dependent, $required) && ($extension_info[$dependent]->status) && !in_array($dependent, $extensions)) {
+          $extensions[] = $dependent;
+        }
+      }
+    }
   }
 
   // Discard default theme.

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -290,7 +290,7 @@ function pm_drush_command() {
   //     'description' => 'Download and enable one or more modules',
   //   );
   $items['pm-uninstall'] = array(
-    'description' => 'Uninstall one or more modules.',
+    'description' => 'Uninstall one or more modules and their dependent modules.',
     'arguments' => array(
       'modules' => 'A list of modules.',
     ),


### PR DESCRIPTION
Currently, there is no way to uninstall modules that depend on one another because Drush checks the dependency chain for each module individually, without considering any of the other modules you are uninstalling.

It's also counterintuitive that although Drupal's core ModuleInstaller::uninstall() function automatically uninstalls dependent modules, Drush (which ultimately just uses the same function) won't let you do the same thing.

Drush should automatically uninstall depending modules, same as core. I can't imagine a scenario where the current behavior is desired. The only argument I could imagine against this is that there's a small performance hit to computing the dependency chain... but we are already incurring that hit by not passing a second parameter to ModuleInstaller::uninstall().

This is a regression introduced by #925, which ostensibly had nothing to do with checking module dependencies.