### PR TITLE
Fix PHP 7.2 warning regarding count()

### DIFF
--- a/commands/make/make.drush.inc
+++ b/commands/make/make.drush.inc
@@ -1022,7 +1022,7 @@ function make_projects($recursion, $contrib_destination, $info, $build_path, $ma
         $backend_options['integrate'] = TRUE;
       }
       $results = drush_backend_invoke_concurrent($invocations, $common_options, $backend_options, 'make-process', '@none');
-      if (count($results['error_log'])) {
+      if (!empty($results['error_log'])) {
         return FALSE;
       }
     }


### PR DESCRIPTION
I am getting some warnings when building a legacy Drupal 7 project in PHP 7.2:

```
count(): Parameter must be an array or an object that implements Countable make.drush.inc:631
```