### PR TITLE
Test against stable Drupal and highest Drupal (8.4.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,30 +23,22 @@ sudo: false
 
 env:
   matrix:
-#D8
     - PHPUNIT_ARGS=--group=base
     - PHPUNIT_ARGS=--group=commands
     - PHPUNIT_ARGS=--exclude-group=base,commands
     - COMPOSER=composer-highest.json PHPUNIT_ARGS=--group=base
     - COMPOSER=composer-highest.json PHPUNIT_ARGS=--group=commands
     - COMPOSER=composer-highest.json PHPUNIT_ARGS=--exclude-group=base,commands
-
-    # - UNISH_DB_URL=sqlite://none/of/this/matters PHPUNIT_ARGS=--group=base
-    # - UNISH_DB_URL=sqlite://none/of/this/matters PHPUNIT_ARGS=--group=commands
-    # - UNISH_DB_URL=sqlite://none/of/this/matters PHPUNIT_ARGS=--group=pm
-    # - UNISH_DB_URL=sqlite://none/of/this/matters PHPUNIT_ARGS=--group=quick-drupal
-    # - UNISH_DB_URL=sqlite://none/of/this/matters PHPUNIT_ARGS=--exclude-group=base,commands,pm,quick-drupal
-    # - UNISH_DB_URL=pgsql://postgres:@localhost PHPUNIT_ARGS=--group=base
-    # - UNISH_DB_URL=pgsql://postgres:@localhost PHPUNIT_ARGS=--group=commands
-    # - UNISH_DB_URL=pgsql://postgres:@localhost PHPUNIT_ARGS=--group=pm
-    # - UNISH_DB_URL=pgsql://postgres:@localhost PHPUNIT_ARGS=--group=quick-drupal
-    # - UNISH_DB_URL=pgsql://postgres:@localhost PHPUNIT_ARGS=--exclude-group=base,commands,pm,quick-drupal
   global:
     # Github deploy
     - secure: VfYokT2CchfuBRJp9/gSwfVGPfsVfkZdDVEuNWEqxww3z4vq+5aLKqoCtPL54E5EIMjhyCE3GVo+biG35Gab1KOVgUs8zD1hAUWA1FPKfMFhoPDfI3ZJC2rX2T1iWK4ZR90pBtcPzS+2OObzTYz8go0PfeSTT6eq69Na1KcNLaE=
     - UNISH_NO_TIMEOUTS=y
     - UNISH_DB_URL=mysql://root:@127.0.0.1
     - UNISH_TMP=/tmp
+
+matrix:
+  allow_failures:
+    - env: COMPOSER=composer-highest.json
 
 before_install:
   - echo 'mbstring.http_input = pass' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ env:
 #D8
     - PHPUNIT_ARGS=--group=base
     - PHPUNIT_ARGS=--group=commands
-    - PHPUNIT_ARGS=--group=pm
-    - PHPUNIT_ARGS=--exclude-group=base,commands,pm TEST_CHILDREN="drush-ops/config-extra"
+    - PHPUNIT_ARGS=--exclude-group=base,commands
+    - COMPOSER=composer-highest.json PHPUNIT_ARGS=--group=base
+    - COMPOSER=composer-highest.json PHPUNIT_ARGS=--group=commands
+    - COMPOSER=composer-highest.json PHPUNIT_ARGS=--exclude-group=base,commands
 
     # - UNISH_DB_URL=sqlite://none/of/this/matters PHPUNIT_ARGS=--group=base
     # - UNISH_DB_URL=sqlite://none/of/this/matters PHPUNIT_ARGS=--group=commands

--- a/tests/resources/codebase/composer-highest.json
+++ b/tests/resources/codebase/composer-highest.json
@@ -15,11 +15,11 @@
   ],
   "require": {
     "composer/installers": "^1.2",
-    "cweagans/composer-patches": "~1.0",
-    "drupal/core": "8.4.x",
-    "drush/drush": "*",
-    "phpunit/phpunit": "4.*",
-    "drupal/empty_theme": "1.0",
+    "cweagans/composer-patches": "~1.6",
+    "drupal/core": "8.4.x-dev",
+    "drush/drush": "*@dev",
+    "phpunit/phpunit": "^4.1",
+    "drupal/empty_theme": "^1.0",
     "drupal/devel": "^1.0@RC",
     "lox/xhprof": "dev-master"
   },

--- a/tests/resources/codebase/composer-highest.json
+++ b/tests/resources/codebase/composer-highest.json
@@ -36,9 +36,6 @@
       "web/themes/contrib/{$name}": ["type:drupal-theme"],
       "drush/contrib/{$name}": ["type:drupal-drush"]
     },
-    "patches": {
-      "drupal/core": {
-        "Update Symfony components to ~3.2 (https://www.drupal.org/node/2712647)": "https://www.drupal.org/files/issues/update_symfony-2712647-333.patch"
-      },
+    "patches": {}
   }
 }

--- a/tests/resources/codebase/composer-highest.json
+++ b/tests/resources/codebase/composer-highest.json
@@ -1,0 +1,44 @@
+{
+  "name": "Site Under Test",
+  "repositories": [
+    {
+      "type": "path",
+      "url": "%PATH-TO-DRUSH%",
+      "options": {
+        "symlink": true
+      }
+    },
+    {
+      "type": "composer",
+      "url": "https://packages.drupal.org/8"
+    }
+  ],
+  "require": {
+    "composer/installers": "^1.2",
+    "cweagans/composer-patches": "~1.0",
+    "drupal/core": "dev-8.4.x",
+    "drush/drush": "*",
+    "phpunit/phpunit": "4.*",
+    "drupal/empty_theme": "1.0",
+    "drupal/devel": "^1.0@RC",
+    "lox/xhprof": "dev-master"
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "extra": {
+    "installer-paths": {
+      "web/core": ["type:drupal-core"],
+      "web/libraries/{$name}": ["type:drupal-library"],
+      "web/modules/unish/{$name}": ["drupal/devel"],
+      "web/themes/unish/{$name}": ["drupal/empty_theme"],
+      "web/modules/contrib/{$name}": ["type:drupal-module"],
+      "web/profiles/contrib/{$name}": ["type:drupal-profile"],
+      "web/themes/contrib/{$name}": ["type:drupal-theme"],
+      "drush/contrib/{$name}": ["type:drupal-drush"]
+    },
+    "patches": {
+      "drupal/core": {
+        "Update Symfony components to ~3.2 (https://www.drupal.org/node/2712647)": "https://www.drupal.org/files/issues/update_symfony-2712647-333.patch"
+      },
+  }
+}

--- a/tests/resources/codebase/composer-highest.json
+++ b/tests/resources/codebase/composer-highest.json
@@ -16,7 +16,7 @@
   "require": {
     "composer/installers": "^1.2",
     "cweagans/composer-patches": "~1.0",
-    "drupal/core": "dev-8.4.x",
+    "drupal/core": "8.4.x",
     "drush/drush": "*",
     "phpunit/phpunit": "4.*",
     "drupal/empty_theme": "1.0",

--- a/unish.sut.php
+++ b/unish.sut.php
@@ -31,7 +31,8 @@ function unish_setup_sut($unish_sandbox) {
   drush_delete_dir($working_dir, TRUE);
   $codebase = 'tests/resources/codebase';
   drush_copy_dir($codebase, $working_dir);
-  foreach (['composer.json', 'composer.lock'] as $filename) {
+  $composer_json = getenv('COMPOSER') ?: 'composer.json';
+  foreach ([$composer_json] as $filename) {
     $path = $working_dir . "/$filename";
     if (file_exists($path)) {
       $contents = file_get_contents($path);
@@ -40,9 +41,14 @@ function unish_setup_sut($unish_sandbox) {
     }
   }
 
-  // We also need to put back the %PATH-TO-DRUSH% token by hand or automatically.
-  // For option parsing, see built-in getopt() function.
-  $cmd = 'composer install --no-interaction --no-progress --no-suggest --working-dir ' . escapeshellarg($working_dir);
+  // getopt() is awkward
+  $verbose = NULL;
+  foreach (['-v','-vv','-vvv','--verbose'] as $needle) {
+    if (in_array($needle, $_SERVER['argv'])) {
+      $verbose = $needle;
+    }
+  }
+  $cmd = "composer $verbose install --no-interaction --no-progress --no-suggest --working-dir " . escapeshellarg($working_dir);
   fwrite(STDERR, 'Executing: ' . $cmd . "\n");
   exec($cmd, $output, $return);
 

--- a/unish.sut.php
+++ b/unish.sut.php
@@ -39,14 +39,14 @@ function unish_setup_sut($unish_sandbox) {
       file_put_contents($path, $new_contents);
     }
   }
-  // @todo Call update instead of install if specified on the CLI. Useful need we need to update composer.lock.
+
   // We also need to put back the %PATH-TO-DRUSH% token by hand or automatically.
   // For option parsing, see built-in getopt() function.
   $cmd = 'composer install --no-interaction --no-progress --no-suggest --working-dir ' . escapeshellarg($working_dir);
   fwrite(STDERR, 'Executing: ' . $cmd . "\n");
   exec($cmd, $output, $return);
 
-  // @todo Not 100% sure this is needed, but I've seen Composer download a second Drush, instead of symlink.
+  // If requirements force it to, Composer downloads a second Drush, instead of symlink.
   $drush_sut = $working_dir . '/vendor/drush/drush';
   if (!is_link($drush_sut)) {
     fwrite(STDERR, "Drush not symlinked in the System-Under-Test.\n");

--- a/unish.sut.php
+++ b/unish.sut.php
@@ -18,35 +18,11 @@ function unish_validate() {
     fwrite(STDERR, 'The drush directory must end in /drush in order to run the tests. This is due to the "path" repository in tests/resources/composer.json');
     exit(1);
   }
-
-  /**
-   * Assure that the composer.lock and the composer.json in the /tests directory
-   * are in sync.
-   *
-   * Based on http://stackoverflow.com/a/28730898/265501.
-   *
-   * @todo. Not sure this is feasible since multiple authors will update the lockfile from different path/to/drush.
-   */
-//  $codebase = __DIR__ . '/tests/resources/codebase';
-//  // If composer.lock is missing then no need for this check.
-//  $lockfile = $codebase . '/composer.lock';
-//  if (file_exists($lockfile)) {
-//    $lock = json_decode(file_get_contents($lockfile))->{'content-hash'};
-//    $json = md5(replace_token(file_get_contents($codebase . '/composer.json')));
-//
-//    if ($lock !== $json) {
-//      fwrite(STDERR, "$lockfile file out of sync with its composer.json.\n");
-//      exit(1);
-//    }
-//
-//    fwrite(STDERR, "$lockfile file up to date with its composer.json.\n");
-//    exit(0);
-//  }
 }
 
 /**
  * Use Composer to build a Drupal codebase, with this Drush symlinked into /vendor.
- * @param $unish_sandbox Path to sandbox.
+ * @param string $unish_sandbox Path to sandbox.
  * @return integer
  *   Exit code.
  */


### PR DESCRIPTION
Expand our test matrix to test against very modern Drupal. Builds against Drual 8.4.x are marked as 'allowed failures' in Travis in order to not perturb Drush development. The failures will be in the Travis logs for interested parties to fix.