### PR TITLE
Fix post updates cannot be run

### DIFF
--- a/lib/Drush/Commands/core/UpdateDBCommands.php
+++ b/lib/Drush/Commands/core/UpdateDBCommands.php
@@ -308,6 +308,7 @@ class UpdateDBCommands extends DrushCommands {
       'init_message' => 'Starting updates',
       'error_message' => 'An unrecoverable error has occurred. You can find the error message below. It is advised to copy it to the clipboard for reference.',
       'finished' => [$this, 'drush_update_finished'],
+      'file' => 'core/includes/update.inc',
     );
     batch_set($batch);
     \Drupal::service('state')->set('system.maintenance_mode', TRUE);


### PR DESCRIPTION
I don't have this problem in 8.1.9 put when I updated to dev-master locally I had
```bash
[warning] call_user_func_array() expects parameter 1 to be a valid callback, function 'update_invoke_post_update' not found or invalid function name batch.inc:232
```
all over my shell when running `drush updb` if it included any post updates. This fixes it.

Note there are a bunch of manual includes of `update.inc` in `UpdateDBCommands`, but I *think* they are all still valid as they are not related to the batch, but I am not 100% sure.