### PR TITLE
Provide progress reporting during config-import

### DIFF
--- a/lib/Drush/Commands/config/ConfigImportCommands.php
+++ b/lib/Drush/Commands/config/ConfigImportCommands.php
@@ -119,7 +119,20 @@ class ConfigImportCommands extends DrushCommands implements CustomEventAwareInte
     }
     else{
       try {
-        $config_importer->import();
+        // This is the contents of \Drupal\Core\Config\ConfigImporter::import.
+        // Copied here so we can log progress.
+        if ($config_importer->hasUnprocessedConfigurationChanges()) {
+          $sync_steps = $config_importer->initialize();
+          foreach ($sync_steps as $step) {
+            $context = array();
+            do {
+              $config_importer->doSyncStep($step, $context);
+              if (isset($context['message'])) {
+                $this->logger()->notice((string) $context['message']);
+              }
+            } while ($context['finished'] < 1);
+          }
+        }
         $this->logger()->success('The configuration was imported successfully.');
       }
       catch (ConfigException $e) {

--- a/lib/Drush/Commands/config/ConfigImportCommands.php
+++ b/lib/Drush/Commands/config/ConfigImportCommands.php
@@ -128,7 +128,7 @@ class ConfigImportCommands extends DrushCommands implements CustomEventAwareInte
             do {
               $config_importer->doSyncStep($step, $context);
               if (isset($context['message'])) {
-                $this->logger()->notice((string) $context['message']);
+                $this->logger()->notice(str_replace('Synchronizing', 'Synchronized', (string)$context['message']));
               }
             } while ($context['finished'] < 1);
           }


### PR DESCRIPTION
Adds a notice for each operation during sync. Unfortunately, the notice is shown after the operation completes and the message is not easily customized. An example:

```
Collection  Config                 Operation                
             core.date_format.long  update 
             core.extension         update 
             dblog.settings         update
Import the listed configuration changes? (y/n): y
 [notice] Synchronizing extensions: install options.
 [notice] Synchronizing extensions: install aggregator.
 [notice] Synchronizing extensions: uninstall ban.
 [notice] Synchronizing configuration: update core.date_format.long.
 [notice] Synchronizing configuration: update core.extension.
 [notice] Synchronizing configuration: update dblog.settings.
 [notice] Finalizing configuration synchronization.
 [success] The configuration was imported successfully.
```