### PR TITLE
Allow psysh version 0.8.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": ">=5.6.0",
     "ext-dom": "*",
     "psr/log": "~1.0",
-    "psy/psysh": "~0.6",
+    "psy/psysh": "0.6.* || ~0.8",
     "league/container": "~2",
     "consolidation/robo": "~1",
     "symfony/config": "~2.2|^3",


### PR DESCRIPTION
Drupal Console allows `"psy/psysh": "0.6.* || ~0.8",` which can cause Composer angst if Drupal Console is added to a project before Drush.

There appear to be no API changes in 0.8, at least not that affect Drush.