### PR TITLE
Fixes #3289: Bash helpers don't work on Mac.

### DIFF
--- a/examples/example.prompt.sh
+++ b/examples/example.prompt.sh
@@ -2,7 +2,13 @@
 #
 # Example PS1 prompt.
 #
-# Use `drush init` to copy this to ~/.drush/drush.prompt.sh, and source it in ~/.bashrc
+# Use `drush init` to copy this to ~/.drush/drush.prompt.sh, and source it in
+# ~/.bashrc or ~/.bash_profile.
+#
+# Note that your Bash session must already have the __git_ps1 function available.
+# Typically this is provided by git-prompt.sh, see instructions for downloading
+# and including this file here:
+# https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh
 #
 # Features:
 #

--- a/src/Commands/core/InitCommands.php
+++ b/src/Commands/core/InitCommands.php
@@ -128,17 +128,13 @@ class InitCommands extends DrushCommands implements BuilderAwareInterface, IOAwa
 
         if (!empty($_ENV['SHELL']) && strstr($_ENV['SHELL'], 'zsh')) {
             $file = $home . '/.zshrc';
-        }
-        elseif (file_exists($home . '/.bash_profile')) {
+        } elseif (file_exists($home . '/.bash_profile')) {
             $file = $home . '/.bash_profile';
-        }
-        elseif (file_exists($home . '/.bashrc')) {
+        } elseif (file_exists($home . '/.bashrc')) {
             $file = $home . '/.bashrc';
-        }
-        elseif (file_exists($home . '/.profile')) {
+        } elseif (file_exists($home . '/.profile')) {
             $file = $home . '/.profile';
-        }
-        elseif (file_exists($home . '/.functions')) {
+        } elseif (file_exists($home . '/.functions')) {
             $file = $home . '/.functions';
         }
 

--- a/src/Commands/core/InitCommands.php
+++ b/src/Commands/core/InitCommands.php
@@ -124,7 +124,7 @@ class InitCommands extends DrushCommands implements BuilderAwareInterface, IOAwa
     protected function findBashrc($home)
     {
         # Set a default value in case nothing else exists.
-        $file = $home . '/.bash_profile';
+        $file = $home . '/.bashrc';
 
         if (!empty($_ENV['SHELL']) && strstr($_ENV['SHELL'], 'zsh')) {
             $file = $home . '/.zshrc';

--- a/src/Commands/core/InitCommands.php
+++ b/src/Commands/core/InitCommands.php
@@ -123,7 +123,26 @@ class InitCommands extends DrushCommands implements BuilderAwareInterface, IOAwa
      */
     protected function findBashrc($home)
     {
-        return $home . "/.bashrc";
+        # Set a default value in case nothing else exists.
+        $file = $home . '/.bash_profile';
+
+        if (!empty($_ENV['SHELL']) && strstr($_ENV['SHELL'], 'zsh')) {
+            $file = $home . '/.zshrc';
+        }
+        elseif (file_exists($home . '/.bash_profile')) {
+            $file = $home . '/.bash_profile';
+        }
+        elseif (file_exists($home . '/.bashrc')) {
+            $file = $home . '/.bashrc';
+        }
+        elseif (file_exists($home . '/.profile')) {
+            $file = $home . '/.profile';
+        }
+        elseif (file_exists($home . '/.functions')) {
+            $file = $home . '/.functions';
+        }
+
+        return $file;
     }
 
     /**


### PR DESCRIPTION
Fixes #3289   