### PR TITLE
Fixes #3306: Make sure that rsync with %files resolves correctly

### DIFF
--- a/src/SiteAlias/HostPath.php
+++ b/src/SiteAlias/HostPath.php
@@ -179,8 +179,17 @@ class HostPath
         if (empty($pathAlias)) {
             return $this;
         }
+        // Make sure that the resolved path always ends in a '\'.
+        $resolvedPath .= '/';
+        // Avoid double / in path.
+        //   $this->path: %files/foo
+        //   $pathAlias:   files
+        // We add one to the length of $pathAlias to account for the '%' in $this->path.
+        if (strlen($this->path) > (strlen($pathAlias) + 1)) {
+            $resolvedPath = rtrim($resolvedPath, '/');
+        }
         // Once the path alias is resolved, replace the alias in the $path with the result.
-        $this->path = rtrim($resolvedPath, '/') . substr($this->path, strlen($pathAlias) + 1);
+        $this->path = $resolvedPath . substr($this->path, strlen($pathAlias) + 1);
 
         // Using a path alias such as %files is equivalent to making explicit
         // use of @self:%files. We set implicit to false here so that the resolved

--- a/tests/RsyncTest.php
+++ b/tests/RsyncTest.php
@@ -115,7 +115,7 @@ class RsyncCase extends CommandUnishTestCase
         $output = $this->getOutput();
         $level = $this->logLevel();
         $pattern = in_array($level, ['verbose', 'debug']) ? "Calling system(rsync -e 'ssh ' -akzv --stats --progress %s /tmp);" : "Calling system(rsync -e 'ssh ' -akz %s /tmp);";
-        $expected = sprintf($pattern, $this->webroot(). "/sites/$uri/files");
+        $expected = sprintf($pattern, $this->webroot(). "/sites/$uri/files/");
         $this->assertEquals($expected, $output);
     }
 }


### PR DESCRIPTION
%files should resolve to `sites/default/files/` as it historically has, not `sites/default/files`.

With this PR:
```
$ ./sut -s rsync %files /tmp
Calling system(rsync -e 'ssh ' -akz /PATH/sites/dev/files/ /tmp);
$ ./sut -s rsync %files/ /tmp
Calling system(rsync -e 'ssh ' -akz /PATH/sites/dev/files/ /tmp);
$ ./sut -s rsync %files/foo /tmp
Calling system(rsync -e 'ssh ' -akz /PATH/sites/dev/files/foo /tmp);
$ ./sut -s rsync %files/foo/ /tmp
Calling system(rsync -e 'ssh ' -akz /PATH/sites/dev/files/foo/ /tmp);
```

This may need backporting to Drush 8, as I am seeing the `/` being dropped there as well. Drush 7 isn't working for me right now.