### PR TITLE
Fix exit code handling in sql-cli

### DIFF
--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -131,7 +131,7 @@ class SqlCommands extends DrushCommands
     {
         $this->further($options);
         $sql = SqlBase::create($options);
-        if (!drush_shell_proc_open($sql->connect())) {
+        if (drush_shell_proc_open($sql->connect())) {
             throw new \Exception('Unable to open database shell. Rerun with --debug to see any error message.');
         }
     }


### PR DESCRIPTION
Fixes #2824

Looking at the documentation of drush_shell_proc_open. I think the conditions should be the other way around.

ping @jibran for review