### PR TITLE
Find uri from site directory basename

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -171,7 +171,7 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
 
     public function aliasManager()
     {
-        return $this->aliasManager();
+        return $this->aliasManager;
     }
 
     public function setAliasManager($aliasManager)
@@ -191,12 +191,21 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
     }
 
     /**
-     * Set the framework uri selected by the user.
+     * If the user did not explicitly select a site URI,
+     * then pick an appropriate site from the cwd.
      */
-    public function setUri($uri)
+    public function refineUriSelection($cwd)
     {
-        if ($this->bootstrapManager) {
-            $this->bootstrapManager->setUri($uri);
+        if (!$this->bootstrapManager || !$this->aliasManager) {
+            return;
+        }
+        $selfAliasRecord = $this->aliasManager->getSelf();
+        $uri = $selfAliasRecord->uri();
+
+        if (empty($uri)) {
+            $uri = $this->bootstrapManager()->selectUri($cwd);
+            $selfAliasRecord->setUri($uri);
+            $this->aliasManager->setSelf($selfAliasRecord);
         }
     }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -207,6 +207,8 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
             $selfAliasRecord->setUri($uri);
             $this->aliasManager->setSelf($selfAliasRecord);
         }
+        // Update the uri in the bootstrap manager
+        $this->bootstrapManager->setUri($uri);
     }
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -3,6 +3,7 @@ namespace Drush;
 
 use Consolidation\AnnotatedCommand\CommandFileDiscovery;
 use Drush\Boot\BootstrapManager;
+use Drush\SiteAlias\AliasManager;
 use Drush\Log\LogLevel;
 
 use Symfony\Component\Console\Application as SymfonyApplication;
@@ -28,6 +29,9 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
 
     /** @var BootstrapManager */
     protected $bootstrapManager;
+
+    /** @var AliasManager */
+    protected $aliasManager;
 
     /**
      * @param string $name
@@ -165,6 +169,16 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
         $this->bootstrapManager = $bootstrapManager;
     }
 
+    public function aliasManager()
+    {
+        return $this->aliasManager();
+    }
+
+    public function setAliasManager($aliasManager)
+    {
+        $this->aliasManager = $aliasManager;
+    }
+
     /**
      * Return the framework uri selected by the user.
      */
@@ -194,6 +208,14 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
         try {
             return parent::find($name);
         } catch (CommandNotFoundException $e) {
+            // Is the unknown command destined for a remote site?
+            if ($this->aliasManager) {
+                $selfAlias = $this->aliasManager->getSelf();
+                if ($selfAlias->isRemote()) {
+                    // TODO: Create a proxy Command object for
+                    // the remote command execution.
+                }
+            }
             // If we have no bootstrap manager, then just re-throw
             // the exception.
             if (!$this->bootstrapManager) {

--- a/src/Boot/BaseBoot.php
+++ b/src/Boot/BaseBoot.php
@@ -23,6 +23,11 @@ abstract class BaseBoot implements Boot, LoggerAwareInterface, ContainerAwareInt
     {
     }
 
+    public function findUri($root, $uri)
+    {
+        return 'default';
+    }
+
     public function setUri($uri)
     {
         $this->uri = $uri;

--- a/src/Boot/Boot.php
+++ b/src/Boot/Boot.php
@@ -12,6 +12,12 @@ namespace Drush\Boot;
 interface Boot
 {
     /**
+     * Select the best URI for the provided cwd. Only called
+     * if the user did not explicitly specify a URI.
+     */
+    public function findUri($root, $uri);
+
+    /**
      * Inject the uri for the specific site to be bootstrapped
      *
      * @param $uri Site to bootstrap

--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -122,6 +122,17 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
         return $this->uri;
     }
 
+    /**
+     * This method is called by the Application iff the user
+     * did not explicitly provide a URI.
+     */
+    public function selectUri($cwd)
+    {
+        $uri = $this->bootstrap()->findUri($this->getRoot(), $cwd);
+        $this->setUri($uri);
+        return $uri;
+    }
+
     public function setUri($uri)
     {
         // TODO: Throw if we already bootstrapped a framework?

--- a/src/Preflight/DependencyInjection.php
+++ b/src/Preflight/DependencyInjection.php
@@ -135,5 +135,6 @@ class DependencyInjection
     {
         $application->setLogger($container->get('logger'));
         $application->setBootstrapManager($container->get('bootstrap.manager'));
+        $application->setAliasManager($container->get('site.alias.manager'));
     }
 }

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -216,7 +216,7 @@ class Preflight
             ->addSearchLocation($this->environment->userConfigPath())
             ->addSearchLocation($this->selectedDrupalRoot() . '/drush')
             ->addSearchLocation($this->selectedComposerRoot() . '/drush');
-        $selfAliasRecord = $aliasManager->findSelf($preflightArgs->alias(), $root, $preflightArgs->uri());
+        $selfAliasRecord = $aliasManager->findSelf($preflightArgs->alias(), $root, $preflightArgs->uri(), $this->environment->cwd());
         $aliasConfig = $selfAliasRecord->exportConfig();
         $configLocator->addAliasConfig($aliasConfig);
 

--- a/src/SiteAlias/AliasRecord.php
+++ b/src/SiteAlias/AliasRecord.php
@@ -107,6 +107,11 @@ class AliasRecord extends Config
         return $this->get('uri');
     }
 
+    public function setUri($uri)
+    {
+        return $this->set('uri', $uri);
+    }
+
     public function remoteHostWithUser()
     {
         $result = $this->remoteHost();

--- a/src/SiteAlias/SiteAliasManager.php
+++ b/src/SiteAlias/SiteAliasManager.php
@@ -185,6 +185,11 @@ class SiteAliasManager
             return new AliasRecord($specParser->parse($aliasName, $root), $aliasName);
         }
 
+        // If there is no root, then return '@none'
+        if (!$root) {
+            return new AliasRecord([], '@none');
+        }
+
         // If there is no URI specified, we will allow it to
         // remain empty for now. We will refine it later via
         // Application::refineUriSelection(), which is called


### PR DESCRIPTION
If URI is not specified, and cwd is inside a site directory (something with settings.php), then use the basename of the sites directory as the URI. Also, inject alias manager into Application so that we may later run a remote command that does not necessarily exist on the local machine.