### PR TITLE
Render Drush command file service definition with Twig template

### DIFF
--- a/src/Commands/generate/GenerateCommands.php
+++ b/src/Commands/generate/GenerateCommands.php
@@ -15,7 +15,6 @@ use Drush\Drush;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Yaml\Dumper as YamlDumper;
 
 /**
  * Drush generate command.
@@ -90,7 +89,7 @@ class GenerateCommands extends DrushCommands
         } elseif (drush_get_context('DRUSH_NEGATIVE')) {
             $override = false;
         }
-        $dumper = new Dumper(new Filesystem(), new YamlDumper(), $override);
+        $dumper = new Dumper(new Filesystem(), $override);
         $helperSet->set($dumper);
 
         $twig_loader = new \Twig_Loader_Filesystem();

--- a/src/Commands/generate/Generators/Drush/DrushCommandFile.php
+++ b/src/Commands/generate/Generators/Drush/DrushCommandFile.php
@@ -28,14 +28,7 @@ class DrushCommandFile extends BaseGenerator
         $vars = $this->collectVars($input, $output, $questions);
         $vars['class'] = Utils::camelize($vars['machine_name'] . 'Commands');
 
-        $this->files['src/Commands/' . $vars['class'] . '.php'] = $this->render('drush-command-file.twig', $vars);
-        $this->services[$vars['machine_name'] . '.commands'] = [
-            'class' => '\Drupal\\' . $vars['machine_name'] . '\Commands\\' . $vars['class'],
-            'tags' => [
-                [
-                    'name' => 'drush.command',
-                ],
-            ],
-        ];
+        $this->setFile('src/Commands/' . $vars['class'] . '.php', 'drush-command-file.twig', $vars);
+        $this->setServicesFile('drush.services.yml', 'drush.services.twig', $vars);
     }
 }

--- a/src/Commands/generate/Generators/Drush/drush.services.twig
+++ b/src/Commands/generate/Generators/Drush/drush.services.twig
@@ -1,0 +1,5 @@
+services:
+  {{ machine_name }}.commands:
+    class: \Drupal\{{ machine_name }}\Commands\{{ class }}
+    tags:
+      - { name: drush.command }

--- a/src/Commands/generate/Generators/Migrate/MigrationGenerator.php
+++ b/src/Commands/generate/Generators/Migrate/MigrationGenerator.php
@@ -37,9 +37,9 @@ class MigrationGenerator extends BaseGenerator
         $vars = $this->collectVars($input, $output, $questions);
         $vars['class'] = Utils::camelize($vars['plugin_label']);
 
-        $path = 'src/Plugin/migrate/source/' . $vars['class'] . '.php';
-        $this->files[$path] = $this->render('migration.twig', $vars);
-        $path = 'config/install/migrate_plus.migration.' . $vars['plugin_id'] . '.yml';
-        $this->files[$path] = $this->render('migration.yml.twig', $vars);
+        $plugin_path = 'src/Plugin/migrate/source/' . $vars['class'] . '.php';
+        $this->setFile($plugin_path, 'migration.twig', $vars);
+        $migration_path = 'config/install/migrate_plus.migration.' . $vars['plugin_id'] . '.yml';
+        $this->setFile($migration_path, 'migration.yml.twig', $vars);
     }
 }


### PR DESCRIPTION
Until now DCG treated hooks and  _services.yml_ files in special way to preserve content of original files when they exist. I've just added more general way to append new content to existing file. A file definition can have some meta information including a property called _header_size_ so the dumper is able to merge the content of the file correctly.

It caused some small API changes addressed in this PR

1. _services.yml_ file should be rendered the same way as any other files (with Twig).
2. Path to _services.yml_ file should be specified explicitly (service tags are not checked any more).
3. Generator application no longer needs Yaml dumper.
