### PR TITLE
Move the setup of testing modules in a trait

### DIFF
--- a/tests/AnnotatedCommandTest.php
+++ b/tests/AnnotatedCommandTest.php
@@ -9,6 +9,7 @@ use Webmozart\PathUtil\Path;
  */
 class AnnotatedCommandCase extends CommandUnishTestCase
 {
+    use TestModuleHelperTrait;
 
     public function testGlobal()
     {
@@ -50,10 +51,9 @@ class AnnotatedCommandCase extends CommandUnishTestCase
     public function testExecute()
     {
         $this->setUpDrupal(1, true);
-        $root = $this->webroot();
 
         // Copy the 'woot' module over to the Drupal site we just set up.
-        $this->setupModulesForTests($root);
+        $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
 
         // Enable our module. This will also clear the commandfile cache.
         $this->drush('pm-enable', ['woot']);
@@ -207,12 +207,12 @@ EOT;
         $this->drush('woot', [], ['help' => null, 'ignored-modules' => 'woot'], null, null, self::EXIT_ERROR);
     }
 
-    public function setupModulesForTests($root)
+    public function setupGlobalExtensionsForTests()
     {
-        $wootModule = Path::join(__DIR__, '/resources/modules/d8/woot');
-        // We install into Unish so that we aren't cleaned up. That causes container to go invalid after tearDownAfterClass().
-        $targetDir = Path::join($root, 'modules/unish/woot');
+        $globalExtension = __DIR__ . '/resources/global-includes';
+        $targetDir = Path::join(self::getSandbox(), 'global-includes');
         $this->mkdir($targetDir);
-        $this->recursiveCopy($wootModule, $targetDir);
+        $this->recursiveCopy($globalExtension, $targetDir);
+        return $targetDir;
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -13,6 +13,7 @@ use Webmozart\PathUtil\Path;
  */
 class ContainerTest extends CommandUnishTestCase
 {
+    use TestModuleHelperTrait;
 
     /**
      * Tests that the existing container is available while Drush rebuilds it.
@@ -20,40 +21,23 @@ class ContainerTest extends CommandUnishTestCase
     public function testContainer()
     {
         $this->setUpDrupal(1, true);
-        $root = $this->webroot();
 
-      // Copy the 'woot' module over to the Drupal site we just set up.
-        $this->setupModulesForTests($root);
+        // Copy the 'woot' module over to the Drupal site we just set up.
+        $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
 
-      // Enable our module.
+        // Enable our module.
         $this->drush('pm-enable', ['woot']);
 
-      // Set up for a config import with just one small piece.
+        // Set up for a config import with just one small piece.
         $this->drush('config-export');
         $this->drush('config-set', ['system.site', 'name', 'config_test']);
 
-      // Trigger the container rebuild we need.
+        // Trigger the container rebuild we need.
         $this->drush('cr');
 
-      // If the event was registered successfully, then upon a config import, we
-      // should get the error message.
+        // If the event was registered successfully, then upon a config import, we
+        // should get the error message.
         $this->drush('config-import', [], [], null, null, CommandUnishTestCase::EXIT_ERROR);
         $this->assertContains("woot config error", $this->getErrorOutput(), 'Event was successfully registered.');
-    }
-
-    /**
-     * Sets up the woot module for the test.
-     *
-     * @param string $root
-     *   The web root.
-     */
-    public function setupModulesForTests($root)
-    {
-        $wootModule = Path::join(__DIR__, '/resources/modules/d8/woot');
-        // We install into Unish so that we aren't cleaned up. That causes
-        // container to go invalid after tearDownAfterClass().
-        $targetDir = Path::join($root, 'modules/unish/woot');
-        $this->mkdir($targetDir);
-        $this->recursiveCopy($wootModule, $targetDir);
     }
 }

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -9,6 +9,7 @@ use Webmozart\PathUtil\Path;
  */
 class QueueCase extends CommandUnishTestCase
 {
+    use TestModuleHelperTrait;
 
     public function testQueue()
     {
@@ -68,7 +69,7 @@ class QueueCase extends CommandUnishTestCase
         $sites = $this->setUpDrupal(1, true);
 
         // Copy the 'woot' module over to the Drupal site we just set up.
-        $this->setupModulesForTests($this->webroot());
+        $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
 
         // Enable woot module, which contains a queue worker that throws a
         // RequeueException.
@@ -100,20 +101,5 @@ class QueueCase extends CommandUnishTestCase
         $this->drush('queue-list', [], ['format' => 'csv']);
         $output = $this->getOutputAsList();
         $this->assertEquals(str_replace('%items', 0, $expected), array_pop($output), 'Queue item processed after being requeued.');
-    }
-
-  /**
-   * Copies the woot module into Drupal.
-   *
-   * @param string $root
-   *   The path to the root directory of Drupal.
-   */
-    public function setupModulesForTests($root)
-    {
-        $wootModule = Path::join(__DIR__, 'resources/modules/d8/woot');
-        $this->assertTrue(file_exists($wootModule));
-        $targetDir = Path::join($root, 'modules/contrib/woot');
-        $this->mkdir($targetDir);
-        $this->recursiveCopy($wootModule, $targetDir);
     }
 }

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -10,18 +10,18 @@ use Webmozart\PathUtil\Path;
  */
 class RoleCase extends CommandUnishTestCase
 {
+    use TestModuleHelperTrait;
 
-  /**
-   * Create, edit, block, and cancel users.
-   */
+    /**
+     * Create, edit, block, and cancel users.
+     */
     public function testRole()
     {
-        $sites = $this->setUpDrupal(1, true);
-        $root = $this->webroot();
+        $this->setUpDrupal(1, true);
 
         // In D8+, the testing profile has no perms.
         // Copy the module to where Drupal expects it.
-        $this->setupModulesForTests($root);
+        $this->setupModulesForTests(['user_form_test'], Path::join($this->webroot(), 'core/modules/user/tests/modules'));
         $this->drush('pm-enable', ['user_form_test']);
 
         $this->drush('role-list');
@@ -61,13 +61,5 @@ class RoleCase extends CommandUnishTestCase
         $this->drush('role-delete', [$rid]);
         $this->drush('role-list');
         $this->assertNotContains($rid, $this->getOutput());
-    }
-
-    public function setupModulesForTests($root)
-    {
-        $sourceDir = Path::join($root, 'core/modules/user/tests/modules/user_form_test');
-        $targetDir = Path::join($root, 'modules/contrib');
-        $this->mkdir($targetDir);
-        $this->recursiveCopy($sourceDir, $targetDir);
     }
 }

--- a/tests/TestModuleHelperTrait.php
+++ b/tests/TestModuleHelperTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Unish;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Webmozart\PathUtil\Path;
+
+/**
+ * Helper for installing testing modules.
+ */
+trait TestModuleHelperTrait
+{
+    /**
+     * Copies the testing modules from a specific path into Drupal.
+     *
+     * @param array $modules A list of testing modules.
+     * @param string $sourcePath The path under which the modules are placed.
+     */
+    public function setupModulesForTests(array $modules, $sourcePath)
+    {
+        $webRoot = $this->webroot();
+        $fileSystem = new Filesystem();
+        foreach ($modules as $module) {
+            $sourceDir = Path::join($sourcePath, $module);
+            $this->assertFileExists($sourceDir);
+            $targetDir = Path::join($webRoot, "modules/unish/$module");
+            $fileSystem->mkdir($targetDir);
+            $this->recursiveCopy($sourceDir, $targetDir);
+        }
+    }
+}

--- a/tests/UpdateDBTest.php
+++ b/tests/UpdateDBTest.php
@@ -10,6 +10,7 @@ use Webmozart\PathUtil\Path;
  */
 class UpdateDBTest extends CommandUnishTestCase
 {
+    use TestModuleHelperTrait;
 
     protected $pathPostUpdate;
 
@@ -53,10 +54,10 @@ class UpdateDBTest extends CommandUnishTestCase
         $sites = $this->setUpDrupal(1, true);
         $options = [
             'yes' => null,
-            'root' => $root = $this->webroot(),
+            'root' => $this->webroot(),
             'uri' => key($sites),
         ];
-        $this->setupModulesForTests($root);
+        $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
         $this->drush('pm-enable', ['woot'], $options);
 
         // Force a pending update.
@@ -107,10 +108,10 @@ LOG;
         $sites = $this->setUpDrupal(1, true);
         $options = [
             'yes' => null,
-            'root' => $root = $this->webroot(),
+            'root' => $this->webroot(),
             'uri' => key($sites),
         ];
-        $this->setupModulesForTests($root);
+        $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
         $this->drush('pm-enable', ['woot'], $options);
 
         // Force re-run of woot_update_8103().
@@ -174,7 +175,7 @@ LOG;
             'uri' => key($sites),
             'include' => __DIR__,
         ];
-        $this->setupModulesForTests($root);
+        $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
         $this->drush('pm-enable', ['woot'], $options);
 
         // Force re-run of the post-update woot_post_update_install_devel().
@@ -219,10 +220,10 @@ YAML_FRAGMENT;
         $sites = $this->setUpDrupal(1, true);
         $options = [
             'yes' => null,
-            'root' => $root = $this->webroot(),
+            'root' => $this->webroot(),
             'uri' => key($sites),
         ];
-        $this->setupModulesForTests($root);
+        $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
         $this->drush('pm-enable', ['woot'], $options);
 
         // Force re-run of woot_update_8103() which is expected to be completed successfully.
@@ -261,15 +262,6 @@ LOG;
 LOG;
 
         $this->assertErrorOutputEquals(preg_replace('#  *#', ' ', $this->simplifyOutput($expected_error_output)));
-    }
-
-    protected function setupModulesForTests($root)
-    {
-        $wootModule = Path::join(__DIR__, '/resources/modules/d8/woot');
-        // We install into Unish so that we aren't cleaned up. That causes container to go invalid after tearDownAfterClass().
-        $targetDir = Path::join($root, 'modules/unish/woot');
-        $this->mkdir($targetDir);
-        $this->recursiveCopy($wootModule, $targetDir);
     }
 
     public function tearDown()


### PR DESCRIPTION
Split from #3402 to reduce the PR footprint there.

There are repetitive tasks and code duplication in some of the tests that are using the testing modules (`woot`). Allow code reusing for the setup of testing modules by moving the common code in a trait.