### PR TITLE
Fix #2285, #2268. Recognize current working dir for multisites

### DIFF
--- a/includes/startup.inc
+++ b/includes/startup.inc
@@ -414,6 +414,9 @@ function drush_startup($argv) {
     // Get the current environment for pnctl_exec.
     $env = drush_env();
 
+    // Make sure Drush can locates original working directory. https://github.com/drush-ops/drush/issues/2285
+    chdir($cwd);
+
     // Launch the new script in the same process.
     // If the launch succeeds, then it will not return.
     $error = pcntl_exec($found_script, $arguments, $env);


### PR DESCRIPTION
Affects hosts that have pcntl_exec(). Other hosts were similarly fixed in #2318. Since #2318 has been in Drush for a long time, I feel comfortable making this change even though 8.x is in maintenance now.