### PR TITLE
fix namespace for Drush command sql-query with option "--db-prefix" in use

### DIFF
--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -271,7 +271,7 @@ class SqlBase
         if (drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_DATABASE)) {
             // Enable prefix processing which can be dangerous so off by default. See http://drupal.org/node/1219850.
             if ($this->getOption('db-prefix')) {
-                $query = \Database::getConnection()->prefixTables($query);
+                $query = Database::getConnection()->prefixTables($query);
             }
         }
         return $query;


### PR DESCRIPTION
I ran following command with Drush 8.x:

> drush.sh sql-query --db-prefix "TRUNCATE TABLE {file_managed}"

and noticed following error message:

> Error: Class 'Database' not found in .../vendor/drush/drush/lib/Drush/Sql/SqlBase.php on line 204 ...

The commit is to fix the issue in branch master. I have another pull request to address the issue for branch 8.x.