### PR TITLE
Remove query string processing from D8 rs bootstrap

### DIFF
--- a/commands/runserver/d8-rs-router.php
+++ b/commands/runserver/d8-rs-router.php
@@ -17,9 +17,6 @@ if (file_exists('.' . $url['path'])) {
   return FALSE;
 }
 
-// Populate the "q" query key with the path, skip the leading slash.
-$_GET['q'] = $_REQUEST['q'] = substr($url['path'], 1);
-
 // We set the base_url so that Drupal generates correct URLs for runserver
 // (e.g. http://127.0.0.1:8888/...), but can still select and serve a specific
 // site in a multisite configuration (e.g. http://mysite.com/...).


### PR DESCRIPTION
Related issue: https://www.drupal.org/node/2850280

ping @Berdir: D8 takes care of path processing right? Drush should not longer preprocess the incoming request.