### PR TITLE
sql-sanitize to generate random user password (fixes #3086)

### DIFF
--- a/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
@@ -5,6 +5,7 @@ use Consolidation\AnnotatedCommand\CommandData;
 use Drupal\Core\Database\Database;
 use Drush\Commands\DrushCommands;
 use Drush\Sql\SqlBase;
+use Drush\Utils\StringUtils;
 use Symfony\Component\Console\Input\InputInterface;
 
 /**
@@ -39,8 +40,13 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
 
         // Sanitize passwords.
         if ($this->isEnabled($options['sanitize-password'])) {
+            $password = $options['sanitize-password'];
+            if (is_null($password)) {
+                $password = StringUtils::generatePassword();
+            }
+
             // Mimic Drupal's /scripts/password-hash.sh
-            $hash = $this->passwordHasher->hash($options['sanitize-password']);
+            $hash = $this->passwordHasher->hash($password);
             $query->fields(['pass' => $hash]);
             $messages[] = dt('User passwords sanitized.');
         }
@@ -86,7 +92,7 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
      * @option sanitize-password The password to assign to all accounts in the
      *   sanitization operation, or "no" to keep passwords unchanged.
      */
-    public function options($options = ['sanitize-email' => 'user+%uid@localhost.localdomain', 'sanitize-password' => 'password'])
+    public function options($options = ['sanitize-email' => 'user+%uid@localhost.localdomain', 'sanitize-password' => NULL])
     {
     }
 


### PR DESCRIPTION
Use StringUtils::generatePassword() to generate a random password when not provided.