### PR TITLE
Fix #3417. sql-sync dump filename not automatically generated

### DIFF
--- a/.circleci/setup.sh
+++ b/.circleci/setup.sh
@@ -30,6 +30,7 @@ echo 'mbstring.http_output = pass' >> $HOME/php.ini
 echo 'memory_limit = -1' >> $HOME/php.ini
 echo 'sendmail_path = /bin/true' >> $HOME/php.ini
 echo 'date.timezone = "UTC"' >> $HOME/php.ini
+echo 'opcache.enable_cli = 0' >> $HOME/php.ini
 
 # Copy our php.ini configuration to the active php.ini file
 # We can't use `php -r 'print php_ini_loaded_file();` when there is no php.ini

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -214,7 +214,7 @@ class SqlCommands extends DrushCommands
      * @notes
      *   createdb is used by sql-sync, since including the DROP TABLE statements interfere with the import when the database is created.
      */
-    public function dump($options = ['result-file' => null, 'create-db' => false, 'data-only' => false, 'ordered-dump' => false, 'gzip' => false, 'extra' => self::REQ, 'extra-dump' => self::REQ])
+    public function dump($options = ['result-file' => self::REQ, 'create-db' => false, 'data-only' => false, 'ordered-dump' => false, 'gzip' => false, 'extra' => self::REQ, 'extra-dump' => self::REQ])
     {
         $sql = SqlBase::create($options);
         if ($sql->dump() === false) {

--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -136,7 +136,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
     {
         $dump_options = $global_options + [
             'gzip' => true,
-            'result-file' => $options['source-dump'] ?: true,
+            'result-file' => $options['source-dump'] ?: 'auto',
         ];
         if (!$options['no-dump']) {
             $this->logger()->notice(dt('Starting to dump database on source.'));


### PR DESCRIPTION
One downside of this fix is that running this code with a prior version of Drush will cause your dump files to be names `auto` instead of date based backups. I think mismatched Drush versions are a lot less common now that we are local to the project.