### PR TITLE
Update webmozart/patch-utils minim version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "pear/console_table": "~1.3.0",
     "phpdocumentor/reflection-docblock": "^2.0",
     "webflo/drupal-finder": "^0",
-    "webmozart/path-util": "~2",
+    "webmozart/path-util": "^2.1.0",
     "sebastian/version": "~1"
   },
   "require-dev": {


### PR DESCRIPTION
[environment.inc](https://github.com/drush-ops/drush/blob/master/includes/environment.inc#L566) calls the getHomeDirectory method from webmozart/patch-utils Path class. That method didn't exist until the 2.1.0 release of patch-utils, but drush's composer.json file allows the 2.0.0 release.

This PR just bumps the minimum version of patch-utils to 2.1.0 while still allowing everything up to, but not including, 3.0.0.