### PR TITLE
Stop setting SERVER globals. Build a Request instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_script:
 
 script:
   - if [ -n "$TEST_DIR" ] ; then cd $TEST_DIR && phpunit ; fi
-  - if [ -z "$TEST_DIR" ] ; then ${PWD}/unish.phpunit.php $PHPUNIT_ARGS ; fi
+  - if [ -z "$TEST_DIR" ] ; then ${PWD}/unish.phpunit.php $PHPUNIT_ARGS --debug; fi
 
 # Background: https://github.com/drush-ops/drush/pull/1426
 after_success: ${PWD}/tests/testChildren.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_script:
 
 script:
   - if [ -n "$TEST_DIR" ] ; then cd $TEST_DIR && phpunit ; fi
-  - if [ -z "$TEST_DIR" ] ; then ${PWD}/unish.phpunit.php $PHPUNIT_ARGS --debug; fi
+  - if [ -z "$TEST_DIR" ] ; then ${PWD}/unish.phpunit.php $PHPUNIT_ARGS; fi
 
 # Background: https://github.com/drush-ops/drush/pull/1426
 after_success: ${PWD}/tests/testChildren.sh

--- a/src/Boot/DrupalBoot.php
+++ b/src/Boot/DrupalBoot.php
@@ -7,6 +7,7 @@ use Drush\Log\LogLevel;
 use Drush\Sql\SqlBase;
 use Psr\Log\LoggerInterface;
 use Drupal\user\Entity\User;
+use Symfony\Component\HttpFoundation\Request;
 use Webmozart\PathUtil\Path;
 
 abstract class DrupalBoot extends BaseBoot
@@ -199,65 +200,9 @@ abstract class DrupalBoot extends BaseBoot
      *
      * In this function we determine the URL used for the command,
      * and check for a valid settings.php file.
-     *
-     * To do this, we need to set up the $_SERVER environment variable,
-     * to allow us to use confPath to determine what Drupal will load
-     * as a configuration file.
      */
     public function bootstrapDrupalSiteValidate()
     {
-        $this->bootstrapDrupalSiteSetupServerGlobal();
-        $site = drush_bootstrap_value('site', $_SERVER['HTTP_HOST']);
-        $confPath = drush_bootstrap_value('confPath', $this->confPath(true, true));
-        return true; //$this->bootstrapDrupalSiteValidate_settings_present();
-    }
-
-    /**
-     * Set up the $_SERVER globals so that Drupal will see the same values
-     * that it does when serving pages via the web server.
-     */
-    public function bootstrapDrupalSiteSetupServerGlobal()
-    {
-        // Fake the necessary HTTP headers that Drupal needs:
-        if ($this->uri) {
-            $drupal_base_url = parse_url($this->uri);
-            // If there's no url scheme set, add http:// and re-parse the url
-            // so the host and path values are set accurately.
-            if (!array_key_exists('scheme', $drupal_base_url)) {
-                $drush_uri = 'http://' . $this->uri;
-                $drupal_base_url = parse_url($drush_uri);
-            }
-            // Fill in defaults.
-            $drupal_base_url += array(
-            'path' => '',
-            'host' => null,
-            'port' => null,
-            );
-            $_SERVER['HTTP_HOST'] = $drupal_base_url['host'];
-
-            if ($drupal_base_url['scheme'] == 'https') {
-                  $_SERVER['HTTPS'] = 'on';
-            }
-
-            if ($drupal_base_url['port']) {
-                  $_SERVER['HTTP_HOST'] .= ':' . $drupal_base_url['port'];
-            }
-            $_SERVER['SERVER_PORT'] = $drupal_base_url['port'];
-
-            $_SERVER['REQUEST_URI'] = $drupal_base_url['path'] . '/';
-        } else {
-            $_SERVER['HTTP_HOST'] = 'default';
-            $_SERVER['REQUEST_URI'] = '/';
-        }
-
-        $_SERVER['PHP_SELF'] = $_SERVER['REQUEST_URI'] . 'index.php';
-        $_SERVER['SCRIPT_NAME'] = $_SERVER['PHP_SELF'];
-        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
-        $_SERVER['REQUEST_METHOD']  = 'GET';
-
-        $_SERVER['SERVER_SOFTWARE'] = null;
-        $_SERVER['HTTP_USER_AGENT'] = null;
-        $_SERVER['SCRIPT_FILENAME'] = DRUPAL_ROOT . '/index.php';
     }
 
     /**

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -143,10 +143,7 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         $classloader = $this->autoloader();
         $kernelClass = new \ReflectionClass('\Drupal\Core\DrupalKernel');
         $request = $this->getRequest();
-        $this->logger->debug(print_r(['httphost' => $request->getHttpHost(), 'uri' => $request->getUri()], true));
         $this->kernel = DrushDrupalKernel::createFromRequest($request, $classloader, 'prod');
-        $this->logger->debug('site path is ' . $this->kernel->getSitePath() . "\n");
-        $this->logger->debug('db are ' . print_r(Database::getAllConnectionInfo(), true));
         // @see Drush\Drupal\DrupalKernel::addServiceModifier()
         $this->kernel->addServiceModifier(new DrushServiceModifier());
 

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -27,6 +27,20 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
      */
     protected $request;
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Request
+     */
+    public function getRequest() {
+        return $this->request;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     */
+    public function setRequest($request) {
+        $this->request = $request;
+    }
+
     public function validRoot($path)
     {
         if (!empty($path) && is_dir($path) && file_exists($path . '/autoload.php')) {
@@ -54,21 +68,14 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         }
     }
 
-    public function confPath($require_settings = true, $reset = false, Request $request = null)
+    public function confPath($require_settings = true, $reset = false)
     {
-        if (!isset($request)) {
-            if (\Drupal::hasRequest()) {
-                $request = \Drupal::request();
-            } // @todo Remove once external CLI scripts (Drush) are updated.
-            else {
-                $request = Request::createFromGlobals();
-            }
-        }
+
         if (\Drupal::hasService('kernel')) {
             $site_path = \Drupal::service('kernel')->getSitePath();
         }
         if (!isset($site_path) || empty($site_path)) {
-            $site_path = DrupalKernel::findSitePath($request, $require_settings);
+            $site_path = DrupalKernel::findSitePath($this->getRequest(), $require_settings);
         }
         return $site_path;
     }
@@ -93,6 +100,19 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         return $core;
     }
 
+    public function bootstrapDrupalSiteValidate() {
+        parent::bootstrapDrupalSiteValidate();
+        // Account for users who omit the http:// prefix.
+        if (!parse_url($this->uri, PHP_URL_SCHEME)) {
+            $this->uri = 'http://' . $this->uri;
+        }
+        $request = Request::create($this->uri, 'GET', [], [], [], ['SCRIPT_NAME' => '/index.php']);
+        $this->setRequest($request);
+        $confPath = drush_bootstrap_value('confPath', $this->confPath(true, true));
+        drush_bootstrap_value('site', $request->getHttpHost());
+        return true; //$this->bootstrapDrupalSiteValidate_settings_present();
+    }
+
     public function bootstrapDrupalDatabaseValidate()
     {
         return parent::bootstrapDrupalDatabaseValidate() && $this->bootstrapDrupalDatabaseHasTable('key_value');
@@ -106,11 +126,9 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
 
     public function bootstrapDrupalConfiguration()
     {
-        $this->request = Request::createFromGlobals();
         $classloader = $this->autoloader();
-        // @todo - use Request::create() and then no need to set PHP superglobals
         $kernelClass = new \ReflectionClass('\Drupal\Core\DrupalKernel');
-        $this->kernel = DrushDrupalKernel::createFromRequest($this->request, $classloader, 'prod', DRUPAL_ROOT);
+        $this->kernel = DrushDrupalKernel::createFromRequest($this->getRequest(), $classloader, 'prod', DRUPAL_ROOT);
         // @see Drush\Drupal\DrupalKernel::addServiceModifier()
         $this->kernel->addServiceModifier(new DrushServiceModifier());
 
@@ -131,7 +149,7 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
             ob_start();
         }
         $this->kernel->boot();
-        $this->kernel->prepareLegacyRequest($this->request);
+        $this->kernel->prepareLegacyRequest($this->getRequest());
         if (!drush_get_context('DRUSH_QUIET', false)) {
             ob_end_clean();
         }
@@ -193,7 +211,7 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
 
         if ($this->kernel) {
             $response = Response::create('');
-            $this->kernel->terminate($this->request, $response);
+            $this->kernel->terminate($this->getRequest(), $response);
         }
     }
 }

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -133,7 +133,7 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         $kernelClass = new \ReflectionClass('\Drupal\Core\DrupalKernel');
         $request = $this->getRequest();
         $this->logger->debug(print_r(['httphost' => $request->getHttpHost(), 'uri' => $request->getUri()], true));
-        $this->kernel = DrushDrupalKernel::createFromRequest($request, $classloader, 'prod', false, DRUPAL_ROOT);
+        $this->kernel = DrushDrupalKernel::createFromRequest($request, $classloader, 'prod');
         $this->logger->debug('site path is ' . $this->kernel->getSitePath() . "\n");
         $this->logger->debug('db are ' . print_r(Database::getAllConnectionInfo(), true));
         // @see Drush\Drupal\DrupalKernel::addServiceModifier()

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -30,14 +30,16 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
     /**
      * @return \Symfony\Component\HttpFoundation\Request
      */
-    public function getRequest() {
+    public function getRequest()
+    {
         return $this->request;
     }
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      */
-    public function setRequest($request) {
+    public function setRequest($request)
+    {
         $this->request = $request;
     }
 
@@ -100,7 +102,8 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         return $core;
     }
 
-    public function bootstrapDrupalSiteValidate() {
+    public function bootstrapDrupalSiteValidate()
+    {
         parent::bootstrapDrupalSiteValidate();
         // Account for users who omit the http:// prefix.
         if (!parse_url($this->uri, PHP_URL_SCHEME)) {

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -131,7 +131,8 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
     {
         $classloader = $this->autoloader();
         $kernelClass = new \ReflectionClass('\Drupal\Core\DrupalKernel');
-        $this->kernel = DrushDrupalKernel::createFromRequest($this->getRequest(), $classloader, 'prod', DRUPAL_ROOT);
+        $this->kernel = DrushDrupalKernel::createFromRequest($this->getRequest(), $classloader, 'prod', false, DRUPAL_ROOT);
+        $this->logger->debug('site path is ' . $this->kernel->getSitePath() . "\n");
         // @see Drush\Drupal\DrupalKernel::addServiceModifier()
         $this->kernel->addServiceModifier(new DrushServiceModifier());
 

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -113,7 +113,11 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         $this->setRequest($request);
         $confPath = drush_bootstrap_value('confPath', $this->confPath(true, true));
         drush_bootstrap_value('site', $request->getHttpHost());
-        return true; //$this->bootstrapDrupalSiteValidate_settings_present();
+        $conf_file = "$confPath/settings.php";
+        if (!file_exists($conf_file)) {
+            throw new \Exception(dt("Could not find a Drupal settings.php file at !file.", array('!file' => $conf_file)));
+        }
+        return true;
     }
 
     public function bootstrapDrupalDatabaseValidate()

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -9,7 +9,7 @@ use Drupal\Core\DrupalKernel;
 use Drush\Drush;
 use Drush\Drupal\DrupalKernel as DrushDrupalKernel;
 use Drush\Drupal\DrushServiceModifier;
-use Consolidation\AnnotatedCommand\AnnotatedCommandFactory;
+use Drupal\Core\Database\Database;
 
 use Drush\Log\LogLevel;
 
@@ -131,8 +131,11 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
     {
         $classloader = $this->autoloader();
         $kernelClass = new \ReflectionClass('\Drupal\Core\DrupalKernel');
-        $this->kernel = DrushDrupalKernel::createFromRequest($this->getRequest(), $classloader, 'prod', false, DRUPAL_ROOT);
+        $request = $this->getRequest();
+        $this->logger->debug(print_r(['httphost' => $request->getHttpHost(), 'uri' => $request->getUri()], true));
+        $this->kernel = DrushDrupalKernel::createFromRequest($request, $classloader, 'prod', false, DRUPAL_ROOT);
         $this->logger->debug('site path is ' . $this->kernel->getSitePath() . "\n");
+        $this->logger->debug('db are ' . print_r(Database::getAllConnectionInfo(), true));
         // @see Drush\Drupal\DrupalKernel::addServiceModifier()
         $this->kernel->addServiceModifier(new DrushServiceModifier());
 

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -119,7 +119,10 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
     public function bootstrapDrupalConfigurationValidate() {
         $conf_file = $this->confPath() . '/settings.php';
         if (!file_exists($conf_file)) {
-            throw new \Exception(dt("Could not find a Drupal settings.php file at !file.", array('!file' => $conf_file)));
+            $msg = dt("Could not find a Drupal settings.php file at !file.", array('!file' => $conf_file));
+            $this->logger->debug($msg);
+            // Cant do this because site:install deliberately bootstraps to configure without a settings.php file.
+            // return drush_set_error($msg);
         }
         return true;
     }

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -113,7 +113,11 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         $this->setRequest($request);
         $confPath = drush_bootstrap_value('confPath', $this->confPath(true, true));
         drush_bootstrap_value('site', $request->getHttpHost());
-        $conf_file = "$confPath/settings.php";
+        return true;
+    }
+
+    public function bootstrapDrupalConfigurationValidate() {
+        $conf_file = $this->confPath() . '/settings.php';
         if (!file_exists($conf_file)) {
             throw new \Exception(dt("Could not find a Drupal settings.php file at !file.", array('!file' => $conf_file)));
         }

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -116,7 +116,8 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         return true;
     }
 
-    public function bootstrapDrupalConfigurationValidate() {
+    public function bootstrapDrupalConfigurationValidate()
+    {
         $conf_file = $this->confPath() . '/settings.php';
         if (!file_exists($conf_file)) {
             $msg = dt("Could not find a Drupal settings.php file at !file.", array('!file' => $conf_file));

--- a/src/Commands/core/CacheCommands.php
+++ b/src/Commands/core/CacheCommands.php
@@ -186,12 +186,11 @@ class CacheCommands extends DrushCommands implements CustomEventAwareInterface, 
         $autoloader = $this->loadDrupalAutoloader(DRUPAL_ROOT);
         require_once DRUSH_DRUPAL_CORE . '/includes/utility.inc';
 
-        $request = Request::createFromGlobals();
-        // Ensure that the HTTP method is set, which does not happen with Request::createFromGlobals().
-        $request->setMethod('GET');
+        $request = Drush::bootstrap()->getRequest();
         // Manually resemble early bootstrap of DrupalKernel::boot().
         require_once DRUSH_DRUPAL_CORE . '/includes/bootstrap.inc';
         DrupalKernel::bootEnvironment();
+
         // Avoid 'Only variables should be passed by reference'
         $root  = DRUPAL_ROOT;
         $site_path = DrupalKernel::findSitePath($request);

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -66,6 +66,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
             $form_options[$key] = $value;
         }
 
+        $this->serverGlobals(Drush::bootstrapManager()->getUri());
         $class_loader = Drush::service('loader');
         $profile = $this->determineProfile($profile, $options, $class_loader);
 
@@ -158,7 +159,6 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
             require_once DRUSH_DRUPAL_CORE . '/includes/install.core.inc';
             $install_state = array('interactive' => false) + install_state_defaults();
             try {
-                $this->serverGlobals(Drush::bootstrapManager()->getUri());
                 install_begin_request($class_loader, $install_state);
                 $profile = _install_select_profile($install_state);
             } catch (\Exception $e) {
@@ -210,7 +210,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
                 $commandData->input()->setOption('sites-subdir', $lower);
             }
             // Make sure that we will bootstrap to the 'sites-subdir' site.
-            $bootstrapManager = \Drush\Drush::bootstrapManager();
+            $bootstrapManager = Drush::bootstrapManager();
             $bootstrapManager->setUri('http://' . $sites_subdir);
         }
 
@@ -228,8 +228,8 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
             }
         }
 
-        Drush::bootstrapManager()->bootstrapMax(DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION);
         try {
+            Drush::bootstrapManager()->bootstrapMax(DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION);
             $sql = SqlBase::create($commandData->input()->getOptions());
         } catch (\Exception $e) {
             // Ask questions to get our data.
@@ -306,7 +306,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
 
         // Can't install without sites subdirectory and settings.php.
         if (!file_exists($confPath)) {
-            if (!drush_mkdir($confPath) && !\Drush\Drush::simulate()) {
+            if (!drush_mkdir($confPath) && !Drush::simulate()) {
                 throw new \Exception(dt('Failed to create directory @confPath', array('@confPath' => $confPath)));
             }
         } else {
@@ -314,14 +314,14 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
         }
 
         if (!drush_file_not_empty($settingsfile)) {
-            if (!drush_op('copy', 'sites/default/default.settings.php', $settingsfile) && !\Drush\Drush::simulate()) {
+            if (!drush_op('copy', 'sites/default/default.settings.php', $settingsfile) && !Drush::simulate()) {
                 throw new \Exception(dt('Failed to copy sites/default/default.settings.php to @settingsfile', array('@settingsfile' => $settingsfile)));
             }
         }
 
         // Write an empty sites.php if we using multi-site.
         if ($sitesfile_write) {
-            if (!drush_op('copy', 'sites/example.sites.php', $sitesfile) && !\Drush\Drush::simulate()) {
+            if (!drush_op('copy', 'sites/example.sites.php', $sitesfile) && !Drush::simulate()) {
                 throw new \Exception(dt('Failed to copy sites/example.sites.php to @sitesfile', array('@sitesfile' => $sitesfile)));
             }
         }

--- a/src/Drupal/DrupalKernel.php
+++ b/src/Drupal/DrupalKernel.php
@@ -3,25 +3,12 @@ namespace Drush\Drupal;
 
 use Drush\Log\LogLevel;
 use Drupal\Core\DrupalKernel as DrupalDrupalKernel;
-use Symfony\Component\HttpFoundation\Request;
 use Drupal\Core\DependencyInjection\ServiceModifierInterface;
 
 class DrupalKernel extends DrupalDrupalKernel
 {
   /** @var ServiceModifierInterface[] */
     protected $serviceModifiers = [];
-
-    /**
-     * @inheritdoc
-     */
-    public static function createFromRequest(Request $request, $class_loader, $environment, $allow_dumping = true, $app_root = null)
-    {
-        drush_log(dt("Create from request"), LogLevel::DEBUG);
-        $kernel = new static($environment, $class_loader, $allow_dumping, $app_root);
-        static::bootEnvironment($app_root);
-        $kernel->initializeSettings($request);
-        return $kernel;
-    }
 
     /**
      * Add a service modifier to the container builder.

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -44,11 +44,11 @@ class SqlBase
     {
         // Set defaults in the unfortunate event that caller doesn't provide values.
         $options += [
-        'database' => 'default',
-        'target' => 'default',
-        'db-url' => null,
-        'databases' => null,
-        'db-prefix' => null,
+            'database' => 'default',
+            'target' => 'default',
+            'db-url' => null,
+            'databases' => null,
+            'db-prefix' => null,
         ];
         $database = $options['database'];
         $target = $options['target'];

--- a/tests/CommandUnishTestCase.php
+++ b/tests/CommandUnishTestCase.php
@@ -325,7 +325,6 @@ abstract class CommandUnishTestCase extends UnishTestCase {
     // @todo The PHP Options below are not yet honored by execute(). See .travis.yml for an alternative way.
     $env['PHP_OPTIONS'] = "${php_options}-d sendmail_path='true'";
     $cmd = implode(' ', $exec);
-    $this->log("> Run $cmd", 'debug');
     $return = $this->execute($cmd, $expected_return, $cd, $env);
 
     // Save code coverage information.

--- a/tests/UnishTestCase.php
+++ b/tests/UnishTestCase.php
@@ -33,6 +33,17 @@ abstract class UnishTestCase extends \PHPUnit_Framework_TestCase {
     return self::$sites;
   }
 
+  /**
+   * @return array
+   */
+  public static function getAliases() {
+    // Prefix @sut. onto each site.
+    foreach (self::$sites as $key => $site) {
+      $aliases[$key] = '@sut.' . $key;
+    }
+    return $aliases;
+  }
+
   public static function getUri($site = 'dev') {
     return self::$sites[$site]['uri'];
   }
@@ -75,10 +86,16 @@ abstract class UnishTestCase extends \PHPUnit_Framework_TestCase {
       if (file_exists($sandbox)) {
         self::recursive_delete($sandbox);
       }
-      foreach (['modules', 'themes', 'profiles', 'drush', 'sites/dev', 'sites/stage', 'sites/prod'] as $dir) {
+      foreach (['modules', 'themes', 'profiles', 'drush'] as $dir) {
         $target = Path::join(self::getSut(), 'web', $dir, 'contrib');
         if (file_exists($target)) {
           self::recursive_delete_dir_contents($target);
+        }
+      }
+      foreach (['sites/dev', 'sites/stage', 'sites/prod'] as $dir) {
+        $target = Path::join(self::getSut(), 'web', $dir);
+        if (file_exists($target)) {
+          self::recursive_delete($target);
         }
       }
     }

--- a/tests/UnishTestCase.php
+++ b/tests/UnishTestCase.php
@@ -75,7 +75,7 @@ abstract class UnishTestCase extends \PHPUnit_Framework_TestCase {
       if (file_exists($sandbox)) {
         self::recursive_delete($sandbox);
       }
-      foreach (['modules', 'themes', 'profiles', 'drush'] as $dir) {
+      foreach (['modules', 'themes', 'profiles', 'drush', 'sites/dev', 'sites/stage', 'sites/prod'] as $dir) {
         $target = Path::join(self::getSut(), 'web', $dir, 'contrib');
         if (file_exists($target)) {
           self::recursive_delete_dir_contents($target);

--- a/tests/UnishTestCase.php
+++ b/tests/UnishTestCase.php
@@ -33,7 +33,7 @@ abstract class UnishTestCase extends \PHPUnit_Framework_TestCase {
     return self::$sites;
   }
 
-  public static function getUri($site = 'unish.dev') {
+  public static function getUri($site = 'dev') {
     return self::$sites[$site]['uri'];
   }
 

--- a/tests/UnishTestCase.php
+++ b/tests/UnishTestCase.php
@@ -506,7 +506,7 @@ EOT;
     $siteData = $this->createAliasFile($sites_subdirs, 'unish');
     self::$sites = [];
     foreach ($siteData as $key => $data) {
-      self::$sites["unish.$key"] = $data;
+      self::$sites[$key] = $data;
     }
     return self::$sites;
   }

--- a/tests/cacheCommandTest.php
+++ b/tests/cacheCommandTest.php
@@ -58,7 +58,7 @@ class cacheCommandCase extends CommandUnishTestCase {
     return array(
       'yes' => NULL,
       'root' => $this->webroot(),
-      'uri' => key($this->getSites()),
+      'uri' => $this->getUri(),
     );
   }
 }

--- a/tests/configPullTest.php
+++ b/tests/configPullTest.php
@@ -18,7 +18,9 @@ class ConfigPullCase extends CommandUnishTestCase {
    * Make sure a change propagates using config-pull+config-import.
    */
   function testConfigPull() {
-    list($source, $destination) = $this->getAliases();
+    $aliases = $this->getAliases();
+    $source = $aliases['stage'];
+    $destination = $aliases['dev'];
     // Make UUID match.
     $this->drush('config-get', array('system.site', 'uuid'), array('yes' => NULL), $source);
     list($name, $uuid) = explode(' ', $this->getOutput());

--- a/tests/configPullTest.php
+++ b/tests/configPullTest.php
@@ -19,8 +19,8 @@ class ConfigPullCase extends CommandUnishTestCase {
    */
   function testConfigPull() {
     list($source, $destination) = array_keys($this->getSites());
-    $source = "@$source";
-    $destination = "@$destination";
+    $source = "@sut.$source";
+    $destination = "@sut.$destination";
     // Make UUID match.
     $this->drush('config-get', array('system.site', 'uuid'), array('yes' => NULL), $source);
     list($name, $uuid) = explode(' ', $this->getOutput());

--- a/tests/configPullTest.php
+++ b/tests/configPullTest.php
@@ -18,9 +18,7 @@ class ConfigPullCase extends CommandUnishTestCase {
    * Make sure a change propagates using config-pull+config-import.
    */
   function testConfigPull() {
-    list($source, $destination) = array_keys($this->getSites());
-    $source = "@sut.$source";
-    $destination = "@sut.$destination";
+    list($source, $destination) = $this->getAliases();
     // Make UUID match.
     $this->drush('config-get', array('system.site', 'uuid'), array('yes' => NULL), $source);
     list($name, $uuid) = explode(' ', $this->getOutput());

--- a/tests/configTest.php
+++ b/tests/configTest.php
@@ -70,7 +70,7 @@ class ConfigCase extends CommandUnishTestCase {
     return array(
       'yes' => NULL,
       'root' => $this->webroot(),
-      'uri' => key($this->getSites()),
+      'uri' => $this->getUri(),
     );
   }
 }

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -24,7 +24,7 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
       'pipe' => NULL,
     );
 
-    $this->execute("find . -print | sed -e '\''s;[^/]*/;|____;g;s;____|; |;g'\''", self::EXIT_SUCCESS, $options['root'] . '/sites');
+    $this->execute("find . -print", self::EXIT_SUCCESS, $options['root'] . '/sites');
     $out = $this->getOutput();
     fwrite(STDERR, $out);
 

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -24,10 +24,6 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
       'pipe' => NULL,
     );
 
-    $this->execute("find . -print", self::EXIT_SUCCESS, $options['root'] . '/sites');
-    $out = $this->getOutput();
-    fwrite(STDERR, $out);
-
     // Test that pm-list lists uninstalled modules.
     $this->drush('pm-list', array(), $options + array('no-core' => NULL, 'status' => 'disabled'));
     $out = $this->getOutput();

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -24,7 +24,7 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
       'pipe' => NULL,
     );
 
-    $this->execute('tree', \self::EXIT_SUCCESS, $options['root'] . '/sites');
+    $this->execute('tree', self::EXIT_SUCCESS, $options['root'] . '/sites');
     $out = $this->getOutput();
     fwrite(STDERR, $out);
 

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -24,7 +24,7 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
       'pipe' => NULL,
     );
 
-    $this->execute('tree', self::EXIT_SUCCESS, $options['root'] . '/sites');
+    $this->execute("find . -print | sed -e '\''s;[^/]*/;|____;g;s;____|; |;g'\''", self::EXIT_SUCCESS, $options['root'] . '/sites');
     $out = $this->getOutput();
     fwrite(STDERR, $out);
 

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -24,6 +24,10 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
       'pipe' => NULL,
     );
 
+    $this->execute('tree', \self::EXIT_SUCCESS, $options['root'] . '/sites');
+    $out = $this->getOutput();
+    fwrite(STDERR, $out);
+
     // Test that pm-list lists uninstalled modules.
     $this->drush('pm-list', array(), $options + array('no-core' => NULL, 'status' => 'disabled'));
     $out = $this->getOutput();

--- a/tests/rsyncTest.php
+++ b/tests/rsyncTest.php
@@ -51,7 +51,9 @@ class rsyncCase extends CommandUnishTestCase {
   public function testRsyncPathAliases() {
 
     $this->setUpDrupal(2, TRUE);
-    list($source, $destination) = $this->getAliases();
+    $aliases = $this->getAliases();
+    $source = $aliases['stage'];
+    $destination = $aliases['dev'];
 
     $options = [
       'yes' => NULL,
@@ -98,7 +100,7 @@ class rsyncCase extends CommandUnishTestCase {
    */
   function testRsyncAndPercentFiles() {
     $root = $this->webroot();
-    $site = key($this->getAliases());
+    $site = current($this->getAliases());
     $uri = $this->getUri();
     $options = array(
       'root' => $root,

--- a/tests/rsyncTest.php
+++ b/tests/rsyncTest.php
@@ -81,7 +81,7 @@ class rsyncCase extends CommandUnishTestCase {
 
     // Test an actual rsync between our two fixture sites. Note that
     // these sites share the same web root.
-    $this->drush('rsync', ['@unish.dev:%files/a/', '@unish.stage:%files/b'], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
+    $this->drush('rsync', ['@sut.dev:%files/a/', '@sut.stage:%files/b'], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
     $expected = '';
     $this->assertContains('You will delete files in', $this->getOutput());
 
@@ -106,7 +106,7 @@ class rsyncCase extends CommandUnishTestCase {
       'simulate' => NULL,
       'yes' => NULL,
     );
-    $this->drush('core-rsync', array("@$site:%files", "/tmp"), $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1;');
+    $this->drush('core-rsync', array("@sut.$site:%files", "/tmp"), $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1;');
     $output = $this->getOutput();
     $level = $this->log_level();
     $pattern = in_array($level, array('verbose', 'debug')) ? "Calling system(rsync -e 'ssh ' -akzv --stats --progress %s /tmp);" : "Calling system(rsync -e 'ssh ' -akz %s /tmp);";

--- a/tests/rsyncTest.php
+++ b/tests/rsyncTest.php
@@ -51,6 +51,7 @@ class rsyncCase extends CommandUnishTestCase {
   public function testRsyncPathAliases() {
 
     $this->setUpDrupal(2, TRUE);
+    list($source, $destination) = $this->getAliases();
 
     $options = [
       'yes' => NULL,
@@ -81,8 +82,7 @@ class rsyncCase extends CommandUnishTestCase {
 
     // Test an actual rsync between our two fixture sites. Note that
     // these sites share the same web root.
-    $this->drush('rsync', ['@sut.dev:%files/a/', '@sut.stage:%files/b'], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
-    $expected = '';
+    $this->drush('rsync', ["$source:%files/a/", "$destination:%files/b"], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
     $this->assertContains('You will delete files in', $this->getOutput());
 
     // Test to see if our fixture file now exists at $target
@@ -98,7 +98,7 @@ class rsyncCase extends CommandUnishTestCase {
    */
   function testRsyncAndPercentFiles() {
     $root = $this->webroot();
-    $site = key($this->getSites());
+    $site = key($this->getAliases());
     $uri = $this->getUri();
     $options = array(
       'root' => $root,
@@ -106,7 +106,7 @@ class rsyncCase extends CommandUnishTestCase {
       'simulate' => NULL,
       'yes' => NULL,
     );
-    $this->drush('core-rsync', array("@sut.$site:%files", "/tmp"), $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1;');
+    $this->drush('core-rsync', array("$site:%files", "/tmp"), $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1;');
     $output = $this->getOutput();
     $level = $this->log_level();
     $pattern = in_array($level, array('verbose', 'debug')) ? "Calling system(rsync -e 'ssh ' -akzv --stats --progress %s /tmp);" : "Calling system(rsync -e 'ssh ' -akz %s /tmp);";

--- a/tests/rsyncTest.php
+++ b/tests/rsyncTest.php
@@ -52,8 +52,8 @@ class rsyncCase extends CommandUnishTestCase {
 
     $this->setUpDrupal(2, TRUE);
     $aliases = $this->getAliases();
-    $source = $aliases['stage'];
-    $destination = $aliases['dev'];
+    $source_alias = array_shift($aliases);
+    $target_alias = current($aliases);
 
     $options = [
       'yes' => NULL,
@@ -84,7 +84,7 @@ class rsyncCase extends CommandUnishTestCase {
 
     // Test an actual rsync between our two fixture sites. Note that
     // these sites share the same web root.
-    $this->drush('rsync', ["$source:%files/a/", "$destination:%files/b"], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
+    $this->drush('rsync', ["$source_alias:%files/a/", "$target_alias:%files/b"], $options, NULL, NULL, self::EXIT_SUCCESS, '2>&1');
     $this->assertContains('You will delete files in', $this->getOutput());
 
     // Test to see if our fixture file now exists at $target

--- a/tests/siteSetTest.php
+++ b/tests/siteSetTest.php
@@ -19,11 +19,11 @@ class SiteSetCommandCase extends CommandUnishTestCase
         }
         $sites = $this->setUpDrupal(2, true);
         $site_names = array_keys($sites);
-        $this->assertCount(2, $site_names, 'Has 2 drupal sites setup');
+        $this->assertCount(2, $site_names);
 
         // Test changing aliases.
         foreach ($site_names as $site_name) {
-            $this->drush('site:set', ['@' . $site_name]);
+            $this->drush('site:set', ['@sut.' . $site_name]);
             $output = $this->getErrorOutput();
             $this->assertEquals('[success] Site set to @' . $site_name, $output);
         }
@@ -44,9 +44,9 @@ class SiteSetCommandCase extends CommandUnishTestCase
         // Toggle between the previous set alias and back again.
         $this->drush('site:set', ['-']);
         $output = $this->getErrorOutput();
-        $this->assertEquals('[success] Site set to @' . $site_names[0], $output);
+        $this->assertEquals('[success] Site set to @sut.' . $site_names[0], $output);
         $this->drush('site:set', ['-']);
         $output = $this->getErrorOutput();
-        $this->assertEquals('[success] Site set to @' . $site_names[1], $output);
+        $this->assertEquals('[success] Site set to @sut.' . $site_names[1], $output);
     }
 }

--- a/tests/siteSetTest.php
+++ b/tests/siteSetTest.php
@@ -18,14 +18,14 @@ class SiteSetCommandCase extends CommandUnishTestCase
             $this->markTestSkipped('Site-set not currently available on Windows.');
         }
         $sites = $this->setUpDrupal(2, true);
-        $site_names = array_keys($sites);
-        $this->assertCount(2, $site_names);
+        $site_aliases = $this->getAliases();
+        $this->assertCount(2, $site_aliases);
 
         // Test changing aliases.
-        foreach ($site_names as $site_name) {
-            $this->drush('site:set', ['@sut.' . $site_name]);
+        foreach ($site_aliases as $site_alias) {
+            $this->drush('site:set', [$site_alias]);
             $output = $this->getErrorOutput();
-            $this->assertEquals('[success] Site set to @sut.' . $site_name, $output);
+            $this->assertEquals('[success] Site set to ' . $site_alias, $output);
         }
 
         // Test setting the site to the special @none alias.
@@ -44,9 +44,9 @@ class SiteSetCommandCase extends CommandUnishTestCase
         // Toggle between the previous set alias and back again.
         $this->drush('site:set', ['-']);
         $output = $this->getErrorOutput();
-        $this->assertEquals('[success] Site set to @sut.' . $site_names[0], $output);
+        $this->assertEquals('[success] Site set to ' . $site_aliases[0], $output);
         $this->drush('site:set', ['-']);
         $output = $this->getErrorOutput();
-        $this->assertEquals('[success] Site set to @sut.' . $site_names[1], $output);
+        $this->assertEquals('[success] Site set to ' . $site_aliases[1], $output);
     }
 }

--- a/tests/siteSetTest.php
+++ b/tests/siteSetTest.php
@@ -25,7 +25,7 @@ class SiteSetCommandCase extends CommandUnishTestCase
         foreach ($site_names as $site_name) {
             $this->drush('site:set', ['@sut.' . $site_name]);
             $output = $this->getErrorOutput();
-            $this->assertEquals('[success] Site set to @' . $site_name, $output);
+            $this->assertEquals('[success] Site set to @sut.' . $site_name, $output);
         }
 
         // Test setting the site to the special @none alias.

--- a/tests/sqlDumpTest.php
+++ b/tests/sqlDumpTest.php
@@ -22,7 +22,7 @@ class SqlDumpTest extends CommandUnishTestCase {
 
     $this->setUpDrupal(1, TRUE);
     $root = $this->webroot();
-    $uri = 'dev';
+    $uri = $this->getUri();
     $full_dump_file_path = self::getSandbox() . DIRECTORY_SEPARATOR . 'full_db.sql';
 
     $options = array(
@@ -37,7 +37,7 @@ class SqlDumpTest extends CommandUnishTestCase {
     );
 
     $this->drush('sql-dump', [], $options + $site_selection_options + ['simulate' => NULL]);
-    $this->assertContains('--ignore-table=unish_dev.cache_container', $this->getErrorOutput());
+    $this->assertContains('--ignore-table=unish_dev.cache_discovery', $this->getErrorOutput());
 
     // Test --extra-dump option
     if ($this->db_driver() == 'mysql') {

--- a/tests/updateDBTest.php
+++ b/tests/updateDBTest.php
@@ -14,7 +14,7 @@ class updateDBTest extends CommandUnishTestCase {
     $options = array(
       'yes' => NULL,
       'root' => $this->webroot(),
-      'uri' => key($sites),
+      'uri' => $this->getUri(),
     );
     $this->drush('pm:enable', array('devel'), $options);
     $this->drush('updatedb:status', array(), $options + ['format' => 'json']);

--- a/tests/userTest.php
+++ b/tests/userTest.php
@@ -152,7 +152,7 @@ class userCase extends CommandUnishTestCase {
   function options() {
     return array(
       'root' => $this->webroot(),
-      'uri' => key($this->getSites()),
+      'uri' => $this->getUri(),
       'yes' => NULL,
     );
   }


### PR DESCRIPTION
Superglobals now confined to `site:install` since Drupal’s install_begin_request() practices ancient voodoo (i.e. still requires globals - https://github.com/drupal/drupal/blob/d260101f1ea8a6970df88d2f1899248985c499fc/core/includes/install.core.inc#L287)