### PR TITLE
Update batch cache flush

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -287,7 +287,7 @@ class UpdateDBCommands extends DrushCommands {
     // Apply post update hooks.
     $post_updates = \Drupal::service('update.post_update_registry')->getPendingUpdateFunctions();
     if ($post_updates) {
-      $operations[] = [[$this, 'cacheRebuild'], []];
+      $operations[] = 'drupal_flush_all_caches';
       foreach ($post_updates as $function) {
         $operations[] = ['update_invoke_post_update', [$function]];
       }


### PR DESCRIPTION
The batch uses drush_update_cache_rebuild() whereas core via the UI uses drupal_flush_all_caches().

This causes reproducible bugs, steps to reproduce:

1. git co 8.1.1
2. composer install
3. drush si minimal
4. drush en hal config -y
5. drush config-edit rest.settings and change the link_domain - it actually not important but it is what I did.
6. git co 8.3.0
7. composer install
8. drush updatedb -y
9. BOOM
