### PR TITLE
Change installation instructions to recommend cgr instead of 'composer global'

### DIFF
--- a/docs/install-alternative.md
+++ b/docs/install-alternative.md
@@ -1,28 +1,32 @@
 Install a global Drush via Composer
 ------------------
-Follow the instructions below, or [watch a video by Drupalize.me](https://youtu.be/eAtDaD8xz0Q).
+Follow the instructions below:
 
 1. [Install Composer globally](https://getcomposer.org/doc/00-intro.md#globally).
+1. Install the [cgr tool](https://github.com/consolidation/cgr) following the [instructions in that project](https://github.com/consolidation/cgr#installation-and-usage).
 1. Add composer's `bin` directory to the system path by placing `export PATH="$HOME/.composer/vendor/bin:$PATH"` into your ~/.bash_profile (Mac OS users) or into your ~/.bashrc (Linux users).		
-1. Install latest stable Drush: `composer global require drush/drush`.
+1. Install latest stable Drush: `cgr drush/drush`.
 1. Verify that Drush works: `drush status`
 
+Please do not install Drush using `composer global require`. See [Fixing the Composer Global command](https://pantheon.io/blog/fixing-composer-global-command) for more information.
+
 #### Notes
-* Update to latest release (per your specification in ~/.composer/composer.json): `composer global update`
+* Update to latest release (per your specification in ~/.composer/composer.json): `cgr update drush/drush`
 * Install a specific version of Drush:
 
         # Install a specific version of Drush, e.g. Drush 7.1.0
-        composer global require drush/drush:7.1.0
+        cgr update drush/drush:7.1.0
 
         # Install 8.x branch as a git clone. Great for contributing back to Drush project.
-        composer global require drush/drush:8.x-dev --prefer-source
+        cgr drush/drush:8.x-dev --prefer-source
+
 
 * Alternate way to install for all users via Composer:
 
-        COMPOSER_HOME=/opt/drush COMPOSER_BIN_DIR=/usr/local/bin COMPOSER_VENDOR_DIR=/opt/drush/7 composer require drush/drush:7
+        COMPOSER_HOME=/opt/drush COMPOSER_BIN_DIR=/usr/local/bin COMPOSER_VENDOR_DIR=/opt/drush/8 composer require drush/drush:^8
 
 * [Documentation for composer's require command.](http://getcomposer.org/doc/03-cli.md#require)
-* Uninstall with : `composer global remove drush/drush`
+* Uninstall with : `cgr remove drush/drush`
 
 Windows
 ------------


### PR DESCRIPTION
Still getting support requests about this; c.f. #3470. Let's get 'composer global' out of the maintenance branch installation instructions too.