### PR TITLE
Make sure that site alias manager is inflected for command objects that need it.

### DIFF
--- a/src/Boot/BaseBoot.php
+++ b/src/Boot/BaseBoot.php
@@ -114,6 +114,8 @@ abstract class BaseBoot implements Boot, LoggerAwareInterface, ContainerAwareInt
 
     protected function inflect($object)
     {
+        // See \Drush\Runtime\DependencyInjection::addDrushServices and
+        // \Robo\Robo\addInflectors
         $container = $this->getContainer();
         if ($object instanceof \Robo\Contract\ConfigAwareInterface) {
             $object->setConfig($container->get('config'));
@@ -138,6 +140,9 @@ abstract class BaseBoot implements Boot, LoggerAwareInterface, ContainerAwareInt
         }
         if ($object instanceof \Robo\Contract\VerbosityThresholdInterface) {
             $object->setOutputAdapter($container->get('outputAdapter'));
+        }
+        if ($object instanceof \Drush\SiteAlias\SiteAliasManagerAwareInterface) {
+            $object->setOutputAdapter($container->get('site.alias.manager'));
         }
     }
 

--- a/src/Runtime/DependencyInjection.php
+++ b/src/Runtime/DependencyInjection.php
@@ -101,7 +101,7 @@ class DependencyInjection
             ->withMethodCall('addSearchLocation', ['CommandFiles'])
             ->withMethodCall('setSearchPattern', ['#.*(Commands|CommandFile).php$#']);
 
-        // Add inflectors
+        // Add inflectors. @see \Drush\Boot\BaseBoot::inflect
         $container->inflector(\Drush\Boot\AutoloaderAwareInterface::class)
             ->invokeMethod('setAutoloader', ['loader']);
         $container->inflector(\Drush\SiteAlias\SiteAliasManagerAwareInterface::class)


### PR DESCRIPTION
The problem is that League/Container does not provide public access to the inflectors, so we need to remember to update our duplicate inflection method when new services are added to the container as inflectors.