### PR TITLE
Fix the batch finished callback for 'updatedb' command

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -257,7 +257,7 @@ class UpdateDBCommands extends DrushCommands
             'title' => 'Updating',
             'init_message' => 'Starting updates',
             'error_message' => 'An unrecoverable error has occurred. You can find the error message below. It is advised to copy it to the clipboard for reference.',
-            'finished' => [$this, 'drush_update_finished'],
+            'finished' => [$this, 'updateFinished'],
             'file' => 'core/includes/update.inc',
         );
         batch_set($batch);


### PR DESCRIPTION
Until a solution will land for https://github.com/drush-ops/drush/pull/3095, let's apply a quick fix for the batch finished callback of the `updatedb` command. Right now, that is still using an inexistent callback (`drush_update_finished`). As the batch API checks first for the existence of the function/method, this fails silently, without throwing any exception or error.