### PR TITLE
Fix typo and strangely formatted line about global commands

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,11 +15,11 @@ Global Drush Commands
 
 Commandfiles that don't ship inside Drupal modules are called 'global' commandfiles. See the examples/Commands folder for examples. In general, its better to use modules to carry your Drush commands. If you still prefer using a global commandfiles, please note:
 
-1. The file's namespace should be \Drush\Commands\[dir-name].
+1. The file's namespace should be `\Drush\Commands\[dir-name]`.
 1. The filename must end in Commands.php (e.g. FooCommands.php)
 1. The enclosing directory must be named Commands
 1. The directory above Commands must be one of: 
-    1.  Folders listed in the 'include' option (see `drush topic docs-configuration`).
+    1.  Folders listed in the 'include' option (see `drush topic docs:configuration`).
     1.  ../drush, /drush and /sites/all/drush relative to the current Drupal installation.
 
 Avoiding the loading of certain Commandfiles (Note: not functional right now).


### PR DESCRIPTION
Hello.

I was curious as to why a global command should have the namespace `Drush\Commands[dir-name]` (notice the missing backslash), when I noticed the source actually contained this said character. So here is a PR making it forced code block, so it actually shows :)

The other change is a typo for what you should read about. There is no `docs-configuration`, only `docs:configuration`