### PR TITLE
Improve the log of the updatedb command

### DIFF
--- a/tests/UpdateDBTest.php
+++ b/tests/UpdateDBTest.php
@@ -82,7 +82,20 @@ class UpdateDBTest extends CommandUnishTestCase
 
  // Do you wish to run the specified pending updates?: yes.
 LOG;
-        $this->assertOutputEquals(preg_replace('#  *#', ' ', trim($expected_output)));
+        $this->assertOutputEquals(preg_replace('#  *#', ' ', $this->simplifyOutput($expected_output)));
+
+        $expected_error_output = <<<LOG
+ [notice] Update started: woot_update_8101
+ [ok] Update completed: woot_update_8101
+ [notice] Update started: woot_update_8102
+ [error] This is the exception message thrown in woot_update_8102
+ [error] Update failed: woot_update_8102
+ [notice] This is the update message from woot_update_8101
+ [error] Update aborted by: woot_update_8102
+ [error] Finished performing updates.
+LOG;
+
+        $this->assertErrorOutputEquals(preg_replace('#  *#', ' ', $this->simplifyOutput($expected_error_output)));
     }
 
     /**

--- a/tests/resources/modules/d8/woot/woot.install
+++ b/tests/resources/modules/d8/woot/woot.install
@@ -4,12 +4,12 @@
  * Good update.
  */
 function woot_update_8101() {
-  return t('woot_update_8101');
+  return t('This is the update message from woot_update_8101');
 }
 
 /**
  * Failing update.
  */
 function woot_update_8102() {
-  throw new \Exception('8102 error');
+  throw new \Exception('This is the exception message thrown in woot_update_8102');
 }


### PR DESCRIPTION
This partially fixes #3296.

The output of the `updatedb` command can be quite confusing, since misleading messages are being output, and incorrect statuses are being communicated.

Here is some example output from the current update test suite:

```
 [notice] Executing woot_update_8101
 [ok] Performing woot_update_8101
 [notice] Executing woot_update_8102
 [error]  8102 error 
 [ok] Performing woot_update_8102
 [notice] woot_update_8101
 [error]  Failed batch process: woot_update_8102 
 [error]  Finished performing updates.
```

* There appears to be duplicated information about "executing" and "performing" each individual update. In fact when the log mentions that it is "Performing hook_update_x" the update has already finished.
* Update 8102 failed, so there should not be any `[ok]` associated with it.
* It shouldn't mention that the "batch process" failed. That the batch API is used behind the scenes is an implementation detail and not important to mention in the log output.

Edit: Note that the scope of this PR is solely to change the existing messages so they are less confusing. The order of the messages is being corrected in #3302, missing errors are in #3308.