### PR TITLE
Fix broken reference to $name in LoginCommands

### DIFF
--- a/src/Commands/core/LoginCommands.php
+++ b/src/Commands/core/LoginCommands.php
@@ -31,7 +31,7 @@ class LoginCommands extends DrushCommands
         // the *local* machine.
         $alias = drush_get_context('DRUSH_TARGET_SITE_ALIAS');
         if (drush_sitealias_is_remote_site($alias)) {
-            $return = drush_invoke_process($alias, 'user-login', $name, drush_redispatch_get_options(), array('integrate' => false));
+            $return = drush_invoke_process($alias, 'user-login', $options['name'], drush_redispatch_get_options(), array('integrate' => false));
             if ($return['error_status']) {
                 throw new \Exception('Unable to execute user login.');
             } else {


### PR DESCRIPTION
Only really applies to remote execution, but this just fixes the broken variable reference.