### PR TITLE
Do not allow drush to run a command in preflight successfully and again in the regular bootstrap

### DIFF
--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -643,6 +643,14 @@ function drush_preflight_command_dispatch() {
   // remote command dispatching and site-list command dispatching, and always let
   // the command handler run on the local machine.
   if (is_array($command) && !empty($command['handle-remote-commands'])) {
+    if (isset($values)) {
+      if (is_array($values) && ($values['error_status'] > 0)) {
+        // Force an error result code.  Note that drush_shutdown() will still run.
+        drush_set_context('DRUSH_EXECUTION_COMPLETED', TRUE);
+        exit($values['error_status']);
+      }
+      return TRUE;
+    }
     return FALSE;
   }
   if (isset($remote_host)) {


### PR DESCRIPTION
We discovered that drush uli in certain circumstances will execute twice.
I'll show it with drush -vd. I'm not sure if the bug also exists in Drush 9.

The server has a global drush 8.1.16 and the vendor folder of the project also has a drush executable.

`$ drush8 @myproject.dev uli -vd`

```
Using the Drush script found at /usr/local/src/drush8/drush.launcher using pcntl_exec
Drush preflight prepare loaded autoloader at                         [preflight]
/usr/local/src/drush8/vendor/autoload.php [0.01 sec, 2.45 MB]
Starting Drush preflight. [0.01 sec, 2.45 MB]                                                                                                                                                                                                                      [preflight]
Cache HIT cid: 8.1.16-commandfiles-0-5e6df3b528f4f0f3e00472493f0eb7de [0.01 sec, 2.73 MB]                                                                                                                                                                              [debug]
Scanning into /etc/drush for /.*aliases\.drush(8|)rc\.php$/ [0.04 sec, 5 MB]                                                                                                                                                                                           [debug]
...
Loaded alias @myproject.dev from file /etc/drush/myproject.aliases.drushrc.php [2.12 sec, 7.3 MB]                                                                                                                                                           [notice]
Begin redispatch via drush_invoke_process(). [2.12 sec, 7.31 MB]                                                                                                                                                                                                      [notice]
Backend invoke: env COLUMNS=270  /var/www/customprojects_D8/myproject/dev/vendor/drush/drush/drush.launcher  --root=/var/www/customprojects_D8/myproject/dev/docroot --verbose --debug  user-login 2>&1 [2.13 sec, 7.31 MB]                                [command]
Calling proc_open(env COLUMNS=270  /var/www/customprojects_D8/myproject/dev/vendor/drush/drush/drush.launcher  --root=/var/www/customprojects_D8/myproject/dev/docroot --verbose --debug  user-login 2>&1);
Drush preflight prepare loaded autoloader at                         [preflight]
/var/www/customprojects_D8/myproject/dev/vendor/autoload.php
[0.01 sec, 2.75 MB]
Starting Drush preflight. [0.01 sec, 2.75 MB]                                                                                                                                                                                                                      [preflight]
Cache HIT cid: 8.1.16-commandfiles-0-7d604cc7822369e48675695b14fcf8b3 [0.01 sec, 2.97 MB]                                                                                                                                                                              [debug]
Scanning into /etc/drush for /.*aliases\.drush(8|)rc\.php$/ [0.04 sec, 5.31 MB]                                                                                                                                                                                        [debug]
...
Scanning into /var/www/customprojects_D8/myproject/dev/docroot/sites/default for /.*\.alias\.drush(8|)rc\.php$/ [0.91 sec, 5.96 MB]                                                                                                                               [debug]
Bootstrap to phase 0. [0.94 sec, 7.78 MB]                                                                                                                                                                                                                          [bootstrap]
Bootstrap to phase -1. [0.94 sec, 7.79 MB]                                                                                                                                                                                                                         [bootstrap]
Found command: user-login (commandfile=user) [0.94 sec, 7.79 MB]                                                                                                                                                                                                   [bootstrap]
Calling hook drush_user_login [0.95 sec, 7.96 MB]                                                                                                                                                                                                                      [debug]
Drush bootstrap phase : bootstrap_drupal_root() [0.95 sec, 8.16 MB]                                                                                                                                                                                                [bootstrap]
Initialized Drupal 8.3.7 root directory at /var/www/customprojects_D8/myproject/dev/docroot [0.95 sec, 8.16 MB]                                                                                                                                               [bootstrap]
Find command files for phase 1 (max=) [0.95 sec, 6.96 MB]                                                                                                                                                                                                              [debug]
Cache HIT cid: 8.1.16-commandfiles-1-ba664f64d08f5fadbd1880c26872e847 [0.95 sec, 6.96 MB]                                                                                                                                                                              [debug]
Cache HIT cid: 8.1.16-annotationfiles-1-fd5c348feaf38b2bd39b8ca5bc9f020a [0.95 sec, 7.03 MB]                                                                                                                                                                           [debug]
Scanning into /etc/drush for /.*aliases\.drush(8|)rc\.php$/ [0.95 sec, 7.04 MB]                                                                                                                                                                                        [debug]
...
Drush bootstrap phase : bootstrap_drupal_site() [1.8 sec, 7.87 MB]                                                                                                                                                                                                 [bootstrap]
Initialized Drupal site default at sites/default [1.8 sec, 7.87 MB]                                                                                                                                                                                                [bootstrap]
Find command files for phase 2 (max=) [1.81 sec, 7.87 MB]                                                                                                                                                                                                              [debug]
Cache HIT cid: 8.1.16-install_profile-66ecfeb9791a023150773849f1550c5d [1.81 sec, 7.87 MB]                                                                                                                                                                             [debug]
Cache HIT cid: 8.1.16-commandfiles-2-38b2b113566a80e626eb4bcef07b27a5 [1.81 sec, 7.88 MB]                                                                                                                                                                              [debug]
Drush bootstrap phase : bootstrap_drupal_configuration() [1.82 sec, 8.72 MB]                                                                                                                                                                                       [bootstrap]
Create from request [1.82 sec, 8.73 MB]                                                                                                                                                                                                                                [debug]
add service modifier [1.83 sec, 8.87 MB]                                                                                                                                                                                                                               [debug]
Find command files for phase 3 (max=) [1.83 sec, 8.87 MB]                                                                                                                                                                                                              [debug]
sql-query: SELECT 1; [1.83 sec, 8.94 MB]                                                                                                                                                                                                                              [notice]
Executing: mysql --defaults-extra-file=/tmp/drush_8v45Mv --database=myproject_dev --host=localhost --silent  < /tmp/drush_j8kVtR
  1
sql-query: SHOW TABLES; [1.84 sec, 8.94 MB]                                                                                                                                                                                                                           [notice]
Executing: mysql --defaults-extra-file=/tmp/drush_QRjksO --database=myproject_dev --host=localhost --silent  < /tmp/drush_9xzH79
  batch
  block_content
  ...
  webform_submission_log
Drush bootstrap phase : bootstrap_drupal_database() [1.85 sec, 8.98 MB]                                                                                                                                                                                            [bootstrap]
Successfully connected to the Drupal database. [1.85 sec, 8.98 MB]                                                                                                                                                                                                 [bootstrap]
Find command files for phase 4 (max=) [1.85 sec, 8.98 MB]                                                                                                                                                                                                              [debug]
Drush bootstrap phase : bootstrap_drupal_full() [1.85 sec, 8.98 MB]                                                                                                                                                                                                [bootstrap]
About to bootstrap the Drupal 8 Kernel. [1.85 sec, 8.98 MB]                                                                                                                                                                                                            [debug]
Finished bootstraping the Drupal 8 Kernel. [1.96 sec, 18.26 MB]                                                                                                                                                                                                        [debug]
Cache HIT cid: 8.1.16-install_profile-66ecfeb9791a023150773849f1550c5d [1.96 sec, 18.41 MB]                                                                                                                                                                            [debug]
Find command files for phase 5 (max=) [1.96 sec, 18.45 MB]                                                                                                                                                                                                             [debug]
Cache HIT cid: 8.1.16-install_profile-66ecfeb9791a023150773849f1550c5d [1.96 sec, 18.45 MB]                                                                                                                                                                            [debug]
Cache HIT cid: 8.1.16-commandfiles-5-142609b618088311257818c000f9ce93 [1.96 sec, 18.74 MB]                                                                                                                                                                             [debug]
No graphical display appears to be available, not starting browser. [2.03 sec, 24.87 MB]                                                                                                                                                                              [notice]
Returned from hook drush_user_login [2.03 sec, 24.86 MB]                                                                                                                                                                                                               [debug]
http://default/en/user/reset/1/1519894250/<obfuscated>/login
Command dispatch complete [2.03 sec, 24.81 MB]                                                                                                                                                                                                                        [notice]
End redispatch via drush_invoke_process(). [4.27 sec, 7.31 MB]                                                                                                                                                                                                        [notice]
Bootstrap to phase 0. [4.27 sec, 7.3 MB]                                                                                                                                                                                                                           [bootstrap]
Bootstrap to phase -1. [4.27 sec, 7.31 MB]                                                                                                                                                                                                                         [bootstrap]
Found command: user-login (commandfile=user) [4.27 sec, 7.31 MB]                                                                                                                                                                                                   [bootstrap]
Calling hook drush_user_login [4.27 sec, 7.55 MB]                                                                                                                                                                                                                      [debug]
in the user login
Drush bootstrap phase : bootstrap_drupal_root() [4.28 sec, 8.09 MB]                                                                                                                                                                                                [bootstrap]
Initialized Drupal 8.3.7 root directory at /var/www/customprojects_D8/myproject/dev/docroot [4.28 sec, 8.09 MB]                                                                                                                                               [bootstrap]
Find command files for phase 1 (max=) [4.29 sec, 6.89 MB]                                                                                                                                                                                                              [debug]
Cache HIT cid: 8.1.16-commandfiles-1-ba664f64d08f5fadbd1880c26872e847 [4.29 sec, 6.9 MB]                                                                                                                                                                               [debug]
Cache HIT cid: 8.1.16-annotationfiles-1-fd5c348feaf38b2bd39b8ca5bc9f020a [4.29 sec, 6.97 MB]                                                                                                                                                                           [debug]
Drush bootstrap phase : bootstrap_drupal_site() [4.29 sec, 7.48 MB]                                                                                                                                                                                                [bootstrap]
Initialized Drupal site default at sites/default [4.29 sec, 7.48 MB]                                                                                                                                                                                               [bootstrap]
Find command files for phase 2 (max=) [4.3 sec, 7.48 MB]                                                                                                                                                                                                               [debug]
Cache HIT cid: 8.1.16-install_profile-66ecfeb9791a023150773849f1550c5d [4.3 sec, 7.48 MB]                                                                                                                                                                              [debug]
Cache HIT cid: 8.1.16-commandfiles-2-38b2b113566a80e626eb4bcef07b27a5 [4.3 sec, 7.49 MB]                                                                                                                                                                               [debug]
Drush bootstrap phase : bootstrap_drupal_configuration() [4.31 sec, 8.33 MB]                                                                                                                                                                                       [bootstrap]
Create from request [4.31 sec, 8.34 MB]                                                                                                                                                                                                                                [debug]
add service modifier [4.31 sec, 8.48 MB]                                                                                                                                                                                                                               [debug]
Find command files for phase 3 (max=) [4.31 sec, 8.48 MB]                                                                                                                                                                                                              [debug]
sql-query: SELECT 1; [4.31 sec, 8.56 MB]                                                                                                                                                                                                                              [notice]
Executing: mysql --defaults-extra-file=/tmp/drush_eox5lE --database=myproject_dev --host=localhost --silent  < /tmp/drush_YZJtoZ
  1
sql-query: SHOW TABLES; [4.32 sec, 8.56 MB]                                                                                                                                                                                                                           [notice]
Executing: mysql --defaults-extra-file=/tmp/drush_MZLqjY --database=myproject_dev --host=localhost --silent  < /tmp/drush_cPJKkj
  batch
  ...
  webform_submission_log
Drush bootstrap phase : bootstrap_drupal_database() [4.33 sec, 8.6 MB]                                                                                                                                                                                             [bootstrap]
Successfully connected to the Drupal database. [4.33 sec, 8.6 MB]                                                                                                                                                                                                  [bootstrap]
Find command files for phase 4 (max=) [4.33 sec, 8.6 MB]                                                                                                                                                                                                               [debug]
Drush bootstrap phase : bootstrap_drupal_full() [4.33 sec, 8.6 MB]                                                                                                                                                                                                 [bootstrap]
About to bootstrap the Drupal 8 Kernel. [4.33 sec, 8.6 MB]                                                                                                                                                                                                             [debug]
Finished bootstraping the Drupal 8 Kernel. [4.44 sec, 17.87 MB]                                                                                                                                                                                                        [debug]
Cache HIT cid: 8.1.16-install_profile-66ecfeb9791a023150773849f1550c5d [4.44 sec, 18.02 MB]                                                                                                                                                                            [debug]
Find command files for phase 5 (max=) [4.44 sec, 18.06 MB]                                                                                                                                                                                                             [debug]
Cache HIT cid: 8.1.16-install_profile-66ecfeb9791a023150773849f1550c5d [4.44 sec, 18.06 MB]                                                                                                                                                                            [debug]
Cache HIT cid: 8.1.16-commandfiles-5-142609b618088311257818c000f9ce93 [4.44 sec, 18.35 MB]                                                                                                                                                                             [debug]
No graphical display appears to be available, not starting browser. [4.51 sec, 24.47 MB]                                                                                                                                                                              [notice]
Returned from hook drush_user_login [4.51 sec, 24.47 MB]                                                                                                                                                                                                               [debug]
http://default/en/user/reset/1/1519894247/<obfuscated>/login
Command dispatch complete [4.51 sec, 24.42 MB]
```

As you can see, we get two drush user-login links back. One from the preflight and one from the regular bootstrap. This is from the following function in preflight.inc / drush_main()

```
$command_handled = drush_preflight_command_dispatch();
if (!$command_handled) {
  $return = $bootstrap->bootstrap_and_dispatch();
} 
```

Now, if we apply the pull request, we see that it successfully takes the correct drush and then quits as it got the results it needed.

`$ drush8 @myproject.dev uli -vd`

```
Using the Drush script found at /usr/local/src/drush8/drush.launcher using pcntl_exec
Drush preflight prepare loaded autoloader at                         [preflight]
/usr/local/src/drush8/vendor/autoload.php [0.01 sec, 2.45 MB]
Starting Drush preflight. [0.01 sec, 2.45 MB]                                                                                                                                                                                                                      [preflight]
Cache HIT cid: 8.1.16-commandfiles-0-5e6df3b528f4f0f3e00472493f0eb7de [0.01 sec, 2.73 MB]                                                                                                                                                                              [debug]
Scanning into /etc/drush for /.*aliases\.drush(8|)rc\.php$/ [0.04 sec, 5 MB]                                                                                                                                                                                           [debug]
...                                                                                                                                                                                   [debug]
Scanning into /root/.drush for /.*\.alias\.drush(8|)rc\.php$/ [2.11 sec, 7.33 MB]                                                                                                                                                                                      [debug]
Loaded alias @myproject.dev from file /etc/drush/myproject.aliases.drushrc.php [2.11 sec, 7.3 MB]                                                                                                                                                           [notice]
Begin redispatch via drush_invoke_process(). [2.12 sec, 7.31 MB]                                                                                                                                                                                                      [notice]
Backend invoke: env COLUMNS=270  /var/www/customprojects_D8/myproject/dev/vendor/drush/drush/drush.launcher  --root=/var/www/customprojects_D8/myproject/dev/docroot --verbose --debug  user-login 2>&1 [2.12 sec, 7.31 MB]                                [command]
Calling proc_open(env COLUMNS=270  /var/www/customprojects_D8/myproject/dev/vendor/drush/drush/drush.launcher  --root=/var/www/customprojects_D8/myproject/dev/docroot --verbose --debug  user-login 2>&1);
Drush preflight prepare loaded autoloader at                         [preflight]
/var/www/customprojects_D8/myproject/dev/vendor/autoload.php
[0.01 sec, 2.75 MB]
Starting Drush preflight. [0.01 sec, 2.75 MB]                                                                                                                                                                                                                      [preflight]
Cache HIT cid: 8.1.16-commandfiles-0-7d604cc7822369e48675695b14fcf8b3 [0.01 sec, 2.97 MB]                                                                                                                                                                              [debug]
Scanning into /etc/drush for /.*aliases\.drush(8|)rc\.php$/ [0.03 sec, 5.31 MB]                                                                                                                                                                                        [debug]
...
Scanning into /var/www/customprojects_D8/myproject/dev/docroot/sites/default for /.*\.alias\.drush(8|)rc\.php$/ [0.81 sec, 5.96 MB]                                                                                                                               [debug]
Bootstrap to phase 0. [0.86 sec, 7.78 MB]                                                                                                                                                                                                                          [bootstrap]
Bootstrap to phase -1. [0.86 sec, 7.79 MB]                                                                                                                                                                                                                         [bootstrap]
Found command: user-login (commandfile=user) [0.86 sec, 7.79 MB]                                                                                                                                                                                                   [bootstrap]
Calling hook drush_user_login [0.86 sec, 7.96 MB]                                                                                                                                                                                                                      [debug]
Drush bootstrap phase : bootstrap_drupal_root() [0.86 sec, 8.16 MB]                                                                                                                                                                                                [bootstrap]
Initialized Drupal 8.3.7 root directory at /var/www/customprojects_D8/myproject/dev/docroot [0.86 sec, 8.16 MB]                                                                                                                                               [bootstrap]
Find command files for phase 1 (max=) [0.87 sec, 6.96 MB]                                                                                                                                                                                                              [debug]
Cache HIT cid: 8.1.16-commandfiles-1-ba664f64d08f5fadbd1880c26872e847 [0.87 sec, 6.96 MB]                                                                                                                                                                              [debug]
Cache HIT cid: 8.1.16-annotationfiles-1-fd5c348feaf38b2bd39b8ca5bc9f020a [0.87 sec, 7.03 MB]                                                                                                                                                                           [debug]
Scanning into /etc/drush for /.*aliases\.drush(8|)rc\.php$/ [0.87 sec, 7.04 MB]                                                                                                                                                                                        [debug]
...
Scanning into /var/www/customprojects_D8/myproject/dev/docroot/sites/default for /.*\.alias\.drush(8|)rc\.php$/ [1.63 sec, 7.39 MB]                                                                                                                               [debug]
Drush bootstrap phase : bootstrap_drupal_site() [1.64 sec, 7.87 MB]                                                                                                                                                                                                [bootstrap]
Initialized Drupal site default at sites/default [1.64 sec, 7.87 MB]                                                                                                                                                                                               [bootstrap]
Find command files for phase 2 (max=) [1.64 sec, 7.87 MB]                                                                                                                                                                                                              [debug]
Cache HIT cid: 8.1.16-install_profile-66ecfeb9791a023150773849f1550c5d [1.64 sec, 7.87 MB]                                                                                                                                                                             [debug]
Cache HIT cid: 8.1.16-commandfiles-2-38b2b113566a80e626eb4bcef07b27a5 [1.64 sec, 7.88 MB]                                                                                                                                                                              [debug]
Drush bootstrap phase : bootstrap_drupal_configuration() [1.66 sec, 8.72 MB]                                                                                                                                                                                       [bootstrap]
Create from request [1.66 sec, 8.73 MB]                                                                                                                                                                                                                                [debug]
add service modifier [1.66 sec, 8.87 MB]                                                                                                                                                                                                                               [debug]
Find command files for phase 3 (max=) [1.66 sec, 8.87 MB]                                                                                                                                                                                                              [debug]
sql-query: SELECT 1; [1.66 sec, 8.94 MB]                                                                                                                                                                                                                              [notice]
Executing: mysql --defaults-extra-file=/tmp/drush_D1Kv1c --database=myproject_dev --host=localhost --silent  < /tmp/drush_1n3ReW
  1
sql-query: SHOW TABLES; [1.67 sec, 8.94 MB]                                                                                                                                                                                                                           [notice]
Executing: mysql --defaults-extra-file=/tmp/drush_9NEEDK --database=myproject_dev --host=localhost --silent  < /tmp/drush_yZuzPt
  batch

  webform_submission_log
Drush bootstrap phase : bootstrap_drupal_database() [1.68 sec, 8.98 MB]                                                                                                                                                                                            [bootstrap]
Successfully connected to the Drupal database. [1.68 sec, 8.98 MB]                                                                                                                                                                                                 [bootstrap]
Find command files for phase 4 (max=) [1.68 sec, 8.98 MB]                                                                                                                                                                                                              [debug]
Drush bootstrap phase : bootstrap_drupal_full() [1.69 sec, 8.98 MB]                                                                                                                                                                                                [bootstrap]
About to bootstrap the Drupal 8 Kernel. [1.69 sec, 8.98 MB]                                                                                                                                                                                                            [debug]
Finished bootstraping the Drupal 8 Kernel. [1.78 sec, 18.26 MB]                                                                                                                                                                                                        [debug]
Cache HIT cid: 8.1.16-install_profile-66ecfeb9791a023150773849f1550c5d [1.79 sec, 18.41 MB]                                                                                                                                                                            [debug]
Find command files for phase 5 (max=) [1.79 sec, 18.45 MB]                                                                                                                                                                                                             [debug]
Cache HIT cid: 8.1.16-install_profile-66ecfeb9791a023150773849f1550c5d [1.79 sec, 18.45 MB]                                                                                                                                                                            [debug]
Cache HIT cid: 8.1.16-commandfiles-5-142609b618088311257818c000f9ce93 [1.79 sec, 18.74 MB]                                                                                                                                                                             [debug]
No graphical display appears to be available, not starting browser. [1.86 sec, 24.87 MB]                                                                                                                                                                              [notice]
Returned from hook drush_user_login [1.86 sec, 24.86 MB]                                                                                                                                                                                                               [debug]
http://default/en/user/reset/1/1519894756/rQLXJSMnAXpQhIj9orP5yYfKscYN5p-_NXXw2XsybG4/login
Command dispatch complete [1.86 sec, 24.81 MB]                                                                                                                                                                                                                        [notice]
End redispatch via drush_invoke_process(). [4.06 sec, 7.31 MB]
```

The solution might not be ideal as we have duplicate code at the bottom of the function and in the middle, but refactoring it is most likely something for Drush 9. To me, this is a pretty severe bug though.