### PR TITLE
Improve grammar of `user-add-role` help text

### DIFF
--- a/src/Drupal/Commands/core/UserCommands.php
+++ b/src/Drupal/Commands/core/UserCommands.php
@@ -154,8 +154,8 @@ class UserCommands extends DrushCommands
      * @command user-add-role
      *
      * @validate-entity-load user_role role
-     * @param string $role The name of the role to add
-     * @param string $names A comma delimited list user names.
+     * @param string $role The name of the role to add.
+     * @param string $names A comma delimited list of user names.
      * @aliases urol
      * @complete \Drush\Commands\core\UserCommands::complete
      * @usage drush user-add-role "power user" user3


### PR DESCRIPTION
Minor fixes to the grammar of the `user-add-role` help texts. It currently looks like this:

```
Arguments:
  role  The name of the role to add        
  names A comma delimited list user names. 
```

The first help text doesn't end in a period, and the second sentence is missing a word.