### PR TITLE
Enable separate configurability of the Drush cache directory.

### DIFF
--- a/examples/example.drush.yml
+++ b/examples/example.drush.yml
@@ -71,6 +71,9 @@ drush:
       - '${env.home}/.drush/sites'
       - /etc/drush/sites
 
+    # Specify a folder where Drush should store its file based caches. If unspecified, defaults to $HOME/.drush.
+    cache-directory: /tmp/.drush
+
 # This section is for setting global options.
 options:
   # Specify the base_url that should be used when generating links.

--- a/src/Config/DrushConfig.php
+++ b/src/Config/DrushConfig.php
@@ -39,6 +39,7 @@ class DrushConfig extends ConfigOverlay
     public function cache()
     {
         $candidates = [
+            $this->get('drush.paths.cache-directory'),
             Path::join($this->home(), '.drush/cache'),
             Path::join($this->tmp(), 'drush-' . $this->user() . '/cache'),
         ];


### PR DESCRIPTION
With this PR you can control cache dir without changing the $HOME environment variable. Just set `DRUSH_PATHS_CACHE_DIRECTORY` env variable to the directory you want to use. Drush will create the directory if it doesn't yet exist.

Fixes #3592, #3594 