### PR TITLE
Fix a typo in selectUri method docs.

### DIFF
--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -126,7 +126,7 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
     }
 
     /**
-     * This method is called by the Application iff the user
+     * This method is called by the Application if the user
      * did not explicitly provide a URI.
      */
     public function selectUri($cwd)


### PR DESCRIPTION
Just noticed this typo in a doc comment while going through the code.