### PR TITLE
8.x Fix serving existing files with encoded characters like `%20`

### DIFF
--- a/commands/runserver/d7-rs-router.php
+++ b/commands/runserver/d7-rs-router.php
@@ -46,7 +46,7 @@ function runserver_env($key) {
 }
 
 $url = parse_url($_SERVER["REQUEST_URI"]);
-if (file_exists('.' . $url['path'])) {
+if (file_exists('.' . urldecode($url['path']))) {
   // Serve the requested resource as-is.
   return FALSE;
 }

--- a/commands/runserver/d8-rs-router.php
+++ b/commands/runserver/d8-rs-router.php
@@ -46,7 +46,7 @@ function runserver_env($key) {
 }
 
 $url = parse_url($_SERVER["REQUEST_URI"]);
-if (file_exists('.' . $url['path'])) {
+if (file_exists('.' . urldecode($url['path']))) {
   // Serve the requested resource as-is.
   return FALSE;
 }


### PR DESCRIPTION
Files with spaces (and other percent encoded characters) are not served from the files directory when using `drush runserver`. This change simply decodes the REQUEST_URI path.

Same change as #2889 for the 8.x branch.
