### PR TITLE
Add module machine names to autocomplete for Module label

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "repositories": [
     {
       "type": "vcs",
-      "url": "https://github.com/Chi-teck/drupal-code-generator"
+      "url": "https://github.com/weitzman/drupal-code-generator"
     }
   ],
   "require": {
@@ -36,7 +36,7 @@
     "league/container": "~2",
     "consolidation/robo": "~1",
     "symfony/config": "~2.2|^3",
-    "chi-teck/drupal-code-generator": "dev-master",
+    "chi-teck/drupal-code-generator": "dev-add-normalizer",
     "consolidation/annotated-command": "^2.4",
     "consolidation/output-formatters": "^3.1.10",
     "symfony/yaml": "~2.3|^3",


### PR DESCRIPTION
Ultimately, we might want to omit the Module name question for virtually all generators. Its redundant with machine_name. 