### PR TITLE
Attempt Drupal 8.4.x support in Drush 8.x via the global Drush

### DIFF
--- a/commands/sql/sqlsync.drush.inc
+++ b/commands/sql/sqlsync.drush.inc
@@ -1,7 +1,7 @@
 <?php
 
 use Drush\Log\LogLevel;
-use Webmozart\PathUtil\Path;
+use Drush\Webmozart\PathUtil\Path;
 
 /**
  * Implementation of hook_drush_command().

--- a/composer.json
+++ b/composer.json
@@ -55,20 +55,9 @@
       "ext-pcntl": "*",
       "drush/config-extra": "Provides configuration workflow commands, such as config-merge."
   },
-  "autoload": {
-    "psr-0": {
-      "Drush":        "lib/",
-      "Consolidation": "lib/"
-    }
-  },
   "autoload-dev": {
     "psr-0": {
       "Unish":        "tests/"
-    }
-  },
-  "extra": {
-    "branch-alias": {
-        "dev-master": "8.0.x-dev"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,7 @@
     "symfony/event-dispatcher": "~2.7",
     "symfony/finder": "~2.7",
     "pear/console_table": "~1.3.0",
-    "phpdocumentor/reflection-docblock": "^2.0",
-    "webmozart/path-util": "~2"
+    "phpdocumentor/reflection-docblock": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,33 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b11f17ceeea1d5ea00c9978089edd2dd",
-    "content-hash": "78cd17858c047b08f7a77f5b188755cf",
+    "content-hash": "0ca37468ce6c7fe322d1736f4631d52d",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "2.2.2",
+            "version": "2.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "1f1d92807f72901e049e9df048b412c3bc3652c9"
+                "reference": "6672ea38212f8bffb71fec7eadc8b3372154b17e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/1f1d92807f72901e049e9df048b412c3bc3652c9",
-                "reference": "1f1d92807f72901e049e9df048b412c3bc3652c9",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/6672ea38212f8bffb71fec7eadc8b3372154b17e",
+                "reference": "6672ea38212f8bffb71fec7eadc8b3372154b17e",
                 "shasum": ""
             },
             "require": {
                 "consolidation/output-formatters": "^3.1.5",
                 "php": ">=5.4.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "psr/log": "~1",
+                "psr/log": "^1",
                 "symfony/console": "^2.8|~3",
-                "symfony/event-dispatcher": "^2.5|~3",
-                "symfony/finder": "^2.5|~3"
+                "symfony/event-dispatcher": "^2.5|^3",
+                "symfony/finder": "^2.5|^3"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*",
+                "phpunit/phpunit": "^4.8",
                 "satooshi/php-coveralls": "^1.0",
                 "squizlabs/php_codesniffer": "^2.7"
             },
@@ -57,37 +56,37 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2016-12-16 01:23:33"
+            "time": "2017-04-03T22:37:00+00:00"
         },
         {
             "name": "consolidation/output-formatters",
-            "version": "3.1.5",
+            "version": "3.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "cc821a08b7bd89511038aa081625cb5b573960f6"
+                "reference": "2e09069866bae89d3fb545365f997a40745e34d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/cc821a08b7bd89511038aa081625cb5b573960f6",
-                "reference": "cc821a08b7bd89511038aa081625cb5b573960f6",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/2e09069866bae89d3fb545365f997a40745e34d2",
+                "reference": "2e09069866bae89d3fb545365f997a40745e34d2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "symfony/console": "~2.5|~3.0",
-                "symfony/finder": "~2.5|~3.0",
-                "victorjonsson/markdowndocs": "^1.3"
+                "symfony/console": "^2.8|~3",
+                "symfony/finder": "~2.5|~3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*",
+                "phpunit/phpunit": "^4.8",
                 "satooshi/php-coveralls": "^1.0",
-                "squizlabs/php_codesniffer": "2.*"
+                "squizlabs/php_codesniffer": "^2.7",
+                "victorjonsson/markdowndocs": "^1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
@@ -106,7 +105,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2016-11-23 23:10:13"
+            "time": "2017-05-08T15:59:33+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -139,7 +138,7 @@
                 "MIT"
             ],
             "description": "implementation of xdg base directory specification for php",
-            "time": "2014-10-24 07:27:01"
+            "time": "2014-10-24T07:27:01+00:00"
         },
         {
             "name": "jakub-onderka/php-console-color",
@@ -182,7 +181,7 @@
                     "homepage": "http://www.acci.cz"
                 }
             ],
-            "time": "2014-04-08 15:00:19"
+            "time": "2014-04-08T15:00:19+00:00"
         },
         {
             "name": "jakub-onderka/php-console-highlighter",
@@ -226,7 +225,7 @@
                     "homepage": "http://www.acci.cz/"
                 }
             ],
-            "time": "2015-04-20 18:58:01"
+            "time": "2015-04-20T18:58:01+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -277,7 +276,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2016-09-16 12:04:44"
+            "time": "2016-09-16T12:04:44+00:00"
         },
         {
             "name": "pear/console_table",
@@ -332,20 +331,20 @@
             "keywords": [
                 "console"
             ],
-            "time": "2016-01-21 16:14:31"
+            "time": "2016-01-21T16:14:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
                 "shasum": ""
             },
             "require": {
@@ -381,7 +380,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2016-01-25T08:17:30+00:00"
         },
         {
             "name": "psr/log",
@@ -428,20 +427,20 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "psy/psysh",
-            "version": "v0.8.0",
+            "version": "v0.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "4a8860e13aa68a4bbf2476c014f8a1f14f1bf991"
+                "reference": "38a9d21406597a0440690eafbcb0222f528c8ac6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4a8860e13aa68a4bbf2476c014f8a1f14f1bf991",
-                "reference": "4a8860e13aa68a4bbf2476c014f8a1f14f1bf991",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/38a9d21406597a0440690eafbcb0222f528c8ac6",
+                "reference": "38a9d21406597a0440690eafbcb0222f528c8ac6",
                 "shasum": ""
             },
             "require": {
@@ -471,7 +470,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-develop": "0.8.x-dev"
+                    "dev-develop": "0.9.x-dev"
                 }
             },
             "autoload": {
@@ -501,25 +500,25 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2016-12-07 17:15:07"
+            "time": "2017-05-17T06:49:19+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.15",
+            "version": "v2.8.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d5643cd095e5e37d31e004bb2606b5dd7e96602f"
+                "reference": "efa4d466b67c2fc9bf9419a981e683e1f99fa029"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d5643cd095e5e37d31e004bb2606b5dd7e96602f",
-                "reference": "d5643cd095e5e37d31e004bb2606b5dd7e96602f",
+                "url": "https://api.github.com/repos/symfony/console/zipball/efa4d466b67c2fc9bf9419a981e683e1f99fa029",
+                "reference": "efa4d466b67c2fc9bf9419a981e683e1f99fa029",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
-                "symfony/debug": "~2.7,>=2.7.2|~3.0.0",
+                "symfony/debug": "^2.7.2|~3.0.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
@@ -562,20 +561,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-06 11:59:35"
+            "time": "2017-05-28T14:07:33+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.15",
+            "version": "v2.8.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "62a68f640456f6761d752c62d81631428ef0d8a1"
+                "reference": "344f50ce827413b3640bfcb1e37386a67d06ea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/62a68f640456f6761d752c62d81631428ef0d8a1",
-                "reference": "62a68f640456f6761d752c62d81631428ef0d8a1",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/344f50ce827413b3640bfcb1e37386a67d06ea1f",
+                "reference": "344f50ce827413b3640bfcb1e37386a67d06ea1f",
                 "shasum": ""
             },
             "require": {
@@ -587,7 +586,7 @@
             },
             "require-dev": {
                 "symfony/class-loader": "~2.2|~3.0.0",
-                "symfony/http-kernel": "~2.3.24|~2.5.9|~2.6,>=2.6.2|~3.0.0"
+                "symfony/http-kernel": "~2.3.24|~2.5.9|^2.6.2|~3.0.0"
             },
             "type": "library",
             "extra": {
@@ -619,20 +618,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-15 12:53:17"
+            "time": "2017-04-19T19:56:30+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.15",
+            "version": "v2.8.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934"
+                "reference": "7fc8e2b4118ff316550596357325dfd92a51f531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
-                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7fc8e2b4118ff316550596357325dfd92a51f531",
+                "reference": "7fc8e2b4118ff316550596357325dfd92a51f531",
                 "shasum": ""
             },
             "require": {
@@ -640,7 +639,7 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/config": "^2.0.5|~3.0.0",
                 "symfony/dependency-injection": "~2.6|~3.0.0",
                 "symfony/expression-language": "~2.6|~3.0.0",
                 "symfony/stopwatch": "~2.3|~3.0.0"
@@ -679,20 +678,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-13 01:43:15"
+            "time": "2017-04-26T16:56:54+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.15",
+            "version": "v2.8.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "c0f10576335743b881ac1ed39d18c0fa66048775"
+                "reference": "b058a6f0cb6ee9b6b727aae03d5a62474a308528"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/c0f10576335743b881ac1ed39d18c0fa66048775",
-                "reference": "c0f10576335743b881ac1ed39d18c0fa66048775",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/b058a6f0cb6ee9b6b727aae03d5a62474a308528",
+                "reference": "b058a6f0cb6ee9b6b727aae03d5a62474a308528",
                 "shasum": ""
             },
             "require": {
@@ -728,7 +727,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-13 09:38:12"
+            "time": "2017-05-25T22:57:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -787,30 +786,35 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v2.8.15",
+            "version": "v2.8.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "873e692cdc3ed80ab3c1d6404b087ce396dd4acc"
+                "reference": "168bc7f6bd19c45b3d509db3a46d132fd155beb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/873e692cdc3ed80ab3c1d6404b087ce396dd4acc",
-                "reference": "873e692cdc3ed80ab3c1d6404b087ce396dd4acc",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/168bc7f6bd19c45b3d509db3a46d132fd155beb9",
+                "reference": "168bc7f6bd19c45b3d509db3a46d132fd155beb9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
                 "symfony/polyfill-mbstring": "~1.0"
             },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
             "require-dev": {
+                "ext-iconv": "*",
                 "twig/twig": "~1.20|~2.0"
             },
             "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
                 "ext-symfony_debug": ""
             },
             "type": "library",
@@ -850,20 +854,20 @@
                 "debug",
                 "dump"
             ],
-            "time": "2016-12-06 16:05:07"
+            "time": "2017-05-15T11:59:37+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.15",
+            "version": "v2.8.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff"
+                "reference": "93ccdde79f4b079c7558da4656a3cb1c50c68e02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/befb26a3713c97af90d25dd12e75621ef14d91ff",
-                "reference": "befb26a3713c97af90d25dd12e75621ef14d91ff",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/93ccdde79f4b079c7558da4656a3cb1c50c68e02",
+                "reference": "93ccdde79f4b079c7558da4656a3cb1c50c68e02",
                 "shasum": ""
             },
             "require": {
@@ -899,144 +903,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-14 16:15:57"
-        },
-        {
-            "name": "victorjonsson/markdowndocs",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/victorjonsson/PHP-Markdown-Documentation-Generator.git",
-                "reference": "fdd561fb706d506445c30c2d04f4fcfef601d85a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/victorjonsson/PHP-Markdown-Documentation-Generator/zipball/fdd561fb706d506445c30c2d04f4fcfef601d85a",
-                "reference": "fdd561fb706d506445c30c2d04f4fcfef601d85a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2",
-                "symfony/console": ">=2.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "3.7.23"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "PHPDocsMD": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Victor Jonsson",
-                    "email": "kontakt@victorjonsson.se"
-                }
-            ],
-            "description": "Command line tool for generating markdown-formatted class documentation",
-            "homepage": "https://github.com/victorjonsson/PHP-Markdown-Documentation-Generator",
-            "time": "2016-02-11 22:12:12"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23 20:04:58"
-        },
-        {
-            "name": "webmozart/path-util",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/path-util.git",
-                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
-                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "webmozart/assert": "~1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\PathUtil\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
-            "time": "2015-12-17 08:42:14"
+            "time": "2017-05-01T14:31:55+00:00"
         }
     ],
     "packages-dev": [
@@ -1092,31 +959,31 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.2",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
-                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0|^2.0"
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0",
+                "phpspec/phpspec": "^2.5|^3.2",
                 "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
@@ -1155,7 +1022,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1217,7 +1084,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1264,7 +1131,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1305,29 +1172,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1349,20 +1221,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.9",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
-                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
                 "shasum": ""
             },
             "require": {
@@ -1398,20 +1270,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.31",
+            "version": "4.8.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3"
+                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
-                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/791b1a67c25af50e230f841ee7a9c6eba507dc87",
+                "reference": "791b1a67c25af50e230f841ee7a9c6eba507dc87",
                 "shasum": ""
             },
             "require": {
@@ -1470,7 +1342,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-09 02:45:31"
+            "time": "2017-02-06T05:18:07+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1526,20 +1398,20 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.2",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
@@ -1590,27 +1462,27 @@
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-19 09:18:40"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -1642,7 +1514,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1692,7 +1564,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1759,7 +1631,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1810,20 +1682,20 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
                 "shasum": ""
             },
             "require": {
@@ -1863,7 +1735,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1898,20 +1770,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.22",
+            "version": "v2.7.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "7ac22a73485e6ae5bf8f072d01daf5563efe9b17"
+                "reference": "ace466e63d3c7ccc30057fefc95f67c049357806"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/7ac22a73485e6ae5bf8f072d01daf5563efe9b17",
-                "reference": "7ac22a73485e6ae5bf8f072d01daf5563efe9b17",
+                "url": "https://api.github.com/repos/symfony/process/zipball/ace466e63d3c7ccc30057fefc95f67c049357806",
+                "reference": "ace466e63d3c7ccc30057fefc95f67c049357806",
                 "shasum": ""
             },
             "require": {
@@ -1947,7 +1819,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-21 09:47:03"
+            "time": "2017-04-12T07:39:27+00:00"
         }
     ],
     "aliases": [],

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1,7 +1,7 @@
 <?php
 
 use Drush\Log\LogLevel;
-use Webmozart\PathUtil\Path;
+use Drush\Webmozart\PathUtil\Path;
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Drush\Command\DrushInputAdapter;
 use Drush\Command\DrushOutputAdapter;

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -1225,6 +1225,7 @@ function drush_commands_categorize($commands) {
 }
 
 function drush_command_defaults($key, $commandfile, $path) {
+  //debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
   $defaults =  array(
     'command' => $key,
     'command-hook' => $key,
@@ -1997,6 +1998,8 @@ function drush_shell_alias_replace($target_site_alias) {
 
 function commandfiles_cache() {
   static $commandfiles_cache = NULL;
+
+  //debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
   if (!isset($commandfiles_cache)) {
     $commandfiles_cache = new Drush\Command\Commandfiles();

--- a/includes/context.inc
+++ b/includes/context.inc
@@ -157,10 +157,10 @@ function drush_load_config_file($context, $config_list) {
   foreach ((array)$config_list as $config) {
     if (file_exists($config)) {
       $options = $aliases = $command_specific = $override = array();
-      drush_log(dt('Loading drushrc "!config" into "!context" scope.', array('!config' => realpath($config), '!context' => $context)), LogLevel::BOOTSTRAP);
+      drush_log(dt('Loading drushrc "!config" into "!context" scope.', array('!config' => realpath($config), '!context' => $context)), 'bootstrap'); // LogLevel::BOOTSTRAP
       $ret = @include_once($config);
       if ($ret === FALSE) {
-        drush_log(dt('Cannot open drushrc "!config", ignoring.', array('!config' => realpath($config))), LogLevel::WARNING);
+        drush_log(dt('Cannot open drushrc "!config", ignoring.', array('!config' => realpath($config))), 'warning'); // LogLevel::WARNING
         return FALSE;
       }
       if (!empty($options) || !empty($aliases) || !empty($command_specific) || !empty($override)) {
@@ -198,7 +198,7 @@ function drush_set_config_options($context, $options, $override = array()) {
  * array that use the short form into the long form.
  */
 function drush_expand_short_form_options(&$options) {
-  foreach (drush_get_global_options() as $name => $info) {
+  foreach (drush_get_standard_global_options() as $name => $info) {
     if (is_array($info)) {
       // For any option with a short form, check to see if the short form was set in the
       // options.  If it was, then rename it to its long form.
@@ -240,7 +240,7 @@ function drush_set_config_special_contexts(&$options) {
     // Expand -s into --simulate, etc.
     drush_expand_short_form_options($options);
 
-    foreach (drush_get_global_options() as $name => $info) {
+    foreach (drush_get_standard_global_options() as $name => $info) {
       if (is_array($info)) {
         // For any global option with the 'merge-pathlist' or 'merge-associative' flag, set its
         // value in the specified context.  The option is 'merged' because we

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -230,45 +230,12 @@ function drush_flatten_array($a) {
 }
 
 /**
- * Get the available global options. Used by help command. Command files may
- * modify this list using hook_drush_help_alter().
+ * Get the standard (built-in) global options, prior to modification by hook_drush_help_alter().
  *
  * @param boolean $brief
- *   Return a reduced set of important options. Used by help command.
- *
- * @return
- *   An associative array containing the option definition as the key,
- *   and a descriptive array for each of the available options.  The array
- *   elements for each item are:
- *
- *     - short-form: The shortcut form for specifying the key on the commandline.
- *     - propagate: backend invoke will use drush_get_option to propagate this
- *       option, when set, to any other Drush command that is called.
- *     - context: The drush context where the value of this item is cached.  Used
- *       by backend invoke to propagate values set in code.
- *     - never-post: If TRUE, backend invoke will never POST this item's value
- *       on STDIN; it will always be sent as a commandline option.
- *     - never-propagate: If TRUE, backend invoke will never pass this item on
- *       to the subcommand being executed.
- *     - local-context-only: Backend invoke will only pass this value on for local calls.
- *     - merge: For options such as $options['shell-aliases'] that consist of an array
- *       of items, make a merged array that contains all of the values specified for
- *       all of the contexts (config files) where the option is defined.  The value is stored in
- *       the specified 'context', or in a context named after the option itself if the
- *       context flag is not specified.
- *       IMPORTANT: When the merge flag is used, the option value must be obtained via
- *       drush_get_context('option') rather than drush_get_option('option').
- *     - merge-pathlist: For options such as --include and --config, make a merged list
- *       of options from all contexts; works like the 'merge' flag, but also handles string
- *       values separated by the PATH_SEPARATOR.
- *     - merge-associative: Like 'merge-pathlist', but key values are preserved.
- *     - propagate-cli-value: Used to tell backend invoke to include the value for
- *       this item as specified on the cli.  This can either override 'context'
- *       (e.g., propagate --include from cli value instead of DRUSH_INCLUDE context),
- *       or for an independent global setting (e.g. --user)
- *     - description: The help text for this item. displayed by `drush help`.
+ *   Return a reduced set of important options.
  */
-function drush_get_global_options($brief = FALSE) {
+function drush_get_standard_global_options($brief = FALSE) {
   $options['root']               = array('short-form' => 'r', 'short-has-arg' => TRUE, 'never-post' => TRUE, 'description' => "Drupal root directory to use (default: current directory).", 'example-value' => 'path');
   $options['uri']                = array('short-form' => 'l', 'short-has-arg' => TRUE, 'never-post' => TRUE, 'description' => 'URI of the drupal site to use (only needed in multisite environments or when running on an alternate port).', 'example-value' => 'http://example.com:8888');
   $options['verbose']            = array('short-form' => 'v', 'context' => 'DRUSH_VERBOSE', 'description' => 'Display extra information about the command.');
@@ -328,7 +295,52 @@ function drush_get_global_options($brief = FALSE) {
     $options['redirect-port']       = array('hidden' => TRUE, 'never-propagate' => TRUE, 'description' => 'Used by the user-login command to specify the redirect port on the local machine; it therefore would not do to pass this to the remote machines.');
     $options['cache-clear']         = array('propagate' => TRUE, 'description' => 'If 0, Drush skips normal cache clearing; the caller should then clear if needed.', 'example-value' => '0', );
     $options['local']               = array('propagate' => TRUE, 'description' => 'Don\'t look in global locations for commandfiles, config, and site aliases');
+  }
+  return $options;
+}
 
+/**
+ * Get the available global options. Used by help command. Command files may
+ * modify this list using hook_drush_help_alter().
+ *
+ * @param boolean $brief
+ *   Return a reduced set of important options. Used by help command.
+ *
+ * @return
+ *   An associative array containing the option definition as the key,
+ *   and a descriptive array for each of the available options.  The array
+ *   elements for each item are:
+ *
+ *     - short-form: The shortcut form for specifying the key on the commandline.
+ *     - propagate: backend invoke will use drush_get_option to propagate this
+ *       option, when set, to any other Drush command that is called.
+ *     - context: The drush context where the value of this item is cached.  Used
+ *       by backend invoke to propagate values set in code.
+ *     - never-post: If TRUE, backend invoke will never POST this item's value
+ *       on STDIN; it will always be sent as a commandline option.
+ *     - never-propagate: If TRUE, backend invoke will never pass this item on
+ *       to the subcommand being executed.
+ *     - local-context-only: Backend invoke will only pass this value on for local calls.
+ *     - merge: For options such as $options['shell-aliases'] that consist of an array
+ *       of items, make a merged array that contains all of the values specified for
+ *       all of the contexts (config files) where the option is defined.  The value is stored in
+ *       the specified 'context', or in a context named after the option itself if the
+ *       context flag is not specified.
+ *       IMPORTANT: When the merge flag is used, the option value must be obtained via
+ *       drush_get_context('option') rather than drush_get_option('option').
+ *     - merge-pathlist: For options such as --include and --config, make a merged list
+ *       of options from all contexts; works like the 'merge' flag, but also handles string
+ *       values separated by the PATH_SEPARATOR.
+ *     - merge-associative: Like 'merge-pathlist', but key values are preserved.
+ *     - propagate-cli-value: Used to tell backend invoke to include the value for
+ *       this item as specified on the cli.  This can either override 'context'
+ *       (e.g., propagate --include from cli value instead of DRUSH_INCLUDE context),
+ *       or for an independent global setting (e.g. --user)
+ *     - description: The help text for this item. displayed by `drush help`.
+ */
+function drush_get_global_options($brief = FALSE) {
+  $options = drush_get_standard_global_options($brief);
+  if (!$brief) {
     $command = array(
         'options' => $options,
         '#brief' => FALSE,
@@ -1286,6 +1298,13 @@ function _drush_log($entry) {
     drush_backend_packet('log', $entry);
     return $callback($entry);
   }
+  else {
+    // Log early messages.
+    // TODO: need to check log level.
+    // Maybe we just ensure that our PSR-2 logger is available early.
+    $log_level = $entry['type'];
+//    printf("[%s] %s\n", $entry['type'], $entry['message']);
+  }
 }
 
 // Maintain compatibility with extensions that hook into
@@ -1539,6 +1558,7 @@ function drush_set_error($error, $message = null, $output_label = "") {
 
   $error_log[$error][] = $message;
   if (!drush_backend_packet('set_error', array('error' => $error, 'message' => $message))) {
+    debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
     drush_log(($message) ? $output_label . $message : $output_label . $error, LogLevel::ERROR, $error);
   }
 

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -315,6 +315,21 @@ function drush_conf_path($server_uri, $require_settings = TRUE) {
   return $conf;
 }
 
+function drush_locate_composer_root($start_path = NULL) {
+  return drush_search_up_directory_tree($start_path, 'drush_valid_composer_root');
+}
+
+function drush_valid_composer_root($path) {
+  // This cannot be a composer root unless there is a composer.json file here.
+  if (!file_exists('composer.json')) {
+    return false;
+  }
+  // For now, we'll presume that there is a composer.lock at the project
+  // root, and that no one has created a spurrious composer.lock file
+  // anywhere else.
+  return file_exists('composer.lock');
+}
+
 /**
  * Exhaustive depth-first search to try and locate the Drupal root directory.
  * This makes it possible to run Drush from a subdirectory of the drupal root.
@@ -325,6 +340,10 @@ function drush_conf_path($server_uri, $require_settings = TRUE) {
  *   A path to drupal root, or FALSE if not found.
  */
 function drush_locate_root($start_path = NULL) {
+  return drush_search_up_directory_tree($start_path, 'drush_valid_root');
+}
+
+function drush_search_up_directory_tree($start_path, $fn) {
   $drupal_root = FALSE;
 
   $start_path = empty($start_path) ? drush_cwd() : $start_path;
@@ -334,7 +353,7 @@ function drush_locate_root($start_path = NULL) {
       $path = realpath($path);
     }
     // Check the start path.
-    if (drush_valid_root($path)) {
+    if ($fn($path)) {
       $drupal_root = $path;
       break;
     }
@@ -344,7 +363,7 @@ function drush_locate_root($start_path = NULL) {
         if ($follow_symlinks && is_link($path)) {
           $path = realpath($path);
         }
-        if (drush_valid_root($path)) {
+        if ($fn($path)) {
           $drupal_root = $path;
           break 2;
         }
@@ -421,6 +440,14 @@ function drush_valid_db_credentials() {
  * @see DRUSH_COMMAND
  */
 function drush_find_drush() {
+  // TEMPORARY: We need this early in the bootstrap for a number of reasons.
+  // Make a better strategy for this later (although this might just do in a pinch).
+  $vendor_path = drush_get_context('DRUSH_VENDOR_PATH');
+  include "$vendor_path/webmozart/assert/src/Assert.php";
+  include "$vendor_path/webmozart/path-util/src/Path.php";
+
+  //debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+
   if ($drush = realpath($_SERVER['argv']['0'])) {
     return Path::canonicalize($drush);
   }

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -11,7 +11,7 @@
  */
 
 use Drush\Log\LogLevel;
-use Webmozart\PathUtil\Path;
+use Drush\Webmozart\PathUtil\Path;
 
 /**
  * Log PHP errors to the Drush log. This is in effect until Drupal's error
@@ -440,14 +440,6 @@ function drush_valid_db_credentials() {
  * @see DRUSH_COMMAND
  */
 function drush_find_drush() {
-  // TEMPORARY: We need this early in the bootstrap for a number of reasons.
-  // Make a better strategy for this later (although this might just do in a pinch).
-  $vendor_path = drush_get_context('DRUSH_VENDOR_PATH');
-  include "$vendor_path/webmozart/assert/src/Assert.php";
-  include "$vendor_path/webmozart/path-util/src/Path.php";
-
-  //debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-
   if ($drush = realpath($_SERVER['argv']['0'])) {
     return Path::canonicalize($drush);
   }

--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -4,7 +4,7 @@
  * @file
  * Filesystem utilities.
  */
-use Webmozart\PathUtil\Path;
+use Drush\Webmozart\PathUtil\Path;
 
 /**
  * @defgroup filesystemfunctions Filesystem convenience functions.

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -43,6 +43,13 @@ function drush_main() {
   // Reset our bootstrap phase to the beginning
   drush_set_context('DRUSH_BOOTSTRAP_PHASE', DRUSH_BOOTSTRAP_NONE);
 
+  $vendor_path = drush_get_context('DRUSH_VENDOR_PATH');
+  $classloader = require $vendor_path . '/autoload.php';
+  drush_set_context('DRUSH_CLASSLOADER', $classloader);
+
+  // Can't log until we have a logger, so we'll create this ASAP.
+  _drush_create_default_logger();
+
   $return = '';
   if (!drush_get_error()) {
     if ($file = drush_get_option('early', FALSE)) {
@@ -118,8 +125,6 @@ function drush_preflight_prepare() {
     return FALSE;
   }
 
-  $classloader = require $vendor_path;
-
   require_once DRUSH_BASE_PATH . '/includes/startup.inc';
   require_once DRUSH_BASE_PATH . '/includes/bootstrap.inc';
   require_once DRUSH_BASE_PATH . '/includes/environment.inc';
@@ -141,10 +146,10 @@ function drush_preflight_prepare() {
 
   // Stash our vendor path and classloader.
   drush_set_context('DRUSH_VENDOR_PATH', dirname($vendor_path));
-  drush_set_context('DRUSH_CLASSLOADER', $classloader);
 
-  // Can't log until we have a logger, so we'll create this ASAP.
-  _drush_create_default_logger();
+  // Register our autoloader -- provides Drush internal classes later.
+  // The Composer autoloader is included later to bring in our dependencies.
+  spl_autoload_register('drush_internal_autoloader');
 
   // Terminate immediately unless invoked as a command line script
   if (!drush_verify_cli()) {
@@ -185,7 +190,21 @@ function drush_preflight_prepare() {
   // Process initial global options such as --debug.
   _drush_preflight_global_options();
 
-  drush_log(dt("Drush preflight prepare loaded autoloader at !autoloader", array('!autoloader' => realpath($vendor_path))), LogLevel::PREFLIGHT);
+  drush_log(dt("Drush preflight prepare loaded autoloader at !autoloader", array('!autoloader' => realpath($vendor_path))), 'preflight'); // LogLevel::PREFLIGHT
+}
+
+/**
+ * Autoload classes in the Drush namespace.
+ */
+function drush_internal_autoloader($className) {
+  if (substr($className,0,6) != "Drush\\") {
+    return;
+  }
+  $classFilePath = dirname(__DIR__) . '/lib/' . strtr($className, '\\', '/') . '.php';
+
+  if(file_exists($classFilePath) && is_readable($classFilePath)) {
+    require($classFilePath);
+  }
 }
 
 /**
@@ -219,7 +238,7 @@ function drush_preflight() {
   _drush_preflight_columns();
 
   // Display is tidy now that column width has been handled.
-  drush_log(dt('Starting Drush preflight.'), LogLevel::PREFLIGHT);
+  drush_log(dt('Starting Drush preflight.'), 'preflight'); // LogLevel::PREFLIGHT
 
   // Statically define a way to call drush again.
   define('DRUSH_COMMAND', drush_find_drush());
@@ -252,9 +271,6 @@ function drush_preflight() {
   drush_load_config('custom');
 
   _drush_preflight_global_options();
-  // Load all the commandfiles findable from any of the
-  // scopes listed above.
-  _drush_find_commandfiles_drush();
 
   // Look up the alias identifier that the user wants to use,
   // either via an argument or via 'site-set'.
@@ -268,6 +284,9 @@ function drush_preflight() {
   // done, since site aliases may set option values that
   // affect these phases.
   $alias_record = _drush_sitealias_set_context_by_name($target_alias);
+
+  // Load the appropriate autoloader
+  drush_composer_autoloader();
 
   // Find the selected site based on --root, --uri or cwd
   drush_preflight_root();
@@ -304,6 +323,11 @@ function drush_preflight() {
     return drush_set_error('DRUSH_BOOTSTRAP_NO_ALIAS', dt("Could not find the alias !alias", array('!alias' => $target_alias)));
   }
 
+  // Load all the commandfiles findable from any of the
+  // scopes listed above.
+  // This previously happened immediately after _drush_preflight_global_options().
+  _drush_find_commandfiles_drush();
+
   // If applicable swaps in shell alias values.
   drush_shell_alias_replace($target_alias);
 
@@ -315,6 +339,40 @@ function drush_preflight() {
 
   // Select the bootstrap object and return it.
   return drush_select_bootstrap_class();
+}
+
+/**
+ * Here is where we need to do magic logic to figure out whether we
+ * want to load our Symfony-2 compatible autoload file, or our Symfony-3
+ * compatible autoload file.
+ */
+function drush_composer_autoloader() {
+  // Start from --root, if it was specified.
+  $root = drush_get_option('root');
+
+  // Find the composer root. If there is no composer root, then we
+  // will just load Drush's autoload file. If there is a composer root,
+  // and we find evidence of Symfony 3 in the lock file, then we will
+  // do something special.
+  // Alternate plan: always load the application autoload file, and then
+  // try to include all of the necessary Drush dependencies that are still
+  // missing.
+  $composer_root = drush_locate_composer_root($root);
+
+  // For now just load the Drush autoloader, until we have implemented
+  // our magical strategy. The general idea is that we will just load
+  // our own autoload file if:
+  //  - There is no composer root
+  //  - "$composer_root/vendor" == $vendor_path (site-local Drush)
+  //  - Maybe also if Drupal version is 7 (or when there are no Symfony components in $composer_root)
+  // Otherwise, we have to inspect the composer.lock at $composer_root,
+  // and find an autoload file of ours that will be compatible with that.
+  // Alternately, we might be able to make a mini vendor directory that
+  // contains only the components that are not overlapping with Drupal 8.3.x
+  // and earlier or Drupal 8.4.x and later.
+  $vendor_path = drush_get_context('DRUSH_VENDOR_PATH');
+  $classloader = require $vendor_path . '/autoload.php';
+  drush_set_context('DRUSH_CLASSLOADER', $classloader);
 }
 
 /**

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -10,7 +10,7 @@
  */
 
 use Drush\Log\LogLevel;
-use Webmozart\PathUtil\Path;
+use Drush\Webmozart\PathUtil\Path;
 
 /**
  * Check to see if the user specified an alias

--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -3,7 +3,7 @@
 namespace Drush\Sql;
 
 use Drush\Log\LogLevel;
-use Webmozart\PathUtil\Path;
+use Drush\Webmozart\PathUtil\Path;
 
 class SqlBase {
 

--- a/lib/Drush/Webmozart/Assert/Assert.php
+++ b/lib/Drush/Webmozart/Assert/Assert.php
@@ -1,0 +1,949 @@
+<?php
+
+/*
+ * This file is part of the webmozart/assert package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Imported into Drush namespace from webmozart/assert version 1.2.0
+namespace Drush\Webmozart\Assert;
+
+use BadMethodCallException;
+use InvalidArgumentException;
+use Traversable;
+use Exception;
+use Throwable;
+use Closure;
+
+/**
+ * Efficient assertions to validate the input/output of your methods.
+ *
+ * @method static void nullOrString($value, $message = '')
+ * @method static void nullOrStringNotEmpty($value, $message = '')
+ * @method static void nullOrInteger($value, $message = '')
+ * @method static void nullOrIntegerish($value, $message = '')
+ * @method static void nullOrFloat($value, $message = '')
+ * @method static void nullOrNumeric($value, $message = '')
+ * @method static void nullOrBoolean($value, $message = '')
+ * @method static void nullOrScalar($value, $message = '')
+ * @method static void nullOrObject($value, $message = '')
+ * @method static void nullOrResource($value, $type = null, $message = '')
+ * @method static void nullOrIsCallable($value, $message = '')
+ * @method static void nullOrIsArray($value, $message = '')
+ * @method static void nullOrIsTraversable($value, $message = '')
+ * @method static void nullOrIsInstanceOf($value, $class, $message = '')
+ * @method static void nullOrNotInstanceOf($value, $class, $message = '')
+ * @method static void nullOrIsEmpty($value, $message = '')
+ * @method static void nullOrNotEmpty($value, $message = '')
+ * @method static void nullOrTrue($value, $message = '')
+ * @method static void nullOrFalse($value, $message = '')
+ * @method static void nullOrEq($value, $value2, $message = '')
+ * @method static void nullOrNotEq($value,$value2,  $message = '')
+ * @method static void nullOrSame($value, $value2, $message = '')
+ * @method static void nullOrNotSame($value, $value2, $message = '')
+ * @method static void nullOrGreaterThan($value, $value2, $message = '')
+ * @method static void nullOrGreaterThanEq($value, $value2, $message = '')
+ * @method static void nullOrLessThan($value, $value2, $message = '')
+ * @method static void nullOrLessThanEq($value, $value2, $message = '')
+ * @method static void nullOrRange($value, $min, $max, $message = '')
+ * @method static void nullOrOneOf($value, $values, $message = '')
+ * @method static void nullOrContains($value, $subString, $message = '')
+ * @method static void nullOrStartsWith($value, $prefix, $message = '')
+ * @method static void nullOrStartsWithLetter($value, $message = '')
+ * @method static void nullOrEndsWith($value, $suffix, $message = '')
+ * @method static void nullOrRegex($value, $pattern, $message = '')
+ * @method static void nullOrAlpha($value, $message = '')
+ * @method static void nullOrDigits($value, $message = '')
+ * @method static void nullOrAlnum($value, $message = '')
+ * @method static void nullOrLower($value, $message = '')
+ * @method static void nullOrUpper($value, $message = '')
+ * @method static void nullOrLength($value, $length, $message = '')
+ * @method static void nullOrMinLength($value, $min, $message = '')
+ * @method static void nullOrMaxLength($value, $max, $message = '')
+ * @method static void nullOrLengthBetween($value, $min, $max, $message = '')
+ * @method static void nullOrFileExists($value, $message = '')
+ * @method static void nullOrFile($value, $message = '')
+ * @method static void nullOrDirectory($value, $message = '')
+ * @method static void nullOrReadable($value, $message = '')
+ * @method static void nullOrWritable($value, $message = '')
+ * @method static void nullOrClassExists($value, $message = '')
+ * @method static void nullOrSubclassOf($value, $class, $message = '')
+ * @method static void nullOrImplementsInterface($value, $interface, $message = '')
+ * @method static void nullOrPropertyExists($value, $property, $message = '')
+ * @method static void nullOrPropertyNotExists($value, $property, $message = '')
+ * @method static void nullOrMethodExists($value, $method, $message = '')
+ * @method static void nullOrMethodNotExists($value, $method, $message = '')
+ * @method static void nullOrKeyExists($value, $key, $message = '')
+ * @method static void nullOrKeyNotExists($value, $key, $message = '')
+ * @method static void nullOrCount($value, $key, $message = '')
+ * @method static void nullOrUuid($values, $message = '')
+ * @method static void allString($values, $message = '')
+ * @method static void allStringNotEmpty($values, $message = '')
+ * @method static void allInteger($values, $message = '')
+ * @method static void allIntegerish($values, $message = '')
+ * @method static void allFloat($values, $message = '')
+ * @method static void allNumeric($values, $message = '')
+ * @method static void allBoolean($values, $message = '')
+ * @method static void allScalar($values, $message = '')
+ * @method static void allObject($values, $message = '')
+ * @method static void allResource($values, $type = null, $message = '')
+ * @method static void allIsCallable($values, $message = '')
+ * @method static void allIsArray($values, $message = '')
+ * @method static void allIsTraversable($values, $message = '')
+ * @method static void allIsInstanceOf($values, $class, $message = '')
+ * @method static void allNotInstanceOf($values, $class, $message = '')
+ * @method static void allNull($values, $message = '')
+ * @method static void allNotNull($values, $message = '')
+ * @method static void allIsEmpty($values, $message = '')
+ * @method static void allNotEmpty($values, $message = '')
+ * @method static void allTrue($values, $message = '')
+ * @method static void allFalse($values, $message = '')
+ * @method static void allEq($values, $value2, $message = '')
+ * @method static void allNotEq($values,$value2,  $message = '')
+ * @method static void allSame($values, $value2, $message = '')
+ * @method static void allNotSame($values, $value2, $message = '')
+ * @method static void allGreaterThan($values, $value2, $message = '')
+ * @method static void allGreaterThanEq($values, $value2, $message = '')
+ * @method static void allLessThan($values, $value2, $message = '')
+ * @method static void allLessThanEq($values, $value2, $message = '')
+ * @method static void allRange($values, $min, $max, $message = '')
+ * @method static void allOneOf($values, $values, $message = '')
+ * @method static void allContains($values, $subString, $message = '')
+ * @method static void allStartsWith($values, $prefix, $message = '')
+ * @method static void allStartsWithLetter($values, $message = '')
+ * @method static void allEndsWith($values, $suffix, $message = '')
+ * @method static void allRegex($values, $pattern, $message = '')
+ * @method static void allAlpha($values, $message = '')
+ * @method static void allDigits($values, $message = '')
+ * @method static void allAlnum($values, $message = '')
+ * @method static void allLower($values, $message = '')
+ * @method static void allUpper($values, $message = '')
+ * @method static void allLength($values, $length, $message = '')
+ * @method static void allMinLength($values, $min, $message = '')
+ * @method static void allMaxLength($values, $max, $message = '')
+ * @method static void allLengthBetween($values, $min, $max, $message = '')
+ * @method static void allFileExists($values, $message = '')
+ * @method static void allFile($values, $message = '')
+ * @method static void allDirectory($values, $message = '')
+ * @method static void allReadable($values, $message = '')
+ * @method static void allWritable($values, $message = '')
+ * @method static void allClassExists($values, $message = '')
+ * @method static void allSubclassOf($values, $class, $message = '')
+ * @method static void allImplementsInterface($values, $interface, $message = '')
+ * @method static void allPropertyExists($values, $property, $message = '')
+ * @method static void allPropertyNotExists($values, $property, $message = '')
+ * @method static void allMethodExists($values, $method, $message = '')
+ * @method static void allMethodNotExists($values, $method, $message = '')
+ * @method static void allKeyExists($values, $key, $message = '')
+ * @method static void allKeyNotExists($values, $key, $message = '')
+ * @method static void allCount($values, $key, $message = '')
+ * @method static void allUuid($values, $message = '')
+ *
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class Assert
+{
+    public static function string($value, $message = '')
+    {
+        if (!is_string($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a string. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function stringNotEmpty($value, $message = '')
+    {
+        static::string($value, $message);
+        static::notEmpty($value, $message);
+    }
+
+    public static function integer($value, $message = '')
+    {
+        if (!is_int($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an integer. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function integerish($value, $message = '')
+    {
+        if (!is_numeric($value) || $value != (int) $value) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an integerish value. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function float($value, $message = '')
+    {
+        if (!is_float($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a float. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function numeric($value, $message = '')
+    {
+        if (!is_numeric($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a numeric. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function boolean($value, $message = '')
+    {
+        if (!is_bool($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a boolean. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function scalar($value, $message = '')
+    {
+        if (!is_scalar($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a scalar. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function object($value, $message = '')
+    {
+        if (!is_object($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an object. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function resource($value, $type = null, $message = '')
+    {
+        if (!is_resource($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a resource. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+
+        if ($type && $type !== get_resource_type($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a resource of type %2$s. Got: %s',
+                static::typeToString($value),
+                $type
+            ));
+        }
+    }
+
+    public static function isCallable($value, $message = '')
+    {
+        if (!is_callable($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a callable. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function isArray($value, $message = '')
+    {
+        if (!is_array($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an array. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function isTraversable($value, $message = '')
+    {
+        if (!is_array($value) && !($value instanceof Traversable)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a traversable. Got: %s',
+                static::typeToString($value)
+            ));
+        }
+    }
+
+    public static function isInstanceOf($value, $class, $message = '')
+    {
+        if (!($value instanceof $class)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an instance of %2$s. Got: %s',
+                static::typeToString($value),
+                $class
+            ));
+        }
+    }
+
+    public static function notInstanceOf($value, $class, $message = '')
+    {
+        if ($value instanceof $class) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an instance other than %2$s. Got: %s',
+                static::typeToString($value),
+                $class
+            ));
+        }
+    }
+
+    public static function isEmpty($value, $message = '')
+    {
+        if (!empty($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an empty value. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function notEmpty($value, $message = '')
+    {
+        if (empty($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a non-empty value. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function null($value, $message = '')
+    {
+        if (null !== $value) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected null. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function notNull($value, $message = '')
+    {
+        if (null === $value) {
+            static::reportInvalidArgument(
+                $message ?: 'Expected a value other than null.'
+            );
+        }
+    }
+
+    public static function true($value, $message = '')
+    {
+        if (true !== $value) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to be true. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function false($value, $message = '')
+    {
+        if (false !== $value) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to be false. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function eq($value, $value2, $message = '')
+    {
+        if ($value2 != $value) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value equal to %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($value2)
+            ));
+        }
+    }
+
+    public static function notEq($value, $value2, $message = '')
+    {
+        if ($value2 == $value) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a different value than %s.',
+                static::valueToString($value2)
+            ));
+        }
+    }
+
+    public static function same($value, $value2, $message = '')
+    {
+        if ($value2 !== $value) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value identical to %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($value2)
+            ));
+        }
+    }
+
+    public static function notSame($value, $value2, $message = '')
+    {
+        if ($value2 === $value) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value not identical to %s.',
+                static::valueToString($value2)
+            ));
+        }
+    }
+
+    public static function greaterThan($value, $limit, $message = '')
+    {
+        if ($value <= $limit) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value greater than %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($limit)
+            ));
+        }
+    }
+
+    public static function greaterThanEq($value, $limit, $message = '')
+    {
+        if ($value < $limit) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value greater than or equal to %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($limit)
+            ));
+        }
+    }
+
+    public static function lessThan($value, $limit, $message = '')
+    {
+        if ($value >= $limit) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value less than %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($limit)
+            ));
+        }
+    }
+
+    public static function lessThanEq($value, $limit, $message = '')
+    {
+        if ($value > $limit) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value less than or equal to %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($limit)
+            ));
+        }
+    }
+
+    public static function range($value, $min, $max, $message = '')
+    {
+        if ($value < $min || $value > $max) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value between %2$s and %3$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($min),
+                static::valueToString($max)
+            ));
+        }
+    }
+
+    public static function oneOf($value, array $values, $message = '')
+    {
+        if (!in_array($value, $values, true)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected one of: %2$s. Got: %s',
+                static::valueToString($value),
+                implode(', ', array_map(array('static', 'valueToString'), $values))
+            ));
+        }
+    }
+
+    public static function contains($value, $subString, $message = '')
+    {
+        if (false === strpos($value, $subString)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to contain %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($subString)
+            ));
+        }
+    }
+
+    public static function startsWith($value, $prefix, $message = '')
+    {
+        if (0 !== strpos($value, $prefix)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to start with %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($prefix)
+            ));
+        }
+    }
+
+    public static function startsWithLetter($value, $message = '')
+    {
+        $valid = isset($value[0]);
+
+        if ($valid) {
+            $locale = setlocale(LC_CTYPE, 0);
+            setlocale(LC_CTYPE, 'C');
+            $valid = ctype_alpha($value[0]);
+            setlocale(LC_CTYPE, $locale);
+        }
+
+        if (!$valid) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to start with a letter. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function endsWith($value, $suffix, $message = '')
+    {
+        if ($suffix !== substr($value, -static::strlen($suffix))) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to end with %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($suffix)
+            ));
+        }
+    }
+
+    public static function regex($value, $pattern, $message = '')
+    {
+        if (!preg_match($pattern, $value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'The value %s does not match the expected pattern.',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function alpha($value, $message = '')
+    {
+        $locale = setlocale(LC_CTYPE, 0);
+        setlocale(LC_CTYPE, 'C');
+        $valid = !ctype_alpha($value);
+        setlocale(LC_CTYPE, $locale);
+
+        if ($valid) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to contain only letters. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function digits($value, $message = '')
+    {
+        $locale = setlocale(LC_CTYPE, 0);
+        setlocale(LC_CTYPE, 'C');
+        $valid = !ctype_digit($value);
+        setlocale(LC_CTYPE, $locale);
+
+        if ($valid) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to contain digits only. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function alnum($value, $message = '')
+    {
+        $locale = setlocale(LC_CTYPE, 0);
+        setlocale(LC_CTYPE, 'C');
+        $valid = !ctype_alnum($value);
+        setlocale(LC_CTYPE, $locale);
+
+        if ($valid) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to contain letters and digits only. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function lower($value, $message = '')
+    {
+        $locale = setlocale(LC_CTYPE, 0);
+        setlocale(LC_CTYPE, 'C');
+        $valid = !ctype_lower($value);
+        setlocale(LC_CTYPE, $locale);
+
+        if ($valid) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to contain lowercase characters only. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function upper($value, $message = '')
+    {
+        $locale = setlocale(LC_CTYPE, 0);
+        setlocale(LC_CTYPE, 'C');
+        $valid = !ctype_upper($value);
+        setlocale(LC_CTYPE, $locale);
+
+        if ($valid) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to contain uppercase characters only. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function length($value, $length, $message = '')
+    {
+        if ($length !== static::strlen($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to contain %2$s characters. Got: %s',
+                static::valueToString($value),
+                $length
+            ));
+        }
+    }
+
+    public static function minLength($value, $min, $message = '')
+    {
+        if (static::strlen($value) < $min) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to contain at least %2$s characters. Got: %s',
+                static::valueToString($value),
+                $min
+            ));
+        }
+    }
+
+    public static function maxLength($value, $max, $message = '')
+    {
+        if (static::strlen($value) > $max) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to contain at most %2$s characters. Got: %s',
+                static::valueToString($value),
+                $max
+            ));
+        }
+    }
+
+    public static function lengthBetween($value, $min, $max, $message = '')
+    {
+        $length = static::strlen($value);
+
+        if ($length < $min || $length > $max) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a value to contain between %2$s and %3$s characters. Got: %s',
+                static::valueToString($value),
+                $min,
+                $max
+            ));
+        }
+    }
+
+    public static function fileExists($value, $message = '')
+    {
+        static::string($value);
+
+        if (!file_exists($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'The file %s does not exist.',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function file($value, $message = '')
+    {
+        static::fileExists($value, $message);
+
+        if (!is_file($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'The path %s is not a file.',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function directory($value, $message = '')
+    {
+        static::fileExists($value, $message);
+
+        if (!is_dir($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'The path %s is no directory.',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function readable($value, $message = '')
+    {
+        if (!is_readable($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'The path %s is not readable.',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function writable($value, $message = '')
+    {
+        if (!is_writable($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'The path %s is not writable.',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function classExists($value, $message = '')
+    {
+        if (!class_exists($value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an existing class name. Got: %s',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function subclassOf($value, $class, $message = '')
+    {
+        if (!is_subclass_of($value, $class)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected a sub-class of %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($class)
+            ));
+        }
+    }
+
+    public static function implementsInterface($value, $interface, $message = '')
+    {
+        if (!in_array($interface, class_implements($value))) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected an implementation of %2$s. Got: %s',
+                static::valueToString($value),
+                static::valueToString($interface)
+            ));
+        }
+    }
+
+    public static function propertyExists($classOrObject, $property, $message = '')
+    {
+        if (!property_exists($classOrObject, $property)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected the property %s to exist.',
+                static::valueToString($property)
+            ));
+        }
+    }
+
+    public static function propertyNotExists($classOrObject, $property, $message = '')
+    {
+        if (property_exists($classOrObject, $property)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected the property %s to not exist.',
+                static::valueToString($property)
+            ));
+        }
+    }
+
+    public static function methodExists($classOrObject, $method, $message = '')
+    {
+        if (!method_exists($classOrObject, $method)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected the method %s to exist.',
+                static::valueToString($method)
+            ));
+        }
+    }
+
+    public static function methodNotExists($classOrObject, $method, $message = '')
+    {
+        if (method_exists($classOrObject, $method)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected the method %s to not exist.',
+                static::valueToString($method)
+            ));
+        }
+    }
+
+    public static function keyExists($array, $key, $message = '')
+    {
+        if (!array_key_exists($key, $array)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected the key %s to exist.',
+                static::valueToString($key)
+            ));
+        }
+    }
+
+    public static function keyNotExists($array, $key, $message = '')
+    {
+        if (array_key_exists($key, $array)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Expected the key %s to not exist.',
+                static::valueToString($key)
+            ));
+        }
+    }
+
+    public static function count($array, $number, $message = '')
+    {
+        static::eq(
+            count($array),
+            $number,
+            $message ?: sprintf('Expected an array to contain %d elements. Got: %d.', $number, count($array))
+        );
+    }
+
+    public static function uuid($value, $message = '')
+    {
+        $value = str_replace(array('urn:', 'uuid:', '{', '}'), '', $value);
+
+        // The nil UUID is special form of UUID that is specified to have all
+        // 128 bits set to zero.
+        if ('00000000-0000-0000-0000-000000000000' === $value) {
+            return;
+        }
+
+        if (!preg_match('/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/', $value)) {
+            static::reportInvalidArgument(sprintf(
+                $message ?: 'Value %s is not a valid UUID.',
+                static::valueToString($value)
+            ));
+        }
+    }
+
+    public static function throws(Closure $expression, $class = 'Exception', $message = '')
+    {
+        static::string($class);
+
+        $actual = 'none';
+        try {
+            $expression();
+        } catch (Exception $e) {
+            $actual = get_class($e);
+            if ($e instanceof $class) {
+                return;
+            }
+        } catch (Throwable $e) {
+            $actual = get_class($e);
+            if ($e instanceof $class) {
+                return;
+            }
+        }
+
+        static::reportInvalidArgument($message ?: sprintf(
+            'Expected to throw "%s", got "%s"',
+            $class,
+            $actual
+        ));
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        if ('nullOr' === substr($name, 0, 6)) {
+            if (null !== $arguments[0]) {
+                $method = lcfirst(substr($name, 6));
+                call_user_func_array(array('static', $method), $arguments);
+            }
+
+            return;
+        }
+
+        if ('all' === substr($name, 0, 3)) {
+            static::isTraversable($arguments[0]);
+
+            $method = lcfirst(substr($name, 3));
+            $args = $arguments;
+
+            foreach ($arguments[0] as $entry) {
+                $args[0] = $entry;
+
+                call_user_func_array(array('static', $method), $args);
+            }
+
+            return;
+        }
+
+        throw new BadMethodCallException('No such method: '.$name);
+    }
+
+    protected static function valueToString($value)
+    {
+        if (null === $value) {
+            return 'null';
+        }
+
+        if (true === $value) {
+            return 'true';
+        }
+
+        if (false === $value) {
+            return 'false';
+        }
+
+        if (is_array($value)) {
+            return 'array';
+        }
+
+        if (is_object($value)) {
+            return get_class($value);
+        }
+
+        if (is_resource($value)) {
+            return 'resource';
+        }
+
+        if (is_string($value)) {
+            return '"'.$value.'"';
+        }
+
+        return (string) $value;
+    }
+
+    protected static function typeToString($value)
+    {
+        return is_object($value) ? get_class($value) : gettype($value);
+    }
+
+    protected static function strlen($value)
+    {
+        if (!function_exists('mb_detect_encoding')) {
+            return strlen($value);
+        }
+
+        if (false === $encoding = mb_detect_encoding($value)) {
+            return strlen($value);
+        }
+
+        return mb_strwidth($value, $encoding);
+    }
+
+    protected static function reportInvalidArgument($message)
+    {
+        throw new InvalidArgumentException($message);
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/lib/Drush/Webmozart/Assert/LICENSE
+++ b/lib/Drush/Webmozart/Assert/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Bernhard Schussek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/Drush/Webmozart/PathUtil/LICENSE
+++ b/lib/Drush/Webmozart/PathUtil/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Bernhard Schussek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/Drush/Webmozart/PathUtil/Path.php
+++ b/lib/Drush/Webmozart/PathUtil/Path.php
@@ -1,0 +1,1009 @@
+<?php
+
+/*
+ * This file is part of the webmozart/path-util package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Imported into Drush namespace from webmozart/path-util version 2.3.0
+namespace Drush\Webmozart\PathUtil;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Drush\Webmozart\Assert\Assert;
+
+/**
+ * Contains utility methods for handling path strings.
+ *
+ * The methods in this class are able to deal with both UNIX and Windows paths
+ * with both forward and backward slashes. All methods return normalized parts
+ * containing only forward slashes and no excess "." and ".." segments.
+ *
+ * @since  1.0
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Thomas Schulz <mail@king2500.net>
+ */
+final class Path
+{
+    /**
+     * The number of buffer entries that triggers a cleanup operation.
+     */
+    const CLEANUP_THRESHOLD = 1250;
+
+    /**
+     * The buffer size after the cleanup operation.
+     */
+    const CLEANUP_SIZE = 1000;
+
+    /**
+     * Buffers input/output of {@link canonicalize()}.
+     *
+     * @var array
+     */
+    private static $buffer = array();
+
+    /**
+     * The size of the buffer.
+     *
+     * @var int
+     */
+    private static $bufferSize = 0;
+
+    /**
+     * Canonicalizes the given path.
+     *
+     * During normalization, all slashes are replaced by forward slashes ("/").
+     * Furthermore, all "." and ".." segments are removed as far as possible.
+     * ".." segments at the beginning of relative paths are not removed.
+     *
+     * ```php
+     * echo Path::canonicalize("\webmozart\puli\..\css\style.css");
+     * // => /webmozart/css/style.css
+     *
+     * echo Path::canonicalize("../css/./style.css");
+     * // => ../css/style.css
+     * ```
+     *
+     * This method is able to deal with both UNIX and Windows paths.
+     *
+     * @param string $path A path string.
+     *
+     * @return string The canonical path.
+     *
+     * @since 1.0 Added method.
+     * @since 2.0 Method now fails if $path is not a string.
+     * @since 2.1 Added support for `~`.
+     */
+    public static function canonicalize($path)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        Assert::string($path, 'The path must be a string. Got: %s');
+
+        // This method is called by many other methods in this class. Buffer
+        // the canonicalized paths to make up for the severe performance
+        // decrease.
+        if (isset(self::$buffer[$path])) {
+            return self::$buffer[$path];
+        }
+
+        // Replace "~" with user's home directory.
+        if ('~' === $path[0]) {
+            $path = static::getHomeDirectory().substr($path, 1);
+        }
+
+        $path = str_replace('\\', '/', $path);
+
+        list($root, $pathWithoutRoot) = self::split($path);
+
+        $parts = explode('/', $pathWithoutRoot);
+        $canonicalParts = array();
+
+        // Collapse "." and "..", if possible
+        foreach ($parts as $part) {
+            if ('.' === $part || '' === $part) {
+                continue;
+            }
+
+            // Collapse ".." with the previous part, if one exists
+            // Don't collapse ".." if the previous part is also ".."
+            if ('..' === $part && count($canonicalParts) > 0
+                    && '..' !== $canonicalParts[count($canonicalParts) - 1]) {
+                array_pop($canonicalParts);
+
+                continue;
+            }
+
+            // Only add ".." prefixes for relative paths
+            if ('..' !== $part || '' === $root) {
+                $canonicalParts[] = $part;
+            }
+        }
+
+        // Add the root directory again
+        self::$buffer[$path] = $canonicalPath = $root.implode('/', $canonicalParts);
+        ++self::$bufferSize;
+
+        // Clean up regularly to prevent memory leaks
+        if (self::$bufferSize > self::CLEANUP_THRESHOLD) {
+            self::$buffer = array_slice(self::$buffer, -self::CLEANUP_SIZE, null, true);
+            self::$bufferSize = self::CLEANUP_SIZE;
+        }
+
+        return $canonicalPath;
+    }
+
+    /**
+     * Normalizes the given path.
+     *
+     * During normalization, all slashes are replaced by forward slashes ("/").
+     * Contrary to {@link canonicalize()}, this method does not remove invalid
+     * or dot path segments. Consequently, it is much more efficient and should
+     * be used whenever the given path is known to be a valid, absolute system
+     * path.
+     *
+     * This method is able to deal with both UNIX and Windows paths.
+     *
+     * @param string $path A path string.
+     *
+     * @return string The normalized path.
+     *
+     * @since 2.2 Added method.
+     */
+    public static function normalize($path)
+    {
+        Assert::string($path, 'The path must be a string. Got: %s');
+
+        return str_replace('\\', '/', $path);
+    }
+
+    /**
+     * Returns the directory part of the path.
+     *
+     * This method is similar to PHP's dirname(), but handles various cases
+     * where dirname() returns a weird result:
+     *
+     *  - dirname() does not accept backslashes on UNIX
+     *  - dirname("C:/webmozart") returns "C:", not "C:/"
+     *  - dirname("C:/") returns ".", not "C:/"
+     *  - dirname("C:") returns ".", not "C:/"
+     *  - dirname("webmozart") returns ".", not ""
+     *  - dirname() does not canonicalize the result
+     *
+     * This method fixes these shortcomings and behaves like dirname()
+     * otherwise.
+     *
+     * The result is a canonical path.
+     *
+     * @param string $path A path string.
+     *
+     * @return string The canonical directory part. Returns the root directory
+     *                if the root directory is passed. Returns an empty string
+     *                if a relative path is passed that contains no slashes.
+     *                Returns an empty string if an empty string is passed.
+     *
+     * @since 1.0 Added method.
+     * @since 2.0 Method now fails if $path is not a string.
+     */
+    public static function getDirectory($path)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        $path = static::canonicalize($path);
+
+        // Maintain scheme
+        if (false !== ($pos = strpos($path, '://'))) {
+            $scheme = substr($path, 0, $pos + 3);
+            $path = substr($path, $pos + 3);
+        } else {
+            $scheme = '';
+        }
+
+        if (false !== ($pos = strrpos($path, '/'))) {
+            // Directory equals root directory "/"
+            if (0 === $pos) {
+                return $scheme.'/';
+            }
+
+            // Directory equals Windows root "C:/"
+            if (2 === $pos && ctype_alpha($path[0]) && ':' === $path[1]) {
+                return $scheme.substr($path, 0, 3);
+            }
+
+            return $scheme.substr($path, 0, $pos);
+        }
+
+        return '';
+    }
+
+    /**
+     * Returns canonical path of the user's home directory.
+     *
+     * Supported operating systems:
+     *
+     *  - UNIX
+     *  - Windows8 and upper
+     *
+     * If your operation system or environment isn't supported, an exception is thrown.
+     *
+     * The result is a canonical path.
+     *
+     * @return string The canonical home directory
+     *
+     * @throws RuntimeException If your operation system or environment isn't supported
+     *
+     * @since 2.1 Added method.
+     */
+    public static function getHomeDirectory()
+    {
+        // For UNIX support
+        if (getenv('HOME')) {
+            return static::canonicalize(getenv('HOME'));
+        }
+
+        // For >= Windows8 support
+        if (getenv('HOMEDRIVE') && getenv('HOMEPATH')) {
+            return static::canonicalize(getenv('HOMEDRIVE').getenv('HOMEPATH'));
+        }
+
+        throw new RuntimeException("Your environment or operation system isn't supported");
+    }
+
+    /**
+     * Returns the root directory of a path.
+     *
+     * The result is a canonical path.
+     *
+     * @param string $path A path string.
+     *
+     * @return string The canonical root directory. Returns an empty string if
+     *                the given path is relative or empty.
+     *
+     * @since 1.0 Added method.
+     * @since 2.0 Method now fails if $path is not a string.
+     */
+    public static function getRoot($path)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        Assert::string($path, 'The path must be a string. Got: %s');
+
+        // Maintain scheme
+        if (false !== ($pos = strpos($path, '://'))) {
+            $scheme = substr($path, 0, $pos + 3);
+            $path = substr($path, $pos + 3);
+        } else {
+            $scheme = '';
+        }
+
+        // UNIX root "/" or "\" (Windows style)
+        if ('/' === $path[0] || '\\' === $path[0]) {
+            return $scheme.'/';
+        }
+
+        $length = strlen($path);
+
+        // Windows root
+        if ($length > 1 && ctype_alpha($path[0]) && ':' === $path[1]) {
+            // Special case: "C:"
+            if (2 === $length) {
+                return $scheme.$path.'/';
+            }
+
+            // Normal case: "C:/ or "C:\"
+            if ('/' === $path[2] || '\\' === $path[2]) {
+                return $scheme.$path[0].$path[1].'/';
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Returns the file name from a file path.
+     *
+     * @param string $path The path string.
+     *
+     * @return string The file name.
+     *
+     * @since 1.1 Added method.
+     * @since 2.0 Method now fails if $path is not a string.
+     */
+    public static function getFilename($path)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        Assert::string($path, 'The path must be a string. Got: %s');
+
+        return basename($path);
+    }
+
+    /**
+     * Returns the file name without the extension from a file path.
+     *
+     * @param string      $path      The path string.
+     * @param string|null $extension If specified, only that extension is cut
+     *                               off (may contain leading dot).
+     *
+     * @return string The file name without extension.
+     *
+     * @since 1.1 Added method.
+     * @since 2.0 Method now fails if $path or $extension have invalid types.
+     */
+    public static function getFilenameWithoutExtension($path, $extension = null)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        Assert::string($path, 'The path must be a string. Got: %s');
+        Assert::nullOrString($extension, 'The extension must be a string or null. Got: %s');
+
+        if (null !== $extension) {
+            // remove extension and trailing dot
+            return rtrim(basename($path, $extension), '.');
+        }
+
+        return pathinfo($path, PATHINFO_FILENAME);
+    }
+
+    /**
+     * Returns the extension from a file path.
+     *
+     * @param string $path           The path string.
+     * @param bool   $forceLowerCase Forces the extension to be lower-case
+     *                               (requires mbstring extension for correct
+     *                               multi-byte character handling in extension).
+     *
+     * @return string The extension of the file path (without leading dot).
+     *
+     * @since 1.1 Added method.
+     * @since 2.0 Method now fails if $path is not a string.
+     */
+    public static function getExtension($path, $forceLowerCase = false)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        Assert::string($path, 'The path must be a string. Got: %s');
+
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+
+        if ($forceLowerCase) {
+            $extension = self::toLower($extension);
+        }
+
+        return $extension;
+    }
+
+    /**
+     * Returns whether the path has an extension.
+     *
+     * @param string            $path       The path string.
+     * @param string|array|null $extensions If null or not provided, checks if
+     *                                      an extension exists, otherwise
+     *                                      checks for the specified extension
+     *                                      or array of extensions (with or
+     *                                      without leading dot).
+     * @param bool              $ignoreCase Whether to ignore case-sensitivity
+     *                                      (requires mbstring extension for
+     *                                      correct multi-byte character
+     *                                      handling in the extension).
+     *
+     * @return bool Returns `true` if the path has an (or the specified)
+     *              extension and `false` otherwise.
+     *
+     * @since 1.1 Added method.
+     * @since 2.0 Method now fails if $path or $extensions have invalid types.
+     */
+    public static function hasExtension($path, $extensions = null, $ignoreCase = false)
+    {
+        if ('' === $path) {
+            return false;
+        }
+
+        $extensions = is_object($extensions) ? array($extensions) : (array) $extensions;
+
+        Assert::allString($extensions, 'The extensions must be strings. Got: %s');
+
+        $actualExtension = self::getExtension($path, $ignoreCase);
+
+        // Only check if path has any extension
+        if (empty($extensions)) {
+            return '' !== $actualExtension;
+        }
+
+        foreach ($extensions as $key => $extension) {
+            if ($ignoreCase) {
+                $extension = self::toLower($extension);
+            }
+
+            // remove leading '.' in extensions array
+            $extensions[$key] = ltrim($extension, '.');
+        }
+
+        return in_array($actualExtension, $extensions);
+    }
+
+    /**
+     * Changes the extension of a path string.
+     *
+     * @param string $path      The path string with filename.ext to change.
+     * @param string $extension New extension (with or without leading dot).
+     *
+     * @return string The path string with new file extension.
+     *
+     * @since 1.1 Added method.
+     * @since 2.0 Method now fails if $path or $extension is not a string.
+     */
+    public static function changeExtension($path, $extension)
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        Assert::string($extension, 'The extension must be a string. Got: %s');
+
+        $actualExtension = self::getExtension($path);
+        $extension = ltrim($extension, '.');
+
+        // No extension for paths
+        if ('/' === substr($path, -1)) {
+            return $path;
+        }
+
+        // No actual extension in path
+        if (empty($actualExtension)) {
+            return $path.('.' === substr($path, -1) ? '' : '.').$extension;
+        }
+
+        return substr($path, 0, -strlen($actualExtension)).$extension;
+    }
+
+    /**
+     * Returns whether a path is absolute.
+     *
+     * @param string $path A path string.
+     *
+     * @return bool Returns true if the path is absolute, false if it is
+     *              relative or empty.
+     *
+     * @since 1.0 Added method.
+     * @since 2.0 Method now fails if $path is not a string.
+     */
+    public static function isAbsolute($path)
+    {
+        if ('' === $path) {
+            return false;
+        }
+
+        Assert::string($path, 'The path must be a string. Got: %s');
+
+        // Strip scheme
+        if (false !== ($pos = strpos($path, '://'))) {
+            $path = substr($path, $pos + 3);
+        }
+
+        // UNIX root "/" or "\" (Windows style)
+        if ('/' === $path[0] || '\\' === $path[0]) {
+            return true;
+        }
+
+        // Windows root
+        if (strlen($path) > 1 && ctype_alpha($path[0]) && ':' === $path[1]) {
+            // Special case: "C:"
+            if (2 === strlen($path)) {
+                return true;
+            }
+
+            // Normal case: "C:/ or "C:\"
+            if ('/' === $path[2] || '\\' === $path[2]) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether a path is relative.
+     *
+     * @param string $path A path string.
+     *
+     * @return bool Returns true if the path is relative or empty, false if
+     *              it is absolute.
+     *
+     * @since 1.0 Added method.
+     * @since 2.0 Method now fails if $path is not a string.
+     */
+    public static function isRelative($path)
+    {
+        return !static::isAbsolute($path);
+    }
+
+    /**
+     * Turns a relative path into an absolute path.
+     *
+     * Usually, the relative path is appended to the given base path. Dot
+     * segments ("." and "..") are removed/collapsed and all slashes turned
+     * into forward slashes.
+     *
+     * ```php
+     * echo Path::makeAbsolute("../style.css", "/webmozart/puli/css");
+     * // => /webmozart/puli/style.css
+     * ```
+     *
+     * If an absolute path is passed, that path is returned unless its root
+     * directory is different than the one of the base path. In that case, an
+     * exception is thrown.
+     *
+     * ```php
+     * Path::makeAbsolute("/style.css", "/webmozart/puli/css");
+     * // => /style.css
+     *
+     * Path::makeAbsolute("C:/style.css", "C:/webmozart/puli/css");
+     * // => C:/style.css
+     *
+     * Path::makeAbsolute("C:/style.css", "/webmozart/puli/css");
+     * // InvalidArgumentException
+     * ```
+     *
+     * If the base path is not an absolute path, an exception is thrown.
+     *
+     * The result is a canonical path.
+     *
+     * @param string $path     A path to make absolute.
+     * @param string $basePath An absolute base path.
+     *
+     * @return string An absolute path in canonical form.
+     *
+     * @throws InvalidArgumentException If the base path is not absolute or if
+     *                                  the given path is an absolute path with
+     *                                  a different root than the base path.
+     *
+     * @since 1.0   Added method.
+     * @since 2.0   Method now fails if $path or $basePath is not a string.
+     * @since 2.2.2 Method does not fail anymore of $path and $basePath are
+     *              absolute, but on different partitions.
+     */
+    public static function makeAbsolute($path, $basePath)
+    {
+        Assert::stringNotEmpty($basePath, 'The base path must be a non-empty string. Got: %s');
+
+        if (!static::isAbsolute($basePath)) {
+            throw new InvalidArgumentException(sprintf(
+                'The base path "%s" is not an absolute path.',
+                $basePath
+            ));
+        }
+
+        if (static::isAbsolute($path)) {
+            return static::canonicalize($path);
+        }
+
+        if (false !== ($pos = strpos($basePath, '://'))) {
+            $scheme = substr($basePath, 0, $pos + 3);
+            $basePath = substr($basePath, $pos + 3);
+        } else {
+            $scheme = '';
+        }
+
+        return $scheme.self::canonicalize(rtrim($basePath, '/\\').'/'.$path);
+    }
+
+    /**
+     * Turns a path into a relative path.
+     *
+     * The relative path is created relative to the given base path:
+     *
+     * ```php
+     * echo Path::makeRelative("/webmozart/style.css", "/webmozart/puli");
+     * // => ../style.css
+     * ```
+     *
+     * If a relative path is passed and the base path is absolute, the relative
+     * path is returned unchanged:
+     *
+     * ```php
+     * Path::makeRelative("style.css", "/webmozart/puli/css");
+     * // => style.css
+     * ```
+     *
+     * If both paths are relative, the relative path is created with the
+     * assumption that both paths are relative to the same directory:
+     *
+     * ```php
+     * Path::makeRelative("style.css", "webmozart/puli/css");
+     * // => ../../../style.css
+     * ```
+     *
+     * If both paths are absolute, their root directory must be the same,
+     * otherwise an exception is thrown:
+     *
+     * ```php
+     * Path::makeRelative("C:/webmozart/style.css", "/webmozart/puli");
+     * // InvalidArgumentException
+     * ```
+     *
+     * If the passed path is absolute, but the base path is not, an exception
+     * is thrown as well:
+     *
+     * ```php
+     * Path::makeRelative("/webmozart/style.css", "webmozart/puli");
+     * // InvalidArgumentException
+     * ```
+     *
+     * If the base path is not an absolute path, an exception is thrown.
+     *
+     * The result is a canonical path.
+     *
+     * @param string $path     A path to make relative.
+     * @param string $basePath A base path.
+     *
+     * @return string A relative path in canonical form.
+     *
+     * @throws InvalidArgumentException If the base path is not absolute or if
+     *                                  the given path has a different root
+     *                                  than the base path.
+     *
+     * @since 1.0 Added method.
+     * @since 2.0 Method now fails if $path or $basePath is not a string.
+     */
+    public static function makeRelative($path, $basePath)
+    {
+        Assert::string($basePath, 'The base path must be a string. Got: %s');
+
+        $path = static::canonicalize($path);
+        $basePath = static::canonicalize($basePath);
+
+        list($root, $relativePath) = self::split($path);
+        list($baseRoot, $relativeBasePath) = self::split($basePath);
+
+        // If the base path is given as absolute path and the path is already
+        // relative, consider it to be relative to the given absolute path
+        // already
+        if ('' === $root && '' !== $baseRoot) {
+            // If base path is already in its root
+            if ('' === $relativeBasePath) {
+                $relativePath = ltrim($relativePath, './\\');
+            }
+
+            return $relativePath;
+        }
+
+        // If the passed path is absolute, but the base path is not, we
+        // cannot generate a relative path
+        if ('' !== $root && '' === $baseRoot) {
+            throw new InvalidArgumentException(sprintf(
+                'The absolute path "%s" cannot be made relative to the '.
+                'relative path "%s". You should provide an absolute base '.
+                'path instead.',
+                $path,
+                $basePath
+            ));
+        }
+
+        // Fail if the roots of the two paths are different
+        if ($baseRoot && $root !== $baseRoot) {
+            throw new InvalidArgumentException(sprintf(
+                'The path "%s" cannot be made relative to "%s", because they '.
+                'have different roots ("%s" and "%s").',
+                $path,
+                $basePath,
+                $root,
+                $baseRoot
+            ));
+        }
+
+        if ('' === $relativeBasePath) {
+            return $relativePath;
+        }
+
+        // Build a "../../" prefix with as many "../" parts as necessary
+        $parts = explode('/', $relativePath);
+        $baseParts = explode('/', $relativeBasePath);
+        $dotDotPrefix = '';
+
+        // Once we found a non-matching part in the prefix, we need to add
+        // "../" parts for all remaining parts
+        $match = true;
+
+        foreach ($baseParts as $i => $basePart) {
+            if ($match && isset($parts[$i]) && $basePart === $parts[$i]) {
+                unset($parts[$i]);
+
+                continue;
+            }
+
+            $match = false;
+            $dotDotPrefix .= '../';
+        }
+
+        return rtrim($dotDotPrefix.implode('/', $parts), '/');
+    }
+
+    /**
+     * Returns whether the given path is on the local filesystem.
+     *
+     * @param string $path A path string.
+     *
+     * @return bool Returns true if the path is local, false for a URL.
+     *
+     * @since 1.0 Added method.
+     * @since 2.0 Method now fails if $path is not a string.
+     */
+    public static function isLocal($path)
+    {
+        Assert::string($path, 'The path must be a string. Got: %s');
+
+        return '' !== $path && false === strpos($path, '://');
+    }
+
+    /**
+     * Returns the longest common base path of a set of paths.
+     *
+     * Dot segments ("." and "..") are removed/collapsed and all slashes turned
+     * into forward slashes.
+     *
+     * ```php
+     * $basePath = Path::getLongestCommonBasePath(array(
+     *     '/webmozart/css/style.css',
+     *     '/webmozart/css/..'
+     * ));
+     * // => /webmozart
+     * ```
+     *
+     * The root is returned if no common base path can be found:
+     *
+     * ```php
+     * $basePath = Path::getLongestCommonBasePath(array(
+     *     '/webmozart/css/style.css',
+     *     '/puli/css/..'
+     * ));
+     * // => /
+     * ```
+     *
+     * If the paths are located on different Windows partitions, `null` is
+     * returned.
+     *
+     * ```php
+     * $basePath = Path::getLongestCommonBasePath(array(
+     *     'C:/webmozart/css/style.css',
+     *     'D:/webmozart/css/..'
+     * ));
+     * // => null
+     * ```
+     *
+     * @param array $paths A list of paths.
+     *
+     * @return string|null The longest common base path in canonical form or
+     *                     `null` if the paths are on different Windows
+     *                     partitions.
+     *
+     * @since 1.0 Added method.
+     * @since 2.0 Method now fails if $paths are not strings.
+     */
+    public static function getLongestCommonBasePath(array $paths)
+    {
+        Assert::allString($paths, 'The paths must be strings. Got: %s');
+
+        list($bpRoot, $basePath) = self::split(self::canonicalize(reset($paths)));
+
+        for (next($paths); null !== key($paths) && '' !== $basePath; next($paths)) {
+            list($root, $path) = self::split(self::canonicalize(current($paths)));
+
+            // If we deal with different roots (e.g. C:/ vs. D:/), it's time
+            // to quit
+            if ($root !== $bpRoot) {
+                return null;
+            }
+
+            // Make the base path shorter until it fits into path
+            while (true) {
+                if ('.' === $basePath) {
+                    // No more base paths
+                    $basePath = '';
+
+                    // Next path
+                    continue 2;
+                }
+
+                // Prevent false positives for common prefixes
+                // see isBasePath()
+                if (0 === strpos($path.'/', $basePath.'/')) {
+                    // Next path
+                    continue 2;
+                }
+
+                $basePath = dirname($basePath);
+            }
+        }
+
+        return $bpRoot.$basePath;
+    }
+
+    /**
+     * Joins two or more path strings.
+     *
+     * The result is a canonical path.
+     *
+     * @param string[]|string $paths Path parts as parameters or array.
+     *
+     * @return string The joint path.
+     *
+     * @since 2.0 Added method.
+     */
+    public static function join($paths)
+    {
+        if (!is_array($paths)) {
+            $paths = func_get_args();
+        }
+
+        Assert::allString($paths, 'The paths must be strings. Got: %s');
+
+        $finalPath = null;
+        $wasScheme = false;
+
+        foreach ($paths as $path) {
+            $path = (string) $path;
+
+            if ('' === $path) {
+                continue;
+            }
+
+            if (null === $finalPath) {
+                // For first part we keep slashes, like '/top', 'C:\' or 'phar://'
+                $finalPath = $path;
+                $wasScheme = (strpos($path, '://') !== false);
+                continue;
+            }
+
+            // Only add slash if previous part didn't end with '/' or '\'
+            if (!in_array(substr($finalPath, -1), array('/', '\\'))) {
+                $finalPath .= '/';
+            }
+
+            // If first part included a scheme like 'phar://' we allow current part to start with '/', otherwise trim
+            $finalPath .= $wasScheme ? $path : ltrim($path, '/');
+            $wasScheme = false;
+        }
+
+        if (null === $finalPath) {
+            return '';
+        }
+
+        return self::canonicalize($finalPath);
+    }
+
+    /**
+     * Returns whether a path is a base path of another path.
+     *
+     * Dot segments ("." and "..") are removed/collapsed and all slashes turned
+     * into forward slashes.
+     *
+     * ```php
+     * Path::isBasePath('/webmozart', '/webmozart/css');
+     * // => true
+     *
+     * Path::isBasePath('/webmozart', '/webmozart');
+     * // => true
+     *
+     * Path::isBasePath('/webmozart', '/webmozart/..');
+     * // => false
+     *
+     * Path::isBasePath('/webmozart', '/puli');
+     * // => false
+     * ```
+     *
+     * @param string $basePath The base path to test.
+     * @param string $ofPath   The other path.
+     *
+     * @return bool Whether the base path is a base path of the other path.
+     *
+     * @since 1.0 Added method.
+     * @since 2.0 Method now fails if $basePath or $ofPath is not a string.
+     */
+    public static function isBasePath($basePath, $ofPath)
+    {
+        Assert::string($basePath, 'The base path must be a string. Got: %s');
+
+        $basePath = self::canonicalize($basePath);
+        $ofPath = self::canonicalize($ofPath);
+
+        // Append slashes to prevent false positives when two paths have
+        // a common prefix, for example /base/foo and /base/foobar.
+        // Don't append a slash for the root "/", because then that root
+        // won't be discovered as common prefix ("//" is not a prefix of
+        // "/foobar/").
+        return 0 === strpos($ofPath.'/', rtrim($basePath, '/').'/');
+    }
+
+    /**
+     * Splits a part into its root directory and the remainder.
+     *
+     * If the path has no root directory, an empty root directory will be
+     * returned.
+     *
+     * If the root directory is a Windows style partition, the resulting root
+     * will always contain a trailing slash.
+     *
+     * list ($root, $path) = Path::split("C:/webmozart")
+     * // => array("C:/", "webmozart")
+     *
+     * list ($root, $path) = Path::split("C:")
+     * // => array("C:/", "")
+     *
+     * @param string $path The canonical path to split.
+     *
+     * @return string[] An array with the root directory and the remaining
+     *                  relative path.
+     */
+    private static function split($path)
+    {
+        if ('' === $path) {
+            return array('', '');
+        }
+
+        // Remember scheme as part of the root, if any
+        if (false !== ($pos = strpos($path, '://'))) {
+            $root = substr($path, 0, $pos + 3);
+            $path = substr($path, $pos + 3);
+        } else {
+            $root = '';
+        }
+
+        $length = strlen($path);
+
+        // Remove and remember root directory
+        if ('/' === $path[0]) {
+            $root .= '/';
+            $path = $length > 1 ? substr($path, 1) : '';
+        } elseif ($length > 1 && ctype_alpha($path[0]) && ':' === $path[1]) {
+            if (2 === $length) {
+                // Windows special case: "C:"
+                $root .= $path.'/';
+                $path = '';
+            } elseif ('/' === $path[2]) {
+                // Windows normal case: "C:/"..
+                $root .= substr($path, 0, 3);
+                $path = $length > 3 ? substr($path, 3) : '';
+            }
+        }
+
+        return array($root, $path);
+    }
+
+    /**
+     * Converts string to lower-case (multi-byte safe if mbstring is installed).
+     *
+     * @param string $str The string
+     *
+     * @return string Lower case string
+     */
+    private static function toLower($str)
+    {
+        if (function_exists('mb_strtolower')) {
+            return mb_strtolower($str, mb_detect_encoding($str));
+        }
+
+        return strtolower($str);
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/lib/Drush/Webmozart/PathUtil/Url.php
+++ b/lib/Drush/Webmozart/PathUtil/Url.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the webmozart/path-util package.
+ *
+ * (c) Bernhard Schussek <bschussek@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Imported into Drush namespace from webmozart/path-util version 2.3.0
+namespace Drush\Webmozart\PathUtil;
+
+use InvalidArgumentException;
+use Drush\Webmozart\Assert\Assert;
+
+/**
+ * Contains utility methods for handling URL strings.
+ *
+ * The methods in this class are able to deal with URLs.
+ *
+ * @since  2.3
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Claudio Zizza <claudio@budgegeria.de>
+ */
+final class Url
+{
+    /**
+     * Turns a URL into a relative path.
+     *
+     * The result is a canonical path. This class is using functionality of Path class.
+     *
+     * @see Path
+     *
+     * @param string $url     A URL to make relative.
+     * @param string $baseUrl A base URL.
+     *
+     * @return string
+     *
+     * @throws InvalidArgumentException If the URL and base URL does
+     *                                  not match.
+     */
+    public static function makeRelative($url, $baseUrl)
+    {
+        Assert::string($url, 'The URL must be a string. Got: %s');
+        Assert::string($baseUrl, 'The base URL must be a string. Got: %s');
+        Assert::contains($baseUrl, '://', '%s is not an absolute Url.');
+
+        list($baseHost, $basePath) = self::split($baseUrl);
+
+        if (false === strpos($url, '://')) {
+            if (0 === strpos($url, '/')) {
+                $host = $baseHost;
+            } else {
+                $host = '';
+            }
+            $path = $url;
+        } else {
+            list($host, $path) = self::split($url);
+        }
+
+        if ('' !== $host && $host !== $baseHost) {
+            throw new InvalidArgumentException(sprintf(
+                'The URL "%s" cannot be made relative to "%s" since their host names are different.',
+                $host,
+                $baseHost
+            ));
+        }
+
+        return Path::makeRelative($path, $basePath);
+    }
+
+    /**
+     * Splits a URL into its host and the path.
+     *
+     * ```php
+     * list ($root, $path) = Path::split("http://example.com/webmozart")
+     * // => array("http://example.com", "/webmozart")
+     *
+     * list ($root, $path) = Path::split("http://example.com")
+     * // => array("http://example.com", "")
+     * ```
+     *
+     * @param string $url The URL to split.
+     *
+     * @return string[] An array with the host and the path of the URL.
+     *
+     * @throws InvalidArgumentException If $url is not a URL.
+     */
+    private static function split($url)
+    {
+        $pos = strpos($url, '://');
+        $scheme = substr($url, 0, $pos + 3);
+        $url = substr($url, $pos + 3);
+
+        if (false !== ($pos = strpos($url, '/'))) {
+            $host = substr($url, 0, $pos);
+            $url = substr($url, $pos);
+        } else {
+            // No path, only host
+            $host = $url;
+            $url = '/';
+        }
+
+        // At this point, we have $scheme, $host and $path
+        $root = $scheme.$host;
+
+        return array($root, $url);
+    }
+}

--- a/tests/commandUnitTest.php
+++ b/tests/commandUnitTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Drush\Webmozart\PathUtil\Path;
 
 class commandUnitCase extends UnitUnishTestCase {
   /**

--- a/tests/drushScriptTest.php
+++ b/tests/drushScriptTest.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Unish;
-use Webmozart\PathUtil\Path;
+use Drush\Webmozart\PathUtil\Path;
 
 /**
  * Tests for the 'drush' script itself


### PR DESCRIPTION
Despite the fact that [Composer dependency hell is a hard problem](https://pantheon.io/blog/trouble-two-autoloaders), everyone loves the convenience of using a global Drush installation. Drush 9 and Drupal Console [only support site-local installations](https://pantheon.io/blog/avoiding-dependency-hell-site-local-drush), but Drush 8 has continued to support the global installation method.

This story is greatly complicated by Drupal 8.4.x, which has upgraded to a new major version of Symfony (3.x) during a minor release cycle. While [SemVer explicitly allows this](http://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api), it poses a particular problem with Drush. With most SemVer-respecting software, upgrading to match the new requirements of dependencies is a one-time task. Once an app has been upgraded, it no longer needs to remain compatible with older versions of its dependencies.

Not so with Drush.  Drush 8.x remains compatible with Drush 6, 7 and 8. If we do not address the Symfony 3 issue, then Drush 8 will be [forced to drop support for Drupal 8.4.x](https://github.com/drush-ops/drush/pull/2778). This poses some serious problems:

- It complicates the version support story, as traditionally, each major version of Drush has supported specific major versions of Drupal.
- There would be no way to use Drush to update from Drupal 8.3.x to 8.4.0.
- Anyone using Drupal 8.4.0 and later would have to use Drush 9, which means that they would have to use Composer to manage their Drupal site, or do all updates by hand.

This PR lays down the groundwork to attempt to provide support for both Drupal 8.3.x and earlier, and Drupal 8.4.x and later, in the same global installation of Drush at the same time.

Strategy:

- Drush will perform its early bootstrap using only code provided by Drush; no dependencies will be used at first.
- Once Drush has located the desired Composer root for the desired site (currently defined as the folder that contains both `composer.json` and `composer.lock`), then it will select an appropriate compatible autoload file and include it. If no composer root is found (Drupal 7 sites not managed by Composer, and Drupal 6 sites), then Drush will load its current autoload file.
- The later bootstrap stages (bootstrap root and later) then run as they always have.

In its current form, this PR succeeds at delaying the loading of the autoload file until immediately before the bootstrap root phase, after it has found the Composer root. At this point, no attempt is made to identify whether the dependencies in the target Drupal site are compatible or not, nor has any attempt been made to provide classes Drush needs that are compatible with either Symfony 2 or Symfony 3. This is the easier problem, though, and I am sure it is possible. (n.b. The Consolidation components are already compatible with both Symfony 2 and Symfony 3, and abstract some of the differences. These versions of Symfony are already very similar, though.)

There are two problems remaining in the early bootstrap phase, though, as there are two external dependencies that Drush needs from the very beginning:

- webmozart/path-util
- psr/log

In the current version of this PR, Drush is manually including the two files it needs from path-util. This is an interim implementation. For logging, there is a commented-out procedural version of the logger that simply printf's the log messages until the PSR-2 logger becomes available. It is commented out because the interim implementation does not respect verbose / debug modes.

There are a number of ways we can solve the problem of the dependencies needed early in the bootstrap process. If the tests can be made to pass on the code written so far (or at least reduce the failures to only those issues related to unimplemented items mentioned above), then I think this will demonstrate that this is a viable proof-of-concept.

Note that the strategies suggested here are not particularly maintainable. The assumption is that this code will not be brought forward to Drush 9, and that the Drupal community will move to exclusively managing their Drupal sites with Composer prior to any future Drupal change that is unsupportable in Drush 8 (e.g. Symfony 4). Presumably, all of that happens by / with Drupal 9.