### PR TITLE
Fix #3021. Control when post-updates are run during updatedb.

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -85,8 +85,8 @@ class UpdateDBCommands extends DrushCommands
      * List any pending database updates.
      *
      * @command updatedb:status
-     * @option entity-updates Show entity schema updates. Defaults to enabled.
-     * @option post-updates Show post updates. Defaults to enabled.
+     * @option entity-updates Show entity schema updates.
+     * @option post-updates Show post updates.
      * @bootstrap full
      * @aliases updbst,updatedb-status
      * @field-labels

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -18,8 +18,8 @@ class UpdateDBCommands extends DrushCommands
      *
      * @command updatedb
      * @option cache-clear Clear caches upon completion.
-     * @option entity-updates Run automatic entity schema updates at the end of any update hooks. Defaults to disabled.
-     * @option post-updates Run post updates after hook_update_n and entity updates. Defaults to disabled.
+     * @option entity-updates Run automatic entity schema updates at the end of any update hooks.
+     * @option post-updates Run post updates after hook_update_n and entity updates.
      * @bootstrap full
      * @aliases updb
      */
@@ -42,11 +42,9 @@ class UpdateDBCommands extends DrushCommands
         $return = drush_invoke_process('@self', 'updatedb:status', [], ['entity-updates' => $options['entity-updates'], 'post-updates' => $options['post-updates']]);
         if ($return['error_status']) {
             throw new \Exception('Failed getting update status.');
-        }
-        elseif (empty($return['object'])) {
+        } elseif (empty($return['object'])) {
             // Do nothing. updatedb:status already logged a message.
-        }
-        else {
+        } else {
             if (!$this->io()->confirm(dt('Do you wish to run the specified pending updates?'))) {
                 throw new UserAbortException();
             }

--- a/tests/resources/devel.post_update.php
+++ b/tests/resources/devel.post_update.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * This is a test of the emergency broadcast system.
+ */
+function devel_post_update_null_op(&$sandbox = NULL) {
+  $sandbox['#finished'] = 1;
+  return t('Done doing nothing.');
+}

--- a/tests/resources/updatedb_script.php
+++ b/tests/resources/updatedb_script.php
@@ -1,0 +1,5 @@
+<?php
+
+// Set the schema version of devel to a lower version, so we have a pending update.
+$current = drupal_get_installed_schema_version('devel');
+drupal_set_installed_schema_version('devel', $current - 1);

--- a/tests/updateDBTest.php
+++ b/tests/updateDBTest.php
@@ -1,0 +1,53 @@
+<?php
+namespace Unish;
+
+/**
+ *  @group slow
+ *  @group commands
+ */
+class updateDBTest extends CommandUnishTestCase {
+
+  protected $pathPostUpdate;
+
+  public function testUpdateDBStatus() {
+    $sites = $this->setUpDrupal(1, TRUE);
+    $options = array(
+      'yes' => NULL,
+      'root' => $this->webroot(),
+      'uri' => key($sites),
+    );
+    $this->drush('pm:enable', array('devel'), $options);
+    $this->drush('updatedb:status', array(), $options + ['format' => 'json']);
+    $out = $this->getOutputFromJSON();
+    $this->assertNull($out);
+
+    // Force a pending update.
+    $this->drush('php-script', array('updatedb_script'), $options + array('script-path' => __DIR__ . '/resources'));
+
+    // Assert that pending hook_update_n appears
+    $this->drush('updatedb:status', array(), $options + ['format' => 'json']);
+    $out = $this->getOutputFromJSON('devel_update_8002');
+    $this->assertEquals('Add enforced dependencies to system.menu.devel', trim($out->description));
+
+    // Run hook_update_n
+    $this->drush('updatedb', array(), $options);
+
+    // Assert that we ran hook_update_n properly
+    $this->drush('updatedb:status', array(), $options + ['format' => 'json']);
+    $out = $this->getOutputFromJSON();
+    $this->assertNull($out);
+
+    // Assure that a pending post-update is reported.
+    $this->pathPostUpdate = $this->getSut() . '/web/modules/unish/devel/devel.post_update.php';
+    copy(__DIR__ . '/resources/devel.post_update.php', $this->pathPostUpdate);
+    // Assert that pending hook_update_n appears
+    $this->drush('updatedb:status', array(), $options + ['format' => 'json']);
+    $out = $this->getOutputFromJSON('devel-post-null_op');
+    $this->assertEquals('This is a test of the emergency broadcast system.', trim($out->description));
+  }
+
+  function tearDown() {
+    $this->recursive_delete($this->pathPostUpdate, true);
+    parent::tearDown();
+  }
+}


### PR DESCRIPTION
Add option for running them.

Please test this PR. At the moment we have no automated tests for uodatedb.