### PR TITLE
Canonicalize directory

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -340,7 +340,7 @@ class ConfigCommands extends DrushCommands
      */
     public function getStorage($directory)
     {
-        if ($directory == \config_get_config_directory(CONFIG_SYNC_DIRECTORY)) {
+        if ($directory == Path::canonicalize(\config_get_config_directory(CONFIG_SYNC_DIRECTORY))) {
             return \Drupal::service('config.storage.sync');
         } else {
             return new FileStorage($directory);


### PR DESCRIPTION
This should fix #3596.
I've added _Path::canonicalize()_ as it is done in `drush cim` command.
https://github.com/drush-ops/drush/blob/9.3.0/src/Drupal/Commands/config/ConfigImportCommands.php#L168