### PR TITLE
fix Drush command sql-query with option "--db-prefix" in use

### DIFF
--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -2,6 +2,7 @@
 
 namespace Drush\Sql;
 
+use Drupal\Core\Database\Database;
 use Drush\Log\LogLevel;
 use Webmozart\PathUtil\Path;
 
@@ -201,7 +202,7 @@ class SqlBase {
       // Enable prefix processing which can be dangerous so off by default. See http://drupal.org/node/1219850.
       if (drush_get_option('db-prefix')) {
         if (drush_drupal_major_version() >= 7) {
-          $query = \Database::getConnection()->prefixTables($query);
+          $query = Database::getConnection()->prefixTables($query);
         }
         else {
           $query = db_prefix_tables($query);

--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -200,10 +200,11 @@ class SqlBase {
     if (drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_DATABASE)) {
       // Enable prefix processing which can be dangerous so off by default. See http://drupal.org/node/1219850.
       if (drush_get_option('db-prefix')) {
-        if (drush_drupal_major_version() >= 8) {
+        $drupal_major_version = drush_drupal_major_version();
+        if ($drupal_major_version >= 8) {
           $query = \Drupal\Core\Database\Database::getConnection()->prefixTables($query);
         }
-        elseif (drush_drupal_major_version() == 7) {
+        elseif ($drupal_major_version == 7) {
           $query = \Database::getConnection()->prefixTables($query);
         }
         else {

--- a/lib/Drush/Sql/SqlBase.php
+++ b/lib/Drush/Sql/SqlBase.php
@@ -2,7 +2,6 @@
 
 namespace Drush\Sql;
 
-use Drupal\Core\Database\Database;
 use Drush\Log\LogLevel;
 use Webmozart\PathUtil\Path;
 
@@ -201,8 +200,11 @@ class SqlBase {
     if (drush_has_boostrapped(DRUSH_BOOTSTRAP_DRUPAL_DATABASE)) {
       // Enable prefix processing which can be dangerous so off by default. See http://drupal.org/node/1219850.
       if (drush_get_option('db-prefix')) {
-        if (drush_drupal_major_version() >= 7) {
-          $query = Database::getConnection()->prefixTables($query);
+        if (drush_drupal_major_version() >= 8) {
+          $query = \Drupal\Core\Database\Database::getConnection()->prefixTables($query);
+        }
+        elseif (drush_drupal_major_version() == 7) {
+          $query = \Database::getConnection()->prefixTables($query);
         }
         else {
           $query = db_prefix_tables($query);


### PR DESCRIPTION
Pull request #2882 works for Drupal 8 but breaks in Drupal 7. This new pull request makes it work well with both Drupal 8 and Drupal 7. Thanks for code review from @jorrit.