### PR TITLE
Adjust 'site-install' command for better use in Continuous Integration

### DIFF
--- a/lib/Drush/Commands/core/SiteInstallCommands.php
+++ b/lib/Drush/Commands/core/SiteInstallCommands.php
@@ -27,7 +27,6 @@ class SiteInstallCommands extends DrushCommands {
    * @option site-mail From: for system mailings. Defaults to admin@example.com
    * @option sites-subdir Name of directory under 'sites' which should be created. Only needed when the subdirectory does not already exist. Defaults to 'default'
    * @option config-dir A path pointing to a full set of configuration which should be imported after installation.
-   * @option show-passwords Show uid1 account and password once installation completes. Defaults to 'false' if --account-pass is provided.
    * @usage drush site-install expert --locale=uk
    *   (Re)install using the expert install profile. Set default language to Ukrainian.
    * @usage drush site-install --db-url=mysql://root:pass@localhost:port/dbname
@@ -145,11 +144,6 @@ class SiteInstallCommands extends DrushCommands {
    */
   public function post($result, CommandData $commandData) {
     if ($config = $commandData->input()->getOption('config-dir')) {
-      // Skip config import with a warning if specified config dir is empty.
-      if (!$this->hasConfigFiles($config)) {
-        $this->logger()->warning(dt('Configuration import directory @config does not contain any configuration; skipping import.', ['@config' => $config]));
-        return;
-      }
       // Set the destination site UUID to match the source UUID, to bypass a core fail-safe.
       $source_storage = new FileStorage($config);
       $options = ['yes' => TRUE];
@@ -185,6 +179,11 @@ class SiteInstallCommands extends DrushCommands {
       }
       if (!is_dir($config)) {
         throw new \Exception('The config source is not a directory.');
+      }
+      // Skip config import with a warning if specified config dir is empty.
+      if (!$this->hasConfigFiles($config)) {
+        $this->logger()->warning(dt('Configuration import directory @config does not contain any configuration; will skip import.', ['@config' => $config]));
+        $commandData->input()->setOption('config-dir', '');
       }
     }
 


### PR DESCRIPTION
This PR makes two behavior changes to the site-install command to improve its usability with Continuous Integration servers.

## Hide account password

If the CI server creates a Drupal site that persists after the test suite runs, then it is undesirable to have the uid1 password visible in the test logs. With this PR:

- The account password is by default hidden if it is provided on the commandline. Usually, users will not need to know the password if they already explicitly specified what it should be. If a CI script stores the account password in an environment variable, then it may be passed via `drush si --account-pass=$PASS` without exposing the value in the CI logs.
- The option `--show-passwords` / `--show-passwords=0` is available to override the default.

## Make empty --config-dir a warning

Currently, `drush site-install --config-dir=../config` will fail if the configuration directory is empty.

Use case: in a Drupal site template that includes CI scripts to test Drupal, it is desirable to import the configuration files if they are available.  If the template does not handle this automatically, then the user must know where in the script to add the `--config-dir` option once they have exported their configuration. With this change, the template may simply include --config-dir, and everything will start working correctly once the configuration has been exported. Without this change, the template file could still effect this same behavior by conditionally providing `--config-dir`, but the cost is more conditionals in the CI script.