### PR TITLE
Save theme related files to a correct destination

### DIFF
--- a/src/Commands/generate/Helper/InputHandler.php
+++ b/src/Commands/generate/Helper/InputHandler.php
@@ -51,7 +51,13 @@ class InputHandler extends BaseInputHandler
                         break;
 
                     case 'themes/%':
-                        // @todo Handle this case.
+                        if (isset($vars['machine_name'])) {
+                            $machine_name = $vars['machine_name'];
+                            $themes = \Drupal::service('theme_handler')->listInfo();
+                            $directory = isset($themes[$machine_name])
+                                ? $themes[$machine_name]->getPath()
+                                : 'themes/' . $machine_name;
+                        }
                         break;
 
                     case 'profiles':


### PR DESCRIPTION
Should work the same way as for modules. The location can be either in a directory of existing theme or global _themes_ directory. 