### PR TITLE
The cget --include-overridden is currently reversed

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -65,7 +65,7 @@ class ConfigCommands extends DrushCommands
     {
         // Displaying overrides only applies to active storage.
         $factory = $this->getConfigFactory();
-        $config = $options['include-overridden'] ?  $factory->get($config_name) : $factory->getEditable($config_name);
+        $config = $options['include-overridden'] ? $factory->get($config_name) : $factory->getEditable($config_name);
         $value = $config->get($key);
         // @todo If the value is TRUE (for example), nothing gets printed. Is this yaml formatter's fault?
         return $key ? ["$config_name:$key" => $value] : $value;

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -65,7 +65,7 @@ class ConfigCommands extends DrushCommands
     {
         // Displaying overrides only applies to active storage.
         $factory = $this->getConfigFactory();
-        $config = $options['include-overridden'] ? $factory->getEditable($config_name) : $factory->get($config_name);
+        $config = $options['include-overridden'] ?  $factory->get($config_name) : $factory->getEditable($config_name);
         $value = $config->get($key);
         // @todo If the value is TRUE (for example), nothing gets printed. Is this yaml formatter's fault?
         return $key ? ["$config_name:$key" => $value] : $value;


### PR DESCRIPTION
This drove me nut for a bit, it was happening on drush 9 but not drush 8.

According to http://cgit.drupalcode.org/drupal/tree/core/lib/Drupal/Core/Config/ConfigFactoryInterface.php?h=8.4.x#n27 "is always loaded override free."

Although done slightly different, on 8x is like this: https://github.com/drush-ops/drush/blob/8.x/commands/core/config.drush.inc#L844