### PR TITLE
[#3330] Fix logic leading to creation of PGPASSFILE when connecting t…

### DIFF
--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -216,6 +216,10 @@ function drush_mkdir($path) {
 function drush_program_exists($program) {
   if (drush_has_bash()) {
     $bucket = drush_bit_bucket();
+
+    // Remove environment variables (eg. PGPASSFILE=) before testing program.
+    $program = preg_replace('#^([A-Z0-9]+=.+? )+#', '', $program);
+
     // Dont't use drush_op_system() since we don't want output during tests.
     system("command -v $program > $bucket 2>&1", $result_code);
     return $result_code === 0 ? TRUE : FALSE;

--- a/src/Sql/SqlPgsql.php
+++ b/src/Sql/SqlPgsql.php
@@ -15,9 +15,8 @@ class SqlPgsql extends SqlBase
 
     private function createPasswordFile()
     {
-        $password_file = null;
         $dbSpec = $this->getDbSpec();
-        if (null !== ($this->getPasswordFile()) && isset($dbSpec['password'])) {
+        if (null == ($this->getPasswordFile()) && isset($dbSpec['password'])) {
             $pgpass_parts = [
             empty($dbSpec['host']) ? 'localhost' : $dbSpec['host'],
             empty($dbSpec['port']) ? '5432' : $dbSpec['port'],
@@ -34,10 +33,10 @@ class SqlPgsql extends SqlBase
                   $part = str_replace(['\\', ':'], ['\\\\', '\:'], $part);
             });
             $pgpass_contents = implode(':', $pgpass_parts);
-            $password_file = drush_save_data_to_temp_file($pgpass_contents);
-            chmod($password_file, 0600);
+            $this->password_file = drush_save_data_to_temp_file($pgpass_contents);
+            chmod($this->password_file, 0600);
         }
-        return $password_file;
+        return $this->password_file;
     }
 
     public function command()
@@ -128,7 +127,13 @@ class SqlPgsql extends SqlBase
         $data_only = $this->getOption('data-only');
 
         $create_db = $this->getOption('create-db');
-        $exec = 'pg_dump ';
+
+        $environment = "";
+        $pw_file = $this->createPasswordFile();
+        if (isset($pw_file)) {
+            $environment = "PGPASSFILE={$pw_file} ";
+        }
+        $exec = "{$environment}pg_dump ";
         // Unlike psql, pg_dump does not take a '--dbname=' before the database name.
         $extra = str_replace('--dbname=', ' ', $this->creds());
         if (isset($data_only)) {


### PR DESCRIPTION
As discussed in #3330 Drush 9 regressed the use of a PGPASSFILE environment variable to connect to PostgreSQL databases that require a password. This failure is quite crucial in Drush 9 because of the use of the 'psql' tool to perform more operations directly, so even things like drush status will fall into a password prompt with the current code.

The issue here is reversed logic in the SqlPgsql::createPasswordFile() method:

`if (null !== ($this->getPasswordFile()) && isset($dbSpec['password'])) {`

This will only create the password file if it is _not_ null, in other words if it's already existing. See below for why getPasswordFile() always returns null regardless, making this code block unreachable in any scenario.

If you contrast this line to Drush 8's (working) version:

`if (!isset($password_file) && isset($this->db_spec['password'])) {`

you can see that it's meant to be the other way around, creating the password file if it's not already set.

This Drush 8 line entered Drush 9 in b23f454 with a slight refactor:

`if (!isset($this->getPasswordFile()) && isset($dbSpec['password'])) {`

which was corrected to avoid isset() on a method return by 2d98048:

`if (null !== ($this->getPasswordFile()) && isset($dbSpec['password'])) {`

which accidentally reversed the logic of the first part of the statement, leading to the current code. Looking at the Travis config, it looks like pgsql tests with passwords are not performed, so that regression slipped through.

In addition to this logic issue, it appears getPasswordFile() will never return anything except null, because nothing sets the password_file member variable after writing the file. This was also the case in Drush 8, where the private variable $this->password_file actually has no references whatsoever. All code to get the name of the password file in both Drush 8 and Drush 9 actually calls createPasswordFile(), which returns the name. This means a new password file is created for every command, rather than reusing the existing one, because it can never detect that it has actually already created one. I suspect this came about because further back in Drush's history the local variable $password_file was possibly static.

I've fixed these two issues, and a third one where Drush reports that psql is not available because drush_program_exists() can't handle the prepended environment variable that command() adds:

`[warning] The command 'PGPASSFILE=/tmp/drush_42DoXS psql -q' is required for preflight but cannot be found. Please install it and retry.`

My approach there was to use a regex to remove prepended environment variables before running 'command' on $program. Given it appears the pgsql class is the only one in Drush core actually prepending environment variables in this manner, a less generic approach might be warranted to fix this. It might even be better to extend the way the database commands are executed to support passing environment variables through in the environment rather than the shell line, but I'll leave that call to more seasoned Drush contributors.

This PR might also supersede #2073, as I inadvertently fixed the same issue for pg_dump in my commit, coming to the same solution as that PR.