### PR TITLE
Add --result-file-auto to save to a date-based filename under ~/drush-backups directory

### DIFF
--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -195,8 +195,7 @@ class SqlCommands extends DrushCommands
      * @aliases sql-dump
      * @optionset_sql
      * @optionset_table_selection
-     * @option result-file Save to a file. The file should be relative to Drupal root.
-     * @option result-file-auto Save to a date-based filename under ~/drush-backups directory.
+     * @option result-file Save to a file. The file should be relative to Drupal root. If --result-file is provided with the value 'auto', a date-based filename will be created under ~/drush-backups directory.
      * @option create-db Omit DROP TABLE statements. Used by Postgres and Oracle only.
      * @option data-only Dump data without statements to create any of the schema.
      * @option ordered-dump Order by primary key and add line breaks for efficient diffs. Slows down the dump. Mysql only.

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -196,6 +196,7 @@ class SqlCommands extends DrushCommands
      * @optionset_sql
      * @optionset_table_selection
      * @option result-file Save to a file. The file should be relative to Drupal root.
+     * @option result-file-auto Save to a date-based filename under ~/drush-backups directory.
      * @option create-db Omit DROP TABLE statements. Used by Postgres and Oracle only.
      * @option data-only Dump data without statements to create any of the schema.
      * @option ordered-dump Order by primary key and add line breaks for efficient diffs. Slows down the dump. Mysql only.

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -135,10 +135,9 @@ class SqlBase implements ConfigAwareInterface
     {
         /** @var string|bool $file Path where dump file should be stored. If TRUE, generate a path based on usual backup directory and current date.*/
         $file = $this->getOption('result-file');
-        $file_auto = $this->getOption('result-file-auto');
         $file_suffix = '';
         $table_selection = $this->getExpandedTableSelection($this->getOptions(), $this->listTables());
-        $file = $this->dumpFile($file ? $file: $file_auto);
+        $file = $this->dumpFile($file);
         $cmd = $this->dumpCmd($table_selection);
         // Gzip the output from dump command(s) if requested.
         if ($this->getOption('gzip')) {
@@ -186,10 +185,10 @@ class SqlBase implements ConfigAwareInterface
         $database = $this->dbSpec['database'];
 
         // $file is passed in to us usually via --result-file.  If the user
-        // has set $options['result-file-auto'] = TRUE, then we
+        // has set $options['result-file'] = 'auto', then we
         // will generate an SQL dump file in the backup directory.
         if ($file) {
-            if ($file === true) {
+            if ($file === 'auto') {
                 $backup_dir = FsUtils::prepareBackupDir($database);
                 if (empty($backup_dir)) {
                     $backup_dir = $this->getConfig()->tmp();

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -135,9 +135,10 @@ class SqlBase implements ConfigAwareInterface
     {
         /** @var string|bool $file Path where dump file should be stored. If TRUE, generate a path based on usual backup directory and current date.*/
         $file = $this->getOption('result-file');
+        $file_auto = $this->getOption('result-file-auto');
         $file_suffix = '';
         $table_selection = $this->getExpandedTableSelection($this->getOptions(), $this->listTables());
-        $file = $this->dumpFile($file);
+        $file = $this->dumpFile($file ? $file: $file_auto);
         $cmd = $this->dumpCmd($table_selection);
         // Gzip the output from dump command(s) if requested.
         if ($this->getOption('gzip')) {
@@ -185,7 +186,7 @@ class SqlBase implements ConfigAwareInterface
         $database = $this->dbSpec['database'];
 
         // $file is passed in to us usually via --result-file.  If the user
-        // has set $options['result-file'] = TRUE, then we
+        // has set $options['result-file-auto'] = TRUE, then we
         // will generate an SQL dump file in the backup directory.
         if ($file) {
             if ($file === true) {


### PR DESCRIPTION
Fixes #3364.

Drush 9 has lost a Drush 8 feature:

* If `--result-file` is provided with no value, then a date-based filename will be created under ~/drush-backups directory.

That's a really useful option for automated backups, but Symfony Console makes it hard to work with options that can be both Boolean and a string.

This PR adds a new `--result-file-auto` Boolean option to resurrect this.

If both `--result-file` and `--result-file-auto` are given, `--result-file` takes precedence.

![image](https://user-images.githubusercontent.com/1324225/35979066-020ab782-0cf0-11e8-979c-25f027bb5076.png)

Does something like this look like a possible solution to #3364?
