### PR TITLE
Fixes declaration compability (GH-2967)

### DIFF
--- a/src/Sql/SqlOracle.php
+++ b/src/Sql/SqlOracle.php
@@ -22,7 +22,7 @@ class SqlOracle extends SqlBase
         return $command;
     }
 
-    public function creds()
+    public function creds($hide_password = true)
     {
         return ' ' . $this->dbSpec['username'] . '/' . $this->dbSpec['password'] . ($this->dbSpec['host'] == 'USETNS' ? '@' . $this->dbSpec['database'] : '@//' . $this->dbSpec['host'] . ':' . ($db_spec['port'] ? $db_spec['port'] : '1521') . '/' . $this->dbSpec['database']);
     }

--- a/src/Sql/SqlSqlsrv.php
+++ b/src/Sql/SqlSqlsrv.php
@@ -13,7 +13,7 @@ class SqlSqlsrv extends SqlBase
         return 'sqlcmd';
     }
 
-    public function creds()
+    public function creds($hide_password = true)
     {
         // Some drush commands (e.g. site-install) want to connect to the
         // server, but not the database.  Connect to the built-in database.


### PR DESCRIPTION
Fixes PHP 7.x warning:

> Declaration of Drush\Sql\Sqlsqlsrv::creds() should be compatible with Drush\Sql\SqlBase::creds($hide_password = true)

Ref: #2967