### PR TITLE
Exclude default console commands from list of available generators

### DIFF
--- a/src/Commands/generate/GenerateCommands.php
+++ b/src/Commands/generate/GenerateCommands.php
@@ -53,6 +53,7 @@ class GenerateCommands extends DrushCommands
         $application = $this->createApplication();
         if (!$generator) {
             $all = $application->all();
+            unset($all['help'], $all['list']);
             $namespaced = ListCommands::categorize($all, '-');
             $preamble = dt('Run `drush generate [command]` and answer a few questions in order to write starter code to your project.');
             ListCommands::renderListCLI($application, $namespaced, $this->output(), $preamble);


### PR DESCRIPTION
Default Symfony console commands (`help` and `list`) are disallowed in Drush generate application however they are still shown in the categorized list.