### PR TITLE
Replace DRUSH_NOCOLOR with OutputInterface::isDecorated

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -145,7 +145,6 @@ function drush_get_global_options($brief = FALSE) {
     $options['ignored-modules']     = ['description' => "Exclude some modules from consideration when searching for drush command files.", 'example-value' => 'token,views'];
     $options['no-label']            = ['description' => "Remove the site label that drush includes in multi-site command output (e.g. `drush @site1,@site2 status`)."];
     $options['label-separator']     = ['description' => "Specify the separator to use in multi-site command output (e.g. `drush @sites pm-list --label-separator=',' --format=csv`).", 'example-value' => ','];
-    $options['nocolor']             = ['context' => 'DRUSH_NOCOLOR', 'propagate-cli-value' => TRUE, 'description' => "Suppress color highlighting on log messages."];
     $options['show-invoke']         = ['description' => "Show all function names which could have been called for the current command. See drush_invoke()."];
     $options['cache-default-class'] = ['description' => "A cache backend class that implements CacheInterface. Defaults to JSONCache.", 'example-value' => 'JSONCache'];
     $options['cache-class-<bin>']   = ['description' => "A cache backend class that implements CacheInterface to use for a specific cache bin.", 'example-value' => 'className'];

--- a/src/Log/Logger.php
+++ b/src/Log/Logger.php
@@ -59,14 +59,14 @@ class Logger extends RoboLogger
             drush_backend_packet('log', $entry);
         }
 
-        if (drush_get_context('DRUSH_NOCOLOR')) {
-            $red = "[%s]";
-            $yellow = "[%s]";
-            $green = "[%s]";
-        } else {
+        if ($this->output->isDecorated()) {
             $red = "\033[31;40m\033[1m[%s]\033[0m";
             $yellow = "\033[1;33;40m\033[1m[%s]\033[0m";
             $green = "\033[1;32;40m\033[1m[%s]\033[0m";
+        } else {
+            $red = "[%s]";
+            $yellow = "[%s]";
+            $green = "[%s]";
         }
 
         $verbose = \Drush\Drush::verbose();

--- a/src/Preflight/LegacyPreflight.php
+++ b/src/Preflight/LegacyPreflight.php
@@ -3,6 +3,8 @@ namespace Drush\Preflight;
 
 use Drush\Drush;
 use Drush\Config\Environment;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -95,7 +97,7 @@ class LegacyPreflight
         drush_set_context('DRUSH_PER_USER_CONFIGURATION', $environment->userConfigPath());
     }
 
-    public static function setGlobalOptionContexts($input, $output)
+    public static function setGlobalOptionContexts(InputInterface $input, OutputInterface $output)
     {
         $verbose = $output->isVerbose();
         $debug = $output->isDebug();
@@ -110,18 +112,6 @@ class LegacyPreflight
 
         // Pipe implies quiet.
         drush_set_context('DRUSH_QUIET', $quiet || $pipe);
-
-        // Suppress colored logging if --no-ansi (was --nocolor) option is explicitly given or if
-        // terminal does not support it.
-        $nocolor = $input->getOption('no-ansi', false);
-        if (!$nocolor) {
-            // Check for colorless terminal.  If there is no terminal, then
-            // 'tput colors 2>&1' will return "tput: No value for $TERM and no -T specified",
-            // which is not numeric and therefore will put us in no-color mode.
-            $colors = exec('tput colors 2>&1');
-            $nocolor = !($colors === false || (is_numeric($colors) && $colors >= 3));
-        }
-        drush_set_context('DRUSH_NOCOLOR', $nocolor);
     }
 
     /**


### PR DESCRIPTION
I did some debugging related to #2214 and noticed that DRUSH_NOCOLOR is mostly unused now. 

---

Disclaimer: This is very low-level code in Drush, not sure if this is the right thing.