### PR TITLE
Fixes #3351: site-install Drupal 7 with PHP 7.2

### DIFF
--- a/includes/output.inc
+++ b/includes/output.inc
@@ -36,6 +36,11 @@ function drush_print($message = '', $indent = 0, $handle = NULL, $newline = TRUE
   }
   if (!isset($handle)) {
     $handle = STDOUT;
+    // In the past, Drush would use `print` here; now that we are using
+    // fwrite (to avoid problems with php sending the http headers), we
+    // must explicitly capture the output, because ob_start() / ob_end()
+    // does not capture output written via fwrite to STDOUT.
+    drush_backend_output_collect($msg);
   }
   fwrite($handle, $msg);
 }

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -34,12 +34,10 @@ function drush_print($message = '', $indent = 0, $handle = NULL, $newline = TRUE
   if (($charset = drush_get_option('output_charset')) && function_exists('iconv')) {
     $msg = iconv('UTF-8', $charset, $msg);
   }
-  if (isset($handle)) {
-    fwrite($handle, $msg);
+  if (!isset($handle)) {
+    $handle = STDOUT;
   }
-  else {
-    print $msg;
-  }
+  fwrite($handle, $msg);
 }
 
 /**


### PR DESCRIPTION
Always use 'fwrite' instead of 'print' in 'drush_print' to avoid undesired interaction with PHP's handling of the php headers.