### PR TITLE
WIP: Integrate composer/xdebug-handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "ext-dom": "*",
     "chi-teck/drupal-code-generator": "^1.21.0",
     "composer/semver": "^1.4",
+    "composer/xdebug-handler": "dev-master",
     "consolidation/annotated-command": "^2.8.1",
     "consolidation/config": "^1.0.9",
     "consolidation/output-formatters": "^3.1.12",

--- a/drush.php
+++ b/drush.php
@@ -1,5 +1,6 @@
 <?php
 
+use Composer\XdebugHandler\XdebugHandler;
 use Drush\Config\Environment;
 use Drush\Preflight\Preflight;
 use Drush\Runtime\Runtime;
@@ -52,6 +53,10 @@ if (file_exists($autoloadFile = __DIR__ . '/vendor/autoload.php')
 } else {
     throw new \Exception("Could not locate autoload.php. cwd is $cwd; __DIR__ is " . __DIR__);
 }
+
+$xdebug = new XdebugHandler('drush', '--ansi');
+$xdebug->check();
+unset($xdebug);
 
 // Set up environment
 $environment = new Environment(Path::getHomeDirectory(), $cwd, $autoloadFile);


### PR DESCRIPTION
[composer/xdebug-handler](https://github.com/composer/xdebug-handler) is a relatively new package. It has no stable release yet. The package provides the xdebug flag composer (COMPOSER_ALLOW_XEBUG) in a general fashion. It works seamlessly with symfony console.

This PR introduces the same feature for drush with DRUSH_ALLOW_XEBUG.

Some non-scientific benchmarks on macOS with PHP 7.1

 ## Before (current default)

```sh
$ export DRUSH_ALLOW_XDEBUG=1 && time ~/Projects/drush9/drush cr
 [success] Cache rebuild complete.
~/Projects/drush9/drush cr  3,72s user 0,40s system 86% cpu 4,773 total
```

**4,773s**


## After (new default)

```sh
$ export DRUSH_ALLOW_XDEBUG=0 && time ~/Projects/drush9/drush cr
 [success] Cache rebuild complete.
~/Projects/drush9/drush cr  1,12s user 0,35s system 70% cpu 2,091 total
```

**2,091s**

---

This is a big BC break. I am not sure if this improves the DX in general, because i often want to use xdebug in conjunction with php-eval or while debugging update hooks. 

Lets discuss :)