### PR TITLE
Run remote commands even if they do not exist locally

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -233,9 +233,11 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
             // Is the unknown command destined for a remote site?
             if ($this->aliasManager) {
                 $selfAlias = $this->aliasManager->getSelf();
-                $command = new RemoteCommandProxy($name, $this->redispatchHook);
-                $command->setApplication($this);
-                return $command;
+                if ($selfAlias->isRemote()) {
+                    $command = new RemoteCommandProxy($name, $this->redispatchHook);
+                    $command->setApplication($this);
+                    return $command;
+                }
             }
             // If we have no bootstrap manager, then just re-throw
             // the exception.

--- a/src/Application.php
+++ b/src/Application.php
@@ -2,9 +2,12 @@
 namespace Drush;
 
 use Consolidation\AnnotatedCommand\CommandFileDiscovery;
+use Consolidation\AnnotatedCommand\AnnotatedCommand;
 use Drush\Boot\BootstrapManager;
 use Drush\SiteAlias\AliasManager;
 use Drush\Log\LogLevel;
+use Drush\Command\RemoteCommandProxy;
+use Drush\Preflight\RedispatchHook;
 
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command;
@@ -32,6 +35,9 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
 
     /** @var AliasManager */
     protected $aliasManager;
+
+    /** @var RedispatchHook */
+    protected $redispatchHook;
 
     /**
      * @param string $name
@@ -179,6 +185,11 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
         $this->aliasManager = $aliasManager;
     }
 
+    public function setRedispatchHook(RedispatchHook $redispatchHook)
+    {
+        $this->redispatchHook = $redispatchHook;
+    }
+
     /**
      * Return the framework uri selected by the user.
      */
@@ -222,10 +233,9 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
             // Is the unknown command destined for a remote site?
             if ($this->aliasManager) {
                 $selfAlias = $this->aliasManager->getSelf();
-                if ($selfAlias->isRemote()) {
-                    // TODO: Create a proxy Command object for
-                    // the remote command execution.
-                }
+                $command = new RemoteCommandProxy($name, $this->redispatchHook);
+                $command->setApplication($this);
+                return $command;
             }
             // If we have no bootstrap manager, then just re-throw
             // the exception.
@@ -236,9 +246,7 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
             // TODO: We could also fail-fast (throw $e) if bootstrapMax made no progress.
             $this->logger->log(LogLevel::DEBUG, 'Bootstrap futher to find {command}', ['command' => $name]);
             $this->bootstrapManager->bootstrapMax();
-
-            // TODO: parent::find resets log level? Log below not printed, but is printed at LogLevel::WARNING.
-            $this->logger->log(LogLevel::DEBUG, 'Done with bootstrap max');
+            $this->logger->log(LogLevel::DEBUG, 'Done with bootstrap max in Application::find(): trying to find {command} again.', ['command' => $name]);
 
             // Try to find it again. This time the exception will
             // not be caught if the command cannot be found.

--- a/src/Command/RemoteCommandProxy.php
+++ b/src/Command/RemoteCommandProxy.php
@@ -1,0 +1,39 @@
+<?php
+namespace Drush\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Drush\Preflight\RedispatchHook;
+
+/**
+ * Create a placeholder proxy command to represent an unknown command.
+ * We use these only when executing remote commands that do not exist
+ * locally. We will let the remote end decide whether these will be
+ * "command not found," or some other behavior, as the remote end might
+ * have additional functionality installed.
+ *
+ * Also note that, for remote commands, we create the proxy command prior
+ * to attempting to bootstrap Drupal further, so the proxy command may
+ * be used in place of some command name that is available only for
+ * Drupal sites (e.g. pm:list and friends, etc.).
+ */
+class RemoteCommandProxy extends Command
+{
+    /** @var RedispatchHook */
+    protected $redispatchHook;
+
+    public function __construct($name, RedispatchHook $redispatchHook)
+    {
+        parent::__construct($name);
+        $this->redispatchHook = $redispatchHook;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->redispatchHook->redispatchIfRemote($input);
+        $name = $this->getName();
+        throw new \Exception("Command $name could not be executed remotely.");
+    }
+}

--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -162,6 +162,9 @@ class PmCommands extends DrushCommands
         $status_filter = StringUtils::csvToArray(strtolower($options['status']));
 
         foreach ($both as $key => $extension) {
+            // Fill in placeholder values as needed.
+            $extension->info += ['package' => ''];
+
             // Filter out test modules/themes.
             if (strpos($extension->getPath(), 'tests')) {
                 continue;
@@ -202,14 +205,14 @@ class PmCommands extends DrushCommands
             }
 
             $row = [
-            'package' => $extension->info['package'],
-            'display_name' => $extension->info['name']. ' ('. $extension->getName(). ')',
-            'name' => $extension->getName(),
-            'type' => $extension->getType(),
-            'path' => $extension->getPath(),
-            'status' => ucfirst($status),
-            // Suppress notice when version is not present.
-            'version' => @$extension->info['version'],
+                'package' => $extension->info['package'],
+                'display_name' => $extension->info['name']. ' ('. $extension->getName(). ')',
+                'name' => $extension->getName(),
+                'type' => $extension->getType(),
+                'path' => $extension->getPath(),
+                'status' => ucfirst($status),
+                // Suppress notice when version is not present.
+                'version' => @$extension->info['version'],
             ];
             $rows[$key] = $row;
         }

--- a/src/Preflight/DependencyInjection.php
+++ b/src/Preflight/DependencyInjection.php
@@ -136,5 +136,6 @@ class DependencyInjection
         $application->setLogger($container->get('logger'));
         $application->setBootstrapManager($container->get('bootstrap.manager'));
         $application->setAliasManager($container->get('site.alias.manager'));
+        $application->setRedispatchHook($container->get('redispatch.hook'));
     }
 }

--- a/src/Preflight/RedispatchHook.php
+++ b/src/Preflight/RedispatchHook.php
@@ -38,7 +38,9 @@ class RedispatchHook implements InitializeHookInterface
     public function redispatchIfRemote($input)
     {
         // Determine if this is a remote command.
-        if ($input->hasOption('remote-host')) {
+        // n.b. 'hasOption' only means that the option definition exists, so don't use that here.
+        $root = $input->getOption('remote-host');
+        if (!empty($root)) {
             return $this->redispatch($input);
         }
     }

--- a/src/Preflight/RedispatchHook.php
+++ b/src/Preflight/RedispatchHook.php
@@ -5,6 +5,7 @@ namespace Drush\Preflight;
 use Consolidation\AnnotatedCommand\Hooks\InitializeHookInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Consolidation\AnnotatedCommand\AnnotationData;
+use Drush\Log\LogLevel;
 
 /**
  * The RedispatchHook is installed as an init hook that runs before
@@ -31,66 +32,80 @@ class RedispatchHook implements InitializeHookInterface
         if ($annotationData->has('handle-remote-commands')) {
             return;
         }
+        return $this->redispatchIfRemote($input);
+    }
 
+    public function redispatchIfRemote($input)
+    {
         // Determine if this is a remote command.
-        $remote_host = $input->getOption('remote-host');
-        if (isset($remote_host)) {
-            $remote_user = $input->getOption('remote-user');
-
-            // Get the command arguements, and shift off the Drush command.
-            $redispatchArgs = \Drush\Drush::config()->get('runtime.argv');
-            $drush_path = array_shift($redispatchArgs);
-            $command_name = array_shift($redispatchArgs);
-
-            // Remove argument patterns that should not be propagated
-            $redispatchArgs = $this->alterArgsForRedispatch($redispatchArgs);
-
-            // Fetch the commandline options to pass along to the remote command.
-            // The options the user provided on the commandline will be included
-            // in $redispatchArgs. Here, we only need to provide those
-            // preflight options that should be propagated.
-            $redispatchOptions = $this->redispatchOptions($input);
-
-            $backend_options = [
-                'drush-script' => null,
-                'remote-host' => $remote_host,
-                'remote-user' => $remote_user,
-                'additional-global-options' => [],
-                'integrate' => true,
-                'backend' => false,
-            ];
-            if ($input->isInteractive()) {
-                $backend_options['#tty'] = true;
-                $backend_options['interactive'] = true;
-            }
-
-            $invocations = [
-                [
-                    'command' => $command_name,
-                    'args' => $redispatchArgs,
-                ],
-            ];
-            $common_backend_options = [];
-            $default_command = null;
-            $default_site = [
-                'remote-host' => $remote_host,
-                'remote-user' => $remote_user,
-                'root' => $input->getOption('root'),
-                'uri' => $input->getOption('uri'),
-            ];
-            $context = null;
-
-            $values = drush_backend_invoke_concurrent(
-                $invocations,
-                $redispatchOptions,
-                $backend_options,
-                $default_command,
-                $default_site,
-                $context
-            );
-
-            return $this->exitEarly($values);
+        if ($input->hasOption('remote-host')) {
+            return $this->redispatch($input);
         }
+    }
+
+    /**
+     * Called from RemoteCommandProxy::execute() to run remote commands.
+     */
+    public function redispatch($input)
+    {
+        $remote_host = $input->getOption('remote-host');
+        $remote_user = $input->getOption('remote-user');
+
+        // Get the command arguements, and shift off the Drush command.
+        $redispatchArgs = \Drush\Drush::config()->get('runtime.argv');
+        $drush_path = array_shift($redispatchArgs);
+        $command_name = array_shift($redispatchArgs);
+
+        \Drush\Drush::logger()->log(LogLevel::DEBUG, 'Redispatch hook {command}', ['command' => $command_name]);
+
+        // Remove argument patterns that should not be propagated
+        $redispatchArgs = $this->alterArgsForRedispatch($redispatchArgs);
+
+        // Fetch the commandline options to pass along to the remote command.
+        // The options the user provided on the commandline will be included
+        // in $redispatchArgs. Here, we only need to provide those
+        // preflight options that should be propagated.
+        $redispatchOptions = $this->redispatchOptions($input);
+
+        $backend_options = [
+            'drush-script' => null,
+            'remote-host' => $remote_host,
+            'remote-user' => $remote_user,
+            'additional-global-options' => [],
+            'integrate' => true,
+            'backend' => false,
+        ];
+        if ($input->isInteractive()) {
+            $backend_options['#tty'] = true;
+            $backend_options['interactive'] = true;
+        }
+
+        $invocations = [
+            [
+                'command' => $command_name,
+                'args' => $redispatchArgs,
+            ],
+        ];
+        $common_backend_options = [];
+        $default_command = null;
+        $default_site = [
+            'remote-host' => $remote_host,
+            'remote-user' => $remote_user,
+            'root' => $input->getOption('root'),
+            'uri' => $input->getOption('uri'),
+        ];
+        $context = null;
+
+        $values = drush_backend_invoke_concurrent(
+            $invocations,
+            $redispatchOptions,
+            $backend_options,
+            $default_command,
+            $default_site,
+            $context
+        );
+
+        return $this->exitEarly($values);
     }
 
     protected function redispatchOptions(InputInterface $input)
@@ -120,17 +135,20 @@ class RedispatchHook implements InitializeHookInterface
      */
     protected function alterArgsForRedispatch($redispatchArgs)
     {
-
         return array_filter($redispatchArgs, function ($item) {
             return strpos($item, '-D') !== 0;
         });
     }
 
-
     protected function exitEarly($values)
     {
+        \Drush\Drush::logger()->log(LogLevel::DEBUG, 'Redispatch hook exit early');
+
         // TODO: This is how Drush exits from redispatch commands today;
         // perhaps this could be somewhat improved, though.
+        // Note that RemoteCommandProxy::execute() is expecting that
+        // the redispatch() method will not return, so that will need
+        // to be altered if this behavior is changed.
         drush_set_context('DRUSH_EXECUTION_COMPLETED', true);
         exit($values['error_status']);
     }


### PR DESCRIPTION
Create a RemoteCommandProxy class to use to stand in for unknown commands in Application::find() when the command is destined to be executed remotely.

This overcomes a limitation of Symfony Console that prevented us from running commands remotely.