### PR TITLE
Check for null field storage definition in sql:sanitize

### DIFF
--- a/src/Drupal/Commands/sql/SanitizeUserFieldsCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserFieldsCommands.php
@@ -60,7 +60,7 @@ class SanitizeUserFieldsCommands extends DrushCommands implements SanitizePlugin
 
         foreach ($field_definitions as $key => $def) {
             $execute = false;
-            if ($field_storage[$key]->isBaseField()) {
+            if (!isset($field_storage[$key]) || $field_storage[$key]->isBaseField()) {
                 continue;
             }
 


### PR DESCRIPTION
We need to check the storage definition exists when looping through user fields and checking `->isBaseField()` otherwise you get:

```
Error: Call to a member function isBaseField() on null in Drush\Drupal\Commands\sql\SanitizeUserFieldsCommands->sanitize()
```