### PR TITLE
Fix bug in updatedb

### DIFF
--- a/commands/core/drupal/update.inc
+++ b/commands/core/drupal/update.inc
@@ -231,7 +231,7 @@ function drush_update_batch() {
   // Apply post update hooks.
   $post_updates = \Drupal::service('update.post_update_registry')->getPendingUpdateFunctions();
   if ($post_updates) {
-    $operations[] = ['drush_update_cache_rebuild', []];
+    $operations[] = ['drupal_flush_all_caches', []];
     foreach ($post_updates as $function) {
       $operations[] = ['update_invoke_post_update', [$function]];
     }


### PR DESCRIPTION
The batch uses drush_update_cache_rebuild() whereas core via the UI uses drupal_flush_all_caches().

This causes reproducible bugs, steps to reproduce:

1. git co 8.1.1
2. composer install
3. drush si minimal
4. drush en hal config -y
5. drush config-edit rest.settings and change the link_domain - it actually not important but it is what I did.
6. git co 8.3.0
7. composer install
8. drush updatedb -y
9. BOOM