### PR TITLE
Fix issue #2611: Use the Drupal UpdateKernel when running updates

### DIFF
--- a/lib/Drush/Boot/BaseBoot.php
+++ b/lib/Drush/Boot/BaseBoot.php
@@ -62,6 +62,10 @@ abstract class BaseBoot implements Boot, LoggerAwareInterface {
           $command += $this->command_defaults();
           // Insure that we have bootstrapped to a high enough
           // phase for the command prior to enforcing requirements.
+          if ($command['command'] == 'updatedb-batch-process') {
+            global $drupal_update;
+            $drupal_update = TRUE;
+          }
           $bootstrap_result = drush_bootstrap_to_phase($command['bootstrap']);
           $this->enforce_requirement($command);
 

--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -6,7 +6,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Psr\Log\LoggerInterface;
 use Drupal\Core\DrupalKernel;
+use Drupal\Core\Update\UpdateKernel;
 use Drush\Drupal\DrupalKernel as DrushDrupalKernel;
+use Drush\Drupal\DrupalUpdateKernel as DrushDrupalUpdateKernel;
 use Drush\Drupal\DrushServiceModfier;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -118,15 +120,26 @@ class DrupalBoot8 extends DrupalBoot {
   }
 
   function bootstrap_drupal_configuration() {
+    global $drupal_update;
     $this->request = Request::createFromGlobals();
     $classloader = drush_drupal_load_autoloader(DRUPAL_ROOT);
     // @todo - use Request::create() and then no need to set PHP superglobals
     $kernelClass = new \ReflectionClass('\Drupal\Core\DrupalKernel');
     if ($kernelClass->hasMethod('addServiceModifier')) {
-      $this->kernel = DrupalKernel::createFromRequest($this->request, $classloader, 'prod', DRUPAL_ROOT);
+      if (!$drupal_update) {
+        $this->kernel = DrupalKernel::createFromRequest($this->request, $classloader, 'prod');
+      }
+      else {
+        $this->kernel = UpdateKernel::createFromRequest($this->request, $classloader, 'prod');
+      }
     }
     else {
-      $this->kernel = DrushDrupalKernel::createFromRequest($this->request, $classloader, 'prod', DRUPAL_ROOT);
+      if (!$drupal_update) {
+        $this->kernel = DrushDrupalKernel::createFromRequest($this->request, $classloader, 'prod');
+      }
+      else {
+        $this->kernel = DrushDrupalUpdateKernel::createFromRequest($this->request, $classloader, 'prod');
+      }
     }
     // @see Drush\Drupal\DrupalKernel::addServiceModifier()
     $this->kernel->addServiceModifier(new DrushServiceModfier());

--- a/lib/Drush/Commands/core/UpdateDBCommands.php
+++ b/lib/Drush/Commands/core/UpdateDBCommands.php
@@ -184,6 +184,9 @@ class UpdateDBCommands extends DrushCommands {
   }
 
   function updateMain($options) {
+    global $drupal_update;
+    $drupal_update = TRUE;
+
     // In D8, we expect to be in full bootstrap.
     drush_bootstrap_to_phase(DRUSH_BOOTSTRAP_DRUPAL_FULL);
 

--- a/lib/Drush/Drupal/DrupalUpdateKernel.php
+++ b/lib/Drush/Drupal/DrupalUpdateKernel.php
@@ -1,0 +1,46 @@
+<?php
+namespace Drush\Drupal;
+
+use Drush\Log\LogLevel;
+use Drupal\Core\Update\UpdateKernel;
+use Symfony\Component\HttpFoundation\Request;
+use Drupal\Core\DependencyInjection\ServiceModifierInterface;
+
+class DrupalUpdateKernel extends UpdateKernel {
+  /** @var ServiceModifierInterface[] */
+  protected $serviceModifiers = [];
+
+  /**
+   * @inheritdoc
+   */
+  public static function createFromRequest(Request $request, $class_loader, $environment, $allow_dumping = TRUE, $app_root = NULL) {
+    drush_log(dt("Create from request"), LogLevel::DEBUG);
+    $kernel = new static($environment, $class_loader, $allow_dumping);
+    static::bootEnvironment();
+    $kernel->initializeSettings($request);
+    return $kernel;
+  }
+
+  /**
+   * Add a service modifier to the container builder.
+   *
+   * The container is not compiled until $kernel->boot(), so there is a chance
+   * for clients to add compiler passes et. al. before then.
+   */
+  public function addServiceModifier(ServiceModifierInterface $serviceModifier) {
+    drush_log(dt("add service modifier"), LogLevel::DEBUG);
+    $this->serviceModifiers[] = $serviceModifier;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected function getContainerBuilder() {
+    drush_log(dt("get container builder"), LogLevel::DEBUG);
+    $container = parent::getContainerBuilder();
+    foreach ($this->serviceModifiers as $serviceModifier) {
+      $serviceModifier->alter($container);
+    }
+    return $container;
+  }
+}


### PR DESCRIPTION
This is a "clone" of the pull request https://github.com/drush-ops/drush/pull/2612 as I've messed up my drush fork ... Sorry about this...

Unfortunately I am not familiar with the Drush architecture, but the following code is sufficient in order to use the Drupal UpdateKernel during executing updates through drush. Please review it and probably adjust it as needed.