### PR TITLE
Fix #3133. Add site alias generator.

### DIFF
--- a/src/Commands/generate/Generators/Drush/DrushAliasFile.php
+++ b/src/Commands/generate/Generators/Drush/DrushAliasFile.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drush\Commands\generate\Generators\Drush;
+
+use DrupalCodeGenerator\Command\BaseGenerator;
+use Drush\Drush;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * Implements drush-alias-file command.
+ */
+class DrushAliasFile extends BaseGenerator
+{
+
+    protected $name = 'drush-alias-file';
+    protected $description = 'Generates a Drush site alias file.';
+    protected $alias = 'daf';
+    protected $templatePath = __DIR__;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $questions['prefix'] = new Question('File prefix (one word)', 'self');
+        $questions['root'] = new Question('Path to Drupal root', Drush::bootstrapManager()->getRoot());
+        $questions['uri'] = new Question('Drupal uri', Drush::bootstrapManager()->getUri());
+        $questions['host'] = new Question('Remote host');
+        $vars = $this->collectVars($input, $output, $questions);
+
+        if ($vars['host']) {
+            $remote_questions['user'] = new Question('Remote user', Drush::config()->get('env.user'));
+            $vars += $this->collectVars($input, $output, $remote_questions);
+        }
+
+        $this->setFile('../drush/' . $vars['prefix'] . '.site.yml', 'drush-alias-file.twig', $vars);
+    }
+
+}

--- a/src/Commands/generate/Generators/Drush/drush-alias-file.twig
+++ b/src/Commands/generate/Generators/Drush/drush-alias-file.twig
@@ -1,0 +1,70 @@
+# Although most aliases will contain only a few options, a number
+# of settings that are commonly used appear below:
+#
+# - 'uri': The value of --uri should always be the same as
+#   when the site is being accessed from a web browser (e.g. http://example.com)
+# - 'root': The Drupal root; must not be specified as a relative path.
+# - 'host': The fully-qualified domain name of the remote system
+#   hosting the Drupal instance. **Important Note: The remote-host option
+#   must be omitted for local sites, as this option controls various
+#   operations, such as whether or not rsync parameters are for local or
+#   remote machines, and so on. @see hook_drush_sitealias_alter() in drush.api.php
+# - 'user': The username to log in as when using ssh or rsync.
+# - 'os': The operating system of the remote server.  Valid values
+#   are 'Windows' and 'Linux'. Be sure to set this value for all remote
+#   aliases because the default value is PHP_OS if 'remote-host'
+#   is not set, and 'Linux' (or $options['remote-os']) if it is. Therefore,
+#   if you set a 'remote-host' value, and your remote OS is Windows, if you
+#   do not set the 'OS' value, it will default to 'Linux' and could cause
+#   unintended consequences, particularly when running 'drush sql-sync'.
+# - 'ssh': If the target requires special options, such as a non-
+#   standard port, alternative identity file, or alternative
+#   authentication method, the `option` entry under the `ssh` item may
+#   contain a string of extra options that are used with the ssh command,
+#   e.g. "-p 100"
+# - 'paths': An array of aliases for common rsync targets.
+#   Relative aliases are always taken from the Drupal root.
+#   - 'files': Path to 'files' directory.  This will be looked up if not
+#     specified.
+#   - 'drush-script': Path to the remot Drush command.
+# - 'command': These options will only be set if the alias
+#   is used with the specified command.  In the example below, the option
+#   `--no-dump` will be selected whenever the @stage alias
+#   is used in any of the following ways:
+#     - `drush @stage sql-sync @self @live`
+#     - `drush sql-sync @stage @live`
+#     - `drush sql-sync @live @stage`
+#   NOTE: Setting boolean options broke with Symfony 3. This will be fixed
+#     in a future release. See: https://github.com/drush-ops/drush/issues/2956
+#
+# Complex example:
+#
+# @code
+# # File: remote.alias.yml
+# live:
+#   host: server.domain.com
+#   user: www-admin
+#   root: /other/path/to/drupal
+#   uri: http://example.com
+#   ssh:
+#     options: '-p 100'
+#   paths:
+#     drush-script: '/path/to/drush'
+#   command:
+#     site:
+#       install:
+#         options:
+#           admin-password: 'secret-secret'
+# @endcode
+#
+# Altering aliases:
+#
+# See examples/Commands/SiteAliasAlter.php for an example.
+
+dev:
+  root: {{ root }}
+  uri: {{ uri }}
+{% if host %}
+  host: {{ host }}
+  user: {{ user }}
+{% endif %}


### PR DESCRIPTION
Here is a simple generator.

1. This generates one environment called dev. Additional environments are expected to be added by hand
1. Writes to PROJECT_ROOT/drush/[prefix].site.yml. User can rename/move the file by hand.
1. Interactively gathers root, uri, host, user. Reasonable defaults for each are offered.
1. Adds lots of help text at the top for guiding further customization. Thi

Any other requests/suggestions for this?