### PR TITLE
Fix infinite loop in DrupalBoot::scanUpForUri (on Windows)

### DIFF
--- a/src/Boot/DrupalBoot.php
+++ b/src/Boot/DrupalBoot.php
@@ -34,11 +34,13 @@ abstract class DrupalBoot extends BaseBoot
             if (file_exists("$scan/settings.php")) {
                 return $scan;
             }
-            $next = dirname($scan);
+            // Use Path::getDirectory instead of dirname to
+            // avoid certain bugs. Returns a canonicalized path.
+            $next = Path::getDirectory($scan);
             if ($next == $scan) {
                 return false;
             }
-            $scan = Path::canonicalize($next);
+            $scan = $next;
             if ($scan == $root) {
                 return false;
             }


### PR DESCRIPTION
Testing Drush 9.2.1 on XAMPP on Windows, I discovered this nice bug. Any Drush command would use 30% of the CPU and never finish. After some digging it was clear that DrupalBoot::scanUpForUri was the guilty one. 

The bug is only present if you start in the Drupal site root. If you start inside the core or sites folder, the infinite loop isn't triggered. If you start in the Drupal site root, $root and $scan are identical, and as a result (of flawed logic IMHO) scanUpForUri ends up scanning all the way to the file system root.

On Linux scanUpForUri stops when it's gets to the  file system root because $scan and $next becomes equal. On Windows this doesn't happen because of a nice bug in dirname:

`dirname('C:/somedir')` returns `C:\`, not the canonical `C:/`. 

The fix in the pull request is the minimal fix that stops the infinite loop. I considered fixing the root issue, the scanning to the root of the file system, but since I wasn't 100% sure if it could be useful in other use-cases I left it it as is.
