### PR TITLE
Add a legacy 'drush dl' command 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "psr/log": "~1.0",
     "psy/psysh": "~0.6",
     "league/container": "~2",
-    "consolidation/robo": "dev-composer-init",
+    "consolidation/robo": "^1.0.8",
     "symfony/config": "~2.2|^3",
     "chi-teck/drupal-code-generator": "dev-master",
     "consolidation/annotated-command": "~2.4",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "psr/log": "~1.0",
     "psy/psysh": "~0.6",
     "league/container": "~2",
-    "consolidation/robo": "~1",
+    "consolidation/robo": "dev-composer-init",
     "symfony/config": "~2.2|^3",
     "chi-teck/drupal-code-generator": "dev-master",
     "consolidation/annotated-command": "~2.4",

--- a/src/Commands/LegacyCommands.php
+++ b/src/Commands/LegacyCommands.php
@@ -124,7 +124,6 @@ class LegacyCommands extends DrushCommands implements BuilderAwareInterface, IOA
             'repository' => ''
         ]
     ) {
-
         $composerRoot = Drush::bootstrapManager()->getComposerRoot();
 
         if ($options['dev']) {
@@ -133,9 +132,6 @@ class LegacyCommands extends DrushCommands implements BuilderAwareInterface, IOA
 
         if ($composerRoot) {
             return $this->downloadViaRequire($composerRoot, $args, $options);
-        }
-        if ($options['dev']) {
-            return $this->downloadViaClone($args, $options);
         }
         return $this->downloadViaCreateProject($args, $options);
     }
@@ -164,23 +160,6 @@ class LegacyCommands extends DrushCommands implements BuilderAwareInterface, IOA
         );
     }
 
-    protected function getBranch($project)
-    {
-        $uri = "https://updates.drupal.org/release-history/$project/8.x";
-        $releaseData = file_get_contents($uri);
-        $defaultMajor = $this->getDefaultMajor($releaseData);
-
-        return "8.x-${defaultMajor}.x";
-    }
-
-    protected function getDefaultMajor($releaseData)
-    {
-        if (preg_match('#<default_major>([0-9]*)</default_major>#', $releaseData, $matches)) {
-            return $matches[1];
-        }
-        return '1';
-    }
-
     protected function downloadViaCreateProject($args, $options)
     {
         $args = $this->fixProjectArgs($args);
@@ -204,24 +183,6 @@ class LegacyCommands extends DrushCommands implements BuilderAwareInterface, IOA
                 ->noInstall($options['no-install'])
                 ->stability($stability)
                 ->noInteraction();
-        }
-        return $builder;
-    }
-
-    protected function downloadViaClone($args, $options)
-    {
-        $builder = $this->collectionBuilder();
-        $baseDir = drush_cwd();
-
-        foreach ($args as $arg) {
-            $repoUri = "https://git.drupal.org/project/$arg.git";
-            // How would we determine the correct branch?
-            // We probably wouldn't want to have to pull in large
-            // amounts of releasexml parsing code.
-            $branch = $this->getBranch($arg);
-            $targetDir = "$baseDir/$arg";
-            $builder = $this->taskGitStack()
-                ->cloneRepo($repoUri, $targetDir, $branch);
         }
         return $builder;
     }

--- a/src/Commands/LegacyCommands.php
+++ b/src/Commands/LegacyCommands.php
@@ -164,6 +164,23 @@ class LegacyCommands extends DrushCommands implements BuilderAwareInterface, IOA
         );
     }
 
+    protected function getBranch($project)
+    {
+        $uri = "https://updates.drupal.org/release-history/$project/8.x";
+        $releaseData = file_get_contents($uri);
+        $defaultMajor = $this->getDefaultMajor($releaseData);
+
+        return "8.x-${defaultMajor}.x";
+    }
+
+    protected function getDefaultMajor($releaseData)
+    {
+        if (preg_match('#<default_major>([0-9]*)</default_major>#', $releaseData, $matches)) {
+            return $matches[1];
+        }
+        return '1';
+    }
+
     protected function downloadViaCreateProject($args, $options)
     {
         $args = $this->fixProjectArgs($args);
@@ -201,7 +218,7 @@ class LegacyCommands extends DrushCommands implements BuilderAwareInterface, IOA
             // How would we determine the correct branch?
             // We probably wouldn't want to have to pull in large
             // amounts of releasexml parsing code.
-            $branch = '8.x-3.x';
+            $branch = $this->getBranch($arg);
             $targetDir = "$baseDir/$arg";
             $builder = $this->taskGitStack()
                 ->cloneRepo($repoUri, $targetDir, $branch);

--- a/src/Commands/LegacyCommands.php
+++ b/src/Commands/LegacyCommands.php
@@ -122,8 +122,9 @@ class LegacyCommands extends DrushCommands implements BuilderAwareInterface, IOA
             'keep-vcs' => false,
             'no-install' => false,
             'repository' => 'https://packages.drupal.org/8'
-        ])
-    {
+        ]
+    ) {
+    
         $composerRoot = Drush::bootstrapManager()->getComposerRoot();
 
         $args = $this->fixProjectArgs($args);

--- a/src/Commands/LegacyCommands.php
+++ b/src/Commands/LegacyCommands.php
@@ -94,7 +94,7 @@ class LegacyCommands extends DrushCommands implements BuilderAwareInterface, IOA
      */
     public function releases()
     {
-        $msg = 'The pm-releases command was deprecated. Please see `composer show <packagename>`';
+        $msg = 'The pm-releases command was deprecated. Please see `composer search` and `composer show <packagename>`';
         $this->logger()->notice($msg);
     }
 


### PR DESCRIPTION
Wraps 'composer require' / 'composer create-project'.

The `create-project` version can behave strangely; for example, `drush dl drupal` downloads Drupal 8.1.3 instead of 8.3.2. Not sure why that is. Also, it seems that `--dev` does not work; perhaps this is an expected characteristic of the drupal.org packagist.