### PR TITLE
Fix outdated method call

### DIFF
--- a/src/Drupal/Commands/config/ConfigImportCommands.php
+++ b/src/Drupal/Commands/config/ConfigImportCommands.php
@@ -228,7 +228,7 @@ class ConfigImportCommands extends DrushCommands
             $this->getStringTranslation()
         );
         if ($config_importer->alreadyImporting()) {
-            $this->logger()->warn('Another request may be synchronizing configuration already.');
+            $this->logger()->warning('Another request may be synchronizing configuration already.');
         } else {
             try {
                 // This is the contents of \Drupal\Core\Config\ConfigImporter::import.


### PR DESCRIPTION
Found an instance where the old log method is still used instead of the new one from `psr/log`:

```
Error: Call to undefined method Drush\Log\Logger::warn() in Drush\Drupal\Commands\config\ConfigImportCommands->doImport() (line 231 of vendor/drush/drush/src/Drupal/Commands/config/ConfigImportCommands.php)
```