### PR TITLE
#3383 - fix label not being used for drush config:import command

### DIFF
--- a/src/Drupal/Commands/config/ConfigImportCommands.php
+++ b/src/Drupal/Commands/config/ConfigImportCommands.php
@@ -159,24 +159,10 @@ class ConfigImportCommands extends DrushCommands
      */
     public function import($label = null, $options = ['preview' => 'list', 'source' => self::REQ, 'partial' => false, 'diff' => false])
     {
-        global $config_directories;
-
         // Determine source directory.
 
-        if ($target = $options['source']) {
-            if ($label) {
-                $this->logger()->notice('Ambiguous config source: both config label and source path provided. Using path specified as source.');
-            }
-            $source_storage = new FileStorage($target);
-        } else if ($label) {
-            if (array_key_exists($label, $config_directories)) {
-                $source_storage = new FileStorage($config_directories[$label]);
-            }
-        }
-
-        if (!isset($source_storage)) {
-            $source_storage = $this->getConfigStorageSync();
-        }
+        $source_storage_dir = ConfigCommands::getDirectory($label, $options['source']);
+        $source_storage = new FileStorage($source_storage_dir);
 
         // Determine $source_storage in partial case.
         $active_storage = $this->getConfigStorage();

--- a/src/Drupal/Commands/config/ConfigImportCommands.php
+++ b/src/Drupal/Commands/config/ConfigImportCommands.php
@@ -159,10 +159,22 @@ class ConfigImportCommands extends DrushCommands
      */
     public function import($label = null, $options = ['preview' => 'list', 'source' => self::REQ, 'partial' => false, 'diff' => false])
     {
+        global $config_directories;
+
         // Determine source directory.
+
         if ($target = $options['source']) {
+            if ($label) {
+                $this->logger()->notice('Ambiguous config source: both config label and source path provided. Using path specified as source.');
+            }
             $source_storage = new FileStorage($target);
-        } else {
+        } else if ($label) {
+            if (array_key_exists($label, $config_directories)) {
+                $source_storage = new FileStorage($config_directories[$label]);
+            }
+        }
+
+        if (!isset($source_storage)) {
             $source_storage = $this->getConfigStorageSync();
         }
 


### PR DESCRIPTION
This commit fixes the issue by looking for the label in ConfigImportCommands.php's import function. If the label exists, it uses the config directory specified in $config_directories in settings.php for that label (as described in [the documentation](https://drushcommands.com/drush-9x/config/config:import/)). If the source option is specified, it uses that but outputs a notice mentioning what happened.

This fix should retain all existing functionality, and allow users to once again use non-default directories by specifying them in the settings.php.
