### PR TITLE
Update messages are logged in the wrong order

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -212,7 +212,7 @@ class UpdateDBCommands extends DrushCommands
 
         // Log the message that was returned.
         if (!empty($ret['results']['query'])) {
-          $this->logger()->notice(strip_tags((string) $ret['results']['query']));
+            $this->logger()->notice(strip_tags((string) $ret['results']['query']));
         }
 
         if (!empty($ret['#abort'])) {
@@ -270,7 +270,7 @@ class UpdateDBCommands extends DrushCommands
         // update themselves.
         // @see \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface::applyEntityUpdate()
         // @see \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface::applyFieldUpdate()
-        if ($options['entity-updates'] &&  \Drupal::entityDefinitionUpdateManager()->needsUpdates()) {
+        if ($options['entity-updates'] && \Drupal::entityDefinitionUpdateManager()->needsUpdates()) {
             $operations[] = [[$this, 'updateEntityDefinitions'], []];
         }
 

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -210,6 +210,11 @@ class UpdateDBCommands extends DrushCommands
         }
         $context['results'][$module][$number] = array_merge($context['results'][$module][$number], $ret);
 
+        // Log the message that was returned.
+        if (!empty($ret['results']['query'])) {
+          $this->logger()->notice(strip_tags((string) $ret['results']['query']));
+        }
+
         if (!empty($ret['#abort'])) {
             // Record this function in the list of updates that were aborted.
             $context['results']['#abort'][] = $function;
@@ -367,7 +372,7 @@ class UpdateDBCommands extends DrushCommands
     }
 
     /**
-     * Process and display any returned update output.
+     * Batch update callback, clears the cache if needed.
      *
      * @see \Drupal\system\Controller\DbUpdateController::batchFinished()
      * @see \Drupal\system\Controller\DbUpdateController::results()
@@ -382,16 +387,6 @@ class UpdateDBCommands extends DrushCommands
             $this->logger()->info(dt("Skipping cache-clear operation due to --no-cache-clear option."));
         } else {
             drupal_flush_all_caches();
-        }
-
-        // Log update results.
-        unset($results['#abort']);
-        foreach ($results as $module => $updates) {
-            foreach ($updates as $number => $update) {
-                if (empty($update['#abort']) && $update['results']['success'] && !empty($update['results']['query'])) {
-                    $this->logger()->notice(strip_tags($update['results']['query']));
-                }
-            }
         }
     }
 

--- a/tests/UpdateDBTest.php
+++ b/tests/UpdateDBTest.php
@@ -82,7 +82,20 @@ class UpdateDBTest extends CommandUnishTestCase
 
  // Do you wish to run the specified pending updates?: yes.
 LOG;
-        $this->assertOutputEquals(preg_replace('#  *#', ' ', trim($expected_output)));
+        $this->assertOutputEquals(preg_replace('#  *#', ' ', $this->simplifyOutput($expected_output)));
+
+        $expected_error_output = <<<LOG
+ [notice] Executing woot_update_8101
+ [notice] This is the update message from woot_update_8101
+ [ok] Performing woot_update_8101
+ [notice] Executing woot_update_8102
+ [error]  8102 error
+ [ok] Performing woot_update_8102
+ [error]  Failed batch process: woot_update_8102
+ [error]  Finished performing updates.
+LOG;
+
+        $this->assertErrorOutputEquals(preg_replace('#  *#', ' ', $this->simplifyOutput($expected_error_output)));
     }
 
     /**

--- a/tests/resources/modules/d8/woot/woot.install
+++ b/tests/resources/modules/d8/woot/woot.install
@@ -4,7 +4,7 @@
  * Good update.
  */
 function woot_update_8101() {
-  return t('woot_update_8101');
+  return t('This is the update message from woot_update_8101');
 }
 
 /**


### PR DESCRIPTION
Partially fixes #3296.

When performing multiple database updates in a row, the individual messages that are returned by the update hooks are output in the log after all the updates have finished. This might give the impression that the updates have been performed in parallel or out of order, and this might be misleading for system administrators that are investigating a failed update.

Currently the output might look like this:
```
 [notice] Executing woot_update_8101
 [ok] Performing woot_update_8101
 [notice] Executing woot_update_8102
 [error]  8102 error 
 [ok] Performing woot_update_8102
 [notice] woot_update_8101 <----- out of order
 [error]  Failed batch process: woot_update_8102 
 [error]  Finished performing updates. 
```