### PR TITLE
Pass ANSI options to generate command

### DIFF
--- a/src/Commands/generate/GenerateCommands.php
+++ b/src/Commands/generate/GenerateCommands.php
@@ -71,6 +71,12 @@ class GenerateCommands extends DrushCommands
                 '--answers=' . escapeshellarg($options['answers']),
                 '--directory=' . $options['directory']
             ];
+            if ($options['ansi']) {
+                $argv[] = '--ansi';
+            }
+            if ($options['no-ansi']) {
+                $argv[] = '--no-ansi';
+            }
             return $application->run(new StringInput(implode(' ', $argv)));
         }
     }


### PR DESCRIPTION
On some Windows environments color support detection fails. This could be mitigated by passing `--no-ansi` option, which is currently not respected by `drush generate` command. 