### PR TITLE
Stop all processing of queue on SuspendQueueException

### DIFF
--- a/lib/Drush/Queue/Queue8.php
+++ b/lib/Drush/Queue/Queue8.php
@@ -65,9 +65,10 @@ class Queue8 extends QueueBase {
       }
       catch (SuspendQueueException $e) {
         // If the worker indicates there is a problem with the whole queue,
-        // release the item and skip to the next queue.
+        // release the item and stop further processing.
         $queue->releaseItem($item);
         drush_set_error('DRUSH_SUSPEND_QUEUE_EXCEPTION', $e->getMessage());
+        break;
       }
       catch (\Exception $e) {
         // In case of any other kind of exception, log it and leave the item


### PR DESCRIPTION
If a SuspendQueueException is thrown when processing an item the current
implementation will release the item and log an error. Processing of the
queue continues.

According to the documentation of the SuspendQueueException throwing 
this exception indicates that processing of the whole queue should be skipped.

This change breaks the queue item processing loop entirely after logging
the error.

The associated code comment is also updated as it does not make sense.
The queue run command only runs for a single queue so there is nothing
to skip to.