### PR TITLE
SQL commands are bootstrapping too much. Should bootstrap to database.

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -127,17 +127,6 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         return true;
     }
 
-    public function bootstrapDrupalDatabaseValidate()
-    {
-        return parent::bootstrapDrupalDatabaseValidate() && $this->bootstrapDrupalDatabaseHasTable('key_value');
-    }
-
-    public function bootstrapDrupalDatabase()
-    {
-        // D8 omits this bootstrap level as nothing special needs to be done.
-        parent::bootstrapDrupalDatabase();
-    }
-
     public function bootstrapDrupalConfiguration(AnnotationData $annotationData = null)
     {
         // Default to the standard kernel.

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -18,7 +18,7 @@ class SqlCommands extends DrushCommands
      * @option all Show all database connections, instead of just one.
      * @option show-passwords Show database password.
      * @optionset_sql
-     * @bootstrap max
+     * @bootstrap database
      * @hidden
      */
     public function conf($options = ['format' => 'yaml', 'all' => false, 'show-passwords' => false])
@@ -49,7 +49,7 @@ class SqlCommands extends DrushCommands
      * @aliases sql-connect
      * @option extra Add custom options to the connect string (e.g. --extra=--skip-column-names)
      * @optionset_sql
-     * @bootstrap max
+     * @bootstrap database
      * @usage `drush sql-connect` < example.sql
      *   Bash: Import SQL statements from a file into the current database.
      * @usage eval (drush sql-connect) < example.sql
@@ -75,7 +75,7 @@ class SqlCommands extends DrushCommands
      *   Create the database as specified for @site.test.
      * @usage drush sql:create --db-su=root --db-su-pw=rootpassword --db-url="mysql://drupal_db_user:drupal_db_password@127.0.0.1/drupal_db"
      *   Create the database as specified in the db-url option.
-     * @bootstrap max
+     * @bootstrap database
      */
     public function create($options = ['db-su' => self::REQ, 'db-su-pw' => self::REQ])
     {
@@ -103,7 +103,7 @@ class SqlCommands extends DrushCommands
      * @command sql:drop
      * @aliases sql-drop
      * @optionset_sql
-     * @bootstrap max
+     * @bootstrap database
      * @topics docs:policy
      */
     public function drop($options = [])
@@ -131,7 +131,7 @@ class SqlCommands extends DrushCommands
      * @usage drush sql:cli --extra=-A
      *   Open a SQL CLI and skip reading table information.
      * @remote-tty
-     * @bootstrap max
+     * @bootstrap database
      */
     public function cli($options = [])
     {
@@ -161,7 +161,7 @@ class SqlCommands extends DrushCommands
      *   Import sql statements from a file into the current database.
      * @usage drush sql:query --file=example.sql
      *   Alternate way to import sql statements from a file.
-     * @bootstrap max
+     * @bootstrap database
      *
      */
     public function query($query = '', $options = ['result-file' => null, 'file' => self::REQ, 'extra' => self::REQ, 'db-prefix' => false])
@@ -209,7 +209,7 @@ class SqlCommands extends DrushCommands
      * @usage drush sql:dump --extra-dump=--no-data
      *   Pass extra option to mysqldump command.
      * @hidden-options create-db
-     * @bootstrap max
+     * @bootstrap database
      *
      * @notes
      *   createdb is used by sql-sync, since including the DROP TABLE statements interfere with the import when the database is created.


### PR DESCRIPTION
## Problem

Removing the tables from the database could run in trouble because, right now, the `sql:*` commands are doing a full Drupal bootstrap. In my project I have the case when I'm using `sql:drop` to drop all tables before doing a MySQL dump import. But the current DB content could be totally messed-up and, because we are fully bootstrapping, Drupal will try initialize the container, is crashing with exceptions regarding services (mostly services for modules not installed yet).

Also, it's clear that`sql:*` commands are operating at database level and they don't need the full Drupal to be bootstrapped.

## Proposal

1. Make all `sql:*` commands require DATABASE as maximum bootstrap level.
1. Remove the check for `key_value` table in Drupal database bootstrap validation. When running a SQL command, like dropping the tables, there's a big chance that the table doesn't exist making the bootstrap to fail. I have no idea what was the reason for checking if that table exists. I guess this was inherited from older Drush versions and it was a way to check if we're on a Drupal database. But at the database level we shouldn't be aware of that.