### PR TITLE
Move canonical storage of tmp dir to config()->get(env.tmp)

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -271,7 +271,7 @@ function drush_directory_cache($subdir = '') {
   if ($home) {
     $cache_locations[$home] = '.drush/cache';
   }
-  $cache_locations[drush_find_tmp()] = 'drush-' . Drush::config()->get('env.user') . '/cache';
+  $cache_locations[Drush::config()->get('env.tmp')] = 'drush-' . Drush::config()->get('env.user') . '/cache';
   foreach ($cache_locations as $base => $dir) {
     if (!empty($base) && is_writable($base)) {
       $cache_dir = $base . '/' . $dir;

--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -397,61 +397,10 @@ function drush_save_data_to_temp_file($data, $suffix = NULL) {
 /**
  * Returns the path to a temporary directory.
  *
- * This is a custom version of Drupal's file_directory_path().
- * We can't directly rely on sys_get_temp_dir() as this
- * path is not valid in some setups for Mac, and we want to honor
- * an environment variable (used by tests).
+ * @deprecated Use $this->getConfig()->get('env.tmp').
  */
 function drush_find_tmp() {
-  static $temporary_directory;
-
-  if (!isset($temporary_directory)) {
-    $directories = array();
-
-    // Get user specific and operating system temp folders from system environment variables.
-    // See http://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/ntcmds_shelloverview.mspx?mfr=true
-    $tempdir = getenv('TEMP');
-    if (!empty($tempdir)) {
-      $directories[] = $tempdir;
-    }
-    $tmpdir = getenv('TMP');
-    if (!empty($tmpdir)) {
-      $directories[] = $tmpdir;
-    }
-    // Operating system specific dirs.
-    if (drush_is_windows()) {
-      $windir = getenv('WINDIR');
-      if (isset($windir)) {
-        // WINDIR itself is not writable, but it always contains a /Temp dir,
-        // which is the system-wide temporary directory on older versions. Newer
-        // versions only allow system processes to use it.
-        $directories[] = Path::join($windir, 'Temp');
-      }
-    }
-    else {
-      $directories[] = Path::canonicalize('/tmp');
-    }
-    $directories[] = Path::canonicalize(sys_get_temp_dir());
-
-    foreach ($directories as $directory) {
-      if (is_dir($directory) && is_writable($directory)) {
-        $temporary_directory = $directory;
-        break;
-      }
-    }
-
-    if (empty($temporary_directory)) {
-      // If no directory has been found, create one in cwd.
-      $temporary_directory = Path::join(Drush::config()->get('env.cwd'), 'tmp');
-      drush_mkdir($temporary_directory, TRUE);
-      if (!is_dir($temporary_directory)) {
-        return drush_set_error('DRUSH_UNABLE_TO_CREATE_TMP_DIR', dt("Unable to create a temporary directory."));
-      }
-      drush_register_file_for_deletion($temporary_directory);
-    }
-  }
-
-  return $temporary_directory;
+  return Drush::config()->get('env.tmp');
 }
 
 /**
@@ -467,7 +416,7 @@ function drush_find_tmp() {
  */
 function drush_tempnam($pattern, $tmp_dir = NULL, $suffix = '') {
   if ($tmp_dir == NULL) {
-    $tmp_dir = drush_find_tmp();
+    $tmp_dir = Drush::config()->get('env.tmp');
   }
   $tmp_file = tempnam($tmp_dir, $pattern);
   drush_register_file_for_deletion($tmp_file);
@@ -480,7 +429,7 @@ function drush_tempnam($pattern, $tmp_dir = NULL, $suffix = '') {
  * Creates a temporary directory and return its path.
  */
 function drush_tempdir() {
-  $tmp_dir = drush_trim_path(drush_find_tmp());
+  $tmp_dir = drush_trim_path(Drush::config()->get('env.tmp'));
   $tmp_dir .= '/' . 'drush_tmp_' . uniqid(time() . '_');
 
   drush_mkdir($tmp_dir);

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -115,8 +115,7 @@ class Environment
                 // versions only allow system processes to use it.
                 $directories[] = Path::join($windir, 'Temp');
             }
-        }
-        else {
+        } else {
             $directories[] = Path::canonicalize('/tmp');
         }
         $directories[] = Path::canonicalize(sys_get_temp_dir());
@@ -131,7 +130,7 @@ class Environment
         if (empty($temporary_directory)) {
             // If no directory has been found, create one in cwd.
             $temporary_directory = Path::join(Drush::config()->get('env.cwd'), 'tmp');
-            drush_mkdir($temporary_directory, TRUE);
+            drush_mkdir($temporary_directory, true);
             if (!is_dir($temporary_directory)) {
                 throw new \Exception(dt("Unable to create a temporary directory."));
             }

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -92,6 +92,55 @@ class Environment
         return $name;
     }
 
+    protected function getTmp()
+    {
+        $directories = array();
+
+        // Get user specific and operating system temp folders from system environment variables.
+        // See http://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/ntcmds_shelloverview.mspx?mfr=true
+        $tempdir = getenv('TEMP');
+        if (!empty($tempdir)) {
+            $directories[] = $tempdir;
+        }
+        $tmpdir = getenv('TMP');
+        if (!empty($tmpdir)) {
+            $directories[] = $tmpdir;
+        }
+        // Operating system specific dirs.
+        if (self::isWindows()) {
+            $windir = getenv('WINDIR');
+            if (isset($windir)) {
+                // WINDIR itself is not writable, but it always contains a /Temp dir,
+                // which is the system-wide temporary directory on older versions. Newer
+                // versions only allow system processes to use it.
+                $directories[] = Path::join($windir, 'Temp');
+            }
+        }
+        else {
+            $directories[] = Path::canonicalize('/tmp');
+        }
+        $directories[] = Path::canonicalize(sys_get_temp_dir());
+
+        foreach ($directories as $directory) {
+            if (is_dir($directory) && is_writable($directory)) {
+                $temporary_directory = $directory;
+                break;
+            }
+        }
+
+        if (empty($temporary_directory)) {
+            // If no directory has been found, create one in cwd.
+            $temporary_directory = Path::join(Drush::config()->get('env.cwd'), 'tmp');
+            drush_mkdir($temporary_directory, TRUE);
+            if (!is_dir($temporary_directory)) {
+                throw new \Exception(dt("Unable to create a temporary directory."));
+            }
+            // Function not available yet - this is not likely to get reached anyway.
+            // drush_register_file_for_deletion($temporary_directory);
+        }
+        return $temporary_directory;
+    }
+
     /**
      * Convert the environment object into an exported configuration
      * array. This will be fed though the EnvironmentConfigLoader to
@@ -111,6 +160,7 @@ class Environment
                 'home' => $this->homeDir(),
                 'user' => $this->getUsername(),
                 'is-windows' => $this->isWindows(),
+                'tmp' => $this->getTmp(),
             ],
             // These values are available as global options, and
             // will be passed in to the FormatterOptions et. al.

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -5,12 +5,15 @@ namespace Drush\Sql;
 use Drupal\Core\Database\Database;
 use Drush\Drush;
 use Drush\Log\LogLevel;
+use Robo\Common\ConfigAwareTrait;
+use Robo\Contract\ConfigAwareInterface;
 use Webmozart\PathUtil\Path;
 
-class SqlBase
+class SqlBase implements ConfigAwareInterface
 {
 
     use SqlTableSelectionTrait;
+    use ConfigAwareTrait;
 
     // An Drupal style array containing specs for connecting to database.
     public $dbSpec;
@@ -185,7 +188,7 @@ class SqlBase
             if ($file === true) {
                 $backup_dir = drush_prepare_backup_dir($database);
                 if (empty($backup_dir)) {
-                    $backup_dir = drush_find_tmp();
+                    $backup_dir = $this->getConfig()->get('env.tmp');
                 }
                 $file = Path::join($backup_dir, '@DATABASE_@DATE.sql');
             }

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -77,7 +77,10 @@ class SqlBase implements ConfigAwareInterface
     {
         $driver = $db_spec['driver'];
         $class_name = 'Drush\Sql\Sql'. ucfirst($driver);
-        return new $class_name($db_spec, $options);
+        $instance = new $class_name($db_spec, $options);
+        // Inject config
+        $instance->setConfig(Drush::config());
+        return $instance;
     }
 
     /*
@@ -188,7 +191,7 @@ class SqlBase implements ConfigAwareInterface
             if ($file === true) {
                 $backup_dir = drush_prepare_backup_dir($database);
                 if (empty($backup_dir)) {
-                    $backup_dir = $this->getConfig()->get('env.tmp');
+                    $backup_dir = Drush::config()->get('env.tmp');
                 }
                 $file = Path::join($backup_dir, '@DATABASE_@DATE.sql');
             }


### PR DESCRIPTION
As a next step, I was thinking of moving the following functions to a static methods on new FileUtils class, in same directory as StringUtils. Feedback welcome on that.

drush_save_data_to_temp_file()
drush_tempnam()
drush_tempdir()
drush_register_file_for_deletion()
_drush_delete_registered_files()