### PR TITLE
Remove webflo-core-strict

### DIFF
--- a/tests/resources/codebase/composer.json
+++ b/tests/resources/codebase/composer.json
@@ -9,7 +9,6 @@
   "require": {
     "composer/installers": "^1.2",
     "cweagans/composer-patches": "~1.0",
-    "webflo/drupal-core-strict": "8.5.x-dev",
     "drush/drush": "*",
     "phpunit/phpunit": "4.*",
     "drupal/empty_theme": "1.0",


### PR DESCRIPTION
This gets test suite to green. FYI, here is [webflo-core-strict:8.5.x-dev](https://github.com/webflo/drupal-core-strict/blob/8.5.x/composer.json)

Without this PR I am seeing:

```
./unish.sut.php -vvv
... (scroll to bottom)
Package operations: 0 installs, 0 updates, 0 removals
  - Marking drush/drush (9.0.x-dev) as uninstalled, alias of drush/drush (dev-master)
```

Still not sure why that uninstall is happenning.