### PR TITLE
Clarify namespaces in command authoring docs.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -45,7 +45,7 @@ In Drush 9, the default services file, `drush.services.yml`, will be used in ins
 Global Drush Commands
 ==============================
 
-Commandfiles that don't ship inside Drupal modules are called 'global' commandfiles. See the examples/Commands folder for examples. In general, its better to use modules to carry your Drush commands. If you still prefer using a global commandfiles, please note:
+Commandfiles that don't ship inside Drupal modules are called 'global' commandfiles. See the [examples/Commands](/examples/Commands) folder for examples. In general, its better to use modules to carry your Drush commands. If you still prefer using a global commandfiles, please note:
 
 1. The file's fully qualified namespace should be `\Drush\Commands`.
 1. The filename must be have a name like Commands/FooCommands.php

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,7 +47,7 @@ Global Drush Commands
 
 Commandfiles that don't ship inside Drupal modules are called 'global' commandfiles. See the examples/Commands folder for examples. In general, its better to use modules to carry your Drush commands. If you still prefer using a global commandfiles, please note:
 
-1. The file's fully qualifed namespace should be `\Drush\Commands`.
+1. The file's fully qualified namespace should be `\Drush\Commands`.
 1. The filename must be have a name like Commands/FooCommands.php
     1. The prefix `Foo` can be whatever string you want. The file must end in `Commands.php`
     1. The enclosing directory must be named `Commands`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,7 +47,7 @@ Global Drush Commands
 
 Commandfiles that don't ship inside Drupal modules are called 'global' commandfiles. See the examples/Commands folder for examples. In general, its better to use modules to carry your Drush commands. If you still prefer using a global commandfiles, please note:
 
-1. The file's namespace should be `\Drush\Commands`.
+1. The file's fully qualifed namespace should be `\Drush\Commands`.
 1. The filename must be have a name like Commands/FooCommands.php
     1. The prefix `Foo` can be whatever string you want. The file must end in `Commands.php`
     1. The enclosing directory must be named `Commands`


### PR DESCRIPTION
Resolves #3366 

The current docs aren't really incorrect but this might help clarify things for future use. @Skarlso see: http://php.net/manual/en/language.namespaces.rules.php