### PR TITLE
Fix router.php to work with update.php

### DIFF
--- a/misc/d8-rs-router.php
+++ b/misc/d8-rs-router.php
@@ -26,8 +26,34 @@ $base_url = runserver_env('RUNSERVER_BASE_URL');
 // contain multiple dots (such as config entity IDs) in the path. Since this is
 // a virtual resource, served by index.php set the script name explicitly.
 // See https://github.com/drush-ops/drush/issues/2033 for more information.
-$_SERVER['SCRIPT_NAME'] = '/index.php';
+// Work around the PHP bug. Update $_SERVER variables to point to the correct
+// index-file.
+if (substr_count($_SERVER['SCRIPT_FILENAME'], '.') > 1) {
+  $path = $url['path'];
+  // Work backwards through the path to check if the script exists. Otherwise
+  // fallback to index.php.
+  do {
+    $path = dirname($path);
+  } while ($path !== '/' && $path !== '.' && !file_exists('.' . $path));
+  if ($path === '/' ||  $path === '.') {
+    $script = 'index.php';
+  }
+  else {
+    $script = ltrim($path, '/');
+  }
+  $index_file_absolute = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $script;
+  $index_file_relative = DIRECTORY_SEPARATOR . $script;
 
-// Include the main index.php and let Drupal take over.
-// n.b. Drush sets the cwd to the Drupal root during bootstrap.
-include 'index.php';
+  // SCRIPT_FILENAME will point to the router script itself, it should point to
+  // the full path of index.php.
+  $_SERVER['SCRIPT_FILENAME'] = $index_file_absolute;
+
+  // SCRIPT_NAME and PHP_SELF will either point to index.php or contain the full
+  // virtual path being requested depending on the URL being requested. They
+  // should always point to index.php relative to document root.
+  $_SERVER['SCRIPT_NAME'] = $index_file_relative;
+  $_SERVER['PHP_SELF'] = $index_file_relative;
+}
+
+// Require the script and let core take over.
+require $_SERVER['SCRIPT_FILENAME'];


### PR DESCRIPTION
Whilst working with drush runserver for a test environment I discovered that it doesn't support update.php. Drupal core's script has the same problem see: https://www.drupal.org/project/drupal/issues/2929198#comment-12374814

Steps to test
1. Install standard Drupal
2. Start up server using drush runserver --default-server=builtin 8080
3. Visit http://localhost:8080/update.php
4. Click on the continue button
5. You should see the next page either the review or a message saying no updates. Without this patch you get a 404.
6. Ensure that admin/structure/types/manage/article/fields/node.article.body is not broken since this is why with the script in the first place - see https://bugs.php.net/bug.php?id=61286
7. Ensure that http://localhost:8888/update.php/selection/blahd.blah
falls back to an update screen since this is the behaviour on Apache. 