### PR TITLE
Use bundle key in entity:delete command

### DIFF
--- a/src/Drupal/Commands/core/EntityCommands.php
+++ b/src/Drupal/Commands/core/EntityCommands.php
@@ -46,7 +46,8 @@ class EntityCommands extends DrushCommands
         if ($ids = StringUtils::csvToArray($ids)) {
             $entities = $storage->loadMultiple($ids);
         } elseif ($bundle = $options['bundle']) {
-            $entities = $storage->loadByProperties(['type' => $bundle]);
+            $bundleKey = $this->entityTypeManager->getDefinition($entity_type)->getKey('bundle');
+            $entities = $storage->loadByProperties([$bundleKey => $bundle]);
         } else {
             $entities = $storage->loadMultiple();
         }


### PR DESCRIPTION
``entity:delete`` uses 'type' as fixed bundle key. We should use the bundle key from the entity definition. This should work for every entity type.