### PR TITLE
Remove drush_locate_root

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -318,33 +318,6 @@ function drush_conf_path($server_uri, $require_settings = TRUE) {
 }
 
 /**
- * Exhaustive depth-first search to try and locate the Drupal root directory.
- * This makes it possible to run Drush from a subdirectory of the drupal root.
- *
- * @param
- *   Search start path. Defaults to current working directory.
- * @return
- *   A path to drupal root, or FALSE if not found.
- */
-function drush_locate_root($start_path = NULL) {
-  $drupal_root = FALSE;
-
-  $start_path = empty($start_path) ? drush_cwd() : $start_path;
-
-  $drupalFinder = new DrupalFinder();
-  if (!$drupalFinder->locateRoot($start_path)) {
-//    echo ' Drush must be executed within a Drupal site.'. PHP_EOL;
-//    exit(1);
-  }
-
-  // $composerRoot = $drupalFinder->getComposerRoot();
-  $drupalRoot = $drupalFinder->getDrupalRoot();
-  // chdir($drupalRoot);
-
-  return $drupalRoot;
-}
-
-/**
  * Checks whether given path qualifies as a Drupal root.
  *
  * @param string

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -543,13 +543,7 @@ function drush_preflight() {
  */
 function drush_preflight_root() {
   $root = drush_get_option('root');
-  if (!isset($root)) {
-    $root = drush_locate_root();
-  }
-  if ($root) {
-    $root = realpath($root);
-  }
-  Drush::bootstrapManager()->setRoot($root);
+  Drush::bootstrapManager()->locateRoot($root);
 
   // Load the config options from Drupal's /drush, ../drush, and sites/all/drush directories,
   // even prior to bootstrapping the root.

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1443,8 +1443,10 @@ function _drush_find_local_sites_in_sites_folder($a_drupal_root) {
       // First we'll resolve the realpath of the settings.php file,
       // so that we get the correct drupal root when symlinks are in use.
       $real_sitedir = dirname(realpath($filename));
-      $real_root = drush_locate_root($filename);
-      if ($real_root !== FALSE) {
+
+      $drupalFinder = new DrupalFinder();
+      if ($drupalFinder->locateRoot($real_sitedir)) {
+        $real_root = $drupalFinder->getDrupalRoot();
         $a_drupal_site = $real_root . '#' . basename($real_sitedir);
       }
       // If the symlink points to some folder outside of any drupal
@@ -1556,7 +1558,10 @@ function drush_sitealias_build_record_from_settings_file($site_settings_file, $a
 
   if (file_exists($site_settings_file)) {
     if (!isset($drupal_root)) {
-      $drupal_root = drush_locate_root($site_settings_file);
+      $drupalFinder = new DrupalFinder();
+      if ($drupalFinder->locateRoot(dirname($site_settings_file))) {
+        $drupal_root = $drupalFinder->getDrupalRoot();
+      }
     }
 
     $alias_record['root'] = $drupal_root;


### PR DESCRIPTION
In order to write the `pm-*` compatibility commands (wrappers around Composer equivalent), we need to know where the Composer root is. DrupalFinder knows, but we don't keep it around.

This PR aims to move the DrupalFinder into the bootstrap object, so that we can ask for the composer root when we want it.

In progress.