### PR TITLE
Support Symfony Process 3.4 Unish environment variables

### DIFF
--- a/tests/AnnotatedCommandTest.php
+++ b/tests/AnnotatedCommandTest.php
@@ -42,9 +42,9 @@ class AnnotatedCommandCase extends CommandUnishTestCase
         ];
 
         $original = getenv('SHELL_INTERACTIVE');
-        putenv('SHELL_INTERACTIVE=1');
+        $this->setEnv(['SHELL_INTERACTIVE' => 1]);
         $this->drush('generate', ['foo-example'], $options);
-        putenv('SHELL_INTERACTIVE=' . $original);
+        $this->setEnv(['SHELL_INTERACTIVE' => $original]);
 
         $target = Path::join($this->webroot(), 'foo.php');
         $actual = trim(file_get_contents($target));
@@ -74,9 +74,9 @@ class AnnotatedCommandCase extends CommandUnishTestCase
         $optionsExample['directory'] = self::getSandbox();
         $optionsExample['yes'] = null;
         $original = getenv('SHELL_INTERACTIVE');
-        putenv('SHELL_INTERACTIVE=1');
+        $this->setEnv(['SHELL_INTERACTIVE' => 1]);
         $this->drush('generate', ['woot-example'], $optionsExample);
-        putenv('SHELL_INTERACTIVE=' . $original);
+        $this->setEnv(['SHELL_INTERACTIVE' => $original]);
         $target = Path::join(self::getSandbox(), '/src/Commands/ExampleBarCommands.php');
         $actual = trim(file_get_contents($target));
         $this->assertEquals('ExampleBarCommands says Woot mightily.', $actual);

--- a/tests/UnishTestCase.php
+++ b/tests/UnishTestCase.php
@@ -157,17 +157,16 @@ abstract class UnishTestCase extends \PHPUnit_Framework_TestCase
         self::$sandbox = $unish_sandbox;
         self::$usergroup = isset($GLOBALS['UNISH_USERGROUP']) ? $GLOBALS['UNISH_USERGROUP'] : null;
 
-        putenv("CACHE_PREFIX=" . $unish_cache);
+        self::setEnv(['CACHE_PREFIX' => $unish_cache]);
         $home = $unish_sandbox . '/home';
-        putenv("HOME=$home");
-        putenv("HOMEDRIVE=$home");
+        self::setEnv(['HOME' => $home]);
+        self::setEnv(['HOMEDRIVE' => $home]);
         $composer_home = $unish_cache . '/.composer';
-        putenv("COMPOSER_HOME=$composer_home");
-
-        putenv('ETC_PREFIX=' . $unish_sandbox);
-        putenv('SHARE_PREFIX=' . $unish_sandbox);
-        putenv('TEMP=' . Path::join($unish_sandbox, 'tmp'));
-        putenv('DRUSH_AUTOLOAD_PHP=' . PHPUNIT_COMPOSER_INSTALL);
+        self::setEnv(['COMPOSER_HOME' => $composer_home]);
+        self::setEnv(['ETC_PREFIX' => $unish_sandbox]);
+        self::setEnv(['SHARE_PREFIX' => $unish_sandbox]);
+        self::setEnv(['TEMP' => Path::join($unish_sandbox, 'tmp')]);
+        self::setEnv(['DRUSH_AUTOLOAD_PHP' => PHPUNIT_COMPOSER_INSTALL]);
     }
 
     /**
@@ -641,5 +640,22 @@ EOT;
     public function drupalSitewideDirectory()
     {
         return '/sites/all';
+    }
+
+    /**
+     * Set environment variables that should be passed to child processes.
+     *
+     * @param array $vars
+     *   The variables to set.
+     *
+     *   We will change implementation to take advantage of https://github.com/symfony/symfony/pull/19053/files once we drop Symfony 2 compat.
+     */
+    public static function setEnv(array $vars)
+    {
+        foreach ($vars as $k => $v) {
+            putenv($k . '=' . $v);
+            // Value must be a string. See \Symfony\Component\Process\Process::getDefaultEnv.
+            $_SERVER[$k]= (string) $v;
+        }
     }
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -122,9 +122,9 @@ class UserCase extends CommandUnishTestCase
         ];
         $answers = json_encode($answers);
         $original = getenv('SHELL_INTERACTIVE');
-        putenv('SHELL_INTERACTIVE=1');
+        $this->setEnv(['SHELL_INTERACTIVE' => 1]);
         $this->drush('generate', ['content-entity'], ['answers' => $answers, 'directory' => Path::join(self::webroot(), 'modules/contrib')]);
-        putenv('SHELL_INTERACTIVE=' . $original);
+        $this->setEnv(['SHELL_INTERACTIVE' => $original]);
         $this->drush('pm-enable', ['text,unish_article']);
         // Create one unish_article owned by our example user.
         $this->drush('php-script', ['create_unish_articles'], ['script-path' => '../vendor/drush/drush/tests/resources']);


### PR DESCRIPTION
Set $_SERVER as well putenv() when setting env variables in Unish. This is apparently needed in new Process release. Possibly caused by https://github.com/symfony/symfony/pull/25559/files.

The new SetEnv() method will change its implementation once we drop Symfony 2 (March 2018)