### PR TITLE
If drush_backend_parse_output() returns a string, it means the command could have run successfully.

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1049,6 +1049,9 @@ function _drush_backend_invoke($cmds, $common_backend_options = array(), $contex
             $ret['concurrent'][] = $values;
           }
         }
+        elseif (is_string($values)) {
+          $ret['output'] = $values;
+        }
         else {
           $ret = drush_set_error('DRUSH_FRAMEWORK_ERROR', dt("The command could not be executed successfully (returned: !return, code: !code)", array("!return" => $proc['output'], "!code" =>  $proc['code'])));
         }

--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1049,7 +1049,7 @@ function _drush_backend_invoke($cmds, $common_backend_options = array(), $contex
             $ret['concurrent'][] = $values;
           }
         }
-        elseif (is_string($values)) {
+        elseif (is_string($values) && $proc['code'] == DRUSH_SUCCESS) {
           $ret['output'] = $values;
         }
         else {


### PR DESCRIPTION
I'm running into a very strange issue with a site hosted on Aegir (Running Drush 8). It only happens with a Drupal 8 platform based on the standard drupal composer project, which itself includes Drush.
 
In aegir, the `drush provision-verify` command uses `drush_invoke_process()` to run `drush provision-save`. When I do this on the Drupal 8 platform, `drush_invoke_process()` throws the error "The command could not be executed successfully".

If I remove the `vendor/drush/drush` folder from the Drupal 8 platform, the command works as expected!

What happens is that `drush_backend_parse_output()` returns the output of the `drush provision-verify` command as a string when it bootstraps the Drupal8/drush9 platform.

I have no idea how this could be happening, but I figured `_drush_backend_invoke()` should handle that string instead of an array. 
