### PR TITLE
Follow-on to 3075: do not inject global site alias options

### DIFF
--- a/src/Commands/core/RsyncCommands.php
+++ b/src/Commands/core/RsyncCommands.php
@@ -140,8 +140,17 @@ class RsyncCommands extends DrushCommands implements SiteAliasManagerAwareInterf
         $evaluatedPath = HostPath::create($manager, $aliasName);
         $this->pathEvaluator->evaluate($evaluatedPath);
 
+        $aliasRecord = $evaluatedPath->getAliasRecord();
+
         // Inject the source and target alias records into the alias config context.
-        $evaluatedPath->getAliasRecord()->injectIntoConfig($aliasConfigContext, $parameterName);
+        $aliasRecord->injectIntoConfig($aliasConfigContext, $parameterName);
+
+        // If the path is remote, then we will also inject the global
+        // options into the alias config context so that we pick up
+        // things like ssh-options.
+        if ($aliasRecord->isRemote()) {
+            $aliasConfigContext->combine($aliasRecord->export());
+        }
 
         return $evaluatedPath;
     }

--- a/src/SiteAlias/AliasRecord.php
+++ b/src/SiteAlias/AliasRecord.php
@@ -267,14 +267,11 @@ class AliasRecord extends Config
     public function injectIntoConfig($config, $parameterName = '')
     {
         $aliasData = $this->export();
-        $aliasOptions = $aliasData;
-        unset($aliasOptions['alias-parameters']);
         $parameterSpecificData = $this->getParameterSpecificOptions($aliasData, $parameterName);
         if (!empty($parameterSpecificData)) {
-            $aliasOptions = ArrayUtil::mergeRecursiveDistinct($aliasOptions, $parameterSpecificData);
+            // Combine the data from the parameter-specific
+            $config->combine($parameterSpecificData);
         }
-        // Combine the data from the parameter-specific
-        $config->combine($aliasOptions);
         return $this;
     }
 
@@ -298,8 +295,13 @@ class AliasRecord extends Config
     public function legacyRecord()
     {
         $result = $this->exportConfig()->get('options', []);
+
+        // Backend invoke needs a couple of critical items in specific locations.
         if ($this->has('paths.drush-script')) {
             $result['path-aliases']['%drush-script'] = $this->get('paths.drush-script');
+        }
+        if ($this->has('ssh.options')) {
+            $result['ssh-options'] = $this->get('ssh.options');
         }
         return $result;
     }

--- a/tests/resources/alias-fixtures/example.alias.yml
+++ b/tests/resources/alias-fixtures/example.alias.yml
@@ -35,3 +35,7 @@ live:
   host: service-provider.com
   root: /path/on/service-provider
   uri: https://example.com
+  ssh:
+    options: '-o PasswordAuthentication=example'
+  paths:
+    drush-script: '/example/path/to/drush'

--- a/tests/rsyncTest.php
+++ b/tests/rsyncTest.php
@@ -33,6 +33,11 @@ class rsyncCase extends CommandUnishTestCase {
     $expected = "Calling system(rsync -e 'ssh ' -akz --include=\"dev-source\" --exclude=\"stage-target\" /path/to/dev/files /path/to/stage/files);";
     $this->assertOutputEquals($expected);
 
+    // Test simulated rsync on local machine with a remote target
+    $this->drush('rsync', ['@example.dev:files', '@example.live:files'], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
+    $expected = "Calling system(rsync -e 'ssh -o PasswordAuthentication=example' -akz --include=\"dev-source\" /path/to/dev/files www-admin@service-provider.com:/path/on/service-provider/files);";
+    $this->assertOutputEquals($expected);
+
     // Test simulated backend invoke.
     // Note that command-specific options are not processed for remote
     // targets. The aliases are not interpreted at all until they recach

--- a/tests/sqlSyncTest.php
+++ b/tests/sqlSyncTest.php
@@ -52,7 +52,7 @@ class sqlSyncTest extends CommandUnishTestCase {
     // injection will be done.
     $this->drush('sql:sync', ['@synctest.remote', '@synctest.local'], $options, 'user@server/path/to/drupal#sitename', NULL, self::EXIT_SUCCESS, '2>&1');
     $output = $this->getSimplifiedOutput();
-    $this->assertContains("Simulating backend invoke: ssh -o PasswordAuthentication=whatever user@server '/path/to/drush --alias-path=__DIR__/resources/alias-fixtures:__SANDBOX__/etc/drush --root=/path/to/drupal --uri=sitename --no-ansi sql:sync '\''@synctest.remote'\'' '\''@synctest.local'\''", $output);
+    $this->assertContains("Simulating backend invoke: ssh -o PasswordAuthentication=no user@server 'drush --alias-path=__DIR__/resources/alias-fixtures:__SANDBOX__/etc/drush --root=/path/to/drupal --uri=sitename --no-ansi sql:sync '\''@synctest.remote'\'' '\''@synctest.local'\''", $output);
   }
 
   /**


### PR DESCRIPTION
#3075 was overzealous about injecting alias parameter options. This masked actual problems with ssh-option handling in backend invoke.

This PR maintains the #3075 behavior while fixing these bugs. This will give us a commit that has this feature and behaves correctly. The alias parameter behavior is backed out in #3079, which I will rebase after merging this PR into master.