### PR TITLE
Fix issue #1314: drush core-requirements does not output descriptions in render arrays

### DIFF
--- a/commands/core/drupal/environment.inc
+++ b/commands/core/drupal/environment.inc
@@ -389,3 +389,21 @@ function drush_get_token($value = NULL) {
 function drush_url($path = NULL, array $options = array()) {
   return \Drupal\Core\Url::fromUserInput('/' . $path, $options)->toString();
 }
+
+/**
+ * Output a Drupal render array, object or string as plain text.
+ *
+ * @param string $data
+ *   Data to render.
+ *
+ * @return string
+ *   The plain-text representation of the input.
+ */
+function drush_render($data) {
+  if (is_array($data)) {
+    $data = \Drupal::service('renderer')->renderRoot($data);
+  }
+
+  $data = \Drupal\Core\Mail\MailFormatHelper::htmlToText($data);
+  return $data;
+}

--- a/lib/Drush/Commands/core/CoreCommands.php
+++ b/lib/Drush/Commands/core/CoreCommands.php
@@ -136,15 +136,7 @@ class CoreCommands extends DrushCommands {
       $i++;
     }
     $result = new RowsOfFields($rows);
-    $result->addRendererFunction([$this, 'renderCell']);
     return $result;
-  }
-
-  public function renderCell($key, $cellData, FormatterOptions $options) {
-    if ($key =='value') {
-      $cellData = strip_tags($cellData);
-    }
-    return $cellData;
   }
 
   /**

--- a/lib/Drush/Commands/core/CoreCommands.php
+++ b/lib/Drush/Commands/core/CoreCommands.php
@@ -126,7 +126,7 @@ class CoreCommands extends DrushCommands {
       $rows[$i] = [
         'title' => (string) $info['title'],
         'value' => (string) $info['value'],
-        'description' => (string) $info['description'],
+        'description' => drush_render($info['description']),
         'sid' => $severity,
         'severity' => @$severities[$severity]
       ];


### PR DESCRIPTION
Please review new PR following the resolution suggested by @greg-1-anderson in https://github.com/drush-ops/drush/pull/1315#issuecomment-126396642

FYI I couldn't find anyway to override @default-fields so had to temporarily edit the code.  The file http://api.drush.org/api/drush/commands%21core%21outputformat%21topics%21table.html/master suggests a --fields option but that gave me  Unknown option: --fields.

I would be interested in backport to 8.x and have done and tested code changes for that too.