### PR TITLE
Highlight need to run composer in D7 manual install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -80,6 +80,9 @@ Composer - One Drush per Project
 
 Git Clone (i.e. manual install)
 -----------
+
+Note: you will still need to run `composer install` to complete installation.
+
 1. Place the uncompressed drush.tar.gz, drush.zip, or cloned git repository in a directory that is outside of your web root.
 1. Make the 'drush' command executable:
 
@@ -109,6 +112,8 @@ Git Clone (i.e. manual install)
 1. From Drush root, run Composer to fetch dependencies.
 
      `$ composer install`
+
+   Without doing this, you will see this error: *Unable to load autoload.php. Drush now requires Composer in order to install its dependencies and autoload classes. Please see README.md*
 
 See [Configure](configure.md) for next steps.
 


### PR DESCRIPTION
You still need to run composer install at the very end of a Drush 7 manual install, to populate the vendor directory.  This is a bit confusing if you're scanning the install options quickly and have chosen not to use the "composer" methods.  Also, adds exact error message displayed, to aid those searching.