### PR TITLE
Completion and Annotated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
     "pear/console_table": "~1.3.0",
     "phpdocumentor/reflection-docblock": "^2.0",
     "webmozart/path-util": "~2",
-    "sebastian/version": "~1"
+    "sebastian/version": "~1",
+    "stecman/symfony-console-completion": "^0.7.0"
   },
   "require-dev": {
     "lox/xhprof": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "546d303006c9073ab6f5238326b266e5",
+    "content-hash": "e341e5561b685a97a11d540235ea02fb",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -807,6 +807,51 @@
             "time": "2015-06-21T13:59:46+00:00"
         },
         {
+            "name": "stecman/symfony-console-completion",
+            "version": "0.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stecman/symfony-console-completion.git",
+                "reference": "5461d43e53092b3d3b9dbd9d999f2054730f4bbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stecman/symfony-console-completion/zipball/5461d43e53092b3d3b9dbd9d999f2054730f4bbb",
+                "reference": "5461d43e53092b3d3b9dbd9d999f2054730f4bbb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2",
+                "symfony/console": "~2.3 || ~3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stecman\\Component\\Symfony\\Console\\BashCompletion\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stephen Holdaway",
+                    "email": "stephen@stecman.co.nz"
+                }
+            ],
+            "description": "Automatic BASH completion for Symfony Console Component based applications.",
+            "time": "2016-02-24T05:08:54+00:00"
+        },
+        {
             "name": "symfony/config",
             "version": "v2.8.18",
             "source": {
@@ -1550,7 +1595,7 @@
                 "performance",
                 "profiling"
             ],
-            "time": "2015-08-31T22:07:48+00:00"
+            "time": "2015-08-31 22:07:48"
         },
         {
             "name": "phpspec/prophecy",

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -276,7 +276,7 @@ function drush_get_global_options($brief = FALSE) {
   $options['yes']                = array('short-form' => 'y', 'context' => 'DRUSH_AFFIRMATIVE', 'description' => "Assume 'yes' as answer to all prompts.");
   $options['no']                 = array('short-form' => 'n', 'context' => 'DRUSH_NEGATIVE', 'description' => "Assume 'no' as answer to all prompts.");
   $options['simulate']           = array('short-form' => 's', 'context' => 'DRUSH_SIMULATE', 'never-propagate' => TRUE, 'description' => "Simulate all relevant actions (don't actually change the system).", 'symfony-conflict' => TRUE);
-  $options['pipe']               = array('short-form' => 'p', 'hidden' => TRUE, 'description' => "Emit a compact representation of the command for scripting.");
+  // $options['pipe']               = array('short-form' => 'p', 'hidden' => TRUE, 'description' => "Emit a compact representation of the command for scripting.");
   $options['help']               = array('short-form' => 'h', 'description' => "This help system.");
 
   if (!$brief) {

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -204,6 +204,10 @@ function drush_preflight_prepare() {
   drush_init_annotation_commands($container);
   drush_init_application_global_options($container);
 
+  // Add completion command
+  $commandFileInstance = new \Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand();
+  drush_add_command_instance($container, $commandFileInstance);
+
   // Terminate immediately unless invoked as a command line script
   if (!drush_verify_cli()) {
     return drush_set_error('DRUSH_REQUIREMENTS_ERROR', dt('Drush is designed to run via the command line.'));


### PR DESCRIPTION
In 28f1adc, we work around the fact that Annotated command that provide global options (e.g. --notify, --druplicon) are not recognized by drush_get_global_options() and thus not offerred by our completion script.

I'm not sure it makes sense to distinguish global options from local anymore. Further, we should look at completion frameworks like https://github.com/bamarni/symfony-console-autocomplete (requires XML help) and https://github.com/stecman/symfony-console-completion