### PR TITLE
Move options.ssh-options to ssh.options

### DIFF
--- a/isolation/tests/LegacyAliasConverterTest.php
+++ b/isolation/tests/LegacyAliasConverterTest.php
@@ -192,7 +192,9 @@ class LegacyAliasConverterTest extends TestCase
                             'options' => [
                                 'db-url' => 'mysql://pantheon:pw@dbserver.dev.site-id.drush.in:21086/pantheon',
                                 'db-allows-remote' => true,
-                                'ssh-options' => '-p 2222 -o "AddressFamily inet"',
+                            ],
+                            'ssh' => [
+                                'options' => '-p 2222 -o "AddressFamily inet"',
                             ],
                         ],
                         'live' =>
@@ -207,7 +209,9 @@ class LegacyAliasConverterTest extends TestCase
                             'options' => [
                                 'db-url' => 'mysql://pantheon:pw@dbserver.live.site-id.drush.in:10516/pantheon',
                                 'db-allows-remote' => true,
-                                'ssh-options' => '-p 2222 -o "AddressFamily inet"',
+                            ],
+                            'ssh' => [
+                                'options' => '-p 2222 -o "AddressFamily inet"',
                             ],
                         ],
                         'test' =>
@@ -222,7 +226,9 @@ class LegacyAliasConverterTest extends TestCase
                             'options' => [
                                 'db-url' => 'mysql://pantheon:pw@dbserver.test.site-id.drush.in:11621/pantheon',
                                 'db-allows-remote' => true,
-                                'ssh-options' => '-p 2222 -o "AddressFamily inet"',
+                            ],
+                            'ssh' => [
+                                'options' => '-p 2222 -o "AddressFamily inet"',
                             ],
                         ],
                     ],

--- a/tests/SiteAliasConvertTest.php
+++ b/tests/SiteAliasConvertTest.php
@@ -30,7 +30,7 @@ class SiteAliasConvertTest extends CommandUnishTestCase
         $this->assertObjectHasAttribute('@www-drupalvm.dev', $json);
         $dev = $json->{'@drupalvm.dev'};
         $this->assertSame('drupalvm.dev', $dev->host);
-        $this->assertSame('-o PasswordAuthentication=no -i /.vagrant.d/insecure_private_key', $dev->options->{'ssh-options'});
+        $this->assertSame('-o PasswordAuthentication=no -i /.vagrant.d/insecure_private_key', $dev->ssh->{'options'});
         $this->assertSame('/var/www/drupalvm/drupal/vendor/drush/drush/drush', $dev->paths->{'drush-script'});
     }
 }


### PR DESCRIPTION
Legacy alias file conversion was leaving ssh options at `options.ssh-options`, but the new correct location is `ssh.options`.