### PR TITLE
Fixes #3274: pass missing aliases to site-local Drush

### DIFF
--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -258,14 +258,23 @@ class Preflight
         $aliasFileLoader = new \Drush\SiteAlias\SiteAliasFileLoader();
         $this->aliasManager = (new SiteAliasManager($aliasFileLoader))->addSearchLocations($paths);
         $this->aliasManager->setReferenceData($config->export());
+
+        // Find the local site
         $siteLocator = new PreflightSiteLocator($this->aliasManager);
         $selfAliasRecord = $siteLocator->findSite($this->preflightArgs, $this->environment, $root);
-        $this->aliasManager->setSelf($selfAliasRecord);
-        $this->configLocator->addAliasConfig($selfAliasRecord->exportConfig());
 
-        // Process the selected alias. This might change the selected site,
-        // so we will add new site-wide config location for the new root.
-        $root = $this->setSelectedSite($selfAliasRecord->localRoot());
+        // If we did not find a local site, then we are destined to fail
+        // UNLESS RedispatchToSiteLocal::redispatchIfSiteLocalDrush takes over.
+        // Before we try to redispatch to the site-local Drush, though, we must
+        // initiaze the alias manager & c. based on any alias record we did find.
+        if ($selfAliasRecord) {
+            $this->aliasManager->setSelf($selfAliasRecord);
+            $this->configLocator->addAliasConfig($selfAliasRecord->exportConfig());
+
+            // Process the selected alias. This might change the selected site,
+            // so we will add new site-wide config location for the new root.
+            $root = $this->setSelectedSite($selfAliasRecord->localRoot());
+        }
 
         // Now that we have our final Drupal root, check to see if there is
         // a site-local Drush. If there is, we will redispatch to it.
@@ -274,6 +283,19 @@ class Preflight
         $status = RedispatchToSiteLocal::redispatchIfSiteLocalDrush($argv, $root, $this->environment->vendorPath(), $this->logger())    ;
         if ($status !== false) {
             return $status;
+        }
+
+        // If the site locator couldn't find a local site, and we did not
+        // redispatch to a site-local Drush, then we cannot continue.
+        // This can happen when using Drush 9 to call a site-local Drush 8
+        // using an alias record that is only defined in a Drush 8 format.
+        if (!$selfAliasRecord) {
+            // Note that PreflightSiteLocator::findSite only returns 'false'
+            // when preflightArgs->alias() returns an alias name. In all other
+            // instances we will get an alias record, even if it is only a
+            // placeholder 'self' with the root holding the cwd.
+            $aliasName = $preflightArgs->alias();
+            throw new \Exception("The alias $aliasName could not be found.");
         }
 
         // If we did not redispatch, then add the site-wide config for the

--- a/src/Preflight/PreflightSiteLocator.php
+++ b/src/Preflight/PreflightSiteLocator.php
@@ -25,21 +25,19 @@ class PreflightSiteLocator
      * During bootstrap, finds the currently selected site from the parameters
      * provided on the commandline.
      *
+     * If 'false' is returned, that indicates that there was an alias name
+     * provided on the commandline that is either missing or invalid.
+     *
      * @param PreflightArgsInterface $preflightArgs An alias name or site specification
      * @param \Drush\Config\Environment $environment
      * @param string $root The default Drupal root (from site:set, --root or cwd)
      *
-     * @return \Consolidation\SiteAlias\AliasRecord
-     * @throws \Exception
+     * @return \Consolidation\SiteAlias\AliasRecord|false
      */
     public function findSite(PreflightArgsInterface $preflightArgs, Environment $environment, $root)
     {
         $aliasName = $preflightArgs->alias();
-        $selfAliasRecord = $this->determineSelf($preflightArgs, $environment, $root);
-        if (!$selfAliasRecord) {
-            throw new \Exception("The alias $aliasName could not be found.");
-        }
-        return $selfAliasRecord;
+        return $this->determineSelf($preflightArgs, $environment, $root);
     }
 
     /**


### PR DESCRIPTION
Allow un-found aliases on the commandline to be passed through to the site-local Drush.