### PR TITLE
Fixes #2918: Add site-specific search paths 

### DIFF
--- a/src/Config/ConfigLocator.php
+++ b/src/Config/ConfigLocator.php
@@ -451,6 +451,10 @@ class ConfigLocator
 
         $directories = array_filter($directories, 'is_dir');
 
+        if (empty($directories)) {
+            return $result;
+        }
+
         // Find projects
         $finder = new Finder();
         $finder->files()

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -81,7 +81,7 @@ class Preflight
      * Eventually, we might want to expose this table to some form of
      * 'help' output, so folks can see the available conversions.
      */
-    protected function remapArguments()
+    protected function remapOptions()
     {
         return [
             '--ssh-options' => '-Dssh.options',
@@ -94,21 +94,24 @@ class Preflight
             '--db-su' => '-Dsql.db-su',
             '--notify' => '-Dnotify.duration',
             '--xh-link' => '-Dxh.link',
-            // Map command aliases which Console complains about.
-            'si' => 'site-install',
-            'en' => 'pm-enable',
         ];
     }
 
     /**
-     * Removal table for arguments. Anything found here will be silently
-     * removed. The option value is ignored; ergo, both --strict and
-     * --strict=0 will be removed; however, --stricter will not be removed.
+     * Symfony Console dislikes certain command aliases, because
+     * they are too similar to other Drush commands that contain
+     * the same characters.  To avoid the "I don't know which
+     * command you mean"-type errors, we will replace problematic
+     * aliases with their longhand equivalents.
+     *
+     * This should be fixed in Symfony Console.
      */
-    protected function removeArguments()
+    protected function remapCommandAliases()
     {
-        // Now we are going to support rather than remove --strict.
-        return [];
+        return [
+            'si' => 'site-install',
+            'en' => 'pm-enable',
+        ];
     }
 
     /**
@@ -119,7 +122,7 @@ class Preflight
     public function preflightArgs($argv)
     {
         $argProcessor = new ArgsPreprocessor();
-        $remapper = new ArgsRemapper($this->remapArguments(), $this->removeArguments());
+        $remapper = new ArgsRemapper($this->remapOptions(), $this->remapCommandAliases());
         $preflightArgs = new PreflightArgs([]);
         $argProcessor->setArgsRemapper($remapper);
 

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -178,7 +178,7 @@ class Preflight
         // Find all of the available commandfiles, save for those that are
         // provided by modules in the selected site; those will be added
         // during bootstrap.
-        return $this->configLocator->getCommandFilePaths($this->preflightArgs->commandPaths());
+        return $this->configLocator->getCommandFilePaths($this->preflightArgs->commandPaths(), $this->drupalFinder()->getDrupalRoot());
     }
 
     public function loadSiteAutoloader()


### PR DESCRIPTION
- Adds __DRUPAL_ROOT__/drush and __PROJECT_ROOT__/drush as commandfile search paths
- Finds directories containing one or more of:
  - composer.json
  - Commands/
  - src/Commands/
- Does **not** support drush.services.yml for these locations (must make a module for DI)
- Adds commands and hooks in DRUSH_BOOTSTRAP_NONE

Support for drush.services.yml not added for simplicity, and because commandfiles with dependency injection cannot be instantiated until DRUSH_BOOTSTRAP_FULL.