### PR TITLE
Allow the DrupalFinder to be injected into the BootstrapManager

### DIFF
--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -52,9 +52,6 @@ function drush_main() {
   // Select and return the bootstrap class.
   $bootstrap = drush_preflight();
 
-  // Reset our bootstrap phase to the beginning
-  drush_set_context('DRUSH_BOOTSTRAP_PHASE', DRUSH_BOOTSTRAP_NONE);
-
   $return = '';
   if (!drush_get_error()) {
     // TODO: If 'DRUSH_SYMFONY' is set, then disable the legacy command
@@ -610,7 +607,7 @@ function _drush_preflight_global_options() {
   // Copy the simulated option to the Robo configuration object.
   // TODO: Long-term there should be a better way to do this (e.g. via an event listener)
   $config = Drush::service('config');
-  $config->setSimulated(drush_get_context('DRUSH_SIMULATE'));
+  $config->set(\Robo\Config\Config::SIMULATE, drush_get_context('DRUSH_SIMULATE'));
 
   // Copy the output verbosity into the output object
   $verbosity = OutputInterface::VERBOSITY_NORMAL;

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -15,14 +15,14 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
 {
     use AutoloaderAwareTrait;
 
-      /**
-       * @var \Drupal\Core\DrupalKernelInterface
-       */
+    /**
+     * @var \Drupal\Core\DrupalKernelInterface
+     */
     protected $kernel;
 
-      /**
-       * @var \Symfony\Component\HttpFoundation\Request
-       */
+    /**
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
     protected $request;
 
     public function validRoot($path)


### PR DESCRIPTION
(but …create one if it is not). 

Move initial assignment to 'DRUSH_BOOTSTRAP_PHASE' to the bootstrap manager.

More refactoring for #2843.