### PR TITLE
DRUSH_BOOTSTRAP_NONE should == DRUSH_BOOTSTRAP_DRUSH.

### DIFF
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -9,7 +9,7 @@ use Drush\Log\LogLevel;
  * Commands that only preflight, but do not bootstrap, should use
  * a bootstrap level of DRUSH_BOOTSTRAP_NONE.
  */
-define('DRUSH_BOOTSTRAP_NONE', -1);
+define('DRUSH_BOOTSTRAP_NONE', 0);
 
 /**
  * Use drush_bootstrap_max instead of drush_bootstrap_to_phase


### PR DESCRIPTION
We do not necessarily need to merge this on master, but I put this fix into the symfony_dispatch branch, and I want to know if it breaks any legacy code for porting knowledge.