### PR TITLE
Peg Symfony to version 2 in require-dev. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,11 @@
     "sebastian/version": "~1"
   },
   "require-dev": {
+    "symfony/var-dumper": "~2.7",
+    "symfony/console": "~2.7",
+    "symfony/process": "~2.7",
+    "symfony/event-dispatcher": "~2.7",
+    "symfony/finder": "~2.7",
     "lox/xhprof": "dev-master",
     "phpunit/phpunit": "^4",
     "squizlabs/php_codesniffer": "^2.7"


### PR DESCRIPTION
The global installation of Drush 9 is only unofficially supported. All the same, there is a problem that the global install does not support Drupal 8.3.x out-of-the-box due to the composer.json requirement of Symfony 3 components.

This experimental PR requires the older version of Symfony in the require-dev section. This makes the global install of Drush 9 work with Drupal 8.3.x and Drupal 8.4.x.

This will be ignored for site-local Drush, so the supported configurations will continue to work as before.

If this is committed at all, it should be backed out at some point in the future. Unsure if we should do this for master; we probably should do it for Drush 8.x, but it is more convenient to test with the sut on the master branch, so starting here first.