### PR TITLE
Include improved-wrap PR from output-formatter project.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "consolidation/robo": "~1",
     "symfony/config": "~2.2|^3",
     "consolidation/annotated-command": "dev-master",
-    "consolidation/output-formatters": "dev-master",
+    "consolidation/output-formatters": "dev-improved-wrap",
     "symfony/yaml": "~2.3|^3",
     "symfony/var-dumper": "~2.7|^3",
     "symfony/console": "~2.7|^3",


### PR DESCRIPTION
Addresses #2603 (partially).

Note that the output from `drush list` and `drush help` are not being processed by the word wrapper at all at the moment, even with this PR. However, other table output should be wrapped much better with this version.