### PR TITLE
Don\'t add profile dependencies to required_by array of modules

### DIFF
--- a/commands/core/drupal/environment.inc
+++ b/commands/core/drupal/environment.inc
@@ -23,8 +23,20 @@ use Drupal\Core\Logger\RfcLogLevel;
  */
 function drush_get_modules($include_hidden = TRUE) {
   $modules = system_rebuild_module_data();
+  if (\Drupal::hasService('profile_handler')) {
+    // #1356276 adds the profile_handler service but it hasn't been committed
+    // to core yet so we need to check if it exists.
+    $profiles = \Drupal::service('profile_handler')->getProfiles();
+  }
+  else {
+    $profiles[drupal_get_profile()] = [];
+  }
 
   foreach ($modules as $key => $module) {
+    // Profiles don't count as real dependents.
+    if (!empty($module->required_by)) {
+      $module->required_by = array_diff_key($module->required_by, $profiles);
+    }
     if ((!$include_hidden) && (!empty($module->info['hidden']))) {
       unset($modules[$key]);
     }


### PR DESCRIPTION
Using the patch in [D.O Issue#1356276](https://www.drupal.org/node/1356276), it's possible for more than one profile to be installed. Dependencies of profiles have never prevented a module from being uninstalled, but the logic used in pm-uninstall only makes that exception for the active profile.

This patch completely removes profiles from the `required_by` key in the modules list provided by `drush_get_modules()`. If the patch in D.O Issue#1356276 is applied, it uses the `profile_handler` service to get an array of installed modules. Otherwise, it uses `drupal_get_profile()` to emulate that behavior.