### PR TITLE
Update core-cli command to use new command list

### DIFF
--- a/src/Drupal/Commands/core/CliCommands.php
+++ b/src/Drupal/Commands/core/CliCommands.php
@@ -82,7 +82,6 @@ class CliCommands extends DrushCommands {
    */
   protected function getDrushCommands() {
     $application = \Drush::getApplication();
-    //annotation_adapter_add_legacy_commands_to_application($application);
     $commands = $application->all();
 
     $ignored_commands = ['help', 'drush-psysh', 'php-eval', 'core-cli', 'php'];

--- a/src/Psysh/DrushCommand.php
+++ b/src/Psysh/DrushCommand.php
@@ -9,10 +9,9 @@
 
 namespace Drush\Psysh;
 
+use Consolidation\AnnotatedCommand\AnnotatedCommand;
 use Psy\Command\Command as BaseCommand;
 use Symfony\Component\Console\Formatter\OutputFormatter;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -22,43 +21,27 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DrushCommand extends BaseCommand {
 
   /**
-   * @var array
+   * @var \Consolidation\AnnotatedCommand\AnnotatedCommand
    */
-  private $config;
-
-  /**
-   * @var string
-   */
-  private $category = '';
+  private $command;
 
   /**
    * DrushCommand constructor.
    *
-   * This accepts the Drush command configuration array and does a pretty
-   * decent job of building a PsySH command proxy for it. Wheee!
-   *
-   * @param array $config
-   *   Drush command configuration array.
+   * @param \Consolidation\AnnotatedCommand\AnnotatedCommand $command
+   *   Original (annotated) Drush command.
    */
-  public function __construct(array $config) {
-    $this->config = $config;
+  public function __construct(AnnotatedCommand $command) {
+    $this->command = $command;
     parent::__construct();
   }
 
   /**
-   * Get Category of this command.
+   * Get the namespace of this command.
    */
-  public function getCategory() {
-    return $this->category;
-  }
-
-  /**
-   * Sets the category title.
-   *
-   * @param string $category_title
-   */
-  public function setCategory($category_title) {
-    $this->category = $category_title;
+  public function getNamespace() {
+    $parts = explode('-', $this->getName());
+    return count($parts) >= 2 ? array_shift($parts) : 'global';
   }
 
   /**
@@ -66,11 +49,11 @@ class DrushCommand extends BaseCommand {
    */
   protected function configure() {
     $this
-      ->setName($this->config['command'])
-      ->setAliases($this->buildAliasesFromConfig())
-      ->setDefinition($this->buildDefinitionFromConfig())
-      ->setDescription($this->config['description'])
-      ->setHelp($this->buildHelpFromConfig());
+      ->setName($this->command->getName())
+      ->setAliases($this->command->getAliases())
+      ->setDefinition($this->command->getDefinition())
+      ->setDescription($this->command->getDescription())
+      ->setHelp($this->buildHelpFromCommand());
   }
 
   /**
@@ -112,102 +95,6 @@ class DrushCommand extends BaseCommand {
   }
 
   /**
-   * Extract Drush command aliases from config array.
-   *
-   * @return array
-   *   The command aliases.
-   */
-  protected function buildAliasesFromConfig() {
-    return !empty($this->config['aliases']) ? $this->config['aliases'] : [];
-  }
-
-  /**
-   * Build a command definition from Drush command configuration array.
-   *
-   * Currently, adds all non-hidden arguments and options, and makes a decent
-   * effort to guess whether an option accepts a value or not. It isn't always
-   * right :P
-   *
-   * @return array
-   *   the command definition.
-   */
-  protected function buildDefinitionFromConfig() {
-    $definitions = [];
-
-    if (isset($this->config['arguments']) && !empty($this->config['arguments'])) {
-      $required_args = $this->config['required-arguments'];
-
-      if ($required_args === FALSE) {
-        $required_args = 0;
-      }
-      elseif ($required_args === TRUE) {
-        $required_args = count($this->config['arguments']);
-      }
-
-      foreach ($this->config['arguments'] as $name => $argument) {
-        if (!is_array($argument)) {
-          $argument = ['description' => $argument];
-        }
-
-        if (!empty($argument['hidden'])) {
-          continue;
-        }
-
-        $input_type = ($required_args-- > 0) ? InputArgument::REQUIRED : InputArgument::OPTIONAL;
-
-        $definitions[] = new InputArgument($name, $input_type, $argument['description'], NULL);
-      }
-    }
-
-    // First create all global options.
-    $options = $this->config['options'] + drush_get_global_options();
-
-    // Add command specific options.
-    $definitions = array_merge($definitions, $this->createInputOptionsFromConfig($options));
-
-    return $definitions;
-  }
-
-  /**
-   * Creates input definitions from command options.
-   *
-   * @param array $options_config
-   *
-   * @return \Symfony\Component\Console\Input\InputInterface[]
-   */
-  protected function createInputOptionsFromConfig(array $options_config) {
-    $definitions = [];
-
-    foreach ($options_config as $name => $option) {
-      // Some commands will conflict.
-      if (in_array($name, ['help', 'command'])) {
-        continue;
-      }
-
-      if (!is_array($option)) {
-        $option = ['description' => $option];
-      }
-
-      if (!empty($option['hidden'])) {
-        continue;
-      }
-
-      // @todo: Figure out if there's a way to detect InputOption::VALUE_NONE
-      // (i.e. flags) via the config array.
-      if (isset($option['value']) && $option['value'] === 'required') {
-        $input_type = InputOption::VALUE_REQUIRED;
-      }
-      else {
-        $input_type = InputOption::VALUE_OPTIONAL;
-      }
-
-      $definitions[] = new InputOption($name, !empty($option['short-form']) ? $option['short-form'] : '', $input_type, $option['description']);
-    }
-
-    return $definitions;
-  }
-
-  /**
    * Build a command help from the Drush configuration array.
    *
    * Currently it's a word-wrapped description, plus any examples provided.
@@ -215,11 +102,11 @@ class DrushCommand extends BaseCommand {
    * @return string
    *   The help string.
    */
-  protected function buildHelpFromConfig() {
-    $help = wordwrap($this->config['description']);
+  protected function buildHelpFromCommand() {
+    $help = wordwrap($this->command->getDescription());
 
     $examples = [];
-    foreach ($this->config['examples'] as $ex => $def) {
+    foreach ($this->command->getExampleUsages() as $ex => $def) {
       // Skip empty examples and things with obvious pipes...
       if (($ex === '') || (strpos($ex, '|') !== FALSE)) {
         continue;

--- a/src/Psysh/DrushHelpCommand.php
+++ b/src/Psysh/DrushHelpCommand.php
@@ -26,7 +26,7 @@ class DrushHelpCommand extends BaseCommand {
   /**
    * Label for PsySH commands.
    */
-  const PSYSH_CATEGORY = 'PsySH commands';
+  const PSYSH_CATEGORY = 'PsySH';
 
   /**
    * The currently set subcommand.
@@ -71,7 +71,7 @@ class DrushHelpCommand extends BaseCommand {
       $output->page($this->getApplication()->get($name)->asText());
     }
     else {
-      $categories = [];
+      $namespaces = [];
 
       // List available commands.
       $commands = $this->getApplication()->all();
@@ -95,27 +95,29 @@ class DrushHelpCommand extends BaseCommand {
           $aliases = '';
         }
 
+        $namespace = '';
         if ($command instanceof DrushCommand) {
-          $category = (string) $command->getCategory();
-        }
-        else {
-          $category = static::PSYSH_CATEGORY;
+          $namespace = $command->getNamespace();
         }
 
-        if (!isset($categories[$category])) {
-          $categories[$category] = [];
+        if (empty($namespace)) {
+          $namespace = static::PSYSH_CATEGORY;
         }
 
-        $categories[$category][] = sprintf("    <info>%-${width}s</info> %s%s", $name, $command->getDescription(), $aliases);
+        if (!isset($namespaces[$namespace])) {
+          $namespaces[$namespace] = [];
+        }
+
+        $namespaces[$namespace][] = sprintf("    <info>%-${width}s</info> %s%s", $name, $command->getDescription(), $aliases);
       }
 
       $messages = [];
 
-      foreach ($categories as $name => $category) {
+      foreach ($namespaces as $namespace => $command_messages) {
         $messages[] = '';
-        $messages[] = sprintf('<comment>%s</comment>', OutputFormatter::escape($name));
-        foreach ($category as $message) {
-          $messages[] = $message;
+        $messages[] = sprintf('<comment>%s</comment>', OutputFormatter::escape($namespace));
+        foreach ($command_messages as $command_message) {
+          $messages[] = $command_message;
         }
       }
 


### PR DESCRIPTION
See https://github.com/drush-ops/drush/issues/2728

We can remove quite a bit of code that was needed before to convert the drush command config arrays into input options etc.. now we already have those object on the original commands, which is nice :)