### PR TITLE
Support var-dumper 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "symfony/event-dispatcher": "~2.7|^3",
     "symfony/finder": "~2.7|^3",
     "symfony/process": "~2.7|^3",
-    "symfony/var-dumper": "~2.7|^3",
+    "symfony/var-dumper": "~2.7|^3|^4",
     "symfony/yaml": "~2.3|^3",
     "webflo/drupal-finder": "^1.1",
     "webmozart/path-util": "^2.1.0"

--- a/isolation/composer.json
+++ b/isolation/composer.json
@@ -10,7 +10,7 @@
     "ext-dom": "*",
     "psr/log": "~1.0",
     "consolidation/config": "^1.0.9",
-    "symfony/var-dumper": "~2.7|^3",
+    "symfony/var-dumper": "~2.7|^3|^4",
     "symfony/finder": "~2.7|^3",
     "webflo/drupal-finder": "^0",
     "webmozart/path-util": "^2.1.0",


### PR DESCRIPTION
Symfony 4.1 comes with new cool feature called [VarDumper server](https://symfony.com/blog/new-in-symfony-4-1-vardumper-server). This is very useful especially for debugging non-HTML responses and unit tests. Unfortunately, it is not possible to take advantage of VarDumper server on Drupal installation witth Drush  because of dependency conflict.

As a bonus, fixing this would also resolve the issue with installing Drush after Drupal console (https://github.com/hechoendrupal/drupal-console/issues/3249), which is probably caused by this Composer bug https://github.com/composer/composer/issues/7329.