### PR TITLE
Rename Drush's service cache objects stored in the Drupal container

### DIFF
--- a/src/Commands/generate/GenerateCommands.php
+++ b/src/Commands/generate/GenerateCommands.php
@@ -11,6 +11,7 @@ use Drush\Commands\generate\Helper\InputHandler;
 use Drush\Commands\generate\Helper\OutputHandler;
 use Drush\Commands\help\ListCommands;
 use Drush\Drush;
+use Drush\Drupal\DrushServiceModifier;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Filesystem\Filesystem;
@@ -105,7 +106,9 @@ class GenerateCommands extends DrushCommands
         $module_generators = [];
         if (drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_FULL)) {
             $container = \Drupal::getContainer();
-            $module_generators = $container->get('drush.service.generators')->getCommandList();
+            if ($container->has(DrushServiceModifier::DRUSH_GENERATOR_SERVICES)) {
+                $module_generators = $container->get(DrushServiceModifier::DRUSH_GENERATOR_SERVICES)->getCommandList();
+            }
         }
 
         /** @var \Symfony\Component\Console\Command\Command[] $generators */

--- a/src/Drupal/DrupalKernel.php
+++ b/src/Drupal/DrupalKernel.php
@@ -55,16 +55,25 @@ class DrupalKernel extends DrupalDrupalKernel
      */
     protected function initializeContainer()
     {
+        $container_definition = $this->getCachedContainerDefinition();
+
+        if ($this->shouldDrushInvalidateContainer()) {
+            $this->invalidateContainer();
+        }
+        return parent::initializeContainer();
+    }
+
+    protected function shouldDrushInvalidateContainer()
+    {
         if (empty($this->moduleList) && !$this->containerNeedsRebuild) {
             $container_definition = $this->getCachedContainerDefinition();
             foreach ($this->serviceModifiers as $serviceModifier) {
                 if (!$serviceModifier->check($container_definition)) {
-                    $this->invalidateContainer();
-                    break;
+                    return true;
                 }
             }
         }
-        return parent::initializeContainer();
+        return false;
     }
 
     /**

--- a/src/Drupal/DrushServiceModifier.php
+++ b/src/Drupal/DrushServiceModifier.php
@@ -8,6 +8,13 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 
 class DrushServiceModifier implements ServiceModifierInterface
 {
+    // Holds list of command classes implementing Symfony\Console\Component\Command
+    const DRUSH_CONSOLE_SERVICES = 'drush.console.services';
+    // Holds list of command classes implemented with annotated commands
+    const DRUSH_COMMAND_SERVICES = 'drush.command.services';
+    // Holds list of classes implementing Drupal Code Generator classes
+    const DRUSH_GENERATOR_SERVICES = 'drush.generator.services';
+
     /**
      * @inheritdoc
      */
@@ -15,12 +22,12 @@ class DrushServiceModifier implements ServiceModifierInterface
     {
         drush_log(dt("Service modifier alter."), LogLevel::DEBUG_NOTIFY);
         // http://symfony.com/doc/2.7/components/dependency_injection/tags.html#register-the-pass-with-the-container
-        $container->register('drush.service.consolecommands', 'Drush\Command\ServiceCommandlist');
-        $container->addCompilerPass(new FindCommandsCompilerPass('drush.service.consolecommands', 'console.command'));
-        $container->register('drush.service.consolidationcommands', 'Drush\Command\ServiceCommandlist');
-        $container->addCompilerPass(new FindCommandsCompilerPass('drush.service.consolidationcommands', 'drush.command'));
-        $container->register('drush.service.generators', 'Drush\Command\ServiceCommandlist');
-        $container->addCompilerPass(new FindCommandsCompilerPass('drush.service.generators', 'drush.generator'));
+        $container->register(self::DRUSH_CONSOLE_SERVICES, 'Drush\Command\ServiceCommandlist');
+        $container->addCompilerPass(new FindCommandsCompilerPass(self::DRUSH_CONSOLE_SERVICES, 'console.command'));
+        $container->register(self::DRUSH_COMMAND_SERVICES, 'Drush\Command\ServiceCommandlist');
+        $container->addCompilerPass(new FindCommandsCompilerPass(self::DRUSH_COMMAND_SERVICES, 'drush.command'));
+        $container->register(self::DRUSH_GENERATOR_SERVICES, 'Drush\Command\ServiceCommandlist');
+        $container->addCompilerPass(new FindCommandsCompilerPass(self::DRUSH_GENERATOR_SERVICES, 'drush.generator'));
     }
 
     /**
@@ -32,7 +39,9 @@ class DrushServiceModifier implements ServiceModifierInterface
      */
     public function check($container_definition)
     {
-        return isset($container_definition['services']['drush.service.consolecommands']) &&
-        isset($container_definition['services']['drush.service.consolidationcommands']);
+        return
+            isset($container_definition['services'][self::DRUSH_CONSOLE_SERVICES]) &&
+            isset($container_definition['services'][self::DRUSH_COMMAND_SERVICES]) &&
+            isset($container_definition['services'][self::DRUSH_GENERATOR_SERVICES]);
     }
 }


### PR DESCRIPTION
This avoids conflict with Drush 8.

- 'drush.service.consolecommands' => DrushServiceModifier::DRUSH_CONSOLE_SERVICES ('drush.console.services')
- 'drush.service.consolidationcommands' => DrushServiceModifier::DRUSH_COMMAND_SERVICES ('drush.command.services')
- 'drush.service.generators' => DrushServiceModifier::DRUSH_GENERATOR_SERVICES ('drush.generator.services')