### PR TITLE
Fixed failing updb command.

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -352,10 +352,8 @@ class UpdateDBCommands extends DrushCommands
         unset($results['#abort']);
         foreach ($results as $module => $updates) {
             foreach ($updates as $number => $update) {
-                if (empty($update['#abort'])) {
-                    foreach ($update['results'] as $result) {
-                        $this->logger()->notice(strip_tags($result['query']));
-                    }
+                if (empty($update['#abort']) && $update['results']['success']) {
+                    $this->logger()->notice(strip_tags($update['results']['query']));
                 }
             }
         }

--- a/tests/resources/modules/d8/woot/woot.install
+++ b/tests/resources/modules/d8/woot/woot.install
@@ -1,8 +1,15 @@
 <?php
 
 /**
- * Failing update.
+ * Good update.
  */
 function woot_update_8101() {
-  throw new \Exception('8101 error');
+  return t('woot_update_8101');
+}
+
+/**
+ * Failing update.
+ */
+function woot_update_8102() {
+  throw new \Exception('8102 error');
 }


### PR DESCRIPTION
It was failing with "Error: Cannot use object of type
Drupal\Core\StringTranslation\TranslatableMarkup as array in
Drush\Commands\core\UpdateDBCommands->updateFinished() (line 357 of
vendor/drush/drush/src/Commands/core/UpdateDBCommands.php).".