### PR TITLE
Plan for the future (see #3130): Allow for phpunit 5.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ sudo: false
 
 env:
   matrix:
-    - TEST_DIR=isolation
+    - TEST_DIR=isolation ISOLATION_INSTALL='install --prefer-dist'
+    - TEST_DIR=isolation ISOLATION_INSTALL='update --prefer-dist --prefer-lowest'
+    - TEST_DIR=isolation ISOLATION_INSTALL='update --prefer-dist'
     - PHPUNIT_ARGS=--group=base
     - PHPUNIT_ARGS=--group=commands
     - PHPUNIT_ARGS=--exclude-group=base,commands
@@ -48,7 +50,7 @@ before_install:
 
 # Build a System-Under-Test.
 install:
-  - if [ -n "$TEST_DIR" ] ; then composer --working-dir=${PWD}/$TEST_DIR install ; fi
+  - if [ -n "$TEST_DIR" ] ; then composer -n --working-dir=${PWD}/$TEST_DIR $ISOLATION_INSTALL ; fi
   - if [ -z "$TEST_DIR" ] ; then ${PWD}/unish.sut.php ; fi
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "pear/console_table": "~1.3.0",
     "psr/log": "~1.0",
     "psy/psysh": "~0.6",
-    "sebastian/version": "~1",
+    "sebastian/version": "^1|^2",
     "symfony/config": "~2.2|^3",
     "symfony/console": "~2.7|^3",
     "symfony/event-dispatcher": "~2.7|^3",
@@ -50,7 +50,7 @@
   },
   "require-dev": {
     "lox/xhprof": "dev-master",
-    "phpunit/phpunit": "^4",
+    "phpunit/phpunit": "^4.8|^5.5.4",
     "squizlabs/php_codesniffer": "^2.7"
   },
   "autoload": {
@@ -74,7 +74,7 @@
       "find includes -name '*.inc' -print0 | xargs -0 -n1 php -l",
       "find src -name '*.php' -print0 | xargs -0 -n1 php -l"
     ],
-    "isolation": "cd isolation && phpunit --colors=always",
+    "isolation": "cd isolation && vendor/bin/phpunit --colors=always",
     "post-update-cmd": "cd isolation && composer update"
   },
   "extra": {

--- a/isolation/composer.json
+++ b/isolation/composer.json
@@ -16,11 +16,11 @@
     "symfony/finder": "~2.7|^3",
     "webflo/drupal-finder": "^0",
     "webmozart/path-util": "^2.1.0",
-    "sebastian/version": "~1"
+    "sebastian/version": "^1|^2"
   },
   "require-dev": {
     "lox/xhprof": "dev-master",
-    "phpunit/phpunit": "^4"
+    "phpunit/phpunit": "^4.8|^5.5.4"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I started to fix #3130, but then stopped when I realized that mixing Drush with Drupal prevents us from using phpunit 5.x, and erg sebastion/version 2.x, making the upgrade pointless.

However, I realized that at some point, Drupal will upgrade to phpunit 5.x.  While we cannot anticipate every upgrade that Drupal might make, phpunit 4.x is very old, so this is probably overdue, or at least likely to happen eventually.

This PR sets up highest / lowest testing for the isolation tests, and allows the isolation tests to run across different versions of phpunit and sebastion/version. This will give us the flexibility to test with multiple versions of other libraries in the future, if we so desire.

The value for Drush being ahead of the game on upgrades is that it allows newer versions of Drupal to be used with more versions of Drush, making `composer update` easier to get through when there are minor Drupal upgrades. It behoves us to do this due to the limitations in Composer that can come into play when the dependency analysis of an upgrade is complicated (e.g. as it was for the upgrade to Drupal 8.4.0).