### PR TITLE
Allow --uri to be specified on CLI with alias.

### DIFF
--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -79,6 +79,12 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
         if (!$targetRecord = $manager->get($target)) {
             throw new \Exception(dt('Error: no alias record could be found for target !target', ['!target' => $target]));
         }
+        if (!$sourceRecord->uri() && $manager->getSelf()->uri()) {
+            $sourceRecord->setUri($manager->getSelf()->uri());
+        }
+        if (!$targetRecord->uri() && $manager->getSelf()->uri()) {
+            $targetRecord->setUri($manager->getSelf()->uri());
+        }
         if (!$source_db_name = $this->databaseName($sourceRecord)) {
             throw new \Exception(dt('Error: no database record could be found for source !source', ['!source' => $source]));
         }

--- a/src/SiteAlias/SiteAliasManager.php
+++ b/src/SiteAlias/SiteAliasManager.php
@@ -245,7 +245,13 @@ class SiteAliasManager
         if (SiteAliasName::isAliasName($aliasName)) {
             // TODO: Should we do something about `@self` here? At the moment that will cause getAlias to
             // call $this->getSelf(), but we haven't built @self yet.
-            return $this->getAlias($aliasName);
+            // If the alias has no explicitly defined uri, use uri specified
+            // in cli arguments.
+            $alias = $this->getAlias($aliasName);
+            if (!$alias->get('uri') && $preflightArgs->uri()) {
+                $alias->set('uri', $preflightArgs->uri());
+            }
+            return $alias;
         }
 
         // Ditto for a site spec (/path/to/drupal#uri)


### PR DESCRIPTION
Using `--uri` does not work when executing commands against a drush alias in Drush 9.

`drush @blted82.local --uri=site2 status` executes against `site1`.

This PR allows `drush @blted82.local --uri=site2 status` to execute against site2.