### PR TITLE
composer-highest.json uses webflo/drupal-core-strict 

### DIFF
--- a/tests/resources/codebase/composer-highest.json
+++ b/tests/resources/codebase/composer-highest.json
@@ -16,7 +16,7 @@
   "require": {
     "composer/installers": "^1.2",
     "cweagans/composer-patches": "~1.6",
-    "drupal/core": "8.4.x-dev",
+    "webflo/drupal-core-strict": "8.4.x-dev",
     "drush/drush": "*@dev",
     "phpunit/phpunit": "^4.1",
     "drupal/empty_theme": "^1.0",


### PR DESCRIPTION
We use webflo/drupal-core-strict instead of drupal/core.

This fixes mysterious test fails per https://www.drupal.org/node/2882456