### PR TITLE
Fix infinite recursion when empty path is provided to drush_mkdir

### DIFF
--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -318,6 +318,12 @@ function drush_move_dir($src, $dest, $overwrite = FALSE) {
  * halted if the required directory cannot be created.
  */
 function drush_mkdir($path, $required = TRUE) {
+  if (!is_string($path) || $path === '') {
+    if (!$required) {
+      return FALSE;
+    }
+    return drush_set_error('DRUSH_INVALID_DIRECTORY_PATH', dt('Unable to create directory. Invalid path provided.'));
+  }
   if (!is_dir($path)) {
     if (drush_mkdir(dirname($path))) {
       if (@mkdir($path)) {


### PR DESCRIPTION
New pull request for https://github.com/drush-ops/drush/pull/2862 since I closed it and can't seem to re-open it.