### PR TITLE
Site alias location filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "consolidation/annotated-command": "^2.8.1",
     "consolidation/config": "^1.0.9",
     "consolidation/output-formatters": "^3.1.12",
-    "consolidation/site-alias": "dev-location-filters",
+    "consolidation/site-alias": "^1",
     "consolidation/robo": "^1.1.5",
     "grasmash/yaml-expander": "^1.1.1",
     "league/container": "~2",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "consolidation/annotated-command": "^2.8.1",
     "consolidation/config": "^1.0.9",
     "consolidation/output-formatters": "^3.1.12",
-    "consolidation/site-alias": "^0.1",
+    "consolidation/site-alias": "dev-location-filters",
     "consolidation/robo": "^1.1.5",
     "grasmash/yaml-expander": "^1.1.1",
     "league/container": "~2",

--- a/examples/example.site.yml
+++ b/examples/example.site.yml
@@ -71,6 +71,25 @@
 #       - /etc/drush/sites
 # @endcode
 #
+# It is also possible to create a named location that contains a group
+# of related site aliases. For example, if you had a number of sites
+# for local schools, you could define a location named "schools":
+#
+# @code
+# drush:
+#   paths:
+#     alias-path:
+#       - '${env.home}/.drush/sites/schools'
+# @endcode
+#
+# Site aliases stored in this directory may then be referenced by its
+# full alias name, including its location, e.g.:
+#
+#   $ drush @schools.example.dev
+#
+# Such alias files may still be referenced by their shorter name, e.g.
+# `@example.dev`.
+#
 # If you run the command `drush core:init`, this configuration will
 # be done for you automatically.
 #
@@ -84,6 +103,18 @@
 # site, use the "site:alias" command with the built-in alias "@self":
 #
 #   $ drush site:alias @self
+#
+# The `site:alias` command may also be used to list all of the sites and
+# environments in a given location, e.g.:
+#
+#   $ drush site:alias @schools
+#
+# Or it may be used to list all of the environments in a given site:
+#
+#   $ drush site:alias @example
+#
+# If called without any parameters, it will list all of the sites and
+# environments in all locations.
 #
 # Drush also supports *remote* site aliases.  When a site alias is
 # defined for a remote site, Drush will use the ssh command to run

--- a/examples/example.site.yml
+++ b/examples/example.site.yml
@@ -88,10 +88,13 @@
 #   $ drush @schools.example.dev
 #
 # Such alias files may still be referenced by their shorter name, e.g.
-# `@example.dev`.
+# `@example.dev`. Note that it is necessary to individually list every
+# location where site alias files may be stored; Drush never does recursive
+# (deep) directory searches for alias files.
 #
-# If you run the command `drush core:init`, this configuration will
-# be done for you automatically.
+# The command `drush core:init` will automatically configure your
+# ~/.drush/drush.yml configuration file to add `~/.drush/sites` and
+# `/etc/drush/sites` as locations where alias files may be placed.
 #
 # Files stored in one of the search path locations can be used to create
 # aliases to local and remote Drupal installations.  These aliases can be

--- a/isolation/tests/SiteAliasFileLoaderTest.php
+++ b/isolation/tests/SiteAliasFileLoaderTest.php
@@ -100,6 +100,6 @@ class SiteAliasFileLoaderTest extends TestCase
         $this->sut->addSearchLocation($this->fixturesDir() . '/sitealiases/single');
 
         $all = $this->sut->loadAll();
-        $this->assertEquals('@single.alternate,@single.common,@single.dev', implode(',', array_keys($all)));
+        $this->assertEquals('@single.single.alternate,@single.single.common,@single.single.dev', implode(',', array_keys($all)));
     }
 }

--- a/tests/SiteAliasConvertTest.php
+++ b/tests/SiteAliasConvertTest.php
@@ -25,10 +25,11 @@ class SiteAliasConvertTest extends CommandUnishTestCase
         file_put_contents(Path::join(self::getSandbox(), 'etc/drush/drush.yml'), Yaml::dump($config, 3));
 
         $this->drush('site:alias', [], ['format' => 'json']);
+        // $this->assertEquals('', $this->getOutput());
         $json = $this->getOutputFromJSON();
-        $this->assertObjectHasAttribute('@drupalvm.dev', $json);
-        $this->assertObjectHasAttribute('@www-drupalvm.dev', $json);
-        $dev = $json->{'@drupalvm.dev'};
+        $this->assertObjectHasAttribute('@testSiteAliasConvert.drupalvm.dev', $json);
+        $this->assertObjectHasAttribute('@testSiteAliasConvert.www-drupalvm.dev', $json);
+        $dev = $json->{'@testSiteAliasConvert.drupalvm.dev'};
         $this->assertSame('drupalvm.dev', $dev->host);
         $this->assertSame('-o PasswordAuthentication=no -i /.vagrant.d/insecure_private_key', $dev->ssh->{'options'});
         $this->assertSame('/var/www/drupalvm/drupal/vendor/drush/drush/drush', $dev->paths->{'drush-script'});


### PR DESCRIPTION
Allow site aliases to be referred to by a 'location' component of the alias name that is based on the name of the folder the alias file is stored in.

See the PR at https://github.com/consolidation/site-alias/pull/1