### PR TITLE
Disable the PsySH version check

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -5,6 +5,7 @@ use Drupal\Component\Assertion\Handle;
 use Drush\Psysh\DrushHelpCommand;
 use Drush\Psysh\DrushCommand;
 use Drush\Psysh\Shell;
+use Psy\VersionUpdater\Checker;
 
 /**
  * Implements hook_drush_command().
@@ -40,6 +41,9 @@ function drush_cli_core_cli() {
 
   // Set the Drush specific history file path.
   $configuration->setHistoryFile(drush_history_path_cli());
+
+  // Disable checking for updates. Our dependencies are managed with Composer.
+  $configuration->setUpdateCheck(Checker::NEVER);
 
   $shell = new Shell($configuration);
 


### PR DESCRIPTION
I had noticed that launching `drush php` is often inexplicably slow, taking up to 30 seconds to launch. I've now discovered that this happens when I am on a slow mobile connection. PsySH has a feature to check for updates, and by default this checks once per week. Unfortunately since we are using a "bundled" version and generate the configuration on the fly when launching it this performs the update check every single time it is launched.

I can understand the usefulness of this feature when using PsySH standalone, but I think this version check is pretty pointless in our typical use case. PsySH is a dependency of Drush which is a dev dependency of Drupal which is a dependency of a custom web project which will typically only be updated whenever a security update is available. I don't think most maintainers of Drupal sites are going to jump at the opportunity to update their production instances just because this niche developer tool has a new update :stuck_out_tongue:

I had a look to port this to the master branch too but it was not immediately clear to me where the PsySH configuration was being generated.