### PR TITLE
Fix 'drush help' w/out command name

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -185,6 +185,9 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
      */
     public function find($name)
     {
+        if (empty($name)) {
+            return;
+        }
         $command = $this->bootstrapAndFind($name);
         // Avoid exception when help is being built by https://github.com/bamarni/symfony-console-autocomplete.
         // @todo Find a cleaner solution.

--- a/src/Commands/help/HelpCommands.php
+++ b/src/Commands/help/HelpCommands.php
@@ -27,7 +27,7 @@ class HelpCommands extends DrushCommands
      *
      * @return \Consolidation\AnnotatedCommand\Help\HelpDocument
      */
-    public function help($command_name, $options = ['format' => 'helpcli', 'include-field-labels' => false, 'table-style' => 'compact'])
+    public function help($command_name = '', $options = ['format' => 'helpcli', 'include-field-labels' => false, 'table-style' => 'compact'])
     {
         $application = Drush::getApplication();
         $command = $application->get($command_name);


### PR DESCRIPTION
Allow Drush help validate to behave as intended when 'drush help' is run without a command name.