### PR TITLE
Update drush generate according to DCG changes

### DIFF
--- a/src/Commands/generate/Generators/Drush/DrushCommandFile.php
+++ b/src/Commands/generate/Generators/Drush/DrushCommandFile.php
@@ -3,10 +3,10 @@
 namespace Drush\Commands\generate\Generators\Drush;
 
 use DrupalCodeGenerator\Command\BaseGenerator;
-use DrupalCodeGenerator\Question;
 use DrupalCodeGenerator\Utils;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
 
 /**
  * Implements drush-command-file command.
@@ -24,7 +24,8 @@ class DrushCommandFile extends BaseGenerator
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
-        $questions = Utils::defaultQuestions() + [new Question('Absolute path to legacy Drush commandfile (optional - for porting)')];
+        $questions = Utils::defaultQuestions();
+        $questions['source'] = new Question('Absolute path to legacy Drush command file (optional - for porting)');
 
         $vars = $this->collectVars($input, $output, $questions);
         $vars['class'] = Utils::camelize($vars['machine_name'] . 'Commands');

--- a/src/Commands/generate/Generators/Migrate/MigrationGenerator.php
+++ b/src/Commands/generate/Generators/Migrate/MigrationGenerator.php
@@ -6,6 +6,7 @@ use DrupalCodeGenerator\Command\BaseGenerator;
 use DrupalCodeGenerator\Utils;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
 
 /**
  * Implements `generate migration` command.
@@ -22,9 +23,9 @@ class MigrationGenerator extends BaseGenerator
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
-        $questions = Utils::defaultQuestions() + Utils::defaultPluginQuestions() + [
-            'migration_group' => ['Migration group', 'default'],
-            'destination_plugin' => ['Destination plugin', 'entity:node'],
+        $questions = Utils::defaultPluginQuestions() + [
+            'migration_group' => new Question('Migration group', 'default'),
+            'destination_plugin' => new Question('Destination plugin', 'entity:node'),
         ];
 
         $vars = $this->collectVars($input, $output, $questions);


### PR DESCRIPTION
Eventually DCG Question wrapper has been removed. At the moment the only point of keeping Question wrapper is [lack of setter methods](https://github.com/symfony/symfony/issues/23147) in original class.
I've added a small trait with helper functions to set question text and default value.

Generators have to use native Symfony console questions. All three types of questions are supported (_Question_, _ConfirmationQuestion_, _ChoiceQuestion_).

Also updated MigrationGenerator and fixed a small bug with missing 'source' key in DrushCommandFile generator.