### PR TITLE
Fix drush docs, link to 8.x docs from within the 8.x documentation

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,18 +1,18 @@
 The _examples_ folder contains example files which you may copy and edit as needed. Read the documentation right in the file. If you see an opportunity to improve the file, please submit a pull request.
 
-* [drush.wrapper](https://raw.githubusercontent.com/drush-ops/drush/master/examples/drush.wrapper). A handy launcher script which calls the Drush located in vendor/bin/drush and can add options like --local, --root, etc.
-* [example.aliases.drushrc.php](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.aliases.drushrc.php). Example site alias definitions.
-* [example.bashrc](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.bashrc). Enhance your shell with lots of Drush niceties including bash completion.
-* [example.drush.ini](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.drush.ini). Configure your PHP just for Drush requests.
-* [example.drushrc.php](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.drushrc.php). A Drush configuration file.
-* [example.make](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.make). An ini style make file.
-* [example.make.yml](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.make.yml). A YML make file. 
-* [example.prompt.sh](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.prompt.sh). Displays Git repository and Drush alias status in your prompt.
-* [git-bisect.example.sh](https://raw.githubusercontent.com/drush-ops/drush/master/examples/git-bisect.example.sh). Spelunking through Drush's git history with bisect.
-* [helloworld.script](https://raw.githubusercontent.com/drush-ops/drush/master/examples/helloworld.script). An example Drush script. 
-* [pm_update.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/master/examples/pm_update.drush.inc). Restore sqlsrv driver after core update.
-* [policy.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/master/examples/policy.drush.inc). A policy file can disallow prohibited commands/options etc.
-* [sandwich.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/master/examples/sandwich.drush.inc). A fun example command inspired by a famous XKCD comic.
-* [sync_via_http.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/master/examples/sync_via_http.drush.inc). sql-sync modification that transfers via http instead of rsync. 
-* [sync_enable.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/master/examples/sync_enable.drush.inc). Automatically enable modules after a sql-sync.
-* [xkcd.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/master/examples/xkcd.drush.inc). A fun example command that browses XKCD comics.  
+* [drush.wrapper](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/drush.wrapper). A handy launcher script which calls the Drush located in vendor/bin/drush and can add options like --local, --root, etc.
+* [example.aliases.drushrc.php](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/example.aliases.drushrc.php). Example site alias definitions.
+* [example.bashrc](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/example.bashrc). Enhance your shell with lots of Drush niceties including bash completion.
+* [example.drush.ini](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/example.drush.ini). Configure your PHP just for Drush requests.
+* [example.drushrc.php](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/example.drushrc.php). A Drush configuration file.
+* [example.make](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/example.make). An ini style make file.
+* [example.make.yml](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/example.make.yml). A YML make file. 
+* [example.prompt.sh](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/example.prompt.sh). Displays Git repository and Drush alias status in your prompt.
+* [git-bisect.example.sh](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/git-bisect.example.sh). Spelunking through Drush's git history with bisect.
+* [helloworld.script](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/helloworld.script). An example Drush script. 
+* [pm_update.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/pm_update.drush.inc). Restore sqlsrv driver after core update.
+* [policy.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/policy.drush.inc). A policy file can disallow prohibited commands/options etc.
+* [sandwich.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/sandwich.drush.inc). A fun example command inspired by a famous XKCD comic.
+* [sync_via_http.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/sync_via_http.drush.inc). sql-sync modification that transfers via http instead of rsync. 
+* [sync_enable.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/sync_enable.drush.inc). Automatically enable modules after a sql-sync.
+* [xkcd.drush.inc](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/xkcd.drush.inc). A fun example command that browses XKCD comics.  

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,14 +4,14 @@ Drush is a command line shell and Unix scripting interface for Drupal. Drush cor
 
 Resources
 -----------
-* [Install documentation](http://docs.drush.org/en/master/install/)
+* [Install documentation](http://docs.drush.org/en/8.x/install/)
 * [General documentation](http://docs.drush.org)
 * [API Documentation](http://api.drush.org)
 * [Drush Commands](http://drushcommands.com)
 * Subscribe [this atom feed](https://github.com/drush-ops/drush/releases.atom) to receive notification on new releases. Also, [Version eye](https://www.versioneye.com/).
 * [Drush packages available via Composer](http://packages.drush.org)
 * [A list of modules that include Drush integration](https://www.drupal.org/project/project_module?f[2]=im_vid_3%3A4654&solrsort=ds_project_latest_release+desc)
-* Drush comes with a [full test suite](https://github.com/drush-ops/drush/blob/master/tests/README.md) powered by [PHPUnit](https://github.com/sebastianbergmann/phpunit). Each commit gets tested by the awesome [Travis.ci continuous integration service](https://travis-ci.org/drush-ops/drush).
+* Drush comes with a [full test suite](https://github.com/drush-ops/drush/blob/8.x/tests/README.md) powered by [PHPUnit](https://github.com/sebastianbergmann/phpunit). Each commit gets tested by the awesome [Travis.ci continuous integration service](https://travis-ci.org/drush-ops/drush).
 
 Support
 -----------
@@ -36,7 +36,7 @@ Some people pronounce the dru with a long u like Drupal. Fidelity points go to t
 
 ##### Does Drush have unit tests?
   
-Drush has an excellent suite of unit tests. See [tests/README.md](https://github.com/drush-ops/drush/blob/master/tests/README.md) for more information.
+Drush has an excellent suite of unit tests. See [tests/README.md](https://github.com/drush-ops/drush/blob/8.x/tests/README.md) for more information.
 
 
 Credits

--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -14,8 +14,8 @@ Follow the instructions below, or [watch a video by Drupalize.me](https://youtu.
         # Install a specific version of Drush, e.g. Drush 7.1.0
         composer global require drush/drush:7.1.0
 
-        # Install master branch as a git clone. Great for contributing back to Drush project.
-        composer global require drush/drush:dev-master --prefer-source
+        # Install 8.x branch as a git clone. Great for contributing back to Drush project.
+        composer global require drush/drush:8.x-dev --prefer-source
 
 * Alternate way to install for all users via Composer:
 
@@ -30,5 +30,5 @@ Drush on Windows is experimental, since Drush's test suite is not running there 
 
 * [Acquia Dev Desktop](https://www.acquia.com/downloads) is excellent, and includes Drush. See the terminal icon after setting up a web site.
 * Or consider running Linux/OSX via Virtualbox. [Drupal VM](http://www.drupalvm.com/) and [Vlad](https://github.com/hashbangcode/vlad) are popular.* These Windows packages include Drush and its dependencies (including MSys).     * [7.0.0 (stable)](https://github.com/drush-ops/drush/releases/download/7.0.0/windows-7.0.0.zip).    * [6.6.0](https://github.com/drush-ops/drush/releases/download/6.6.0/windows-6.6.0.zip).    * [6.0](https://github.com/drush-ops/drush/releases/download/6.0.0/Drush-6.0-2013-08-28-Installer-v1.0.21.msi).
-* Or install LAMP on your own, and run Drush via [Git's shell](https://git-for-windows.github.io/), in order to insure that [all depedencies](https://github.com/acquia/DevDesktopCommon/tree/master/bintools-win/msys/bin) are available.   
+* Or install LAMP on your own, and run Drush via [Git's shell](https://git-for-windows.github.io/), in order to insure that [all depedencies](https://github.com/acquia/DevDesktopCommon/tree/8.x/bintools-win/msys/bin) are available.   
 * When creating site aliases for Windows remote machines, pay particular attention to information presented in the example.aliases.drushrc.php file, especially when setting values for 'remote-host' and 'os', as these are very important when running Drush rsync and Drush sql-sync commands.

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,10 +17,10 @@ drush init
 ```
     
 * MAMP users, and anyone wishing to launch a non-default PHP, needs to [edit ~/.bashrc so that the right PHP is in your $PATH](http://stackoverflow.com/questions/4145667/how-to-override-the-path-of-php-to-use-the-mamp-path/10653443#10653443).
-* We have documented [alternative ways to install](http://docs.drush.org/en/master/install-alternative/), including [Windows](http://docs.drush.org/en/master/install-alternative/#windows).
+* We have documented [alternative ways to install](http://docs.drush.org/en/8.x/install-alternative/), including [Windows](http://docs.drush.org/en/8.x/install-alternative/#windows).
 * If you need to pass custom php.ini values, run `php -d foo=bar drush.phar --php-options=foo=bar`
-* Your shell now has [useful bash aliases and tab completion for command names, site aliases, options, and arguments](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.bashrc).
-* A [drushrc.php](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.drushrc.php) has been copied to ~/.drush above. Customize it to save typing and standardize options for commands.
+* Your shell now has [useful bash aliases and tab completion for command names, site aliases, options, and arguments](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/example.bashrc).
+* A [drushrc.php](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/example.drushrc.php) has been copied to ~/.drush above. Customize it to save typing and standardize options for commands.
 * Upgrade using this same procedure.
 
 Install a site-local Drush
@@ -28,7 +28,7 @@ Install a site-local Drush
 In addition to the global Drush, it is recommended that Drupal 8 sites be [built using Composer, with Drush listed as a dependency](https://github.com/drupal-composer/drupal-project).
 
 1. When you run `drush`, the global Drush is called first and then hands execution to the site-local Drush. This gives you the convenience of running `drush` without specifying the full path to the executable, without sacrificing the safety provided by a site-local Drush.
-2. Optional: Copy the [examples/drush.wrapper](https://github.com/drush-ops/drush/blob/master/examples/drush.wrapper) file to your project root and modify to taste. This is a handy launcher script; add --local here to turn off all global configuration locations, and maintain consistency over configuration/aliases/commandfiles for your team.
+2. Optional: Copy the [examples/drush.wrapper](https://github.com/drush-ops/drush/blob/8.x/examples/drush.wrapper) file to your project root and modify to taste. This is a handy launcher script; add --local here to turn off all global configuration locations, and maintain consistency over configuration/aliases/commandfiles for your team.
 3. Note that if you have multiple Drupal sites on your system, it is possible to use a different version of Drush with each one.
 
 Drupal Compatibility

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,5 +46,5 @@ $ drush rsync @staging:%files/ @live:%files
 $ drush sql-sync --structure-tables-key=custom @live @dev
 ```
 
-See [example.aliases.drushrc.php](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.aliases.drushrc.php) for more information.
+See [example.aliases.drushrc.php](https://raw.githubusercontent.com/drush-ops/drush/8.x/examples/example.aliases.drushrc.php) for more information.
 


### PR DESCRIPTION
I think the docs for Drush 8 should reference 8.x examples. A few link are broken because Drush 9 (master) diverged from Drush 8 (8.x)