### PR TITLE
fix namespace for Drush command sql-query with option "--db-prefix" in use (branch 8.x)

### DIFF
--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -2,6 +2,7 @@
 
 namespace Drush\Sql;
 
+use Drupal\Core\Database\Database;
 use Drush\Log\LogLevel;
 use Webmozart\PathUtil\Path;
 
@@ -201,7 +202,7 @@ class SqlBase {
       // Enable prefix processing which can be dangerous so off by default. See http://drupal.org/node/1219850.
       if (drush_get_option('db-prefix')) {
         if (drush_drupal_major_version() >= 7) {
-          $query = \Database::getConnection()->prefixTables($query);
+          $query = Database::getConnection()->prefixTables($query);
         }
         else {
           $query = db_prefix_tables($query);


### PR DESCRIPTION
I ran following command with Drush 8.x:

> drush.sh sql-query --db-prefix "TRUNCATE TABLE {file_managed}"

and noticed following error message:

> Error: Class 'Database' not found in .../vendor/drush/drush/lib/Drush/Sql/SqlBase.php on line 204 ...

The commit is to fix the issue in branch 8.x. I have another pull request to address the issue for branch master.