### PR TITLE
Fix infinite loop of dispatching when drupal root in symlinked.

### DIFF
--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -268,7 +268,7 @@ class Preflight
         // a site-local Drush. If there is, we will redispatch to it.
         // NOTE: termination handlers have not been set yet, so it is okay
         // to exit early without taking special action.
-        $status = RedispatchToSiteLocal::redispatchIfSiteLocalDrush($argv, $root, $this->environment->vendorPath(), $this->logger())    ;
+        $status = RedispatchToSiteLocal::redispatchIfSiteLocalDrush($argv, realpath($root), $this->environment->vendorPath(), $this->logger())    ;
         if ($status !== false) {
             return $status;
         }


### PR DESCRIPTION
Fix infinite loop of dispatching when drupal root lives in a symlinked directory.

### Description:
- when I have a d8 installation like /home/vagrant/sites/d8 where   /home/vagrant/sites -> /var/www/
- Path::isBasePath keeps returning false. 
- This causes constant dispatching and an infinite loop with messages . `[preflight] Redispatch to site-local Drush: /home/vagrant/sites/d8/vendor/drush/drush/drush.`

Fixes : #2755 