### PR TITLE
Enable calling module and theme generators by their aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require": {
     "php": ">=5.6.0",
     "ext-dom": "*",
-    "chi-teck/drupal-code-generator": "^1.17.3",
+    "chi-teck/drupal-code-generator": "^1.21.0",
     "composer/semver": "^1.4",
     "consolidation/annotated-command": "^2.8.1",
     "consolidation/config": "^1.0.7",

--- a/src/Commands/generate/GenerateCommands.php
+++ b/src/Commands/generate/GenerateCommands.php
@@ -58,7 +58,6 @@ class GenerateCommands extends DrushCommands
             ListCommands::renderListCLI($application, $namespaced, $this->output(), $preamble);
             return null;
         } else {
-
             // Symfony console cannot recognize the command by alias when
             // multiple commands have the same prefix.
             if ($generator == 'module') {

--- a/src/Commands/generate/GenerateCommands.php
+++ b/src/Commands/generate/GenerateCommands.php
@@ -58,6 +58,13 @@ class GenerateCommands extends DrushCommands
             ListCommands::renderListCLI($application, $namespaced, $this->output(), $preamble);
             return null;
         } else {
+
+            // Symfony console cannot recognize the command by alias when
+            // multiple commands have the same prefix.
+            if ($generator == 'module') {
+                $generator = 'module-standard';
+            }
+
             // Create an isolated input.
             $argv = [
                 $generator,
@@ -124,12 +131,6 @@ class GenerateCommands extends DrushCommands
             $generator->setName($new_name);
             // Remove alias if it is same as new name.
             if ($aliases = $generator->getAliases()) {
-                foreach ($aliases as $key => $alias) {
-                    // These dont work due to Console 'guessing' wrong.
-                    if ($alias == 'module' || $alias == 'theme') {
-                        unset($aliases[$key]);
-                    }
-                }
                 $generator->setAliases(array_diff($aliases, [$new_name]));
             }
         }


### PR DESCRIPTION
Currently it's not possible to run `drush generate module` or `drush generate theme` because Symfony console application cannot identify these commands by aliases (see https://github.com/symfony/symfony/issues/25355). As a workaround I propose we identify `generate module` command explicitly because it is potentially one of the most used generators.

For `generate theme` it is not a problem any longer as it has been renamed (d8:theme:standard => d8:theme) in DCG 1.21.