### PR TITLE
#3163: always fwrite in drush_print, instead of print. (backport)

### DIFF
--- a/commands/core/outputformat/html.tpl.php
+++ b/commands/core/outputformat/html.tpl.php
@@ -4,25 +4,25 @@
   <h3>Global Options (see `drush topic core-global-options` for the full list)</h3>
   <table><?php
     foreach ($global_options_rows as $key => $row) {
-      print '<tr>';
+      drush_print('<tr>');
       foreach ($row as $value) {
-        print  "<td>" . htmlspecialchars($value) . "</td>\n";
+        drush_print("<td>" . htmlspecialchars($value) . "</td>\n");
       }
-      print "</tr>\n";
+      drush_print("</tr>\n");
     } ?>
   </table>
   <h3>Command list</h3>
   <table><?php
     foreach ($input as $key => $command) {
-      print "  <tr><td><a href=\"#$key\">$key</a></td><td>" . $command['description'] . "</td></tr>\n";
+      drush_print("  <tr><td><a href=\"#$key\">$key</a></td><td>" . $command['description'] . "</td></tr>\n");
     } ?>
   </table>
 <h3>Command detail</h3>
 <dl><?php
       foreach ($input as $key => $command) {
-        print "\n<a name=\"$key\"></a><dt>$key</dt><dd><pre>\n";
+        drush_print("\n<a name=\"$key\"></a><dt>$key</dt><dd><pre>\n");
         drush_core_helpsingle($key);
-        print "</pre></dd>\n";
+        drush_print("</pre></dd>\n");
       }
     ?>
 </body>

--- a/commands/core/watchdog.drush.inc
+++ b/commands/core/watchdog.drush.inc
@@ -222,7 +222,7 @@ function drush_core_watchdog_show_many($filter = NULL) {
         $last_wid = $row->wid;
       }
       $tbl->addData($table);
-      print $tbl->_buildTable();
+      drush_print($tbl->_buildTable());
       sleep($sleep_delay);
     }
   }

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -649,7 +649,7 @@ function drush_prompt($prompt, $default = NULL, $required = TRUE, $password = FA
   fclose($stdin);
   if ($password) {
     drush_shell_exec("stty echo");
-    print "\n";
+    drush_print("\n");
   }
   return $line;
 }

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -26,13 +26,16 @@ use Drush\Log\LogLevel;
  * @param $newline
  *    Add a "\n" to the end of the output.  Defaults to TRUE.
  */
-function drush_print($message = '', $indent = 0, $handle = STDOUT, $newline = TRUE) {
+function drush_print($message = '', $indent = 0, $handle = NULL, $newline = TRUE) {
   $msg = str_repeat(' ', $indent) . (string)$message;
   if ($newline) {
     $msg .= "\n";
   }
   if (($charset = drush_get_option('output_charset')) && function_exists('iconv')) {
     $msg = iconv('UTF-8', $charset, $msg);
+  }
+  if (!$handle) {
+    $handle = STDOUT;
   }
   fwrite($handle, $msg);
 }

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -26,7 +26,7 @@ use Drush\Log\LogLevel;
  * @param $newline
  *    Add a "\n" to the end of the output.  Defaults to TRUE.
  */
-function drush_print($message = '', $indent = 0, $handle = NULL, $newline = TRUE) {
+function drush_print($message = '', $indent = 0, $handle = STDOUT, $newline = TRUE) {
   $msg = str_repeat(' ', $indent) . (string)$message;
   if ($newline) {
     $msg .= "\n";
@@ -34,12 +34,7 @@ function drush_print($message = '', $indent = 0, $handle = NULL, $newline = TRUE
   if (($charset = drush_get_option('output_charset')) && function_exists('iconv')) {
     $msg = iconv('UTF-8', $charset, $msg);
   }
-  if (isset($handle)) {
-    fwrite($handle, $msg);
-  }
-  else {
-    print $msg;
-  }
+  fwrite($handle, $msg);
 }
 
 /**


### PR DESCRIPTION
Backport of https://github.com/drush-ops/drush/pull/3170. There are additional print statements in the 8.x branch. I am comparing them all against master, to see how it was handled there.