### PR TITLE
Symfony dispatch remove contexts

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -30,7 +30,7 @@ class Application extends SymfonyApplication
         //   --alias-path
         //   --local
         //
-        // Global options registerd with Symfony:
+        // Global options registered with Symfony:
         //
         //   --remote-host
         //   --remote-user
@@ -43,6 +43,10 @@ class Application extends SymfonyApplication
         //   --verbose / -v
         //   --help
         //   --quiet
+        //   --debug / -d : equivalent to -vv
+        //   --yes / -y : equivalent to --no-interaction
+        //   --nocolor  : equivalent to --no-ansi
+        //
         //
         // No longer supported
         //
@@ -54,15 +58,13 @@ class Application extends SymfonyApplication
         //   --strict            Not supported by Symfony
         //   --interactive       If command isn't -n, then it is interactive
         //   --command-specific  Now handled by consolidation/config component
-        //
+        //   --php               If needed prefix command with PATH=/path/to/php:$PATH. Also see #env_vars in site aliases.
+        //   --php-options
+        //   --pipe
         // Not handled yet (to be implemented):
         //
-        //   --debug / -d
+
         //   --uri / -l
-        //   --yes / -y
-        //   --pipe
-        //   --php
-        //   --php-options
         //   --tty
         //   --exclude
         //   --backend
@@ -70,7 +72,6 @@ class Application extends SymfonyApplication
         //   --ignored-modules
         //   --no-label
         //   --label-separator
-        //   --nocolor
         //   --cache-default-class
         //   --cache-class-<bin>
         //   --confirm-rollback
@@ -85,6 +86,17 @@ class Application extends SymfonyApplication
         //   --shell-aliases
         //   --path-aliases
         //   --ssh-options
+
+
+        $this->getDefinition()
+            ->addOption(
+                new InputOption('--debug', 'd', InputOption::VALUE_NONE, 'Equivalent to -vv')
+            );
+
+        $this->getDefinition()
+            ->addOption(
+                new InputOption('--yes', 'y', InputOption::VALUE_NONE, 'Equivalent to --no-interaction.')
+            );
 
         $this->getDefinition()
             ->addOption(

--- a/src/Commands/DrushCommands.php
+++ b/src/Commands/DrushCommands.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Drush\Commands;
 
 use Drush\Style\DrushStyle;
@@ -51,26 +50,21 @@ abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface
      */
     public static function printFile($file)
     {
-        // Don't even bother to print the file in --no mode
-        if (drush_get_context('DRUSH_NEGATIVE')) {
-            return;
-        }
+
         if ((substr($file, -4) == ".htm") || (substr($file, -5) == ".html")) {
             $tmp_file = drush_tempnam(basename($file));
             file_put_contents($tmp_file, drush_html_to_text(file_get_contents($file)));
             $file = $tmp_file;
         }
-        // Do not wait for user input in --yes or --pipe modes
-        if (drush_get_context('DRUSH_PIPE')) {
-            drush_print_pipe(file_get_contents($file));
-        } elseif (drush_get_context('DRUSH_AFFIRMATIVE')) {
-            drush_print(file_get_contents($file));
-        } elseif (drush_shell_exec_interactive("less %s", $file)) {
-            return;
-        } elseif (drush_shell_exec_interactive("more %s", $file)) {
-            return;
-        } else {
-            drush_print(file_get_contents($file));
+
+        if (self::input()->isInteractive()) {
+            if (drush_shell_exec_interactive("less %s", $file)) {
+                return;
+            } elseif (drush_shell_exec_interactive("more %s", $file)) {
+                return;
+            } else {
+                drush_print(file_get_contents($file));
+            }
         }
     }
 }

--- a/src/Commands/core/DrupliconCommands.php
+++ b/src/Commands/core/DrupliconCommands.php
@@ -28,7 +28,7 @@ class DrupliconCommands extends DrushCommands
         $this->printed = true;
         $annotationData = $commandData->annotationData();
         $commandName = $annotationData['command'];
-        if ($commandData->input()->getOption('druplicon')) {
+        if ($commandData->input()->hasOption('druplicon') && $commandData->input()->getOption('druplicon')) {
             $this->logger()->debug(dt('Displaying Druplicon for "!command" command.', array('!command' => $commandName)));
             $misc_dir = DRUSH_BASE_PATH . '/misc';
             if (drush_get_context('DRUSH_NOCOLOR')) {

--- a/src/Commands/core/EditCommands.php
+++ b/src/Commands/core/EditCommands.php
@@ -2,6 +2,7 @@
 namespace Drush\Commands\core;
 
 use Drush\Commands\DrushCommands;
+use Drush\Drush;
 
 class EditCommands extends DrushCommands
 {
@@ -84,7 +85,7 @@ class EditCommands extends DrushCommands
                 $aliases_header = array('aliases' => '-- Aliases --');
             }
         }
-        if ($site_root = drush_get_context('DRUSH_DRUPAL_SITE_ROOT')) {
+        if ($site_root = Drush::bootstrap()->confPath()) {
             $path = realpath($site_root . '/settings.php');
             $drupal[$path] = $path;
             if (file_exists($site_root . '/settings.local.php')) {

--- a/src/Commands/core/NotifyCommands.php
+++ b/src/Commands/core/NotifyCommands.php
@@ -39,19 +39,15 @@ class NotifyCommands extends DrushCommands
 
     public function shutdown(CommandData $commandData)
     {
-        $cmd = $commandData->input()->getFirstArgument();
+
+        $input = $commandData->input();
+        $cmd = $input->getFirstArgument();
 
         if (empty($cmd)) {
             return;
         }
 
-        // pm-download handles its own notification.
-        if ($cmd != 'pm-download' && self::isAllowed($commandData)) {
-            $msg = $commandData->annotationData()->get('notify', dt("Command '!command' completed.", array('!command' => $cmd)));
-            $this->shutdownSend($msg, $commandData);
-        }
-
-        if ($commandData->input()->getOption('notify') && drush_get_error()) {
+        if ($input->hasOption('notify') && $input->getOption('notify') && drush_get_error()) {
             // If the only error is that notify failed, do not try to notify again.
             $log = drush_get_error_log();
             if (count($log) == 1 && array_key_exists('NOTIFY_COMMAND_NOT_FOUND', $log)) {

--- a/src/Commands/core/RsyncCommands.php
+++ b/src/Commands/core/RsyncCommands.php
@@ -80,7 +80,7 @@ class RsyncCommands extends DrushCommands
         }
 
         $mode = '-'. $options['mode'];
-        if (drush_get_context('DRUSH_VERBOSE')) {
+        if ($this->io()->isVerbose()) {
             $mode .= 'v';
             $verbose = ' --stats --progress';
         }

--- a/src/Commands/core/SiteCommands.php
+++ b/src/Commands/core/SiteCommands.php
@@ -3,6 +3,7 @@ namespace Drush\Commands\core;
 
 use Drush\Commands\DrushCommands;
 
+use Drush\Drush;
 use Drush\SiteAlias\SiteAliasManagerAwareInterface;
 use Drush\SiteAlias\SiteAliasManagerAwareTrait;
 use Drush\SiteAlias\SiteAliasName;
@@ -219,7 +220,7 @@ class SiteCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
     public static function siteSiteList()
     {
         $site_list = array();
-        $base_path = drush_get_context('DRUSH_DRUPAL_ROOT');
+        $base_path = Drush::bootstrapManager()->getRoot();
         if ($base_path) {
             $base_path .= '/sites';
             $files = drush_scan_directory($base_path, '/settings\.php/', array('.', '..', 'CVS', 'all'), 0, 1);

--- a/src/Commands/core/StatusCommands.php
+++ b/src/Commands/core/StatusCommands.php
@@ -17,7 +17,7 @@ class StatusCommands extends DrushCommands
     /**
      * @command core-status
      * @param $filter A field to filter on. @deprecated - use --field option instead.
-     * @option project A comma delimited list of projects. their paths will be added to path-aliases section.
+     * @option project A comma delimited list of projects. Their paths will be added to path-aliases section.
      * @aliases status, st
      *n
      * @table-style compact

--- a/src/Commands/core/XhprofCommands.php
+++ b/src/Commands/core/XhprofCommands.php
@@ -64,7 +64,7 @@ class XhprofCommands extends DrushCommands
 
     public static function xhprofIsEnabled(InputInterface $input)
     {
-        if ($input->getOption('xh-link')) {
+        if ($input->hasOption('xh-link') && $input->getOption('xh-link')) {
             if (!extension_loaded('xhprof') && !extension_loaded('tideways')) {
                 throw new \Exception(dt('You must enable the xhprof or tideways PHP extensions in your CLI PHP in order to profile.'));
             }

--- a/src/Commands/help/HelpCommands.php
+++ b/src/Commands/help/HelpCommands.php
@@ -13,7 +13,7 @@ class HelpCommands extends DrushCommands
      * Display usage details for a command.
      *
      * @command help
-     * @param $name A command name
+     * @param $command_name A command name
      * @usage drush help pm-uninstall
      *   Show help for a command.
      * @usage drush help pmu
@@ -27,10 +27,10 @@ class HelpCommands extends DrushCommands
      *
      * @return \Consolidation\AnnotatedCommand\Help\HelpDocument
      */
-    public function help($name, $options = ['format' => 'helpcli', 'include-field-labels' => false, 'table-style' => 'compact'])
+    public function help($command_name, $options = ['format' => 'helpcli', 'include-field-labels' => false, 'table-style' => 'compact'])
     {
         $application = Drush::getApplication();
-        $command = $application->get($name);
+        $command = $application->get($command_name);
         if ($command instanceof AnnotatedCommand) {
             $command->optionsHook();
         }
@@ -49,7 +49,7 @@ class HelpCommands extends DrushCommands
      */
     public function validate(CommandData $commandData)
     {
-        $name = $commandData->input()->getArgument('name');
+        $name = $commandData->input()->getArgument('command_name');
         if (empty($name)) {
             throw new \Exception(dt("The help command requires that a command name be provided. Run `drush list` to see a list of available commands."));
         } else {

--- a/src/Commands/help/ListCommands.php
+++ b/src/Commands/help/ListCommands.php
@@ -30,7 +30,7 @@ class ListCommands extends DrushCommands
      *
      * @return \DOMDocument
      */
-    public function helpList($filter, $options = ['format' => 'listcli', 'raw' => false, 'filter' => null])
+    public function helpList($filter = null, $options = ['format' => 'listcli', 'raw' => false, 'filter' => null])
     {
         $application = Drush::getApplication();
         annotation_adapter_add_legacy_commands_to_application($application);
@@ -122,32 +122,6 @@ class ListCommands extends DrushCommands
         $output
         ->writeln($preamble);
         $output->writeln('');
-
-        // For now ,this table does not need TableFormatter.
-        $table = new Table($output);
-        $table->setStyle('compact');
-        $global_options_help = drush_get_global_options(true);
-        $options = $application->getDefinition()->getOptions();
-        // Only display this table for Drush help, not 'generate' command.
-        if ($application->getName() == 'Drush Commandline Tool') {
-            $table->addRow([new TableCell('Global options. See `drush topic core-global-options` for the full list.', array('colspan' => 2))]);
-            foreach ($global_options_help as $key => $help) {
-                $data = [
-                    'name' => '--' . $options[$key]->getName(),
-                    'description' => $help['description'],
-                    // Not using $options[$key]->getDescription() as description is too long for -v
-                    'accept_value' => $options[$key]->acceptValue(),
-                    'is_value_required' => $options[$key]->isValueRequired(),
-                    'shortcut' => $options[$key]->getShortcut(),
-                ];
-                $table->addRow([
-                    HelpCLIFormatter::formatOptionKeys($data),
-                    HelpCLIFormatter::formatOptionDescription($data)
-                ]);
-            }
-            $table->addRow(['', '']);
-            $table->render();
-        }
 
         $rows[] = ['Available commands:', ''];
         foreach ($namespaced as $namespace => $list) {

--- a/src/Drupal/Commands/core/CliCommands.php
+++ b/src/Drupal/Commands/core/CliCommands.php
@@ -9,11 +9,15 @@ use Drush\Psysh\DrushCommand;
 use Drush\Psysh\DrushHelpCommand;
 use Drupal\Component\Assertion\Handle;
 use Drush\Psysh\Shell;
+use Drush\SiteAlias\SiteAliasManagerAwareInterface;
+use Drush\SiteAlias\SiteAliasManagerAwareTrait;
 use Psy\Configuration;
 use Psy\VersionUpdater\Checker;
 
-class CliCommands extends DrushCommands
+class CliCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {
+
+    use SiteAliasManagerAwareTrait;
 
     /**
      * Drush's PHP Shell.
@@ -180,7 +184,7 @@ class CliCommands extends DrushCommands
             if ($site_name) {
                 $site_suffix = $site_name;
             } else {
-                $drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT');
+                $drupal_root = Drush::bootstrapManager()->getRoot();
                 $site_suffix = md5($drupal_root);
             }
 
@@ -190,7 +194,7 @@ class CliCommands extends DrushCommands
         $full_path = "$cli_directory/$file_name";
 
         // Output the history path if verbose is enabled.
-        if (drush_get_context('DRUSH_VERBOSE')) {
+        if ($this->io()->isVerbose()) {
             $this->logger()->log(LogLevel::SUCCESS, dt('History: @full_path', ['@full_path' => $full_path]));
         }
 

--- a/src/Drupal/Commands/core/DrupalCommands.php
+++ b/src/Drupal/Commands/core/DrupalCommands.php
@@ -6,6 +6,7 @@ use Drupal\Core\CronInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drush\Commands\DrushCommands;
 use Drush\Drupal\DrupalUtil;
+use Drush\Drush;
 
 class DrupalCommands extends DrushCommands
 {
@@ -89,7 +90,7 @@ class DrupalCommands extends DrushCommands
 
         foreach ($searchpaths as $searchpath) {
             foreach ($file = drush_scan_directory($searchpath, '/\.html.twig/', array('tests')) as $file) {
-                $relative = str_replace(drush_get_context('DRUSH_DRUPAL_ROOT') . '/', '', $file->filename);
+                $relative = str_replace(Drush::bootstrapManager()->getRoot() . '/', '', $file->filename);
                 // @todo Dynamically disable twig debugging since there is no good info there anyway.
                 twig_render_template($relative, array('theme_hook_original' => ''));
                 $this->logger()

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -205,6 +205,15 @@ class Preflight
         $runner = new \Robo\Runner();
         $runner->registerCommandClasses($application, $commandClasses);
 
+        // Process legacy Drush global options.
+        if ($input->getParameterOption(['--yes', '-y'], false, true)) {
+            $input->setInteractive(false);
+        }
+        // Use -vvv for even more verbose logging.
+        if ($input->getParameterOption(['--debug', '-d'], false, true)) {
+            $output->setVerbosity(Output::VERBOSITY_DEBUG);
+        }
+
         // Run the Symfony Application
         // Predispatch: call a remote Drush command if applicable (via a 'pre-init' hook)
         // Bootstrap: bootstrap site to the level requested by the command (via a 'post-init' hook)

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -201,11 +201,6 @@ class Preflight
         $discovery = $this->commandDiscovery();
         $commandClasses = $discovery->discover($searchpath, '\Drush');
 
-        // For now: use Symfony's built-in help, as Drush's version
-        // assumes we are using the legacy Drush dispatcher.
-        unset($commandClasses[dirname(__DIR__) . '/Commands/help/HelpCommands.php']);
-        unset($commandClasses[dirname(__DIR__) . '/Commands/help/ListCommands.php']);
-
         // Use the robo runner to register commands with Symfony application.
         $runner = new \Robo\Runner();
         $runner->registerCommandClasses($application, $commandClasses);

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -205,15 +205,6 @@ class Preflight
         $runner = new \Robo\Runner();
         $runner->registerCommandClasses($application, $commandClasses);
 
-        // Process legacy Drush global options.
-        if ($input->getParameterOption(['--yes', '-y'], false, true)) {
-            $input->setInteractive(false);
-        }
-        // Use -vvv for even more verbose logging.
-        if ($input->getParameterOption(['--debug', '-d'], false, true)) {
-            $output->setVerbosity(Output::VERBOSITY_DEBUG);
-        }
-
         // Run the Symfony Application
         // Predispatch: call a remote Drush command if applicable (via a 'pre-init' hook)
         // Bootstrap: bootstrap site to the level requested by the command (via a 'post-init' hook)

--- a/src/Style/DrushStyle.php
+++ b/src/Style/DrushStyle.php
@@ -26,20 +26,4 @@ class DrushStyle extends SymfonyStyle
             return array_search($return, $choices);
         }
     }
-
-    public function confirm($question, $default = true)
-    {
-        // Automatically accept confirmations if the --yes argument was supplied.
-        if (drush_get_context('DRUSH_AFFIRMATIVE')) {
-            $this->comment($question . ': yes.');
-            return true;
-        } // Automatically cancel confirmations if the --no argument was supplied.
-        elseif (drush_get_context('DRUSH_NEGATIVE')) {
-            $this->warning($question . ': no.');
-            return false;
-        }
-
-        $return = parent::confirm($question, $default);
-        return $return;
-    }
 }


### PR DESCRIPTION
Based on #2843. Remove `drush_get_context()` where possible, and other modernization changes.