### PR TITLE
Fix serving existing files with encoded characters like `%20`

### DIFF
--- a/misc/d8-rs-router.php
+++ b/misc/d8-rs-router.php
@@ -12,7 +12,7 @@ function runserver_env($key) {
 }
 
 $url = parse_url($_SERVER["REQUEST_URI"]);
-if (file_exists('.' . $url['path'])) {
+if (file_exists('.' . urldecode($url['path']))) {
   // Serve the requested resource as-is.
   return FALSE;
 }


### PR DESCRIPTION
Files with spaces (and other percent encoded characters) are not served from the files directory when using `drush runserver`. This change simply decodes the REQUEST_URI path.