### PR TITLE
 Add private copy of ArgvInput to fix Console bug

### DIFF
--- a/src/Preflight/PreflightArgs.php
+++ b/src/Preflight/PreflightArgs.php
@@ -4,8 +4,8 @@ namespace Drush\Preflight;
 use Consolidation\Config\Config;
 use Consolidation\Config\ConfigInterface;
 
+use Drush\Symfony\DrushArgvInput;
 use Drush\Utils\StringUtils;
-use Symfony\Component\Console\Input\ArgvInput;
 use Drush\Symfony\LessStrictArgvInput;
 
 /**
@@ -484,7 +484,7 @@ class PreflightArgs extends Config implements PreflightArgsInterface
         // In strict mode (the default), create an ArgvInput. When
         // strict mode is disabled, create a more forgiving input object.
         if ($this->isStrict() && !$this->isBackend()) {
-            return new ArgvInput($this->args());
+            return new DrushArgvInput($this->args());
         }
 
         // If in backend mode, read additional options from stdin.

--- a/src/Symfony/DrushArgvInput.php
+++ b/src/Symfony/DrushArgvInput.php
@@ -1,0 +1,361 @@
+<?php
+
+/*
+ *
+ * A copy of ArgvInput (v3.4.2) while commenting out a section of hasParameterOption() per https://github.com/symfony/symfony/issues/25825.
+ *
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Drush\Symfony;
+
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Input\InputDefinition;
+
+/**
+ * ArgvInput represents an input coming from the CLI arguments.
+ *
+ * Usage:
+ *
+ *     $input = new ArgvInput();
+ *
+ * By default, the `$_SERVER['argv']` array is used for the input values.
+ *
+ * This can be overridden by explicitly passing the input values in the constructor:
+ *
+ *     $input = new ArgvInput($_SERVER['argv']);
+ *
+ * If you pass it yourself, don't forget that the first element of the array
+ * is the name of the running application.
+ *
+ * When passing an argument to the constructor, be sure that it respects
+ * the same rules as the argv one. It's almost always better to use the
+ * `StringInput` when you want to provide your own input.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @see http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+ * @see http://www.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html#tag_12_02
+ */
+class DrushArgvInput extends Input
+{
+    private $tokens;
+    private $parsed;
+
+    /**
+     * @param array|null           $argv       An array of parameters from the CLI (in the argv format)
+     * @param InputDefinition|null $definition A InputDefinition instance
+     */
+    public function __construct(array $argv = null, InputDefinition $definition = null)
+    {
+        if (null === $argv) {
+            $argv = $_SERVER['argv'];
+        }
+
+        // strip the application name
+        array_shift($argv);
+
+        $this->tokens = $argv;
+
+        parent::__construct($definition);
+    }
+
+    protected function setTokens(array $tokens)
+    {
+        $this->tokens = $tokens;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parse()
+    {
+        $parseOptions = true;
+        $this->parsed = $this->tokens;
+        while (null !== $token = array_shift($this->parsed)) {
+            if ($parseOptions && '' == $token) {
+                $this->parseArgument($token);
+            } elseif ($parseOptions && '--' == $token) {
+                $parseOptions = false;
+            } elseif ($parseOptions && 0 === strpos($token, '--')) {
+                $this->parseLongOption($token);
+            } elseif ($parseOptions && '-' === $token[0] && '-' !== $token) {
+                $this->parseShortOption($token);
+            } else {
+                $this->parseArgument($token);
+            }
+        }
+    }
+
+    /**
+     * Parses a short option.
+     *
+     * @param string $token The current token
+     */
+    private function parseShortOption($token)
+    {
+        $name = substr($token, 1);
+
+        if (strlen($name) > 1) {
+            if ($this->definition->hasShortcut($name[0]) && $this->definition->getOptionForShortcut($name[0])->acceptValue()) {
+                // an option with a value (with no space)
+                $this->addShortOption($name[0], substr($name, 1));
+            } else {
+                $this->parseShortOptionSet($name);
+            }
+        } else {
+            $this->addShortOption($name, null);
+        }
+    }
+
+    /**
+     * Parses a short option set.
+     *
+     * @param string $name The current token
+     *
+     * @throws RuntimeException When option given doesn't exist
+     */
+    private function parseShortOptionSet($name)
+    {
+        $len = strlen($name);
+        for ($i = 0; $i < $len; ++$i) {
+            if (!$this->definition->hasShortcut($name[$i])) {
+                throw new RuntimeException(sprintf('The "-%s" option does not exist.', $name[$i]));
+            }
+
+            $option = $this->definition->getOptionForShortcut($name[$i]);
+            if ($option->acceptValue()) {
+                $this->addLongOption($option->getName(), $i === $len - 1 ? null : substr($name, $i + 1));
+
+                break;
+            } else {
+                $this->addLongOption($option->getName(), null);
+            }
+        }
+    }
+
+    /**
+     * Parses a long option.
+     *
+     * @param string $token The current token
+     */
+    private function parseLongOption($token)
+    {
+        $name = substr($token, 2);
+
+        if (false !== $pos = strpos($name, '=')) {
+            if (0 === strlen($value = substr($name, $pos + 1))) {
+                // if no value after "=" then substr() returns "" since php7 only, false before
+                // see http://php.net/manual/fr/migration70.incompatible.php#119151
+                if (\PHP_VERSION_ID < 70000 && false === $value) {
+                    $value = '';
+                }
+                array_unshift($this->parsed, $value);
+            }
+            $this->addLongOption(substr($name, 0, $pos), $value);
+        } else {
+            $this->addLongOption($name, null);
+        }
+    }
+
+    /**
+     * Parses an argument.
+     *
+     * @param string $token The current token
+     *
+     * @throws RuntimeException When too many arguments are given
+     */
+    private function parseArgument($token)
+    {
+        $c = count($this->arguments);
+
+        // if input is expecting another argument, add it
+        if ($this->definition->hasArgument($c)) {
+            $arg = $this->definition->getArgument($c);
+            $this->arguments[$arg->getName()] = $arg->isArray() ? array($token) : $token;
+
+            // if last argument isArray(), append token to last argument
+        } elseif ($this->definition->hasArgument($c - 1) && $this->definition->getArgument($c - 1)->isArray()) {
+            $arg = $this->definition->getArgument($c - 1);
+            $this->arguments[$arg->getName()][] = $token;
+
+            // unexpected argument
+        } else {
+            $all = $this->definition->getArguments();
+            if (count($all)) {
+                throw new RuntimeException(sprintf('Too many arguments, expected arguments "%s".', implode('" "', array_keys($all))));
+            }
+
+            throw new RuntimeException(sprintf('No arguments expected, got "%s".', $token));
+        }
+    }
+
+    /**
+     * Adds a short option value.
+     *
+     * @param string $shortcut The short option key
+     * @param mixed  $value    The value for the option
+     *
+     * @throws RuntimeException When option given doesn't exist
+     */
+    private function addShortOption($shortcut, $value)
+    {
+        if (!$this->definition->hasShortcut($shortcut)) {
+            throw new RuntimeException(sprintf('The "-%s" option does not exist.', $shortcut));
+        }
+
+        $this->addLongOption($this->definition->getOptionForShortcut($shortcut)->getName(), $value);
+    }
+
+    /**
+     * Adds a long option value.
+     *
+     * @param string $name  The long option key
+     * @param mixed  $value The value for the option
+     *
+     * @throws RuntimeException When option given doesn't exist
+     */
+    private function addLongOption($name, $value)
+    {
+        if (!$this->definition->hasOption($name)) {
+            throw new RuntimeException(sprintf('The "--%s" option does not exist.', $name));
+        }
+
+        $option = $this->definition->getOption($name);
+
+        if (null !== $value && !$option->acceptValue()) {
+            throw new RuntimeException(sprintf('The "--%s" option does not accept a value.', $name));
+        }
+
+        if (in_array($value, array('', null), true) && $option->acceptValue() && count($this->parsed)) {
+            // if option accepts an optional or mandatory argument
+            // let's see if there is one provided
+            $next = array_shift($this->parsed);
+            if ((isset($next[0]) && '-' !== $next[0]) || in_array($next, array('', null), true)) {
+                $value = $next;
+            } else {
+                array_unshift($this->parsed, $next);
+            }
+        }
+
+        if (null === $value) {
+            if ($option->isValueRequired()) {
+                throw new RuntimeException(sprintf('The "--%s" option requires a value.', $name));
+            }
+
+            if (!$option->isArray() && !$option->isValueOptional()) {
+                $value = true;
+            }
+        }
+
+        if ($option->isArray()) {
+            $this->options[$name][] = $value;
+        } else {
+            $this->options[$name] = $value;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFirstArgument()
+    {
+        foreach ($this->tokens as $token) {
+            if ($token && '-' === $token[0]) {
+                continue;
+            }
+
+            return $token;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasParameterOption($values, $onlyParams = false)
+    {
+        $values = (array) $values;
+
+        foreach ($this->tokens as $token) {
+            if ($onlyParams && '--' === $token) {
+                return false;
+            }
+            foreach ($values as $value) {
+                if ($token === $value || 0 === strpos($token, $value.'=')) {
+                    return true;
+                }
+
+/**
+ * Commented out until https://github.com/symfony/symfony/issues/25825 is resolved and released.
+ */
+//                if (0 === strpos($token, '-') && 0 !== strpos($token, '--')) {
+//                    $noValue = explode('=', $token);
+//                    $token = $noValue[0];
+//                    $searchableToken = str_replace('-', '', $token);
+//                    $searchableValue = str_replace('-', '', $value);
+//                    if ('' !== $searchableToken && '' !== $searchableValue && false !== strpos($searchableToken, $searchableValue)) {
+//                        return true;
+//                    }
+//                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameterOption($values, $default = false, $onlyParams = false)
+    {
+        $values = (array) $values;
+        $tokens = $this->tokens;
+
+        while (0 < count($tokens)) {
+            $token = array_shift($tokens);
+            if ($onlyParams && '--' === $token) {
+                return false;
+            }
+
+            foreach ($values as $value) {
+                if ($token === $value || 0 === strpos($token, $value.'=')) {
+                    if (false !== $pos = strpos($token, '=')) {
+                        return substr($token, $pos + 1);
+                    }
+
+                    return array_shift($tokens);
+                }
+            }
+        }
+
+        return $default;
+    }
+
+    /**
+     * Returns a stringified representation of the args passed to the command.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $tokens = array_map(function ($token) {
+            if (preg_match('{^(-[^=]+=)(.+)}', $token, $match)) {
+                return $match[1].$this->escapeToken($match[2]);
+            }
+
+            if ($token && '-' !== $token[0]) {
+                return $this->escapeToken($token);
+            }
+
+            return $token;
+        }, $this->tokens);
+
+        return implode(' ', $tokens);
+    }
+}


### PR DESCRIPTION
A private copy of ArgvInput (v3.4.2) that has commented out the poor section of hasParameterOption(). Is it OK for other versions of Sumfony to get this file, including Symfony2 users? If not, how to filter to just right installations?

ArgvInput has private members so seems like copying is the only way (thats what LessStrictArgvInput does as well).