### PR TITLE
Fix site-alias --format=list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "symfony/config": "~2.2|^3",
     "chi-teck/drupal-code-generator": "^1.17.3",
     "consolidation/annotated-command": "^2.4.10",
-    "consolidation/output-formatters": "^3.1.10",
+    "consolidation/output-formatters": "^3.1.11",
     "symfony/yaml": "~2.3|^3",
     "symfony/var-dumper": "~2.7|^3",
     "symfony/console": "~2.7|^3",

--- a/src/Commands/core/SiteCommands.php
+++ b/src/Commands/core/SiteCommands.php
@@ -2,6 +2,7 @@
 namespace Drush\Commands\core;
 
 use Drush\Commands\DrushCommands;
+use Consolidation\OutputFormatters\StructuredData\ListDataFromKeys;
 
 class SiteCommands extends DrushCommands
 {
@@ -101,7 +102,7 @@ class SiteCommands extends DrushCommands
      * @topics docs-aliases
      * @complete \Drush\Commands\CompletionCommands::completeSiteAliases
      *
-     * @return array
+     * @return \Consolidation\OutputFormatters\StructuredData\ListDataFromKeys
      */
     public function siteAlias($site = null, $options = ['format' => 'yaml'])
     {
@@ -118,7 +119,7 @@ class SiteCommands extends DrushCommands
             $site_specs[$site] = $result_record;
         }
         ksort($site_specs);
-        return $site_specs;
+        return new ListDataFromKeys($site_specs);
     }
 
     /**


### PR DESCRIPTION
Update to OutputFormatters 3.1.11 so that we can use ListDataFromKeys to fix site-alias --format=list.