### PR TITLE
Fix missing state argument

### DIFF
--- a/src/Drupal/Commands/core/LocaleCommands.php
+++ b/src/Drupal/Commands/core/LocaleCommands.php
@@ -32,6 +32,7 @@ class LocaleCommands extends DrushCommands
     public function __construct(ModuleHandlerInterface $moduleHandler, StateInterface $state)
     {
         $this->moduleHandler = $moduleHandler;
+        $this->state = $state;
     }
 
     /**


### PR DESCRIPTION
Fix #2812

Drush 9.0.0-beta3

`drush locale-update`:
Error: Call to a member function get() on null in /vendor/drush/drush/src/Drupal/Commands/core/LocaleCommands.php on line 111