### PR TITLE
Clean up config import and export methods to fix diff #2939

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -5,6 +5,7 @@ use Consolidation\AnnotatedCommand\CommandError;
 use Consolidation\AnnotatedCommand\CommandData;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Config\StorageInterface;
 use Drush\Commands\DrushCommands;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -311,6 +312,39 @@ class ConfigCommands extends DrushCommands
         if ($config->isNew()) {
             $msg = dt('Config !name does not exist', array('!name' => $config_name));
             return new CommandError($msg);
+        }
+    }
+
+    /**
+     * Copies configuration objects from source storage to target storage.
+     *
+     * @param \Drupal\Core\Config\StorageInterface $source
+     *   The source config storage service.
+     * @param \Drupal\Core\Config\StorageInterface $destination
+     *   The destination config storage service.
+     */
+    public static function copyConfig(StorageInterface $source, StorageInterface $destination)
+    {
+        // Make sure the source and destination are on the default collection.
+        if ($source->getCollectionName() != StorageInterface::DEFAULT_COLLECTION) {
+            $source = $source->createCollection(StorageInterface::DEFAULT_COLLECTION);
+        }
+        if ($destination->getCollectionName() != StorageInterface::DEFAULT_COLLECTION) {
+            $destination = $destination->createCollection(StorageInterface::DEFAULT_COLLECTION);
+        }
+
+        // Export all the configuration.
+        foreach ($source->listAll() as $name) {
+            $destination->write($name, $source->read($name));
+        }
+
+        // Export configuration collections.
+        foreach ($source->getAllCollectionNames() as $collection) {
+            $source = $source->createCollection($collection);
+            $destination = $destination->createCollection($collection);
+            foreach ($source->listAll() as $name) {
+                $destination->write($name, $source->read($name));
+            }
         }
     }
 }

--- a/src/Drupal/Commands/config/ConfigImportCommands.php
+++ b/src/Drupal/Commands/config/ConfigImportCommands.php
@@ -160,10 +160,8 @@ class ConfigImportCommands extends DrushCommands
     {
         // Determine source directory.
         if ($target = $options['source']) {
-            $source_dir = $target;
             $source_storage = new FileStorage($target);
         } else {
-            $source_dir = \config_get_config_directory($label ?: CONFIG_SYNC_DIRECTORY);
             $source_storage = $this->getConfigStorageSync();
         }
 
@@ -194,16 +192,18 @@ class ConfigImportCommands extends DrushCommands
             }
             ConfigCommands::configChangesTablePrint($change_list);
         } else {
-            // Copy active storage to the temporary directory.
-            $temp_dir = drush_tempdir();
-            $temp_storage = new FileStorage($temp_dir);
-            $source_dir_storage = new FileStorage($source_dir);
-            foreach ($source_dir_storage->listAll() as $name) {
-                if ($data = $active_storage->read($name)) {
-                    $temp_storage->write($name, $data);
-                }
-            }
-            drush_shell_exec('diff -x %s -u %s %s', '*.git', $temp_dir, $source_dir);
+            // Copy active storage to a temporary directory.
+            $temp_active_dir = drush_tempdir();
+            $temp_active_storage = new FileStorage($temp_active_dir);
+            ConfigCommands::copyConfig($active_storage, $temp_active_storage);
+
+            // Copy sync storage to a temporary directory as it could be
+            // modified by the partial option or by decorated sync storages.
+            $temp_sync_dir = drush_tempdir();
+            $temp_sync_storage = new FileStorage($temp_sync_dir);
+            ConfigCommands::copyConfig($source_storage, $temp_sync_storage);
+
+            drush_shell_exec('diff -u %s %s', $temp_active_dir, $temp_sync_dir);
             $output = drush_shell_exec_output();
             drush_print(implode("\n", $output));
         }


### PR DESCRIPTION
Cleaning up the config import to fix #2939

As a side effect the temporary filders will not be in git and therefore #2855 is solved too.