### PR TITLE
Fix count() calls on uncountable variables in \Console_Table class

### DIFF
--- a/includes/output.inc
+++ b/includes/output.inc
@@ -300,7 +300,9 @@ function _drush_format_table($rows, $header = FALSE, $widths = array(), $console
     $tbl->setHeaders($headers);
   }
 
-  $tbl->addData($newrows);
+  // Silent this call to prevent a count() notice due to uncountable variables.
+  // See https://github.com/drush-ops/drush/issues/3226
+  @$tbl->addData($newrows);
   return $tbl;
 }
 


### PR DESCRIPTION
This is for #3226. 
In PHP 7.2, there is a notice raised because the PEAR `console_table` makes a `\count()` call on a variable that is not an `array`/`Countable` . Because maintaining a fixed version of this PEAR package is not worth the effort at this stage (Drush 9.x no longer uses this package), we avoid the notice by silencing PHP with the `@silent` operator. 