### PR TITLE
Fixes #2767: Avoid 'non-existent service' error

### DIFF
--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -160,19 +160,23 @@ class DrupalBoot8 extends DrupalBoot {
     // The upshot is that the list of console commands is not available
     // until after $kernel->boot() is called.
     $container = \Drupal::getContainer();
-    $serviceCommandlist = $container->get('drush.service.consolecommands');
-    foreach ($serviceCommandlist->getCommandList() as $command) {
-      if (!$this->commandIgnored($command, $ignored_modules)) {
-        drush_log(dt('Add a command: !name', ['!name' => $command->getName()]), LogLevel::DEBUG);
-        annotationcommand_adapter_cache_module_console_commands($command);
+    if ($container->has('drush.service.consolecommands')) {
+      $serviceCommandlist = $container->get('drush.service.consolecommands');
+      foreach ($serviceCommandlist->getCommandList() as $command) {
+        if (!$this->commandIgnored($command, $ignored_modules)) {
+          drush_log(dt('Add a command: !name', ['!name' => $command->getName()]), LogLevel::DEBUG);
+          annotationcommand_adapter_cache_module_console_commands($command);
+        }
       }
     }
     // Do the same thing with the annotation commands.
-    $serviceCommandlist = $container->get('drush.service.consolidationcommands');
-    foreach ($serviceCommandlist->getCommandList() as $commandhandler) {
-      if (!$this->commandIgnored($commandhandler, $ignored_modules)) {
-        drush_log(dt('Add a commandhandler: !name', ['!name' => get_class($commandhandler)]), LogLevel::DEBUG);
-        annotationcommand_adapter_cache_module_service_commands($commandhandler);
+    if ($container->has('drush.service.consolidationcommands')) {
+      $serviceCommandlist = $container->get('drush.service.consolidationcommands');
+      foreach ($serviceCommandlist->getCommandList() as $commandhandler) {
+        if (!$this->commandIgnored($commandhandler, $ignored_modules)) {
+          drush_log(dt('Add a commandhandler: !name', ['!name' => get_class($commandhandler)]), LogLevel::DEBUG);
+          annotationcommand_adapter_cache_module_service_commands($commandhandler);
+        }
       }
     }
   }


### PR DESCRIPTION
Do not attempt to access the cached Drush commandfile services unless they exist in the container. This converts a crashing scenario into one where commands are merely missing. A 'drush cr' should bring back the missing commands.

Needs testing to confirm whether 'drush cr' will repair this problem once this change is in place.