### PR TITLE
#3163: don't use STDOUT as a function parameter default for backwards compatability, i.e. see drush_print_prompt()

### DIFF
--- a/includes/output.inc
+++ b/includes/output.inc
@@ -29,13 +29,16 @@ use Drush\Utils\StringUtils;
  * @deprecated
  *   Use $this->output()->writeln() in a command method.
  */
-function drush_print($message = '', $indent = 0, $handle = STDOUT, $newline = TRUE) {
+function drush_print($message = '', $indent = 0, $handle = NULL, $newline = TRUE) {
   $msg = str_repeat(' ', $indent) . (string)$message;
   if ($newline) {
     $msg .= "\n";
   }
   if (($charset = drush_get_option('output_charset')) && function_exists('iconv')) {
     $msg = iconv('UTF-8', $charset, $msg);
+  }
+  if (!$handle) {
+    $handle = STDOUT;
   }
   fwrite($handle, $msg);
 }


### PR DESCRIPTION
This is a problem because of backwards compatability. drush_print_prompt() has a handle with a default of NULL and then it passes that to drush_print(). Since it passes a default, the file descriptor is NULL and not STDOUT. We could fix all internal calls, sure, but I think for backwards compatibility with drush_print() we shouldn't change the default, and we should handle it in the function.

See #3163 and the conversation on https://github.com/drush-ops/drush/pull/3171