### PR TITLE
Environment variables are prepended to Drush command in the wrong order

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -135,10 +135,11 @@ function drush_build_drush_command($drush_path = NULL, $php = NULL, $os = NULL, 
 
   // Add environmental variables, if present
   if (!empty($environment_variables)) {
-    $prefix .= ' env';
+    $env = 'env';
     foreach ($environment_variables as $key=>$value) {
-      $prefix .= ' ' . drush_escapeshellarg($key, $os) . '=' . drush_escapeshellarg($value, $os);
+      $env .= ' ' . drush_escapeshellarg($key, $os) . '=' . drush_escapeshellarg($value, $os);
     }
+    $prefix = $env . ' ' . $prefix;
   }
 
   return trim($prefix . ' ' . drush_escapeshellarg($drush_path, $os) . $additional_options);

--- a/tests/BackendTest.php
+++ b/tests/BackendTest.php
@@ -28,6 +28,9 @@ class BackendCase extends CommandUnishTestCase
                 'paths' => [
                     'drush-script' => '/usr/local/bin/drush',
                 ],
+                '#env-vars' => [
+                    'TEST_VAR' => 'test_value'
+                ],
             ],
         ];
         // n.b. writeUnishConfig will overwrite the alias files create by setupDrupal
@@ -41,7 +44,7 @@ class BackendCase extends CommandUnishTestCase
         $output = preg_replace('#  *#', ' ', $output);
         $output = preg_replace('# -t #', ' ', $output); // volkswagon away the -t, it's not relevant to what we're testing here
         $output = preg_replace('#' . self::getSandbox() . '#', '__SANDBOX__', $output);
-        $this->assertContains("Simulating backend invoke: ssh -o PasswordAuthentication=no www-admin@server.isp.com '/usr/local/bin/drush --alias-path=__SANDBOX__/etc/drush/sites --root=/path/to/drupal --uri=http://example.com --no-interaction status", $output);
+        $this->assertContains("Simulating backend invoke: ssh -o PasswordAuthentication=no www-admin@server.isp.com 'env TEST_VAR=test_value /usr/local/bin/drush --alias-path=__SANDBOX__/etc/drush/sites --root=/path/to/drupal --uri=http://example.com --no-interaction status", $output);
     }
 
     /**

--- a/tests/resources/alias-fixtures/drupalvm.aliases.drushrc.php
+++ b/tests/resources/alias-fixtures/drupalvm.aliases.drushrc.php
@@ -15,6 +15,9 @@ $aliases['drupalvm.dev'] = [
   'path-aliases' => [
     '%drush-script' => '/var/www/drupalvm/drupal/vendor/drush/drush/drush',
   ],
+  '#env-vars' => [
+    'TEST_VAR' => 'Test environment variable value',
+  ],
 ];
 
 $aliases['www.drupalvm.dev'] = [
@@ -25,5 +28,8 @@ $aliases['www.drupalvm.dev'] = [
   'ssh-options' => '-o PasswordAuthentication=no -i ' . '/.vagrant.d/insecure_private_key',
   'path-aliases' => [
     '%drush-script' => '/var/www/drupalvm/drupal/vendor/drush/drush/drush',
+  ],
+  '#env-vars' => [
+    'TEST_VAR' => 'Test environment variable value',
   ],
 ];


### PR DESCRIPTION
`drush_build_drush_build_command()` adds environment variables in the wrong place within the command string. For example, if I have an alias like:

```php
$aliases['example'] = [
  '#env-vars' => [
    'FOO' => 'bar',
  ],
];
```

And Drush is loaded via Composer so that its path is something like:

```sh
~/.composer/vendor/drush-ops/drush/drush.php
```

`drush_build_drush_build_command()` will construct a command string that looks like:

```sh
/usr/local/bin/php  -c /etc/php/php.ini env FOO=bar --php=/usr/local/bin/php --php-options=' -c /etc/php/php.ini'
```

This will lead to Drush failing to execute any commands for that alias with the error:

> Could not open input file: env

Because the command trying to load a file named `env` into PHP.

The correct command string should be instead:

```sh
env FOO=bar /usr/local/bin/php  -c /etc/php/php.ini--php=/usr/local/bin/php --php-options=' -c /etc/php/php.ini'
```

Original issue: https://github.com/drush-ops/drush/issues/3078
h/t @axel-rutz for the solution, posted here: https://github.com/axel-rutz/drush/commit/c41235578ab3f9ff6b0dacae3d45a48b3dfae08e