### PR TITLE
Issue #2709: Fixed non-reporting of config-import errors.

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -688,7 +688,12 @@ function _drush_config_import(StorageComparer $storage_comparer) {
           } while ($context['finished'] < 1);
         }
       }
-      drush_log('The configuration was imported successfully.', LogLevel::SUCCESS);
+      if ($config_importer->getErrors()) {
+        throw new \Drupal\Core\Config\ConfigException('Errors occurred during import');
+      }
+      else {
+        drush_log('The configuration was imported successfully.', LogLevel::SUCCESS);
+      }
     }
     catch (ConfigException $e) {
       // Return a negative result for UI purposes. We do not differentiate


### PR DESCRIPTION
Fixes (at least partially) #2709 

If an error occurs during config import, Drupal will catch it internally and then clear the exception so that the import proceeds gracefully: http://cgit.drupalcode.org/drupal/tree/core/lib/Drupal/Core/Config/ConfigImporter.php#n762

This means that Drush can't assume that an import was successful just because an import finished without throwing an exception. It must check if any errors were reported.