### PR TITLE
Fix the way to create PostgreSQL database

### DIFF
--- a/src/Sql/SqlPgsql.php
+++ b/src/Sql/SqlPgsql.php
@@ -76,7 +76,7 @@ class SqlPgsql extends SqlBase
     public function createdbSql($dbname, $quoted = false)
     {
         if ($quoted) {
-            $dbname = '`' . $dbname . '`';
+            $dbname = '"' . $dbname . '"';
         }
         $sql[] = sprintf('drop database if exists %s;', $dbname);
         $sql[] = sprintf("create database %s ENCODING 'UTF8';", $dbname);


### PR DESCRIPTION
This pull request should make it possible to create a PostgreSQL database with Drush sql:create command.
In PostgreSQL backticks don't exist, so they must be replaced by quotes.