### PR TITLE
Rough implementation of @hook obsolete.

### DIFF
--- a/src/Commands/LegacyCommands.php
+++ b/src/Commands/LegacyCommands.php
@@ -5,6 +5,13 @@ use Drush\Drush;
 
 class LegacyCommands extends DrushCommands
 {
+    /**
+     * @hook obsolete pm:test
+     */
+    public function test()
+    {
+        throw new \Exception('The pm:test command is just so very old it just is not a thing any more.');
+    }
 
     /**
      * Drupal 8 does not support disabling modules. See pm:uninstall command.

--- a/src/Preflight/DependencyInjection.php
+++ b/src/Preflight/DependencyInjection.php
@@ -139,6 +139,7 @@ class DependencyInjection
         $application->setLogger($container->get('logger'));
         $application->setBootstrapManager($container->get('bootstrap.manager'));
         $application->setAliasManager($container->get('site.alias.manager'));
+        $application->setHookManager($container->get('hookManager'));
         $application->setRedispatchHook($container->get('redispatch.hook'));
         $application->setTildeExpansionHook($container->get('tildeExpansion.hook'));
     }


### PR DESCRIPTION
Here is a prototype for `@hook obsolete`.

Any commandfile may implement `@hook obsolete command:name`. If a user then runs `drush command:name`, then the method annotated with `@hook obsolete` will be called. It is expected that this method should throw an exception to indicate that the command is obsolete.

This happens prior to the point where the $input object is parsed, so the obsolete command may contain any number of arguments or options, and the disposition of the items on the commandline will have no effect on the calling of the `@hook obsolete` method.

The one shortfall here is that a separate hook method is needed for every alias / variation of the obsolete command. Perhaps the annotated command library should be enhanced to allow a single method to be annotated with multiple hooks to allow for this use-case.