### PR TITLE
info files with "refname 'HEAD' is ambiguous"

### DIFF
--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -391,7 +391,7 @@ class DrushMakeProject {
       }
     }
     require_once dirname(__FILE__) . '/../pm/pm.drush.inc';
-    if (drush_shell_cd_and_exec($this->download_location, 'git log -1 --pretty=format:%ct')) {
+    if (drush_shell_cd_and_exec($this->download_location, 'git log -1 --pretty=format:%ct 2>/dev/null')) {
       $output = drush_shell_exec_output();
       $datestamp = $output[0];
     }


### PR DESCRIPTION
In certain cases, the following can be added to info files by Drush:

datestamp = "warning: refname 'HEAD' is ambiguous."

datestamp should be an integer. This is a fix.

To reproduce the problem, use drush make to build a makefile which references a repository containing a tag "HEAD". The error is because tag "HEAD" is the same as Git's use of HEAD to indicate the current position. 