### PR TITLE
watchdog:delete command fixed, when no option is given.

### DIFF
--- a/src/Drupal/Commands/core/WatchdogCommands.php
+++ b/src/Drupal/Commands/core/WatchdogCommands.php
@@ -168,7 +168,7 @@ class WatchdogCommands extends DrushCommands
                 throw new \Exception(dt('Watchdog message #!wid does not exist.', ['!wid' => $substring]));
             }
         } else {
-            if ((!isset($substring))&&(!isset($options['type']))&&(!isset($options['severity']))) {
+            if ((empty($substring))&&(!isset($options['type']))&&(!isset($options['severity']))) {
                 throw new \Exception(dt('No options provided.'));
             }
             $where = $this->where($options['type'], $options['severity'], $substring, 'OR');


### PR DESCRIPTION
drush watchdog:delete command fixed when no option is given. Earlier it give's following error:
_SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1: DELETE FROM {watchdog}
WHERE (); Array
(
)_