### PR TITLE
Backport of #3174, SSH command escaping

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1130,12 +1130,14 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
   );
   $backend_options += array(
     '#tty' => FALSE,
+    '#local-os' => 'LOCAL',
   );
 
   $hostname = $site_record['remote-host'];
   $username = $site_record['remote-user'];
   $ssh_options = $site_record['ssh-options'];
-  $os = drush_os($site_record);
+  $remote_os = drush_os($site_record);
+  $local_os = $backend_options['#local-os'];
 
   if (drush_is_local_host($hostname)) {
     $hostname = null;
@@ -1150,15 +1152,15 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
 
   $cmd[] = $command;
   foreach ($args as $arg) {
-    $cmd[] = drush_escapeshellarg($arg, $os);
+    $cmd[] = drush_escapeshellarg($arg, $remote_os);
   }
-  $option_str = _drush_backend_argument_string($command_options, $os);
+  $option_str = _drush_backend_argument_string($command_options, $remote_os);
   if (!empty($option_str)) {
     $cmd[] = " " . $option_str;
   }
   $command = implode(' ', array_filter($cmd, 'strlen'));
   if (isset($hostname)) {
-    $username = (isset($username)) ? drush_escapeshellarg($username, "LOCAL") . "@" : '';
+    $username = (isset($username)) ? drush_escapeshellarg($username, $local_os) . "@" : '';
     $ssh_options = $site_record['ssh-options'];
     $ssh_options = (isset($ssh_options)) ? $ssh_options : drush_get_option('ssh-options', "-o PasswordAuthentication=no");
 
@@ -1167,8 +1169,8 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
     if ($backend_options['#tty']) {
       $ssh_cmd[] = '-t';
     }
-    $ssh_cmd[] = $username . drush_escapeshellarg($hostname, "LOCAL");
-    $ssh_cmd[] = drush_escapeshellarg($command . ' 2>&1', "LOCAL");
+    $ssh_cmd[] = $username . drush_escapeshellarg($hostname, $local_os);
+    $ssh_cmd[] = drush_escapeshellarg($command . ' 2>&1', $local_os);
 
     // Remove NULLs and separate with spaces
     $command = implode(' ', array_filter($ssh_cmd, 'strlen'));

--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1130,14 +1130,12 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
   );
   $backend_options += array(
     '#tty' => FALSE,
-    '#local-os' => 'LOCAL',
   );
 
   $hostname = $site_record['remote-host'];
   $username = $site_record['remote-user'];
   $ssh_options = $site_record['ssh-options'];
-  $remote_os = drush_os($site_record);
-  $local_os = $backend_options['#local-os'];
+  $os = drush_os($site_record);
 
   if (drush_is_local_host($hostname)) {
     $hostname = null;
@@ -1152,15 +1150,15 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
 
   $cmd[] = $command;
   foreach ($args as $arg) {
-    $cmd[] = drush_escapeshellarg($arg, $remote_os);
+    $cmd[] = drush_escapeshellarg($arg, $os);
   }
-  $option_str = _drush_backend_argument_string($command_options, $remote_os);
+  $option_str = _drush_backend_argument_string($command_options, $os);
   if (!empty($option_str)) {
     $cmd[] = " " . $option_str;
   }
   $command = implode(' ', array_filter($cmd, 'strlen'));
   if (isset($hostname)) {
-    $username = (isset($username)) ? drush_escapeshellarg($username, $local_os) . "@" : '';
+    $username = (isset($username)) ? drush_escapeshellarg($username, "LOCAL") . "@" : '';
     $ssh_options = $site_record['ssh-options'];
     $ssh_options = (isset($ssh_options)) ? $ssh_options : drush_get_option('ssh-options', "-o PasswordAuthentication=no");
 
@@ -1169,8 +1167,8 @@ function _drush_backend_generate_command($site_record, $command, $args = array()
     if ($backend_options['#tty']) {
       $ssh_cmd[] = '-t';
     }
-    $ssh_cmd[] = $username . drush_escapeshellarg($hostname, $local_os);
-    $ssh_cmd[] = drush_escapeshellarg($command . ' 2>&1', $local_os);
+    $ssh_cmd[] = $username . drush_escapeshellarg($hostname, "LOCAL");
+    $ssh_cmd[] = drush_escapeshellarg($command . ' 2>&1', "LOCAL");
 
     // Remove NULLs and separate with spaces
     $command = implode(' ', array_filter($ssh_cmd, 'strlen'));

--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -133,6 +133,8 @@ function drush_is_windows($os = NULL) {
 }
 
 function drush_escapeshellarg($arg, $os = NULL, $raw = FALSE) {
+  // "LOCAL" represents the local/host environment, so reset $os to NULL
+  $os = $os == 'LOCAL' ? NULL : $os;
   // Short-circuit escaping for simple params (keep stuff readable)
   if (preg_match('|^[a-zA-Z0-9.:/_-]*$|', $arg)) {
     return $arg;

--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -129,12 +129,10 @@ function find_wrapper_or_launcher_at_location($location) {
  * Determine whether current OS is a Windows variant.
  */
 function drush_is_windows($os = NULL) {
-  return strtoupper(substr($os ?: PHP_OS, 0, 3)) === 'WIN';
+  return strtoupper(substr($os && $os != 'LOCAL' ? $os : PHP_OS, 0, 3)) === 'WIN';
 }
 
 function drush_escapeshellarg($arg, $os = NULL, $raw = FALSE) {
-  // "LOCAL" represents the local/host environment, so reset $os to NULL
-  $os = $os == 'LOCAL' ? NULL : $os;
   // Short-circuit escaping for simple params (keep stuff readable)
   if (preg_match('|^[a-zA-Z0-9.:/_-]*$|', $arg)) {
     return $arg;

--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -129,7 +129,11 @@ function find_wrapper_or_launcher_at_location($location) {
  * Determine whether current OS is a Windows variant.
  */
 function drush_is_windows($os = NULL) {
-  return strtoupper(substr($os && $os !== 'LOCAL' ? $os : PHP_OS, 0, 3)) === 'WIN';
+  // The _drush_get_os() function may not be available, so resolve "LOCAL"
+  if (!$os || $os == "LOCAL") {
+    $os = PHP_OS;
+  }
+  return strtoupper(substr($os, 0, 3)) === 'WIN';
 }
 
 function drush_escapeshellarg($arg, $os = NULL, $raw = FALSE) {

--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -129,7 +129,7 @@ function find_wrapper_or_launcher_at_location($location) {
  * Determine whether current OS is a Windows variant.
  */
 function drush_is_windows($os = NULL) {
-  return strtoupper(substr($os && $os != 'LOCAL' ? $os : PHP_OS, 0, 3)) === 'WIN';
+  return strtoupper(substr($os && $os !== 'LOCAL' ? $os : PHP_OS, 0, 3)) === 'WIN';
 }
 
 function drush_escapeshellarg($arg, $os = NULL, $raw = FALSE) {


### PR DESCRIPTION
A backport (see #3174) of SSH command escaping that properly handles "LOCAL" as a reference to the host OS, as opposed to the remote OS.