### PR TITLE
Undefined property: DrushMakeProject_Library::$type make.project.inc:154

### DIFF
--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -61,6 +61,11 @@ class DrushMakeProject {
   protected $variant = 'profile-only';
 
   /**
+   * Type of downloaded project.
+   */
+  protected $type = 'core';
+
+  /**
    * Set attributes and retrieve project information.
    */
   protected function __construct($project) {
@@ -636,6 +641,12 @@ class DrushMakeProject_Core extends DrushMakeProject {
  * For processing libraries.
  */
 class DrushMakeProject_Library extends DrushMakeProject {
+
+  /**
+   * Override default project type.
+   */
+  protected $type = 'library';
+
   /**
    * Override constructor for libraries to properly set contrib destination.
    */
@@ -673,6 +684,12 @@ class DrushMakeProject_Library extends DrushMakeProject {
  * For processing modules.
  */
 class DrushMakeProject_Module extends DrushMakeProject {
+
+  /**
+   * Override default project type.
+   */
+  protected $type = 'module';
+
   /**
    * Override constructor for modules to properly set contrib destination.
    */
@@ -686,6 +703,12 @@ class DrushMakeProject_Module extends DrushMakeProject {
  * For processing installation profiles.
  */
 class DrushMakeProject_Profile extends DrushMakeProject {
+
+  /**
+   * Override default project type.
+   */
+  protected $type = 'profile';
+
   /**
    * Override contructor for installation profiles to properly set contrib
    * destination.
@@ -707,6 +730,12 @@ class DrushMakeProject_Profile extends DrushMakeProject {
  * For processing themes.
  */
 class DrushMakeProject_Theme extends DrushMakeProject {
+
+  /**
+   * Override default project type.
+   */
+  protected $type = 'theme';
+
   /**
    * Override contructor for themes to properly set contrib destination.
    */
@@ -720,6 +749,12 @@ class DrushMakeProject_Theme extends DrushMakeProject {
  * For processing translations.
  */
 class DrushMakeProject_Translation extends DrushMakeProject {
+
+  /**
+   * Override default project type.
+   */
+  protected $type = 'translation';
+
   /**
    * Override constructor for translations to properly set contrib destination.
    */


### PR DESCRIPTION
`DrushMakeProject` class does not define `type` property but uses it extensively throughout its methods. In most cases, there is no problem because `type` is set inside of class constructor from project definition array:

```
class DrushMakeProject {

  protected function __construct($project) {
    $project['base_contrib_destination'] = $project['contrib_destination'];
    foreach ($project as $key => $value) {
      $this->{$key} = $value;
    }
    // ... snip ...
  }
```

For modules and themes, the `type` key is always present in project definition because, even if it is not specified in the makefile, it will be added by `make_prepare_projects()` function:

```
  foreach ($info['projects'] as $key => $project) {
    // Merge the known data onto the project info.
    $project += array(
      'name'                => $key,
      'type'                => 'module',
      'core'                => $info['core'],

      // ... snip ..
```

But it is different for libraries - the `type` key is not added in `make_prepare_libraries()`:

```
    // Merge the known data onto the library info.
    $library += array(
      'name'                => $key,
      'core'                => $info['core'],
      'build_path'          => $build_path,
      'contrib_destination' => $contrib_destination,
      'subdir'              => '',
      'directory_name'      => $key,
      'make_directory'      => $make_dir,
    );
```

So, if a library does not have a specified version inside of a makefile, site administrators will get an `Undefined property` warning during execution of `drush make` command when `make_download_factory()` function is called in `commands/make/make.project.inc:154` with `$this->type` as a second argument.