### PR TITLE
Validate legacy command file

### DIFF
--- a/src/Commands/generate/Generators/Drush/DrushCommandFile.php
+++ b/src/Commands/generate/Generators/Drush/DrushCommandFile.php
@@ -28,7 +28,7 @@ class DrushCommandFile extends BaseGenerator
         $questions['source'] = new Question('Absolute path to legacy Drush command file (optional - for porting)');
         $questions['source']->setValidator(function ($path) {
             if ($path && !is_file($path)) {
-                throw new \UnexpectedValueException(sprintf('Could not open file "%s"', $path));
+                throw new \UnexpectedValueException(sprintf('Could not open file "%s".', $path));
             }
             return $path;
         });

--- a/src/Commands/generate/Generators/Drush/DrushCommandFile.php
+++ b/src/Commands/generate/Generators/Drush/DrushCommandFile.php
@@ -26,13 +26,16 @@ class DrushCommandFile extends BaseGenerator
     {
         $questions = Utils::defaultQuestions();
         $questions['source'] = new Question('Absolute path to legacy Drush command file (optional - for porting)');
+        $questions['source']->setValidator(function ($path) {
+            if ($path && !is_file($path)) {
+                throw new \UnexpectedValueException(sprintf('Could not open file "%s"', $path));
+            }
+            return $path;
+        });
 
         $vars = $this->collectVars($input, $output, $questions);
         $vars['class'] = Utils::camelize($vars['machine_name'] . 'Commands');
         if ($vars['source']) {
-            if (!is_file($vars['source'])) {
-                throw new \InvalidArgumentException('Could not open "' . $vars['source'] . '".');
-            }
             require_once $vars['source'];
             $filename = str_replace(['.drush.inc', '.drush8.inc'], '', basename($vars['source']));
             $command_hook = $filename . '_drush_command';

--- a/src/Commands/generate/Generators/Drush/DrushCommandFile.php
+++ b/src/Commands/generate/Generators/Drush/DrushCommandFile.php
@@ -30,8 +30,15 @@ class DrushCommandFile extends BaseGenerator
         $vars = $this->collectVars($input, $output, $questions);
         $vars['class'] = Utils::camelize($vars['machine_name'] . 'Commands');
         if ($vars['source']) {
+            if (!is_file($vars['source'])) {
+                throw new \InvalidArgumentException('Could not open "' . $vars['source'] . '".');
+            }
             require_once $vars['source'];
             $filename = str_replace(['.drush.inc', '.drush8.inc'], '', basename($vars['source']));
+            $command_hook = $filename . '_drush_command';
+            if (!function_exists($command_hook)) {
+                throw new \InvalidArgumentException('Drush command hook "' . $command_hook . '" does not exist.');
+            }
             $commands = call_user_func($filename . '_drush_command');
             $vars['commands'] = $this->adjustCommands($commands);
         }


### PR DESCRIPTION
Setting wrong file path in `drush generate dcf` causes a fatal error.
"PHP Fatal error:  require_once(): Failed opening required 'wrong file path'"

Throwing exceptions would allow console application fail gracefully.

This PR also handle the case when the provided file has no valid Drush command hook.