### PR TITLE
Fix runserver command to work with image styles

### DIFF
--- a/misc/d8-rs-router.php
+++ b/misc/d8-rs-router.php
@@ -28,32 +28,35 @@ $base_url = runserver_env('RUNSERVER_BASE_URL');
 // See https://github.com/drush-ops/drush/issues/2033 for more information.
 // Work around the PHP bug. Update $_SERVER variables to point to the correct
 // index-file.
-if (substr_count($_SERVER['SCRIPT_FILENAME'], '.') > 1) {
-  $path = $url['path'];
-  // Work backwards through the path to check if the script exists. Otherwise
+$path = $url['path'];
+$script = 'index.php';
+if (strpos($path, '.php') !== FALSE) {
+  // Work backwards through the path to check if a script exists. Otherwise
   // fallback to index.php.
   do {
     $path = dirname($path);
-  } while ($path !== '/' && $path !== '.' && !file_exists('.' . $path));
-  if ($path === '/' ||  $path === '.') {
-    $script = 'index.php';
-  }
-  else {
-    $script = ltrim($path, '/');
-  }
-  $index_file_absolute = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $script;
-  $index_file_relative = DIRECTORY_SEPARATOR . $script;
-
-  // SCRIPT_FILENAME will point to the router script itself, it should point to
-  // the full path of index.php.
-  $_SERVER['SCRIPT_FILENAME'] = $index_file_absolute;
-
-  // SCRIPT_NAME and PHP_SELF will either point to index.php or contain the full
-  // virtual path being requested depending on the URL being requested. They
-  // should always point to index.php relative to document root.
-  $_SERVER['SCRIPT_NAME'] = $index_file_relative;
-  $_SERVER['PHP_SELF'] = $index_file_relative;
+    if (preg_match('/\.php$/', $path) && is_file('.' . $path)) {
+      // Discovered that the path contains an existing PHP file. Use that as the
+      // script to include.
+      $script = ltrim($path, '/');
+      break;
+    }
+  } while ($path !== '/' && $path !== '.');
 }
+
+// Update $_SERVER variables to point to the correct index-file.
+$index_file_absolute = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $script;
+$index_file_relative = DIRECTORY_SEPARATOR . $script;
+
+// SCRIPT_FILENAME will point to the router script itself, it should point to
+// the full path of index.php.
+$_SERVER['SCRIPT_FILENAME'] = $index_file_absolute;
+
+// SCRIPT_NAME and PHP_SELF will either point to index.php or contain the full
+// virtual path being requested depending on the URL being requested. They
+// should always point to index.php relative to document root.
+$_SERVER['SCRIPT_NAME'] = $index_file_relative;
+$_SERVER['PHP_SELF'] = $index_file_relative;
 
 // Require the script and let core take over.
 require $_SERVER['SCRIPT_FILENAME'];


### PR DESCRIPTION
Discovered some problems with https://github.com/drush-ops/drush/pull/3218 - I've updated the corresponding core patch - see https://www.drupal.org/project/drupal/issues/2929198.

The problem is with image styles - to reproduce:
1. Install standard
2. Go to node/add/article 
3. Create an article with an image
4. Save - you should see your uploaded image. IN Drush HEAD you don't. With this patch you do.

I've also tested the update.php stuff that was failing before https://github.com/drush-ops/drush/pull/3218 and that all still works.