### PR TITLE
Bump webflo/drupal-finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "symfony/process": "~2.7|^3",
     "symfony/var-dumper": "~2.7|^3",
     "symfony/yaml": "~2.3|^3",
-    "webflo/drupal-finder": "^1.0",
+    "webflo/drupal-finder": "^1.1",
     "webmozart/path-util": "^2.1.0"
   },
   "require-dev": {


### PR DESCRIPTION
I think drush 9 depends on https://github.com/webflo/drupal-finder/pull/32. We should bump the dependency.