### PR TITLE
Fix drush_batch_command() unexpected output

### DIFF
--- a/src/Drupal/Commands/core/BatchCommands.php
+++ b/src/Drupal/Commands/core/BatchCommands.php
@@ -2,6 +2,7 @@
 namespace Drush\Drupal\Commands\core;
 
 use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class BatchCommands extends DrushCommands
 {
@@ -16,6 +17,10 @@ class BatchCommands extends DrushCommands
      */
     public function process($batch_id)
     {
+        // Suppress the output of the batch process command. This is intended to
+        // be passed to the initiating command rather than being output to the
+        // console.
+        $this->output()->setVerbosity(OutputInterface::VERBOSITY_QUIET);
         return drush_batch_command($batch_id);
     }
 }


### PR DESCRIPTION
This suppresses unexpected output for `src\Drupal\Commands\core\BatchCommands.php`.

It was already done there for `src\Commands\core\UpdateDBCommands.php`: https://github.com/drush-ops/drush/commit/4050545b447da01d1d6998ebdfbdbf7acb04b137