### PR TITLE
Deduplicate the langcode to avoid a message repetition.

### DIFF
--- a/commands/core/locale.d8.drush.inc
+++ b/commands/core/locale.d8.drush.inc
@@ -89,6 +89,10 @@ function drush_locale_update() {
     // @todo Not selecting any language code in the user interface results in
     //   all translations being updated, so we mimick that behavior here.
   }
+  // Deduplicate the list of langcodes since each project may have added the
+  // same language several times.
+  $langcodes = array_unique($langcodes);
+
   // @todo Restricting by projects is not possible in the user interface and is
   //   broken when attempting to do it in a hook_form_alter() implementation so
   //   we do not allow for it here either.


### PR DESCRIPTION
When `drush locale-update` is run without any new translation to import, the following output may occur. This example is based on a 8.2.x core with a site installed in french and running with drush 8.1.10:
```
Traduction de mollom vérifiée.                              [ok]
Traduction de mollom vérifiée.                              [ok]
... x10
Traduction de paragraphs vérifiée.                          [ok]
Traduction de paragraphs vérifiée.                          [ok]
Traduction de paragraphs vérifiée.                          [ok]
Traduction de paragraphs vérifiée.                          [ok]
Traduction de paragraphs vérifiée.                          [ok]
... x10                                                                                                                                                                 [ok]
Traduction de pathauto vérifiée.                            [ok]
Traduction de pathauto vérifiée.                            [ok]
...
```

The command output may be totaly empty instead of showing the quoted output.

The strings are repeated as many times as `locale_translation_get_status()` returns projects.

After applying the fix from the PR, here is the new output (no more duplication):
```
Traduction de devel vérifiée.                          [ok]
Traduction de drupal vérifiée.                          [ok]
Traduction de embed vérifiée.                          [ok]
Traduction de entity vérifiée.                          [ok]
Traduction de entity_browser vérifiée.                          [ok]
```