### PR TITLE
Also load 'drush9.yml' to allow for variant Drush configuration files…

### DIFF
--- a/drush.php
+++ b/drush.php
@@ -1,5 +1,6 @@
 <?php
 
+use Drush\Drush;
 use Drush\Config\Environment;
 use Drush\Preflight\Preflight;
 use Drush\Runtime\Runtime;
@@ -55,6 +56,7 @@ if (file_exists($autoloadFile = __DIR__ . '/vendor/autoload.php')
 
 // Set up environment
 $environment = new Environment(Path::getHomeDirectory(), $cwd, $autoloadFile);
+$environment->setConfigFileVariant(Drush::getMajorVersion());
 $environment->setLoader($loader);
 $environment->applyEnvironment();
 

--- a/examples/example.drush.yml
+++ b/examples/example.drush.yml
@@ -22,6 +22,13 @@
 #
 # If a configuration file is found in any of the above locations, it will be
 # loaded and merged with other configuration files in the search list.
+#
+# Version-specific configuration
+#
+# Drush started using yml files for configuration in version 9; earlier versions
+# of Drush will never attempt to load a drush.yml file. It is also possible
+# to limit the version of Drush that will load a configuration file by placing
+# the Drush major version number in the filename, e.g. drush9.yml.
 
 # Environment variables
 #

--- a/isolation/fixtures/etc/drush/drushIGNORED.yml
+++ b/isolation/fixtures/etc/drush/drushIGNORED.yml
@@ -1,0 +1,2 @@
+test:
+  variant: 'This file should be ignored'

--- a/isolation/fixtures/etc/drush/drushVARIANT.yml
+++ b/isolation/fixtures/etc/drush/drushVARIANT.yml
@@ -1,0 +1,2 @@
+test:
+  variant: 'A variable that only exists in the variant drush.yml'

--- a/isolation/tests/ConfigLocatorTest.php
+++ b/isolation/tests/ConfigLocatorTest.php
@@ -31,6 +31,7 @@ class ConfigLocatorTest extends TestCase
         $sources = $configLocator->sources();
         //$this->assertEquals('environment', $sources['env']['cwd']);
         $this->assertEquals($this->fixturesDir() . '/etc/drush/drush.yml', $sources['test']['system']);
+        $this->assertEquals($this->fixturesDir() . '/etc/drush/drushVARIANT.yml', $sources['test']['variant']);
         $this->assertEquals($this->fixturesDir() . '/home/.drush/drush.yml', $sources['test']['home']);
         $this->assertEquals($this->fixturesDir() . '/sites/d8/drush/drush.yml', $sources['test']['site']);
         $this->assertEquals($this->environment()->drushBasePath() . '/drush.yml', $sources['drush']['php']['minimum-version']);
@@ -90,7 +91,7 @@ class ConfigLocatorTest extends TestCase
      */
     protected function createConfigLocator($isLocal = false, $configPath = '')
     {
-        $configLocator = new ConfigLocator('TEST_');
+        $configLocator = new ConfigLocator('TEST_', 'VARIANT');
         $configLocator->collectSources();
         $configLocator->setLocal($isLocal);
         $configLocator->addUserConfig([$configPath], $this->environment()->systemConfigPath(), $this->environment()->userConfigPath());

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -20,6 +20,7 @@ class Environment
     protected $vendorDir;
 
     protected $docPrefix;
+    protected $configFileVariant;
 
     protected $loader;
     protected $siteLoader;
@@ -228,6 +229,21 @@ class Environment
     public function userConfigPath()
     {
         return $this->homeDir() . '/.drush';
+    }
+
+    public function setConfigFileVariant($variant)
+    {
+        $this->configFileVariant = $variant;
+    }
+
+    /**
+     * Get the config file variant -- defined to be
+     * the Drush major version number. This is for
+     * loading drush.yml and drush9.yml, etc.
+     */
+    public function getConfigFileVariant()
+    {
+        return $this->configFileVariant;
     }
 
     /**

--- a/src/Drush.php
+++ b/src/Drush.php
@@ -81,7 +81,7 @@ class Drush
     {
         if (!static::$version) {
             $drush_info = static::drushReadDrushInfo();
-            $instance = new Version($drush_info['drush_version'], DRUSH_BASE_PATH);
+            $instance = new Version($drush_info['drush_version'], dirname(__DIR__));
             static::$version = $instance->getversion();
         }
         return static::$version;

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -60,7 +60,7 @@ class Preflight
     {
         $this->environment = $environment;
         $this->verify = $verify ?: new PreflightVerify();
-        $this->configLocator = $configLocator ?: new ConfigLocator('DRUSH_');
+        $this->configLocator = $configLocator ?: new ConfigLocator('DRUSH_', $environment->getConfigFileVariant());
         $this->drupalFinder = new DrupalFinder();
         $this->logger = new PreflightLog();
     }


### PR DESCRIPTION
… that we know will not be loaded in future versions of Drush.

For consistency with Drush 8, better organization, and forward-looking to drush10.yml files in future.