### PR TITLE
Inject options from core:rsync and sql:sync alias parameters.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "psr/log": "~1.0",
     "psy/psysh": "~0.6",
     "league/container": "~2",
-    "consolidation/config": "^1.0.3",
+    "consolidation/config": "^1.0.5",
     "consolidation/robo": "^1.1.4",
     "symfony/config": "~2.2|^3",
     "chi-teck/drupal-code-generator": "^1.17.3",

--- a/examples/example.aliases.yml
+++ b/examples/example.aliases.yml
@@ -160,14 +160,16 @@
 #   if you set a 'remote-host' value, and your remote OS is Windows, if you
 #   do not set the 'OS' value, it will default to 'Linux' and could cause
 #   unintended consequences, particularly when running 'drush sql-sync'.
-# - 'ssh-options': If the target requires special options, such as a non-
+# - 'ssh': If the target requires special options, such as a non-
 #   standard port, alternative identity file, or alternative
-#   authentication method, ssh-options can contain a string of extra
-#   options that are used with the ssh command, eg "-p 100"
+#   authentication method, the `option` entry under the `ssh` item may
+#   contain a string of extra options that are used with the ssh command,
+#   e.g. "-p 100"
 # - 'paths': An array of aliases for common rsync targets.
 #   Relative aliases are always taken from the Drupal root.
 #   - 'files': Path to 'files' directory.  This will be looked up if not
 #     specified.
+#   - 'drush-script': Path to the remot Drush command.
 # - 'command': These options will only be set if the alias
 #   is used with the specified command.  In the example below, the option
 #   `--no-dump` will be selected whenever the @stage alias
@@ -177,6 +179,36 @@
 #     - `drush sql-sync @live @stage`
 #   NOTE: Setting boolean options broke with Symfony 3. This will be fixed
 #     in a future release. See: https://github.com/drush-ops/drush/issues/2956
+# - 'alias-parameters': These options will only be set if the alias is
+#   used as the specified parameter. `sql:sync` and `core:rsync` are the two
+#   core commands that use this entry. These commands both have `source`
+#   and `target` parameters.
+#
+# Complex example:
+#
+# @code
+# # File: remote.alias.yml
+# live:
+#   host: server.domain.com
+#   user: www-admin
+#   root: /other/path/to/drupal
+#   uri: http://example.com
+#   ssh:
+#     options: '-p 100'
+#   paths:
+#     drush-script: '/path/to/drush'
+#   command:
+#     site:
+#       install:
+#         options:
+#           admin-password: 'secret-secret'
+#   alias-parameters:
+#     target:
+#       core:
+#         rsnyc:
+#           options:
+#             excplude-paths: sites/default/files/private
+# @endcode
 #
 # Altering aliases:
 #

--- a/isolation/composer.json
+++ b/isolation/composer.json
@@ -9,7 +9,7 @@
     "php": ">=5.6.0",
     "ext-dom": "*",
     "psr/log": "~1.0",
-    "consolidation/config": "dev-master",
+    "consolidation/config": "^1.0.5",
     "grasmash/yaml-expander": "^1.1.1",
     "symfony/yaml": "~2.3|^3",
     "symfony/var-dumper": "~2.7|^3",

--- a/src/Application.php
+++ b/src/Application.php
@@ -149,6 +149,9 @@ class Application extends SymfonyApplication implements LoggerAwareInterface
             return;
         }
         $selfAliasRecord = $this->aliasManager->getSelf();
+        if (!$selfAliasRecord->hasRoot()) {
+            return;
+        }
         $uri = $selfAliasRecord->uri();
 
         if (empty($uri)) {

--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -10,10 +10,15 @@ use Drush\SiteAlias\SiteAliasManagerAwareInterface;
 use Drush\SiteAlias\SiteAliasManagerAwareTrait;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Webmozart\PathUtil\Path;
+use Robo\Contract\ConfigAwareInterface;
+use Robo\Common\ConfigAwareTrait;
+use Drush\Config\ConfigLocator;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
 
-class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInterface
+class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInterface, ConfigAwareInterface
 {
     use SiteAliasManagerAwareTrait;
+    use ConfigAwareTrait;
 
     /**
      * Copy DB data from a source site to a target site. Transfers data via rsync.
@@ -21,27 +26,27 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
      * @command sql:sync
      * @aliases sql-sync
      * @param $source A site-alias or the name of a subdirectory within /sites whose database you want to copy from.
-     * @param $destination A site-alias or the name of a subdirectory within /sites whose database you want to replace.
+     * @param $target A site-alias or the name of a subdirectory within /sites whose database you want to replace.
      * @optionset_table_selection
      * @option no-dump Do not dump the sql database; always use an existing dump file.
      * @option no-sync Do not rsync the database dump file from source to target.
-     * @option runner Where to run the rsync command; defaults to the local site. Can also be 'source' or 'destination'.
+     * @option runner Where to run the rsync command; defaults to the local site. Can also be 'source' or 'target'.
      * @option create-db Create a new database before importing the database dump on the target machine.
      * @option db-su Account to use when creating a new database (e.g. root).
      * @option db-su-pw Password for the db-su account.
      * @option source-dump The path for retrieving the sql-dump on source machine.
-     * @option target-dump The path for storing the sql-dump on destination machine.
+     * @option target-dump The path for storing the sql-dump on target machine.
      * @usage drush sql:sync @source @target
      *   Copy the database from the site with the alias 'source' to the site with the alias 'target'.
      * @usage drush sql:sync #prod #dev
      *   Copy the database from the site in /sites/prod to the site in /sites/dev (multisite installation).
      * @topics docs:aliases,docs:policy,docs:example-sync-via-http
      */
-    public function sqlsync($source, $destination, $options = ['no-dump' => false, 'no-sync' => false, 'runner' => self::REQ, 'create-db' => false, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'target-dump' => self::REQ, 'source-dump' => self::OPT])
+    public function sqlsync($source, $target, $options = ['no-dump' => false, 'no-sync' => false, 'runner' => self::REQ, 'create-db' => false, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'target-dump' => self::REQ, 'source-dump' => self::OPT])
     {
         $manager = $this->siteAliasManager();
         $sourceRecord = $manager->get($source);
-        $destinationRecord = $manager->get($destination);
+        $targetRecord = $manager->get($target);
 
         $backend_options = [];
         $global_options = Drush::redispatchOptions()  + ['strict' => 0];
@@ -50,10 +55,10 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
             $backend_options['backend-simulate'] = true;
         }
 
-        // Create destination DB if needed.
+        // Create target DB if needed.
         if ($options['create-db']) {
-            $this->logger()->notice(dt('Starting to create database on Destination.'));
-            $return = drush_invoke_process($destination, 'sql-create', array(), $global_options, $backend_options);
+            $this->logger()->notice(dt('Starting to create database on target.'));
+            $return = drush_invoke_process($target, 'sql-create', array(), $global_options, $backend_options);
             if ($return['error_status']) {
                 throw new \Exception(dt('sql-create failed.'));
             }
@@ -65,7 +70,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
             'result-file' => $options['source-dump'] ?: true,
         );
         if (!$options['no-dump']) {
-            $this->logger()->notice(dt('Starting to dump database on Source.'));
+            $this->logger()->notice(dt('Starting to dump database on source.'));
             $return = drush_invoke_process($source, 'sql-dump', array(), $dump_options, $backend_options);
             if ($return['error_status']) {
                 throw new \Exception(dt('sql-dump failed.'));
@@ -80,22 +85,22 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
         }
 
         $do_rsync = !$options['no-sync'];
-        // Determine path/to/dump on destination.
+        // Determine path/to/dump on target.
         if ($options['target-dump']) {
-            $destination_dump_path = $options['target-dump'];
+            $target_dump_path = $options['target-dump'];
             $backend_options['interactive'] = false;  // @temporary: See https://github.com/drush-ops/drush/pull/555
-        } elseif (!$sourceRecord->isRemote() && !$destinationRecord->isRemote()) {
-            $destination_dump_path = $source_dump_path;
+        } elseif (!$sourceRecord->isRemote() && !$targetRecord->isRemote()) {
+            $target_dump_path = $source_dump_path;
             $do_rsync = false;
         } else {
             $tmp = '/tmp'; // Our fallback plan.
-            $this->logger()->notice(dt('Starting to discover temporary files directory on Destination.'));
-            $return = drush_invoke_process($destination, 'core-status', array(), array(), array('integrate' => false, 'override-simulated' => true));
+            $this->logger()->notice(dt('Starting to discover temporary files directory on target.'));
+            $return = drush_invoke_process($target, 'core-status', array(), array(), array('integrate' => false, 'override-simulated' => true));
             if (!$return['error_status'] && isset($return['object']['drush-temp'])) {
                 $tmp = $return['object']['drush-temp'];
             }
-            $destination_dump_path = Path::join($tmp, basename($source_dump_path));
-            $backend_options['interactive'] = false;  // No need to prompt as destination is a tmp file.
+            $target_dump_path = Path::join($tmp, basename($source_dump_path));
+            $backend_options['interactive'] = false;  // No need to prompt as target is a tmp file.
         }
 
         if ($do_rsync) {
@@ -105,27 +110,54 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
                 $rsync_options[] = '--remove-source-files';
             }
             if (!$runner = $options['runner']) {
-                $runner = $sourceRecord->isRemote() && $destinationRecord->isRemote() ? $destination : '@self';
+                $runner = $sourceRecord->isRemote() && $targetRecord->isRemote() ? $target : '@self';
             }
             // Since core-rsync is a strict-handling command and drush_invoke_process() puts options at end, we can't send along cli options to rsync.
             // Alternatively, add options like --ssh-options to a site alias (usually on the machine that initiates the sql-sync).
-            $return = drush_invoke_process($runner, 'core-rsync', array_merge(["$source:$source_dump_path", "$destination:$destination_dump_path", '--'], $rsync_options), [], $backend_options);
-            $this->logger()->notice(dt('Copying dump file from Source to Destination.'));
+            $return = drush_invoke_process($runner, 'core-rsync', array_merge(["$source:$source_dump_path", "$target:$target_dump_path", '--'], $rsync_options), [], $backend_options);
+            $this->logger()->notice(dt('Copying dump file from source to target.'));
             if ($return['error_status']) {
                 throw new \Exception(dt('core-rsync failed.'));
             }
         }
 
-        // Import file into destination.
-        $this->logger()->notice(dt('Starting to import dump file onto Destination database.'));
+        // Import file into target.
+        $this->logger()->notice(dt('Starting to import dump file onto target database.'));
         $query_options = $global_options + array(
-            'file' => $destination_dump_path,
+            'file' => $target_dump_path,
             'file-delete' => true,
         );
-        $return = drush_invoke_process($destination, 'sql-query', array(), $query_options, $backend_options);
+        $return = drush_invoke_process($target, 'sql-query', array(), $query_options, $backend_options);
         if ($return['error_status']) {
-            throw new Exception('Failed to rsync the database dump from source to destination.');
+            throw new Exception('Failed to rsync the database dump from source to target.');
         }
+    }
+
+    /**
+     * Inject options from source and target alias parameters.
+     *
+     * @hook command-event sql:sync
+     * @param ConsoleCommandEvent $event
+     */
+    public function preCommandEvent(ConsoleCommandEvent $event)
+    {
+        $input = $event->getInput();
+        $this->injectAliasPathParameterOptions($input, 'source');
+        $this->injectAliasPathParameterOptions($input, 'target');
+    }
+
+    protected function injectAliasPathParameterOptions($input, $parameterName)
+    {
+        // The Drush configuration object is a ConfigOverlay; fetch the alias
+        // context, that already has the options et. al. from the
+        // site-selection alias ('drush @site rsync ...'), @self.
+        $aliasConfigContext = $this->getConfig()->getContext(ConfigLocator::ALIAS_CONTEXT);
+        $manager = $this->siteAliasManager();
+
+        $aliasName = $input->getArgument($parameterName);
+
+        // Inject the source and target alias records into the alias config context.
+        $manager->get($aliasName)->injectIntoConfig($aliasConfigContext, $parameterName);
     }
 
     /**
@@ -134,23 +166,23 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
     public function validate(CommandData $commandData)
     {
         $source = $commandData->input()->getArgument('source');
-        $destination = $commandData->input()->getArgument('destination');
-        // Get destination info for confirmation prompt.
+        $target = $commandData->input()->getArgument('target');
+        // Get target info for confirmation prompt.
         $manager = $this->siteAliasManager();
         if (!$sourceRecord = $manager->get($source)) {
             throw new \Exception(dt('Error: no alias record could be found for source !source', array('!source' => $source)));
         }
-        if (!$destinationRecord = $manager->get($destination)) {
-            throw new \Exception(dt('Error: no alias record could be found for target !destination', array('!destination' => $destination)));
+        if (!$targetRecord = $manager->get($target)) {
+            throw new \Exception(dt('Error: no alias record could be found for target !target', array('!target' => $target)));
         }
         if (!$source_db_name = $this->databaseName($sourceRecord)) {
             throw new \Exception(dt('Error: no database record could be found for source !source', array('!source' => $source)));
         }
-        if (!$target_db_name = $this->databaseName($destinationRecord)) {
-            throw new \Exception(dt('Error: no database record could be found for target !destination', array('!destination' => $destination)));
+        if (!$target_db_name = $this->databaseName($targetRecord)) {
+            throw new \Exception(dt('Error: no database record could be found for target !target', array('!target' => $target)));
         }
         $txt_source = ($sourceRecord->remoteHost() ? $sourceRecord->remoteHost() . '/' : '') . $source_db_name;
-        $txt_destination = ($destinationRecord->remoteHost() ? $destinationRecord->remoteHost() . '/' : '') . $target_db_name;
+        $txt_target = ($targetRecord->remoteHost() ? $targetRecord->remoteHost() . '/' : '') . $target_db_name;
 
         if ($commandData->input()->getOption('no-dump') && !$commandData->input()->getOption('source-dump')) {
             throw new \Exception(dt('The --source-dump option must be supplied when --no-dump is specified.'));
@@ -163,7 +195,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
         if (!Drush::simulate()) {
             $this->output()->writeln(dt("You will destroy data in !target and replace with data from !source.", array(
                 '!source' => $txt_source,
-                '!target' => $txt_destination
+                '!target' => $txt_target
             )));
             if (!$this->io()->confirm(dt('Do you really want to continue?'))) {
                 throw new UserAbortException();

--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -112,6 +112,12 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
             if (!$runner = $options['runner']) {
                 $runner = $sourceRecord->isRemote() && $targetRecord->isRemote() ? $target : '@self';
             }
+            if ($runner == 'source') {
+                $runner = $source;
+            }
+            if (($runner == 'target') || ($runner == 'destination')) {
+                $runner = $target;
+            }
             // Since core-rsync is a strict-handling command and drush_invoke_process() puts options at end, we can't send along cli options to rsync.
             // Alternatively, add options like --ssh-options to a site alias (usually on the machine that initiates the sql-sync).
             $return = drush_invoke_process($runner, 'core-rsync', array_merge(["$source:$source_dump_path", "$target:$target_dump_path", '--'], $rsync_options), [], $backend_options);

--- a/src/Runtime/DependencyInjection.php
+++ b/src/Runtime/DependencyInjection.php
@@ -128,11 +128,6 @@ class DependencyInjection
         $factory = $container->get('commandFactory');
         $factory->setIncludeAllPublicMethods(false);
         $factory->setDataStore($commandCacheDataStore);
-
-        // It is necessary to set the dispatcher when using configureContainer
-        $eventDispatcher = $container->get('eventDispatcher');
-        $eventDispatcher->addSubscriber($hookManager);
-        $application->setDispatcher($eventDispatcher);
     }
 
     protected static function injectApplicationServices(ContainerInterface $container, Application $application)
@@ -142,5 +137,6 @@ class DependencyInjection
         $application->setAliasManager($container->get('site.alias.manager'));
         $application->setRedispatchHook($container->get('redispatch.hook'));
         $application->setTildeExpansionHook($container->get('tildeExpansion.hook'));
+        $application->setDispatcher($container->get('eventDispatcher'));
     }
 }

--- a/src/SiteAlias/AliasRecord.php
+++ b/src/SiteAlias/AliasRecord.php
@@ -297,7 +297,11 @@ class AliasRecord extends Config
      */
     public function legacyRecord()
     {
-        return $this->exportConfig()->get('options', []);
+        $result = $this->exportConfig()->get('options', []);
+        if ($this->has('paths.drush-script')) {
+            $result['path-aliases']['%drush-script'] = $this->get('paths.drush-script');
+        }
+        return $result;
     }
 
     /**

--- a/tests/CommandUnishTestCase.php
+++ b/tests/CommandUnishTestCase.php
@@ -60,6 +60,28 @@ abstract class CommandUnishTestCase extends UnishTestCase {
   protected $idleTimeout = 15;
 
   /**
+   * Get command output and simiplify away things like full paths and extra
+   * whitespace.
+   */
+  protected function getSimplifiedOutput()
+  {
+    $output = $this->getOutput();
+    // We do not care if Drush inserts a -t or not in the string. Depends on whether there is a tty.
+    $output = preg_replace('# -t #', ' ', $output);
+    // Remove double spaces from output to help protect test from false negatives if spacing changes subtlely
+    $output = preg_replace('#  *#', ' ', $output);
+    // Debug flags may be added to command strings if we are in debug mode. Take those out so that tests in phpunit --debug mode work
+    $output = preg_replace('# --debug #', ' ', $output);
+    $output = preg_replace('# --verbose #', ' ', $output);
+    // Get rid of any full paths in the output
+    $output = str_replace(__DIR__, '__DIR__', $output);
+    $output = str_replace(self::getSandbox(), '__SANDBOX__', $output);
+    $output = str_replace(self::getSut(), '__SUT__', $output);
+
+    return $output;
+  }
+
+  /**
    * Accessor for the last output, trimmed.
    *
    * @return string
@@ -435,5 +457,11 @@ abstract class CommandUnishTestCase extends UnishTestCase {
       list($major) = explode('.', $version);
     }
     return (int)$major;
+  }
+
+  protected function assertOutputEquals($expected)
+  {
+    $output = $this->getSimplifiedOutput();
+    $this->assertEquals($expected, $output);
   }
 }

--- a/tests/UnishTestCase.php
+++ b/tests/UnishTestCase.php
@@ -522,6 +522,7 @@ EOT;
     foreach ($siteData as $key => $data) {
       self::$sites["unish.$key"] = $data;
     }
+    return self::$sites;
   }
 
   function createAliasFileData($sites_subdirs, $aliasGroup = 'unish') {

--- a/tests/resources/alias-fixtures/example.alias.yml
+++ b/tests/resources/alias-fixtures/example.alias.yml
@@ -1,9 +1,33 @@
 dev:
   root: /path/to/dev
   uri: dev
+  source:
+    command:
+      core:
+        rsync:
+          options:
+            include-paths: dev-source
+  target:
+    command:
+      core:
+        rsync:
+          options:
+            exclude-paths: dev-target
 stage:
   root: /path/to/stage
   uri: stage
+  source:
+    command:
+      core:
+        rsync:
+          options:
+            include-paths: stage-source
+  target:
+    command:
+      core:
+        rsync:
+          options:
+            exclude-paths: stage-target
 live:
   user: www-admin
   host: service-provider.com

--- a/tests/resources/alias-fixtures/example.alias.yml
+++ b/tests/resources/alias-fixtures/example.alias.yml
@@ -1,33 +1,35 @@
 dev:
   root: /path/to/dev
   uri: dev
-  source:
-    command:
-      core:
-        rsync:
-          options:
-            include-paths: dev-source
-  target:
-    command:
-      core:
-        rsync:
-          options:
-            exclude-paths: dev-target
+  alias-parameters:
+    source:
+      command:
+        core:
+          rsync:
+            options:
+              include-paths: dev-source
+    target:
+      command:
+        core:
+          rsync:
+            options:
+              exclude-paths: dev-target
 stage:
   root: /path/to/stage
   uri: stage
-  source:
-    command:
-      core:
-        rsync:
-          options:
-            include-paths: stage-source
-  target:
-    command:
-      core:
-        rsync:
-          options:
-            exclude-paths: stage-target
+  alias-parameters:
+    source:
+      command:
+        core:
+          rsync:
+            options:
+              include-paths: stage-source
+    target:
+      command:
+        core:
+          rsync:
+            options:
+              exclude-paths: stage-target
 live:
   user: www-admin
   host: service-provider.com

--- a/tests/rsyncTest.php
+++ b/tests/rsyncTest.php
@@ -87,22 +87,6 @@ class rsyncCase extends CommandUnishTestCase {
   }
 
   /**
-   * Test to see if the output is what we expected.
-   */
-  protected function assertOutputEquals($expected)
-  {
-    $output = $this->getOutput();
-    // We do not care if Drush inserts a -t or not in the string. Depends on whether there is a tty.
-    $output = preg_replace('# -t #', ' ', $output);
-    // Remove double spaces from output to help protect test from false negatives if spacing changes subtlely
-    $output = preg_replace('#  *#', ' ', $output);
-    // Get rid of any full paths in the output
-    $output = str_replace(__DIR__, '__DIR__', $output);
-    $output = str_replace(self::getSandbox(), '__SANDBOX__', $output);
-    $this->assertEquals($expected, $output);
-  }
-
-  /**
    * Test to see if rsync @site:%files calculates the %files path correctly.
    * This tests the non-optimized code path. The optimized code path (direct
    * call to Drush API functions rather than an `exec`) has not been implemented.

--- a/tests/rsyncTest.php
+++ b/tests/rsyncTest.php
@@ -33,8 +33,11 @@ class rsyncCase extends CommandUnishTestCase {
     $expected = "Calling system(rsync -e 'ssh ' -akz --include=\"dev-source\" --exclude=\"stage-target\" /path/to/dev/files /path/to/stage/files);";
     $this->assertOutputEquals($expected);
 
-    // Test simulated backend invoke
-    // TODO: Note that command-specific options are not processed. Is this needed? Does Drush 8 support this?
+    // Test simulated backend invoke.
+    // Note that command-specific options are not processed for remote
+    // targets. The aliases are not interpreted at all until they recach
+    // the remote side, at which point they will be evaluated & any needed
+    // injection will be done.
     $this->drush('rsync', ['@example.dev', '@example.stage'], $options, 'user@server/path/to/drupal#sitename', NULL, self::EXIT_SUCCESS, '2>&1');
     $expected = "Simulating backend invoke: ssh -o PasswordAuthentication=no user@server 'drush --alias-path=__DIR__/resources/alias-fixtures --root=/path/to/drupal --uri=sitename --no-ansi rsync '\''@example.dev'\'' '\''@example.stage'\'' 2>&1' 2>&1";
     $this->assertOutputEquals($expected);

--- a/tests/rsyncTest.php
+++ b/tests/rsyncTest.php
@@ -23,19 +23,20 @@ class rsyncCase extends CommandUnishTestCase {
       'alias-path' => __DIR__ . '/resources/alias-fixtures',
     ];
 
-    // Test simulated backend invoke
-    $this->drush('rsync', ['@example.dev', '@example.stage'], $options, 'user@server/path/to/drupal#sitename', NULL, self::EXIT_SUCCESS, '2>&1');
-    $expected = "Simulating backend invoke: ssh -o PasswordAuthentication=no user@server 'drush --alias-path=__DIR__/resources/alias-fixtures --root=/path/to/drupal --uri=sitename --no-ansi rsync '\''@example.dev'\'' '\''@example.stage'\'' 2>&1' 2>&1";
-    $this->assertOutputEquals($expected);
-
     // Test simulated simple rsync with two local sites
-    $this->drush('rsync', ['@example.dev', '@example.stage'], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
-    $expected = "Calling system(rsync -e 'ssh ' -akz /path/to/dev /path/to/stage);";
+    $this->drush('rsync', ['@example.stage', '@example.dev'], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
+    $expected = "Calling system(rsync -e 'ssh ' -akz --include=\"stage-source\" --exclude=\"dev-target\" /path/to/stage /path/to/dev);";
     $this->assertOutputEquals($expected);
 
     // Test simulated rsync with relative paths
     $this->drush('rsync', ['@example.dev:files', '@example.stage:files'], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
-    $expected = "Calling system(rsync -e 'ssh ' -akz /path/to/dev/files /path/to/stage/files);";
+    $expected = "Calling system(rsync -e 'ssh ' -akz --include=\"dev-source\" --exclude=\"stage-target\" /path/to/dev/files /path/to/stage/files);";
+    $this->assertOutputEquals($expected);
+
+    // Test simulated backend invoke
+    // TODO: Note that command-specific options are not processed. Is this needed? Does Drush 8 support this?
+    $this->drush('rsync', ['@example.dev', '@example.stage'], $options, 'user@server/path/to/drupal#sitename', NULL, self::EXIT_SUCCESS, '2>&1');
+    $expected = "Simulating backend invoke: ssh -o PasswordAuthentication=no user@server 'drush --alias-path=__DIR__/resources/alias-fixtures --root=/path/to/drupal --uri=sitename --no-ansi rsync '\''@example.dev'\'' '\''@example.stage'\'' 2>&1' 2>&1";
     $this->assertOutputEquals($expected);
   }
 

--- a/tests/sqlSyncTest.php
+++ b/tests/sqlSyncTest.php
@@ -39,10 +39,10 @@ class sqlSyncTest extends CommandUnishTestCase {
     ];
 
     // Test simulated simple rsync with two local sites
-    $this->drush('sql:sync', ['@synctest.remote', '@synctest.local'], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
+    $this->drush('sql:sync', ['@synctest.remote', '@synctest.local'], $options, '@synctest.local', NULL, self::EXIT_SUCCESS, '2>&1');
     $output = $this->getSimplifiedOutput();
     $this->assertContains("Simulating backend invoke: ssh -o PasswordAuthentication=whatever www-admin@server.isp.simulated '/path/to/drush --backend=2 --strict=0 --alias-path=__DIR__/resources/alias-fixtures:__SANDBOX__/etc/drush --root=__SUT__/web --uri=remote sql-dump --no-ansi --gzip --result-file", $output);
-    $this->assertContains("Simulating backend invoke: __SUT__/vendor/drush/drush/drush --backend=2 --alias-path=__DIR__/resources/alias-fixtures:__SANDBOX__/etc/drush --uri=default core-rsync '@synctest.remote:/simulated/path/to/dump.tgz' '@synctest.local:__SANDBOX__/drush-tmp/dump.tgz' -- --remove-source-files", $output);
+    $this->assertContains("Simulating backend invoke: __SUT__/vendor/drush/drush/drush --backend=2 --alias-path=__DIR__/resources/alias-fixtures:__SANDBOX__/etc/drush --root=__SUT__/web --uri=local core-rsync '@synctest.remote:/simulated/path/to/dump.tgz' '@synctest.local:__SANDBOX__/drush-tmp/dump.tgz' -- --remove-source-files", $output);
     $this->assertContains("Simulating backend invoke: __SUT__/vendor/drush/drush/drush --backend=2 --strict=0 --alias-path=__DIR__/resources/alias-fixtures:__SANDBOX__/etc/drush --root=__SUT__/web --uri=local sql-query --no-ansi --file=__SANDBOX__/drush-tmp/dump.tgz --file-delete", $output);
 
     // Test simulated backend invoke.


### PR DESCRIPTION
Includes tests for both, and documentation in example.aliases.yml.
