### PR TITLE
Warning: Undefined index: 'scheme' in DrupalBoot8::bootstrapDrupalSiteValidate()

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -118,7 +118,7 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         $parsed_url = parse_url($uri);
 
         // Account for users who omit the http:// prefix.
-        if (!$parsed_url['scheme']) {
+        if (empty($parsed_url['scheme'])) {
             $this->uri = 'http://' . $this->uri;
             $parsed_url = parse_url($this->uri);
         }


### PR DESCRIPTION
If I perform a command such as the following I get a warning about an undefined index:

```
$ drush --root="/home/pieter/v/joinup/web" --verbose cache-rebuild
 [info] Undefined index: scheme DrupalBoot8.php:121
 [success] Cache rebuild complete.
```