### PR TITLE
Fix argument remapping. Limit remapping to first argument.

### DIFF
--- a/src/Preflight/ArgsRemapper.php
+++ b/src/Preflight/ArgsRemapper.php
@@ -27,9 +27,9 @@ class ArgsRemapper
     public function remap($argv)
     {
         $result = [];
-        $sawCommmand = false;
+        $sawCommand = false;
         foreach ($argv as $arg) {
-            $arg = $this->checkRemap($arg, $sawCommmand);
+            $arg = $this->checkRemap($arg, $sawCommand);
             if (isset($arg)) {
                 $result[] = $arg;
             }
@@ -41,12 +41,13 @@ class ArgsRemapper
      * Check to see if the provided single arg needs to be remapped. If
      * it does, then the remapping is performed.
      *
-     * @param stinrg $arg One arguent to inspect
+     * @param string $arg One argument to inspect
+     * @param string $sawCommand True if drush command was found
      * @return string The altered argument
      */
-    protected function checkRemap($arg, &$sawCommmand)
+    protected function checkRemap($arg, &$sawCommand)
     {
-        if (!$sawCommmand && ctype_alpha($arg[0])) {
+        if (!$sawCommand && ctype_alpha($arg[0])) {
             $sawCommand = true;
             return $this->remapCommandAlias($arg);
         }

--- a/tests/ArgsRemapperTest.php
+++ b/tests/ArgsRemapperTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Unish;
+
+use \Drush\Preflight\argsRemapper;
+
+/**
+ * Tests the Arguments Remapper.
+ *
+ * @group base
+ */
+class ArgsRemapperTest extends CommandUnishTestCase
+{
+
+    /**
+     * @covers argsRemapper::ArgsRemapper
+     * @dataProvider argsProvider
+     */
+    public function testCommandAliases($argv, $expected)
+    {
+        $remapOptions = [];
+        $remapCommandAliases = [
+            'en' => 'pm:enable'
+        ];
+        $sut = new ArgsRemapper($remapOptions, $remapCommandAliases);
+        $result = $sut->remap($argv);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Provides argumens for ::ArgsRemapper
+     */
+    public function argsProvider()
+    {
+        return [
+            [
+                ['en', 'en'],
+                ['pm:enable', 'en'],
+            ],
+        ];
+    }
+}

--- a/tests/ArgsRemapperTest.php
+++ b/tests/ArgsRemapperTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use \Drush\Preflight\argsRemapper;
+use \Drush\Preflight\ArgsRemapper;
 
 /**
  * Tests the Arguments Remapper.


### PR DESCRIPTION
Fixes #3295 by limiting the remapping to the first argument (properly).