### PR TITLE
Next cache dir candidates are not tested if first fails

### DIFF
--- a/src/Config/DrushConfig.php
+++ b/src/Config/DrushConfig.php
@@ -52,6 +52,6 @@ class DrushConfig extends ConfigOverlay
                 // Do nothing. Jump to the next candidate.
             }
         }
-        throw new \Exception('Cannot create the Drush cache file. Tried directories: ' . implode(', ', $candidates));
+        throw new \Exception('Cannot create the Drush cache directory. Tried next candidates: ' . implode(', ', $candidates));
     }
 }

--- a/src/Config/DrushConfig.php
+++ b/src/Config/DrushConfig.php
@@ -2,6 +2,8 @@
 namespace Drush\Config;
 
 use Consolidation\Config\Util\ConfigOverlay;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -40,10 +42,16 @@ class DrushConfig extends ConfigOverlay
             Path::join($this->home(), '.drush/cache'),
             Path::join($this->tmp(), 'drush-' . $this->user() . '/cache'),
         ];
+
+        $fs = new Filesystem();
         foreach ($candidates as $candidate) {
-            if (drush_mkdir($candidate)) {
+            try {
+                $fs->mkdir($candidate);
                 return $candidate;
+            } catch (IOException $ioException) {
+                // Do nothing. Jump to the next candidate.
             }
         }
+        throw new \Exception('Cannot create the Drush cache file. Tried directories: ' . implode(', ', $candidates));
     }
 }


### PR DESCRIPTION
Fixes #3221 

After `drush_mkdir()` was deprecated, it always returns `TRUE`, even the cache dir candidate has failed to be created. For this reason, the next candidate never get a chance to be tested or used. 