### PR TITLE
Add skip-tables, structure-tables and tables to @optionset_table_selection

### DIFF
--- a/examples/example.drush.yml
+++ b/examples/example.drush.yml
@@ -145,37 +145,6 @@ options:
 
 command:
   sql:
-    options:
-      # TODO: Confirm whether or not this is working
-      # An explicit list of tables which should be included in sql-dump and sql-sync.
-
-#     tables:
-#       common:
-#         - user
-#         - permissions
-#          - role_permissions
-#          - role
-
-      # List of tables whose *data* is skipped by the 'sql-dump' and 'sql-sync'
-      # commands when the "--structure-tables-key=common" option is provided.
-      # You may add specific tables to the existing array or add a new element.
-      structure-tables:
-        common:
-          - cache
-          - 'cache_*'
-          - history
-          - 'search_*'
-          - 'sessions'
-          - 'watchdog'
-      # List of tables to be omitted entirely from SQL dumps made by the 'sql-dump'
-      # and 'sql-sync' commands when the "--skip-tables-key=common" option is
-      # provided on the command line.  This is useful if your database contains
-      # non-Drupal tables used by some other application or during a migration for
-      # example.  You may add new tables to the existing array or add a new element.
-      skip-tables:
-        common:
-          - 'migration_*'
-
     dump:
       options:
         # Specify the filename and path where 'sql-dump' should store backups of
@@ -206,6 +175,34 @@ command:
         # Set a predetermined username and password when using site-install.
 #       account-name: 'alice'
 #       account-pass: 'secret'
+
+sql:
+  # An explicit list of tables which should be included in sql-dump and sql-sync.
+  tables:
+    common:
+      - user
+      - permissions
+      - role_permissions
+      - role
+  # List of tables whose *data* is skipped by the 'sql-dump' and 'sql-sync'
+  # commands when the "--structure-tables-key=common" option is provided.
+  # You may add specific tables to the existing array or add a new element.
+  structure-tables:
+    common:
+      - cache
+      - 'cache_*'
+      - history
+      - 'search_*'
+      - 'sessions'
+      - 'watchdog'
+  # List of tables to be omitted entirely from SQL dumps made by the 'sql-dump'
+  # and 'sql-sync' commands when the "--skip-tables-key=common" option is
+  # provided on the command line.  This is useful if your database contains
+  # non-Drupal tables used by some other application or during a migration for
+  # example.  You may add new tables to the existing array or add a new element.
+  skip-tables:
+    common:
+      - 'migration_*'
 
 ssh:
   # Specify options to pass to ssh in backend invoke.  The default is to prohibit

--- a/src/Commands/OptionsCommands.php
+++ b/src/Commands/OptionsCommands.php
@@ -62,11 +62,7 @@ class OptionsCommands
         'tables-key' => self::REQ,
         'skip-tables-list' => self::REQ,
         'structure-tables-list' => self::REQ,
-        'tables-list' => self::REQ,
-        'skip-tables' => self::REQ,
-        'structure-tables' => self::REQ,
-        'tables' => self::REQ,
-        ])
+        'tables-list' => self::REQ])
     {
     }
 }

--- a/src/Commands/OptionsCommands.php
+++ b/src/Commands/OptionsCommands.php
@@ -62,7 +62,11 @@ class OptionsCommands
         'tables-key' => self::REQ,
         'skip-tables-list' => self::REQ,
         'structure-tables-list' => self::REQ,
-        'tables-list' => self::REQ])
+        'tables-list' => self::REQ,
+        'skip-tables' => self::REQ,
+        'structure-tables' => self::REQ,
+        'tables' => self::REQ,
+        ])
     {
     }
 }

--- a/src/Sql/SqlTableSelectionTrait.php
+++ b/src/Sql/SqlTableSelectionTrait.php
@@ -1,8 +1,15 @@
 <?php
 namespace Drush\Sql;
 
+use Consolidation\Config\ConfigInterface;
+
 trait SqlTableSelectionTrait
 {
+
+    /**
+     * @var ConfigInterface
+     */
+    protected $config;
 
     /**
      * Get a list of all table names and expand input that may contain
@@ -143,12 +150,12 @@ trait SqlTableSelectionTrait
     {
         $key_list = _convert_csv_to_array($options[$option_name . '-key']);
         foreach ($key_list as $key) {
-            $all_tables = $options[$option_name] ?: [];
+            $all_tables = $this->config->get('sql.' . $option_name, []);
             if (array_key_exists($key, $all_tables)) {
                 return $all_tables[$key];
             }
             if ($option_name != 'tables') {
-                $all_tables = isset($options['tables']) ? $options['tables'] : [];
+                $all_tables = $this->config->get('sql.tables', []);
                 if (array_key_exists($key, $all_tables)) {
                     return $all_tables[$key];
                 }


### PR DESCRIPTION
The three settings are missing in optionset_table_selection. Drush does not load the options otherwise.

@greg-1-anderson Should i add the ``@option`` annotation for these options? I think they should not be visible in the help section of the command. Because its not clear how to define an array via CLI. I saw other commands have ``@hidden-options``. What you i use?

It works fine without the annotation anyways.

I have checked the examples in ``example.drush.yml`` and it works as expected with this small fix. 👍 