### PR TITLE
Set maintenance mode to update when running updates

### DIFF
--- a/commands/core/drupal/update.inc
+++ b/commands/core/drupal/update.inc
@@ -39,6 +39,11 @@ use Drupal\Core\Entity\EntityStorageException;
 function drush_update_do_one($module, $number, $dependency_map,  &$context) {
   $function = $module . '_update_' . $number;
 
+  // Disable config entity overrides.
+  if (!defined('MAINTENANCE_MODE')) {
+    define('MAINTENANCE_MODE', 'update');
+  }
+
   // If this update was aborted in a previous step, or has a dependency that
   // was aborted in a previous step, go no further.
   if (!empty($context['results']['#abort']) && array_intersect($context['results']['#abort'], array_merge($dependency_map, array($function)))) {


### PR DESCRIPTION
This is the PR for 8.x.

Post updates use the update function in core, which is great and I will update the core patch to set the constant there as well.

Fixes #3604 