### PR TITLE
#3163: always fwrite in drush_print, instead of print.

### DIFF
--- a/includes/output.inc
+++ b/includes/output.inc
@@ -29,7 +29,7 @@ use Drush\Utils\StringUtils;
  * @deprecated
  *   Use $this->output()->writeln() in a command method.
  */
-function drush_print($message = '', $indent = 0, $handle = NULL, $newline = TRUE) {
+function drush_print($message = '', $indent = 0, $handle = STDOUT, $newline = TRUE) {
   $msg = str_repeat(' ', $indent) . (string)$message;
   if ($newline) {
     $msg .= "\n";
@@ -37,14 +37,7 @@ function drush_print($message = '', $indent = 0, $handle = NULL, $newline = TRUE
   if (($charset = drush_get_option('output_charset')) && function_exists('iconv')) {
     $msg = iconv('UTF-8', $charset, $msg);
   }
-  if (isset($handle)) {
-    fwrite($handle, $msg);
-  }
-  else {
-    print $msg;
-    //$output = Drush::service('output');
-    //$output->write($msg);
-  }
+  fwrite($handle, $msg);
 }
 
 /**


### PR DESCRIPTION
See #3163. Replaces https://github.com/drush-ops/drush/pull/3169