### PR TITLE
Add a composer.json file to the output of the 'drush gen dcf' command.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,10 +6,37 @@ Creating a new Drush command or porting a legacy command is easy. Follow the ste
 1. Run `drush generate drush-command-file`.
 1. Drush will prompt for the machine name of the module that should "own" the file.
     1. (optional) Drush will also prompt for the path to a legacy command file to port. See [tips on porting command to Drush 9](https://weitzman.github.io/blog/port-to-drush9)
-1. Drush will then report that it created a commandfile and a drush.services.yml file. Edit those 2 files as needed.
+    1. The module selected must already exist and be enabled. Use `drush generate module-standard` to create a new module.
+1. Drush will then report that it created a commandfile, a drush.services.yml file and a composer.json file. Edit those files as needed.
 1. Use the classes for the core Drush commands at /src/Drupal/Commands as inspiration and documentation.
 1. See the [dependency injection docs](dependency-injection.md) for interfaces you can implement to gain access to Drush config, Drupal site aliases, etc.
 1. Once your two files are ready, run `drush cr` to get your command recognized by the Drupal container.
+
+Providing Multiple Services File
+================================
+
+A module's composer.json file stipulates the filename where the Drush services (e.g. the Drush command files) are defined. The default services file is `drush.services.yml`, which is defined in the extra section of the composer.json file as follows:
+```
+  "extra": {
+    "drush": {
+      "services": {
+        "drush.services.yml": "^9"
+      }
+    }
+  }
+```
+If for some reason you need to load different services for different versions of Drush, simply define multiple services files in the `services` section. For example:
+```
+  "extra": {
+    "drush": {
+      "services": {
+        "drush-9-99.services.yml": "^9.99",
+        "drush.services.yml": "^9"
+      }
+    }
+  }
+```
+In this example, the file `drush-9-99.services.yml` loads commandfile classes that require features only available in Drush 9.99 and later, and drush.services.yml loads an older commandfile implementation for earlier versions of Drush.
 
 Global Drush Commands
 ==============================

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,7 +12,7 @@ Creating a new Drush command or porting a legacy command is easy. Follow the ste
 1. See the [dependency injection docs](dependency-injection.md) for interfaces you can implement to gain access to Drush config, Drupal site aliases, etc.
 1. Once your two files are ready, run `drush cr` to get your command recognized by the Drupal container.
 
-Providing Multiple Services File
+Specifying the Services File
 ================================
 
 A module's composer.json file stipulates the filename where the Drush services (e.g. the Drush command files) are defined. The default services file is `drush.services.yml`, which is defined in the extra section of the composer.json file as follows:
@@ -25,7 +25,7 @@ A module's composer.json file stipulates the filename where the Drush services (
     }
   }
 ```
-If for some reason you need to load different services for different versions of Drush, simply define multiple services files in the `services` section. For example:
+If for some reason you need to load different services for different versions of Drush, simply define multiple services files in the `services` section. The first one found will be used. For example:
 ```
   "extra": {
     "drush": {
@@ -37,6 +37,10 @@ If for some reason you need to load different services for different versions of
   }
 ```
 In this example, the file `drush-9-99.services.yml` loads commandfile classes that require features only available in Drush 9.99 and later, and drush.services.yml loads an older commandfile implementation for earlier versions of Drush.
+
+It is also possible to use [version ranges](https://getcomposer.org/doc/articles/versions.md#version-range) to exactly specify which version of Drush the services file should be used with (e.g. `"drush.services.yml": ">=9 <9.99"`).
+
+In Drush 9, the default services file, `drush.services.yml`, will be used in instances where there is no `services` section in the Drush extras of the project's composer.json file. In Drush 10, however, the services section must exist, and must name the services file to be used. If a future Drush extension is written such that it only works with Drush 10 and later, then its entry would read `"drush.services.yml": "^10"`, and Drush 9 would not load the extension's commands. It is all the same recommended that Drush 9 extensions explicitly declare their services file with an appropriate version constraint.
 
 Global Drush Commands
 ==============================
@@ -50,7 +54,8 @@ Commandfiles that don't ship inside Drupal modules are called 'global' commandfi
     1.  Folders listed in the 'include' option.
     1.  ../drush, /drush and /sites/all/drush relative to the current Drupal installation.
 
-Avoiding the loading of certain Commandfiles (Note: not functional right now).
+Avoiding the loading of certain Commandfiles
 =================
 - The --ignored-modules global option stops loading of commandfiles from specified modules.
 
+**NOTE:** This is not functional right now.

--- a/src/Commands/generate/Generators/Drush/DrushCommandFile.php
+++ b/src/Commands/generate/Generators/Drush/DrushCommandFile.php
@@ -46,6 +46,7 @@ class DrushCommandFile extends BaseGenerator
             $vars['commands'] = $this->adjustCommands($commands);
         }
         $this->setFile('src/Commands/' . $vars['class'] . '.php', 'drush-command-file.twig', $vars);
+        $this->setFile('composer.json', 'dcf-composer.json.twig', $vars);
         $this->setServicesFile('drush.services.yml', 'drush.services.twig', $vars);
     }
 

--- a/src/Commands/generate/Generators/Drush/DrushCommandFile.php
+++ b/src/Commands/generate/Generators/Drush/DrushCommandFile.php
@@ -133,10 +133,16 @@ class DrushCommandFile extends BaseGenerator
     // Maybe put in BaseGenerator?
     protected function _setFileJson($path, $data)
     {
-        $this->_setFileContent($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $content = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        $this->_setFileContent($path, $content);
+
+        // TODO: Once supported, use:
+        // $this->addFile()
+        //   ->path($path)
+        //  ->content($content);
     }
 
-    // Maybe put in BaseGenerator?
+    // TODO: Remove once `addFile` is available.
     protected function _setFileContent($path, $content)
     {
         $this->files[$path] = [

--- a/src/Commands/generate/Generators/Drush/dcf-composer.json
+++ b/src/Commands/generate/Generators/Drush/dcf-composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "org/{{ machine_name }}",
+  "name": "",
   "description": "This extension provides new commands for Drush.",
   "type": "drupal-drush",
   "authors": [
@@ -7,12 +7,5 @@
   ],
   "require": {
     "php": ">=5.6.0"
-  },
-  "extra": {
-    "drush": {
-      "services": {
-        "drush.services.yml": "^9"
-      }
-    }
   }
 }

--- a/src/Commands/generate/Generators/Drush/dcf-composer.json.twig
+++ b/src/Commands/generate/Generators/Drush/dcf-composer.json.twig
@@ -1,0 +1,18 @@
+{
+  "name": "org/{{ machine_name }}",
+  "description": "This extension provides new commands for Drush.",
+  "type": "drupal-drush",
+  "authors": [
+    { "name": "Author name", "email": "author@example.com" }
+  ],
+  "require": {
+    "php": ">=5.6.0"
+  },
+  "extra": {
+    "drush": {
+      "services": {
+        "drush.services.yml": "^9"
+      }
+    }
+  }
+}

--- a/src/Commands/generate/Generators/Drush/drush-command-file.twig
+++ b/src/Commands/generate/Generators/Drush/drush-command-file.twig
@@ -9,7 +9,8 @@ use Drush\Commands\DrushCommands;
 /**
  *
  * In addition to a commandfile like this one, you need a drush.services.yml
- * in root of your module.
+ * in root of your module, and a composer.json file that provides the name
+ * of the services file to use.
  *
  * See these files for an example of injecting Drupal services:
  *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php

--- a/src/Drupal/DrupalKernel.php
+++ b/src/Drupal/DrupalKernel.php
@@ -142,7 +142,7 @@ class DrupalKernel extends DrupalDrupalKernel
         if (!file_exists($result)) {
             return;
         }
-        drush_log(dt("$module should have an extra.drush.services section. In the future, this will be required in order to use this Drush extension."), LogLevel::WARNING);
+        drush_log(dt("$module should have an extra.drush.services section. See 'Providing Multiple Services File' in 'drush docs:commands' for more information."), LogLevel::WARNING);
         return $result;
     }
 
@@ -165,19 +165,16 @@ class DrupalKernel extends DrupalDrupalKernel
     protected function findModuleDrushServiceProviderFromComposer($dir)
     {
         $composerJsonPath = "$dir/composer.json";
-        drush_log(dt("Looking for $composerJsonPath"), LogLevel::DEBUG);
         if (!file_exists($composerJsonPath)) {
             return false;
         }
         $composerJsonContents = file_get_contents($composerJsonPath);
-        var_export($composerJsonContents);
         $info = json_decode($composerJsonContents, true);
         if (!$info) {
             drush_log(dt('Invalid json in {composer}', ['composer' => $composerJsonPath]), LogLevel::WARNING);
             return false;
         }
         if (!isset($info['extra']['drush']['services'])) {
-            drush_log("No extra.drush.services in $composerJsonPath");
             return false;
         }
         return $info['extra']['drush']['services'];


### PR DESCRIPTION
- Defines a composer.json that the dcf generator writes.
- Improves error reporting for bad composer.json content (still experimenting with right levels)
- Adds some documentation on how to stipulate multiple drush.services.yml files.