### PR TITLE
The debug logs come out as notice

### DIFF
--- a/src/Log/DrushLog.php
+++ b/src/Log/DrushLog.php
@@ -80,9 +80,14 @@ class DrushLog implements LoggerInterface
                 $error_type = LogLevel::WARNING;
                 break;
 
-            // TODO: RfcLogLevel::DEBUG should be 'debug' rather than 'notice'?
             case RfcLogLevel::DEBUG:
+                $error_type = LogLevel::DEBUG;
+                break;
+
             case RfcLogLevel::INFO:
+                $error_type = LogLevel::INFO;
+                break;
+
             case RfcLogLevel::NOTICE:
                 $error_type = LogLevel::NOTICE;
                 break;


### PR DESCRIPTION
I guess this was already planned :
// TODO: RfcLogLevel::DEBUG should be 'debug' rather than 'notice'?

I get too much logs on my production servers.