### PR TITLE
Fixed call to legacy bootstrap function.

### DIFF
--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -169,7 +169,7 @@ class SqlCommands extends DrushCommands
         $filename = $options['file'];
         // Enable prefix processing when db-prefix option is used.
         if ($options['db-prefix']) {
-            drush_bootstrap_max(DRUSH_BOOTSTRAP_DRUPAL_DATABASE);
+            Drush::bootstrapManager()->bootstrapMax(DRUSH_BOOTSTRAP_DRUPAL_DATABASE);
         }
         if (Drush::simulate()) {
             if ($query) {


### PR DESCRIPTION
This commit removed `drush_bootstrap_max()` but it was still being called elsewhere.
https://github.com/drush-ops/drush/commit/440be17aceeacef9308db747bd17e874883cb2ef