### PR TITLE
Use uri from an alias when that alias has no root.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -154,6 +154,9 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
             return;
         }
         $selfAliasRecord = $this->aliasManager->getSelf();
+        if (!$selfAliasRecord->hasRoot() && !$this->bootstrapManager()->drupalFinder()->getDrupalRoot()) {
+            return;
+        }
         $uri = $selfAliasRecord->uri();
 
         if (empty($uri)) {

--- a/src/Application.php
+++ b/src/Application.php
@@ -154,9 +154,6 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
             return;
         }
         $selfAliasRecord = $this->aliasManager->getSelf();
-        if (!$selfAliasRecord->hasRoot()) {
-            return;
-        }
         $uri = $selfAliasRecord->uri();
 
         if (empty($uri)) {

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -263,7 +263,9 @@ class Preflight
 
         // Process the selected alias. This might change the selected site,
         // so we will add new site-wide config location for the new root.
-        $root = $this->setSelectedSite($selfAliasRecord->localRoot());
+        if ($localRoot = $selfAliasRecord->localRoot()) {
+          $root = $this->setSelectedSite($localRoot);
+        }
 
         // Now that we have our final Drupal root, check to see if there is
         // a site-local Drush. If there is, we will redispatch to it.

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -263,9 +263,7 @@ class Preflight
 
         // Process the selected alias. This might change the selected site,
         // so we will add new site-wide config location for the new root.
-        if ($localRoot = $selfAliasRecord->localRoot()) {
-            $root = $this->setSelectedSite($localRoot);
-        }
+        $root = $this->setSelectedSite($selfAliasRecord->localRoot());
 
         // Now that we have our final Drupal root, check to see if there is
         // a site-local Drush. If there is, we will redispatch to it.
@@ -319,11 +317,13 @@ class Preflight
      */
     protected function setSelectedSite($selectedRoot, $fallbackPath = false)
     {
-        $foundRoot = $this->drupalFinder->locateRoot($selectedRoot);
-        if (!$foundRoot && $fallbackPath) {
-            $this->drupalFinder->locateRoot($fallbackPath);
+        if ($selectedRoot || $fallbackPath) {
+            $foundRoot = $this->drupalFinder->locateRoot($selectedRoot);
+            if (!$foundRoot && $fallbackPath) {
+              $this->drupalFinder->locateRoot($fallbackPath);
+            }
+            return $this->drupalFinder()->getDrupalRoot();
         }
-        return $this->drupalFinder()->getDrupalRoot();
     }
 
     /**

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -320,7 +320,7 @@ class Preflight
         if ($selectedRoot || $fallbackPath) {
             $foundRoot = $this->drupalFinder->locateRoot($selectedRoot);
             if (!$foundRoot && $fallbackPath) {
-              $this->drupalFinder->locateRoot($fallbackPath);
+                $this->drupalFinder->locateRoot($fallbackPath);
             }
             return $this->drupalFinder()->getDrupalRoot();
         }

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -264,7 +264,7 @@ class Preflight
         // Process the selected alias. This might change the selected site,
         // so we will add new site-wide config location for the new root.
         if ($localRoot = $selfAliasRecord->localRoot()) {
-          $root = $this->setSelectedSite($localRoot);
+            $root = $this->setSelectedSite($localRoot);
         }
 
         // Now that we have our final Drupal root, check to see if there is


### PR DESCRIPTION
I have a local site alias that defines a uri but no root. A root is not needed anymore because that gets located correctly based on me using vendor/bin/drush. 