### PR TITLE
Better feedback for failing SSH commands.

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1163,7 +1163,7 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
   if (isset($hostname)) {
     $username = (isset($username)) ? drush_escapeshellarg($username, "LOCAL") . "@" : '';
     $ssh_options = $site_record['ssh-options'];
-    $ssh_options = (isset($ssh_options)) ? $ssh_options : drush_get_option('ssh-options', "-o PasswordAuthentication=no");
+    $ssh_options = (isset($ssh_options)) ? $ssh_options : drush_get_option('ssh-options', "-o PasswordAuthentication=no -o ConnectTimeout=10");
 
     $ssh_cmd[] = "ssh";
     $ssh_cmd[] = $ssh_options;

--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1021,6 +1021,9 @@ function _drush_backend_invoke($cmds, $common_backend_options = array(), $contex
       }
 
       $result_code = drush_shell_proc_open($exec_cmd);
+      if ($result_code > 0) {
+        drush_print(dt('Command returned error code !code, this could indicate a problem with SSH.', array('!code' => $result_code)));
+      }
       $ret = array('error_status' => $result_code);
     }
   }


### PR DESCRIPTION
If you are running Drush commands on a remote host and SSH fails for any reason (say, because you forgot to spin up your DrupalVM or Vagrant Box, or the remote host is unavailable), you have to wait two minutes to find out that there's anything wrong, and then Drush silently exits with no indication of any error. Needless to say, this is a pretty bad UX and causes a lot of confusion and issue churn (just search the issue queue for "SSH").

This is a fairly simple solution. It's a little tricky to determine if a failed command is due to a problem with SSH or something else, so it's possible that this could produce false positives. If we want to make it more selective, we could just check for an error_status of 255, which indicates SSH failed to connect. And maybe verify that SSH was actually used to call the command. Let me know where you want to go with it.