### PR TITLE
Use annotated-command cache.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "league/container": "~2",
     "consolidation/robo": "~1",
     "symfony/config": "~2.2",
-    "consolidation/annotated-command": "^2",
+    "consolidation/annotated-command": "^2.4.2",
     "consolidation/output-formatters": "~3",
     "symfony/yaml": "~2.3",
     "symfony/var-dumper": "~2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b5e8481bf5d4e2f11f67f1d715e2eb3",
+    "content-hash": "50ed907c8fba42728e7444e68ff82f95",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "2.4.1",
+            "version": "2.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "81512473b0ac36747b87db2513f4771d9483a78d"
+                "reference": "ccff73e46582a885ce4bb2c57bbd8ba4415dbd24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/81512473b0ac36747b87db2513f4771d9483a78d",
-                "reference": "81512473b0ac36747b87db2513f4771d9483a78d",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/ccff73e46582a885ce4bb2c57bbd8ba4415dbd24",
+                "reference": "ccff73e46582a885ce4bb2c57bbd8ba4415dbd24",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2017-02-13T21:12:55+00:00"
+            "time": "2017-02-27T18:29:21+00:00"
         },
         {
             "name": "consolidation/log",
@@ -1725,25 +1725,30 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1765,20 +1770,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12T18:03:57+00:00"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.9",
+            "version": "1.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
+                "reference": "284fb0679dd25fb5ffb56dad92c72860c0a22f1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/284fb0679dd25fb5ffb56dad92c72860c0a22f1b",
+                "reference": "284fb0679dd25fb5ffb56dad92c72860c0a22f1b",
                 "shasum": ""
             },
             "require": {
@@ -1814,7 +1819,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15T14:06:22+00:00"
+            "time": "2017-02-23T06:14:45+00:00"
         },
         {
             "name": "phpunit/phpunit",

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -6,6 +6,7 @@
  */
 
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Drush\Cache\CommandCache;
 use Drush\Log\LogLevel;
 use League\Container\Container;
 use Robo\Contract\BuilderAwareInterface;
@@ -296,14 +297,21 @@ function drush_init_dependency_injection_container($input = null, $output = null
   \Drush::setContainer($container);
   \Robo\Robo::setContainer($container);
 
+
+
   // Add our own callback to the hook manager
   $hookManager = $container->get('hookManager');
   $hookManager->addOutputExtractor(new Drush\Backend\BackendResultSetter());
   // @todo: do we need both backend result setters? The one below should be removed at some point.
   $hookManager->add('annotatedcomand_adapter_backend_result', HookManager::EXTRACT_OUTPUT);
 
+  // Install our command cache into the command factory
+  $cacheBackend = _drush_cache_get_object('factory');
+  $commandCacheDataStore = new CommandCache($cacheBackend);
+
   $factory = $container->get('commandFactory');
   $factory->setIncludeAllPublicMethods(false);
+  $factory->setDataStore($commandCacheDataStore);
 
   // It is necessary to set the dispatcher when using configureContainer
   $eventDispatcher = $container->get('eventDispatcher');
@@ -312,7 +320,6 @@ function drush_init_dependency_injection_container($input = null, $output = null
 
   return $container;
 }
-
 
 // TODO: Where should this go?
 function drush_init_application_global_options($container) {
@@ -399,7 +406,6 @@ function drush_add_command_instance($container, $commandInstance, $includeAllPub
 function drush_create_commands_from_command_instance($container, $commandInstance, $includeAllPublicMethods = true) {
   $application = $container->get('application');
   $commandFactory = $container->get('commandFactory');
-  $commandFactory->setIncludeAllPublicMethods(false);
   $commandList = $commandFactory->createCommandsFromClass($commandInstance, $includeAllPublicMethods);
   foreach ($commandList as $command) {
     drush_add_command_to_application($container, $command);

--- a/src/Cache/CommandCache.php
+++ b/src/Cache/CommandCache.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drush\Cache;
+
+use Consolidation\AnnotatedCommand\Cache\SimpleCacheInterface;
+
+/**
+ * Command cache implementation.
+ *
+ * This wrapper implements a cache usable with the annotated-command
+ * library's command cache. It uses a Drush JSONCache for its back-end.
+ */
+class CommandCache implements SimpleCacheInterface {
+
+    protected $cacheBackend;
+
+    public function __construct(CacheInterface $cacheBackend) {
+        $this->cacheBackend = $cacheBackend;
+    }
+
+    /**
+     * Test for an entry from the cache
+     * @param string $key
+     * @return boolean
+     */
+    public function has($key) {
+        $cacheItem = $this->cacheBackend->get($key);
+        return $this->valid($cacheItem);
+    }
+    /**
+     * Get an entry from the cache
+     * @param string $key
+     * @return array
+     */
+    public function get($key) {
+        $cacheItem = $this->cacheBackend->get($key);
+        if (!$this->valid($cacheItem)) {
+            return [];
+        }
+        // TODO: FileCache::get() should just return the
+        // data element, not the entire cacheItem. Then we
+        // could make it implement SimpleCacheInterface & do
+        // away with this adapter class.
+        return $cacheItem->data;
+    }
+    /**
+     * Store an entry in the cache
+     * @param string $key
+     * @param array $data
+     */
+    public function set($key, $data) {
+        $this->cacheBackend->set($key, $data);
+    }
+
+    protected function valid($cacheItem) {
+        return is_object($cacheItem) && isset($cacheItem->data);
+    }
+}

--- a/src/Commands/core/CacheCommands.php
+++ b/src/Commands/core/CacheCommands.php
@@ -271,6 +271,7 @@ class CacheCommands extends DrushCommands implements CustomEventAwareInterface {
   static function clearDrush() {
     drush_cache_clear_all(NULL, 'default'); // commandfiles, etc.
     drush_cache_clear_all(NULL, 'complete'); // completion
+    drush_cache_clear_all(NULL, 'factory'); // command info from annotated-command library
     // Release XML. We don't clear tarballs since those never change.
     $matches = drush_scan_directory(drush_directory_cache('download'), "/^https---updates.drupal.org-release-history/", array('.', '..'));
     array_map('unlink', array_keys($matches));

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -43,7 +43,7 @@ class SiteInstallCommands extends DrushCommands {
    * @aliases si
    *
    */
-  public function install($profile, array $additional, $options = ['db-url' => NULL, 'db-prefix' => NULL, 'db-su' => NULL, 'db-su-pw' => NULL, 'account-name' => 'admin', 'account-mail' => 'admin@example.com', 'account-pass' => NULL, 'locale' => 'en', 'site-name' => 'Drush Site-Install', 'site-pass' => NULL, 'sites-subdir' => NULL, 'config-dir' => NULL, 'show-passwords' => NULL]) {
+  public function install($profile, array $additional, $options = ['db-url' => NULL, 'db-prefix' => NULL, 'db-su' => NULL, 'db-su-pw' => NULL, 'account-name' => 'admin', 'account-mail' => 'admin@example.com', 'site-mail' => 'admin@example.com', 'account-pass' => NULL, 'locale' => 'en', 'site-name' => 'Drush Site-Install', 'site-pass' => NULL, 'sites-subdir' => NULL, 'config-dir' => NULL, 'show-passwords' => NULL]) {
     $form_options = [];
     foreach ((array)$additional as $arg) {
       list($key, $value) = explode('=', $arg, 2);


### PR DESCRIPTION
In my testing, this seems to save about 0.02s when using Drush core commandfiles. The difference for Terminus was much greater, though, so I think it really depends on what sort of code you have in your commandfiles.

This cache code does a good job at noticing when methods are added or removed from a commandfile, so there's not much downside to using it. There could be some potential upside if some external commandfiles contain more complicated implementations that take longer to parse.

Fixed #2608.