### PR TITLE
GH-492: Fixes PGPASSFILE error as not an internal or external command

### DIFF
--- a/src/Sql/SqlPgsql.php
+++ b/src/Sql/SqlPgsql.php
@@ -41,10 +41,10 @@ class SqlPgsql extends SqlBase
 
     public function command()
     {
-        $environment = "";
+        $environment = drush_is_windows() ? "SET " : "";
         $pw_file = $this->createPasswordFile();
         if (isset($pw_file)) {
-            $environment = "PGPASSFILE={$pw_file} ";
+            $environment .= "PGPASSFILE={$pw_file} ";
         }
         return "{$environment}psql -q";
     }


### PR DESCRIPTION
Fixes: #492. This PR replaces #880.

----

Under a windows environment for a Postgres database, the variable "PGPASSFILE=..." will be interpreted as a command (not found of course, as it's not a valid command).
The result is it asks for password (but silently with the -q parameter), so the drush command is blocked and the password can't be input by the prompt.

In order to set properly the variable, I added a "SET" command if it's under windows platform.
I don't know if it's the best way to handle environment issue here, but it seems to work.

----
