### PR TITLE
Add logging if an error occurs during an update

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -276,7 +276,7 @@ class UpdateDBCommands extends DrushCommands
         $result = drush_backend_batch_process();
         \Drupal::service('state')->set('system.maintenance_mode', $maintenance_mode_original_state);
 
-        $success = FALSE;
+        $success = false;
         if (!is_array($result)) {
             $this->logger()->error(dt('Batch process did not return a result array. Returned: !type', ['!type' => gettype($result)]));
         } elseif (!array_key_exists('object', $result)) {
@@ -286,7 +286,7 @@ class UpdateDBCommands extends DrushCommands
                 '!process' => implode(', ', $result['object'][0]['#abort']),
             ]));
         } else {
-            $success = TRUE;
+            $success = true;
         }
 
         return $success;


### PR DESCRIPTION
We just had a failure during execution of `drush update-db -vvv` but no error was logged and the build returned a success message:

```
 [success] Finished performing updates. [331.09 sec, 38.91 MB]
```

Here is the full log output with debugging enabled, there were no warnings or errors, but the update failed, and an error code was returned:
```
 [debug] Start bootstrap of the Drupal Kernel. [2.11 sec, 8.16 MB]
 [notice] config_sync should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file. [2.2 sec, 10.79 MB]
 [notice] search_api should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file. [2.2 sec, 10.79 MB]
 [debug] Get container builder [2.2 sec, 10.81 MB]
 [debug] process drush.console.services console.command [2.32 sec, 14.83 MB]
 [debug] process drush.command.services drush.command [2.32 sec, 14.83 MB]
 [debug] process drush.generator.services drush.generator [2.32 sec, 14.86 MB]
 [debug] Finished bootstrap of the Drupal Kernel. [2.52 sec, 25.45 MB]
 [notice] Executing facets_update_8003 [2.57 sec, 30.24 MB]
 [ok] Performing facets_update_8003 [2.59 sec, 30.38 MB]
 [notice] Executing collection_update_8100 [2.61 sec, 30.38 MB]
 [ok] Performing collection_update_8100 [2.62 sec, 30.38 MB]
 [notice] Executing facets_update_8004 [2.64 sec, 30.38 MB]
 [ok] Performing facets_update_8004 [2.7 sec, 31.13 MB]
 [notice] config_sync should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file. [4.53 sec, 37.69 MB]
 [notice] search_api should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file. [4.53 sec, 37.69 MB]
 [debug] Get container builder [4.53 sec, 37.69 MB]
 [debug] process drush.console.services console.command [4.55 sec, 39.63 MB]
 [debug] process drush.command.services drush.command [4.55 sec, 39.63 MB]
 [debug] process drush.generator.services drush.generator [4.55 sec, 39.66 MB]
 [notice] config_sync should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file. [108.4 sec, 476.13 MB]
 [notice] search_api should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file. [108.4 sec, 476.13 MB]
 [debug] Get container builder [108.4 sec, 476.12 MB]
 [debug] process drush.console.services console.command [108.41 sec, 480.06 MB]
 [debug] process drush.command.services drush.command [108.41 sec, 480.06 MB]
 [debug] process drush.generator.services drush.generator [108.41 sec, 480.1 MB]
 [ok] Post updating joinup_core [110.05 sec, 67.2 MB]
 [notice] config_sync should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file. [120.08 sec, 67.12 MB]
 [notice] search_api should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file. [120.09 sec, 67.12 MB]
 [debug] Get container builder [120.09 sec, 67.12 MB]
 [debug] process drush.console.services console.command [120.1 sec, 69.05 MB]
 [debug] process drush.command.services drush.command [120.1 sec, 69.05 MB]
 [debug] process drush.generator.services drush.generator [120.1 sec, 69.09 MB]
 [notice]  [225.87 sec, 482.92 MB]
 [notice]  [225.87 sec, 482.93 MB]
 [notice]  [225.87 sec, 482.93 MB]
 [notice]  [225.87 sec, 482.93 MB]
 [notice]  [225.87 sec, 482.93 MB]
 [notice]  [225.87 sec, 482.93 MB]
 [info] Array to string conversion TsvFormatter.php:37 [225.89 sec, 483.09 MB]
 [info] Array to string conversion TsvFormatter.php:37 [225.89 sec, 483.09 MB]
 [info] Array to string conversion TsvFormatter.php:37 [225.89 sec, 483.09 MB]
 [info] Array to string conversion TsvFormatter.php:37 [225.89 sec, 483.09 MB]
Array	Array	Array	Array
 [command] Backend invoke: /web/content/joinup/Joinup-v1.21/vendor/bin/drush  --backend=2 --verbose --debug --root=/web/content/joinup/Joinup-v1.21/web --uri=default  cache-rebuild 2>&1 [226.21 sec, 38.91 MB]
 [info] /web/content/joinup/Joinup-v1.21/vendor/bin/drush  --backend=2 --verbose --debug --root=/web/content/joinup/Joinup-v1.21/web --uri=default  cache-rebuild 2>&1 [226.21 sec, 38.91 MB]
 [preflight] Config paths: /web/content/joinup/Joinup-v1.21/vendor/drush/drush/drush.yml
 [preflight] Alias paths: /web/content/joinup/Joinup-v1.21/web/drush/sites,/web/content/joinup/Joinup-v1.21/drush/sites
 [preflight] Commandfile paths: /web/content/joinup/Joinup-v1.21/vendor/drush/drush/src
 [bootstrap] Bootstrap to site [226.38 sec, 7.08 MB]
 [bootstrap] Drush bootstrap phase 2 [226.38 sec, 7.08 MB]
 [bootstrap] Try to validate bootstrap phase 2 [226.38 sec, 7.08 MB]
 [bootstrap] Try to validate bootstrap phase 2 [226.38 sec, 7.08 MB]
 [bootstrap] Try to bootstrap at phase 2 [226.38 sec, 7.21 MB]
 [bootstrap] Drush bootstrap phase: bootstrapDrupalRoot() [226.38 sec, 7.21 MB]
 [bootstrap] Change working directory to /web/content/joinup/Joinup-v1.21/web [226.38 sec, 7.21 MB]
 [bootstrap] Initialized Drupal 8.4.3 root directory at /web/content/joinup/Joinup-v1.21/web [226.38 sec, 7.21 MB]
 [bootstrap] Try to validate bootstrap phase 2 [226.38 sec, 7.21 MB]
 [bootstrap] Try to bootstrap at phase 2 [226.39 sec, 7.72 MB]
 [bootstrap] Drush bootstrap phase: bootstrapDrupalSite() [226.39 sec, 7.72 MB]
 [bootstrap] Initialized Drupal site default at sites/default [226.39 sec, 7.72 MB]
 [success] Cache rebuild complete. [330.87 sec, 472.76 MB]
 [success] Finished performing updates. [331.09 sec, 38.91 MB]
```

If a failure occurs during an update, let's make sure this is mentioned in the log, and don't output a success message.