### PR TITLE
Enhance config:status command

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -208,7 +208,7 @@ class ConfigCommands extends DrushCommands
      *   Display configuration items that need to be synchronized.
      * @usage drush config:status --state=Identical
      *   Display configuration items that are in default state.
-     * @usage drush config:status --state='Only in sync directory' --prefix=node.type.
+     * @usage drush config:status --state='Only in sync dir' --prefix=node.type.
      *   Display all content types that would be created in active storage on configuration import.
      * @usage drush config:status --state=Any --format=list
      *   List all config names.
@@ -219,7 +219,7 @@ class ConfigCommands extends DrushCommands
      * @aliases cst,config-status
      * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
      */
-    public function status($options = ['state' => 'Only in DB,Only in sync directory,Different', 'prefix' => '', 'label' => ''])
+    public function status($options = ['state' => 'Only in DB,Only in sync dir,Different', 'prefix' => '', 'label' => ''])
     {
         $config_list = array_fill_keys(
             $this->configFactory->listAll($options['prefix']),
@@ -230,7 +230,7 @@ class ConfigCommands extends DrushCommands
         $storage = $this->getStorage($directory);
         $state_map = [
             'create' => 'Only in DB',
-            'update' => 'Only in sync directory',
+            'update' => 'Only in sync dir',
             'delete' => 'Different',
         ];
         foreach ($this->getChanges($storage) as $collection) {
@@ -257,7 +257,7 @@ class ConfigCommands extends DrushCommands
         $rows = [];
         $color_map = [
             'Only in DB' => 'green',
-            'Only in sync directory' => 'yellow',
+            'Only in sync dir' => 'yellow',
             'Different' => 'red',
             'Identical' => 'white',
         ];

--- a/tests/configTest.php
+++ b/tests/configTest.php
@@ -51,7 +51,7 @@ class ConfigCase extends CommandUnishTestCase {
     $this->assertContains('unish', $page->front, 'Config was successfully imported.');
 
     // Test status of identical configuration.
-    $this->drush('config:status', array(), $options);
+    $this->drush('config:status --format=list', array(), $options);
     $this->assertEquals('', $this->getOutput(), 'config:status correctly reports identical config.');
       
     // Similar, but this time via --partial option.

--- a/tests/configTest.php
+++ b/tests/configTest.php
@@ -51,7 +51,7 @@ class ConfigCase extends CommandUnishTestCase {
     $this->assertContains('unish', $page->front, 'Config was successfully imported.');
 
     // Test status of identical configuration.
-    $this->drush('config:status --format=list', array(), $options);
+    $this->drush('config:status', array(), $options + ['format' => 'list']);
     $this->assertEquals('', $this->getOutput(), 'config:status correctly reports identical config.');
       
     // Similar, but this time via --partial option.


### PR DESCRIPTION
This would allow to filter configuration items by its operation and display results using different formatters.

![config-status-output](https://user-images.githubusercontent.com/673139/31270612-75128f7a-aa9e-11e7-9fc7-b742830c10eb.png)

Related issue #1811.