### PR TITLE
Handle --yes and --debug

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -30,7 +30,7 @@ class Application extends SymfonyApplication
         //   --alias-path
         //   --local
         //
-        // Global options registerd with Symfony:
+        // Global options registered with Symfony:
         //
         //   --remote-host
         //   --remote-user
@@ -43,6 +43,9 @@ class Application extends SymfonyApplication
         //   --verbose / -v
         //   --help
         //   --quiet
+        //   --debug / -d : equivalent to -vv
+        //   --yes / -y : equivalent to --no-interaction
+        //
         //
         // No longer supported
         //
@@ -57,9 +60,8 @@ class Application extends SymfonyApplication
         //
         // Not handled yet (to be implemented):
         //
-        //   --debug / -d
+
         //   --uri / -l
-        //   --yes / -y
         //   --pipe
         //   --php
         //   --php-options
@@ -85,6 +87,17 @@ class Application extends SymfonyApplication
         //   --shell-aliases
         //   --path-aliases
         //   --ssh-options
+
+
+        $this->getDefinition()
+            ->addOption(
+                new InputOption('--debug', 'd', InputOption::VALUE_NONE, 'Equivalent to -vv')
+            );
+
+        $this->getDefinition()
+            ->addOption(
+                new InputOption('--yes', 'y', InputOption::VALUE_NONE, 'Equivalent to --no-interaction.')
+            );
 
         $this->getDefinition()
             ->addOption(

--- a/src/Application.php
+++ b/src/Application.php
@@ -45,6 +45,7 @@ class Application extends SymfonyApplication
         //   --quiet
         //   --debug / -d : equivalent to -vv
         //   --yes / -y : equivalent to --no-interaction
+        //   --nocolor  : equivalent to --no-ansi
         //
         //
         // No longer supported
@@ -57,14 +58,14 @@ class Application extends SymfonyApplication
         //   --strict            Not supported by Symfony
         //   --interactive       If command isn't -n, then it is interactive
         //   --command-specific  Now handled by consolidation/config component
+        //   --php               If needed prefix command with PATH=/path/to/php:$PATH
+        //   --php-options
         //
         // Not handled yet (to be implemented):
         //
 
         //   --uri / -l
         //   --pipe
-        //   --php
-        //   --php-options
         //   --tty
         //   --exclude
         //   --backend
@@ -72,7 +73,6 @@ class Application extends SymfonyApplication
         //   --ignored-modules
         //   --no-label
         //   --label-separator
-        //   --nocolor
         //   --cache-default-class
         //   --cache-class-<bin>
         //   --confirm-rollback

--- a/src/Application.php
+++ b/src/Application.php
@@ -58,14 +58,13 @@ class Application extends SymfonyApplication
         //   --strict            Not supported by Symfony
         //   --interactive       If command isn't -n, then it is interactive
         //   --command-specific  Now handled by consolidation/config component
-        //   --php               If needed prefix command with PATH=/path/to/php:$PATH
+        //   --php               If needed prefix command with PATH=/path/to/php:$PATH. Also see #env_vars in site aliases.
         //   --php-options
-        //
+        //   --pipe
         // Not handled yet (to be implemented):
         //
 
         //   --uri / -l
-        //   --pipe
         //   --tty
         //   --exclude
         //   --backend

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -206,7 +206,7 @@ class Preflight
         }
         // Use -vvv for even more verbose logging.
         if ($input->getParameterOption(['--debug', '-d'], false, true)) {
-            $output->setVerbosity(Output::VERBOSITY_VERBOSE);
+            $output->setVerbosity(Output::VERBOSITY_DEBUG);
         }
 
         // Run the Symfony Application

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -14,6 +14,7 @@ use Consolidation\AnnotatedCommand\CommandFileDiscovery;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use Webmozart\PathUtil\Path;
@@ -198,6 +199,15 @@ class Preflight
         // Use the robo runner to register commands with Symfony application.
         $runner = new \Robo\Runner();
         $runner->registerCommandClasses($application, $commandClasses);
+
+        // Process legacy Drush global options.
+        if ($input->getParameterOption(['--yes', '-y'], false, true)) {
+            $input->setInteractive(false);
+        }
+        // Use -vvv for even more verbose logging.
+        if ($input->getParameterOption(['--debug', '-d'], false, true)) {
+            $output->setVerbosity(Output::VERBOSITY_VERBOSE);
+        }
 
         // Run the Symfony Application
         // Predispatch: call a remote Drush command if applicable (via a 'pre-init' hook)

--- a/src/Style/DrushStyle.php
+++ b/src/Style/DrushStyle.php
@@ -26,20 +26,4 @@ class DrushStyle extends SymfonyStyle
             return array_search($return, $choices);
         }
     }
-
-    public function confirm($question, $default = true)
-    {
-        // Automatically accept confirmations if the --yes argument was supplied.
-        if (drush_get_context('DRUSH_AFFIRMATIVE')) {
-            $this->comment($question . ': yes.');
-            return true;
-        } // Automatically cancel confirmations if the --no argument was supplied.
-        elseif (drush_get_context('DRUSH_NEGATIVE')) {
-            $this->warning($question . ': no.');
-            return false;
-        }
-
-        $return = parent::confirm($question, $default);
-        return $return;
-    }
 }


### PR DESCRIPTION
1. --yes behaves like --no-interaction. The effect is that prompts just proceed with defaults. At this time we lose Drush's feature to print out the question and response even during a --yes request. --no is still not supported.
1. --debug maps to -vv. Folks wanting more should use -vvv which maps pretty well to Drush's old DEBUG_NOTIFY level.

The new code in Preflight.php could easily be moved elsewhere if anyone has thoughts on that.