### PR TITLE
fix #3624: Change usage of '--config-dir' site-install option.

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -71,7 +71,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
      * @aliases si,sin,site-install
      *
      */
-    public function install(array $profile, $options = ['db-url' => self::REQ, 'db-prefix' => self::REQ, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'account-name' => 'admin', 'account-mail' => 'admin@example.com', 'site-mail' => 'admin@example.com', 'account-pass' => self::REQ, 'locale' => 'en', 'site-name' => 'Drush Site-Install', 'site-pass' => self::REQ, 'sites-subdir' => self::REQ, 'config-dir' => self::REQ, 'existing-config' => FALSE])
+    public function install(array $profile, $options = ['db-url' => self::REQ, 'db-prefix' => self::REQ, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'account-name' => 'admin', 'account-mail' => 'admin@example.com', 'site-mail' => 'admin@example.com', 'account-pass' => self::REQ, 'locale' => 'en', 'site-name' => 'Drush Site-Install', 'site-pass' => self::REQ, 'sites-subdir' => self::REQ, 'config-dir' => self::REQ, 'existing-config' => false])
     {
         $additional = $profile;
         $profile = array_shift($additional) ?: '';

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -20,6 +20,25 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
     use SiteAliasManagerAwareTrait;
 
     /**
+     * Drupal version exploded.
+     *
+     * eg. [8,6,0-alpha1]
+     *
+     * @var array
+     */
+    protected $version_parts = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct()
+    {
+        $drupal_root = Drush::bootstrapManager()->getRoot();
+        $version = Drush::bootstrap()->getVersion($drupal_root);
+        $this->version_parts = explode('.', $version);
+    }
+
+    /**
      * Install Drupal along with modules/themes/configuration/profile.
      *
      * @command site:install
@@ -36,6 +55,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
      * @option site-mail From: for system mailings. Defaults to admin@example.com
      * @option sites-subdir Name of directory under 'sites' which should be created.
      * @option config-dir A path pointing to a full set of configuration which should be installed during installation.
+     * @option existing-config Configuration from "sync" directory should be installed during installation. This option is ignored if --config-dir is already set.
      * @usage drush si expert --locale=uk
      *   (Re)install using the expert install profile. Set default language to Ukrainian.
      * @usage drush si --db-url=mysql://root:pass@localhost:port/dbname
@@ -51,7 +71,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
      * @aliases si,sin,site-install
      *
      */
-    public function install(array $profile, $options = ['db-url' => self::REQ, 'db-prefix' => self::REQ, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'account-name' => 'admin', 'account-mail' => 'admin@example.com', 'site-mail' => 'admin@example.com', 'account-pass' => self::REQ, 'locale' => 'en', 'site-name' => 'Drush Site-Install', 'site-pass' => self::REQ, 'sites-subdir' => self::REQ, 'config-dir' => self::REQ])
+    public function install(array $profile, $options = ['db-url' => self::REQ, 'db-prefix' => self::REQ, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'account-name' => 'admin', 'account-mail' => 'admin@example.com', 'site-mail' => 'admin@example.com', 'account-pass' => self::REQ, 'locale' => 'en', 'site-name' => 'Drush Site-Install', 'site-pass' => self::REQ, 'sites-subdir' => self::REQ, 'config-dir' => self::REQ, 'existing-config' => FALSE])
     {
         $additional = $profile;
         $profile = array_shift($additional) ?: '';
@@ -81,6 +101,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
             'parameters' => [
                 'profile' => $profile,
                 'langcode' => $options['locale'],
+                'existing_config' => $options['existing-config'],
             ],
             'forms' => [
                 'install_settings_form' => [
@@ -137,6 +158,13 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
 
     protected function determineProfile($profile, $options, $class_loader)
     {
+        // --config-dir fails with Standard profile and any other one that carries content entities.
+        // Force to minimal install profile only for drupal <= 8.5.x.
+        if ($options['config-dir'] && $this->version_parts[0] <= 8 && $this->version_parts[1] <= 5) {
+            $this->logger()->info(dt("Using 'minimal' install profile since --config-dir option was provided."));
+            $profile = 'minimal';
+        }
+
         if (empty($profile)) {
             $boot = Drush::bootstrap();
             $profile = $boot->getKernel()->getInstallProfile();
@@ -165,6 +193,24 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
             $profile = 'standard';
         }
         return $profile;
+    }
+
+    /**
+     * Post installation, run the configuration import.
+     *
+     * @hook post-command site-install
+     */
+    public function post($result, CommandData $commandData)
+    {
+        // Only for drupal <= 8.5.x.
+        if ($config = $commandData->input()->getOption('config-dir') && $this->version_parts[0] <= 8 && $this->version_parts[1] <= 5) {
+            // Set the destination site UUID to match the source UUID, to bypass a core fail-safe.
+            $source_storage = new FileStorage($config);
+            $options = ['yes' => true];
+            drush_invoke_process('@self', 'config-set', ['system.site', 'uuid', $source_storage->read('system.site')['uuid']], $options);
+            // Run a full configuration import.
+            drush_invoke_process('@self', 'config-import', [], ['source' => $config] + $options);
+        }
     }
 
     /**

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -35,7 +35,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
      * @option site-name Defaults to Site-Install
      * @option site-mail From: for system mailings. Defaults to admin@example.com
      * @option sites-subdir Name of directory under 'sites' which should be created.
-     * @option config-dir A path pointing to a full set of configuration which should be used during installation.
+     * @option config-dir A path pointing to a full set of configuration which should be installed during installation.
      * @usage drush si expert --locale=uk
      *   (Re)install using the expert install profile. Set default language to Ukrainian.
      * @usage drush si --db-url=mysql://root:pass@localhost:port/dbname


### PR DESCRIPTION
Fix #3624

Regarding https://www.drupal.org/project/drupal/issues/2788777 that allow a site to be installed from an existing configuration from 8.6.x version, here an update to change the usage of `--config-dir` option.

Up to now, this option allowed to import a full set of configuration after installation.
From now, configuration does not import anymore after installation, but during installation.