### PR TITLE
Fix issue #2622: Update the timestamps of files and directories of git checkouts to the latest commit timestamp during make

### DIFF
--- a/commands/make/make.download.inc
+++ b/commands/make/make.download.inc
@@ -353,6 +353,10 @@ function make_download_git($name, $type, $download, $download_location) {
     chdir($cwd);
   }
 
+  // Set the timestamps of files and directories to the latest commit timestamp
+  // of the git checkout directory.
+  drush_update_git_checkout_timestamps($tmp_location);
+
   // Move the directory into the final resting location.
   drush_copy_dir($tmp_location, $download_location, FILE_EXISTS_OVERWRITE);
 

--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -745,5 +745,40 @@ function drush_is_nested_directory($base_dir, $test_is_nested) {
 }
 
 /**
+ * Updates the timestamps of files and directories to the date of the latest
+ * commit.
+ *
+ * We have to perform this action when we are downloading project files from
+ * git during make in order to ensure that files in git checkouts of the same
+ * revision will always have the same timestamps otherwise syncing project
+ * files will always have to take update actions e.g. update the timestamps of
+ * the files.
+ * We use the timestamp of the latest commit of the git checkout directory for
+ * all the files and the directories, as retrieving the latest commit for each
+ * file and directory is slow.
+ *
+ * @param $git_checkout_dir
+ *   The git checkout directory.
+ */
+function drush_update_git_checkout_timestamps($git_checkout_dir) {
+  // Get the current directory (so we can move back later).
+  $cwd = getcwd();
+  // Change into the working copy of the cloned repo.
+  chdir($git_checkout_dir);
+
+  $latest_commit_timestamp = (int) exec('git log -1 --pretty=format:%ct');
+  $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($git_checkout_dir));
+  foreach($iterator as $path) {
+    // Skip updating timestamps of parent directories.
+    if ($path->isFile() || ($path->getFilename() == '.')) {
+      touch($path->getPathname(), $latest_commit_timestamp);
+    }
+  }
+
+  // Move back to last current directory (first line).
+  chdir($cwd);
+}
+
+/**
  * @} End of "defgroup filesystemfunctions".
  */


### PR DESCRIPTION
Instead of leaving the timestamps of files and directories to the current time set the timestamps to the timestamp of the latest git commit from the cloned git repository.