### PR TITLE
Improve site alias example documentation.

### DIFF
--- a/examples/example.site.yml
+++ b/examples/example.site.yml
@@ -1,18 +1,87 @@
 #
 # Example of valid statements for an alias file.
+
+# Basic Alias File Usage
 #
-# To convert legacy alias (*.aliases.drushrc.php) to yml, run the
-# site:alias-convert command.
+# In its most basic form, the Drush site alias feature provides a way
+# for teams to share short names that refer to the live and staging sites
+# (usually remote) for a given Drupal site.
 #
-# Aliases are commonly used to define short names for
-# local or remote Drupal installations; however, an alias
-# is really nothing more than a collection of options.
+# 1. Make a local working clone of your Drupal site and then
+#    `cd` to the project work to select it.
+# 2. Add an alias file called $PROJECT/drush/sites/self.site.yml,
+#    where $PROJECT is the project root (location of composer.json file).
+# 3. Run remote commands against the shared live or stage sites
 #
-# Drush site aliases always contain one or more environments;
-# for example, a site may have "dev", "test" and "live"
-# environments. The default environment is "dev"; the dev
-# environment of a site named "example" may therefore be
-# referred to as either "@example.dev" or "@example".
+# Following these steps, a cache-rebuild on the live environment would be:
+#
+#   $ drush @live cache-rebuild
+#
+# The site alias file should be named `self.site.yml` because this name is
+# special, and is used to define the different environments (usually remote)
+# of the current Drupal site.
+#
+# The contents of the alias file should look something like the example below:
+#
+# @code
+# # File: self.site.yml
+# live:
+#   host: server.domain.com
+#   user: www-admin
+#   root: /other/path/to/live/drupal
+#   uri: http://example.com
+# stage:
+#   host: server.domain.com
+#   user: www-admin
+#   root: /other/path/to/stage/drupal
+#   uri: http://stage.example.com
+# @endcode
+#
+# The top-level element names (`live` and `stage` in the example above) are
+# used to identify the different environments available for this site. These
+# may be used on the command line to select a different target environment
+# to operate on by prepending an `@` character, e.g. `@live` or `@stage`.
+#
+# All of the available aliases for a site's environments may be listed via:
+#
+#   $ drush site:alias @self
+#
+# The elements of a site alias environment are:
+#
+# - 'host': The fully-qualified domain name of the remote system
+#   hosting the Drupal instance. **Important Note: The remote-host option
+#   must be omitted for local sites, as this option controls various
+#   operations, such as whether or not rsync parameters are for local or
+#   remote machines, and so on.
+# - 'user': The username to log in as when using ssh or rsync.
+# - 'root': The Drupal root; must not be specified as a relative path.
+# - 'uri': The value of --uri should always be the same as
+#   when the site is being accessed from a web browser (e.g. http://example.com)
+#
+# Drush uses ssh to run commands on remote systems; all team members should
+# install ssh keys on the target servers (e.g. via ssh-add).
+
+# Advanced Site Alias File Usage
+#
+# It is also possible to create site alias files that reference other
+# sites on the same local system. Site alias files for other local sites
+# are usually stored in the directory `~/.drush/sites`; however, Drush does
+# not search this location for alias files by default. To use this location,
+# you must add the path in your Drush configuration file. For example,
+# to re-add both of the default user alias path from Drush 8, put the following
+# in your ~/.drush/drush.yml configuration file:
+#
+# @code
+# drush:
+#   paths:
+#     alias-path:
+#       - '${env.home}/.drush/sites'
+#       - /etc/drush/sites
+# @endcode
+#
+# The command `drush core:init` will automatically configure your
+# ~/.drush/drush.yml configuration file to add `~/.drush/sites` and
+# `/etc/drush/sites` as locations where alias files may be placed.
 #
 # A canonical alias named "example" that points to a local
 # Drupal site named "http://example.com" looks like this:
@@ -28,138 +97,37 @@
 # defines the name of the site alias, and the top-level key ("dev")
 # defines the name of the environment.
 #
-# With this alias definition, then the following commands
-# are equivalent:
+# With these definitions in place, it is possible to run commands targeting
+# the dev environment of the target site via:
 #
 #   $ drush @example.dev status
+#
+# This command is equivalent to the longer form:
+#
 #   $ drush --root=/path/to/drupal --uri=http://example.com status
 #
-# See the --uri option documentation below for hints on setting its value.
+# See "Additional Site Alias Options" below for more information.
+
+# Converting Legacy Alias Files
 #
-# Any option that can be placed on the Drush commandline
-# can also appear in an alias definition inside an 'options' section.
+# To convert legacy alias (*.aliases.drushrc.php) to yml, run the
+# site:alias-convert command.
+
+# Altering aliases:
 #
-# Drush will search for aliases in any of these files using
-# the alias search path.  The following locations are examined
-# for alias files:
+# See examples/Commands/SiteAliasAlterCommands.php for an example.
+
+# Environment variables:
 #
-#   1. In any path set in drush.alias-path in drush.yml
-#      or (equivalently) any path passed in via --alias-path=...
-#      on the command line.
-#   2. In one of the site-specific locations:
-#        a. The /drush/sites folder for the current Drupal site
-#        b. The /drush/sites folder in the directory above the current Drupal site
+# It is no longer possible to set environment variables from within an alias.
+# This is a planned feature.
+
+# Additional Site Alias Options
 #
-# These locations are no longer searched recursively; alias files must
-# appear directly inside one of the search locations, or it will not be found.
+# Aliases are commonly used to define short names for
+# local or remote Drupal installations; however, an alias
+# is really nothing more than a collection of options.
 #
-# The preferred locations for alias files, then, are:
-#
-#   $ROOT/drush/sites
-#   $ROOT/../drush/sites
-#
-# If you would like to add additional locations, you can do so by
-# listing additional locations in your configuration files. For example,
-# to re-add the default user alias path from Drush 8, put the following
-# in your ~/.drush/drush.yml configuration file:
-#
-# @code
-# drush:
-#   paths:
-#     alias-path:
-#       - '${env.home}/.drush/sites'
-#       - /etc/drush/sites
-# @endcode
-#
-# It is also possible to create a named location that contains a group
-# of related site aliases. For example, if you had a number of sites
-# for local schools, you could define a location named "schools":
-#
-# @code
-# drush:
-#   paths:
-#     alias-path:
-#       - '${env.home}/.drush/sites/schools'
-# @endcode
-#
-# Site aliases stored in this directory may then be referenced by its
-# full alias name, including its location, e.g.:
-#
-#   $ drush @schools.example.dev
-#
-# Such alias files may still be referenced by their shorter name, e.g.
-# `@example.dev`. Note that it is necessary to individually list every
-# location where site alias files may be stored; Drush never does recursive
-# (deep) directory searches for alias files.
-#
-# The command `drush core:init` will automatically configure your
-# ~/.drush/drush.yml configuration file to add `~/.drush/sites` and
-# `/etc/drush/sites` as locations where alias files may be placed.
-#
-# Files stored in one of the search path locations can be used to create
-# aliases to local and remote Drupal installations.  These aliases can be
-# used in place of a site specification on the command line, and may also
-# be used in arguments to certain commands such as "drush rsync" and
-# "drush sql:sync".
-#
-# To see an example alias definition for the current bootstrapped
-# site, use the "site:alias" command with the built-in alias "@self":
-#
-#   $ drush site:alias @self
-#
-# The `site:alias` command may also be used to list all of the sites and
-# environments in a given location, e.g.:
-#
-#   $ drush site:alias @schools
-#
-# Or it may be used to list all of the environments in a given site:
-#
-#   $ drush site:alias @example
-#
-# If called without any parameters, it will list all of the sites and
-# environments in all locations.
-#
-# Drush also supports *remote* site aliases.  When a site alias is
-# defined for a remote site, Drush will use the ssh command to run
-# the requested command on the remote machine.  The simplest remote
-# alias looks like this:
-#
-# @code
-# # File: remote.site.yml
-# live:
-#   host: server.domain.com
-#   user: www-admin
-#   root: /other/path/to/drupal
-#   uri: http://example.com
-# @endcode
-#
-# Drush also treats the site alias file /drush/sites/self.site.yml
-# (in the Drupal root or project root) specially. If your current
-# working directory is inside a Drupal project, then aliases such
-# as `@self.live` may be referenced simply as `@live`. Commit the
-# file self.site.yml to your site's repository to share remote aliases
-# for a site with team members.
-#
-# The built-in alias "@none" represents the state of no Drupal site;
-# to ignore the site at the cwd and just see default drush status:
-#
-#   $ drush @none status
-#
-# See `drush help site:alias` for more options for displaying site
-# aliases.
-#
-# Although most aliases will contain only a few options, a number
-# of settings that are commonly used appear below:
-#
-# - 'uri': The value of --uri should always be the same as
-#   when the site is being accessed from a web browser (e.g. http://example.com)
-# - 'root': The Drupal root; must not be specified as a relative path.
-# - 'host': The fully-qualified domain name of the remote system
-#   hosting the Drupal instance. **Important Note: The remote-host option
-#   must be omitted for local sites, as this option controls various
-#   operations, such as whether or not rsync parameters are for local or
-#   remote machines, and so on.
-# - 'user': The username to log in as when using ssh or rsync.
 # - 'os': The operating system of the remote server.  Valid values
 #   are 'Windows' and 'Linux'. Be sure to set this value for all remote
 #   aliases because the default value is PHP_OS if 'remote-host'
@@ -206,17 +174,44 @@
 #         options:
 #           admin-password: 'secret-secret'
 # @endcode
+
+# Site Alias Files for Service Providers
 #
-# Altering aliases:
+# There are a number of service providers that manage Drupal sites as a
+# service. Drush allows service providers to create collections of site alias
+# files to reference all of the sites available to a single user. In order
+# to so this, a new location must be defined in your Drush configuration
+# file:
 #
-# See examples/Commands/SiteAliasAlterCommands.php for an example.
+# @code
+# drush:
+#   paths:
+#     alias-path:
+#       - '${env.home}/.drush/sites/provider-name'
+# @endcode
 #
-# Environment variables:
+# Site aliases stored in this directory may then be referenced by its
+# full alias name, including its location, e.g.:
 #
-# It is no longer possible to set environment variables from within an alias.
-# This is a planned feature.
+#   $ drush @provider-name.example.dev
 #
-# See https://github.com/consolidation/site-alias for more developer information about Site Aliases.
+# Such alias files may still be referenced by their shorter name, e.g.
+# `@example.dev`. Note that it is necessary to individually list every
+# location where site alias files may be stored; Drush never does recursive
+# (deep) directory searches for alias files.
+#
+# The `site:alias` command may also be used to list all of the sites and
+# environments in a given location, e.g.:
+#
+#   $ drush site:alias @provider-name
+#
+# Add the option `--format=list` to show only the names of each site and
+# environment without also showing the values in each alias record.
+
+# Developer Information
+#
+# See https://github.com/consolidation/site-alias for more developer
+# information about Site Aliases.
 #
 # An example appears below. Edit to suit and remove the @code / @endcode and
 # leading hashes to enable.
@@ -241,4 +236,4 @@
 #   root: /path/to/docroot
 #   uri: https://dev.example.com
 # @endcode
-#
+

--- a/examples/example.site.yml
+++ b/examples/example.site.yml
@@ -13,9 +13,9 @@
 #    where $PROJECT is the project root (location of composer.json file).
 # 3. Run remote commands against the shared live or stage sites
 #
-# Following these steps, a cache-rebuild on the live environment would be:
+# Following these steps, a cache:rebuild on the live environment would be:
 #
-#   $ drush @live cache-rebuild
+#   $ drush @live cache:rebuild
 #
 # The site alias file should be named `self.site.yml` because this name is
 # special, and is used to define the different environments (usually remote)


### PR DESCRIPTION
The primary goal of this rewrite is to pull the canonical site alias example up to the top of the example file, so that beginning users can read just the first section and get the overall idea on how to use the recommended workflow for site alias files that are local to a single site.

More advanced workflows and use cases are pushed down to the lower sections of the document.