### PR TITLE
Let generators define destination generated code

### DIFF
--- a/src/Commands/generate/Helper/InputPreprocessor.php
+++ b/src/Commands/generate/Helper/InputPreprocessor.php
@@ -35,42 +35,16 @@ class InputPreprocessor extends Helper
             $questions['name'][1] = false;
         }
 
-        /** @var \Symfony\Component\Console\Command\Command $command */
+        if (!isset($questions['machine_name'])) {
+            return;
+        }
+
+        /** @var \DrupalCodeGenerator\Command\GeneratorInterface $command */
         $command = $this->getHelperSet()->getCommand();
-        $command_name = $command->getName();
-
-        $excluded = [
-            'module-configuration-entity',
-            'module-content-entity',
-            'module-plugin-manager',
-            'module-standard',
-            'theme-standard',
-            'settings-local',
-            'yml-theme-info',
-            'yml-module-info',
-        ];
-        if (in_array($command_name, $excluded)) {
-            return;
-        }
-
-        // Theme related generators (only one so far).
-        if ($command_name == 'theme-file') {
-            $themes = [];
-            foreach (\Drupal::service('theme_handler')->listInfo() as $machine_name => $theme) {
-                $themes[$machine_name] = $theme->info['name'];
-            }
-            $questions['name'][3] = array_values($themes);
-            $questions['machine_name'][1] = function ($vars) use ($themes) {
-                $machine_name = array_search($vars['name'], $themes);
-                return $machine_name ?: Utils::human2machine($vars['name']);
-            };
-            $questions['machine_name'][3] = array_keys($themes);
-
-            return;
-        }
+        $destination = $command->getDestination();
 
         // Module related generators.
-        if (isset($questions['machine_name'])) {
+        if ($destination == 'modules/%') {
             $modules = [];
             // @todo - For better UX, match on both labels and machine names.
             $moduleHandler = \Drupal::moduleHandler();
@@ -90,6 +64,18 @@ class InputPreprocessor extends Helper
                 // Only machine name exists.
                 $questions['machine_name'][1] = 'example';
             }
+        // Theme related generators.
+        } elseif ($destination == 'themes/%') {
+            $themes = [];
+            foreach (\Drupal::service('theme_handler')->listInfo() as $machine_name => $theme) {
+                $themes[$machine_name] = $theme->info['name'];
+            }
+            $questions['name'][3] = array_values($themes);
+            $questions['machine_name'][1] = function ($vars) use ($themes) {
+                $machine_name = array_search($vars['name'], $themes);
+                return $machine_name ?: Utils::human2machine($vars['name']);
+            };
+            $questions['machine_name'][3] = array_keys($themes);
         }
     }
 }

--- a/src/Commands/generate/Helper/InputPreprocessor.php
+++ b/src/Commands/generate/Helper/InputPreprocessor.php
@@ -32,7 +32,7 @@ class InputPreprocessor extends Helper
 
         if (isset($questions['name'])) {
             // @todo Pick up default name from current working directory when possible.
-            $questions['name'][1] = false;
+            $questions['name'][1] = '';
         }
 
         if (!isset($questions['machine_name'])) {


### PR DESCRIPTION
**Problem:**
At the moment both input handler and input preprocessor rely on hardcoded mapping of DCG generator names.
https://github.com/drush-ops/drush/blob/master/src/Commands/generate/Helper/InputHandler.php#L29
https://github.com/drush-ops/drush/blob/master/src/Commands/generate/Helper/InputPreprocessor.php#L40

There are two major problem with this approach.

1. The mapping has to be synchronized with DCG. For example if DCG gets new theme generator, Drush generate may not be able to handle it automatically. Currently for all unknown generators we assume that if a generator asks for [machine name](https://github.com/drush-ops/drush/blob/master/src/Commands/generate/Helper/InputHandler.php#L56) the generated code can be stored to existing module. This is too optimistic.

2. Third party generators has no such mapping at all. So that they can only provide code for existing modules.


**Solution:**
Generators should be able to define destination for the generated code themselves. I've just [added](https://github.com/Chi-teck/drupal-code-generator/blob/master/src/Command/GeneratorInterface.php#L40) a way that can help helpers get clue about generated code.



