### PR TITLE
Drush 8.x: Adding cwd option to core-cli

### DIFF
--- a/commands/core/cli.drush.inc
+++ b/commands/core/cli.drush.inc
@@ -19,6 +19,7 @@ function cli_drush_command() {
     'topics' => array('docs-repl'),
     'options' => array(
       'version-history' => 'Use command history based on Drupal version (Default is per site).',
+       'cwd' => 'Changes the working directory of the shell (Default is the project root directory)',
     ),
   );
   $items['docs-repl'] = array(
@@ -93,6 +94,12 @@ function drush_cli_core_cli() {
   // any shutdown functions will still run ok after the shell has exited.
   if ($drupal_major_version == 7) {
     Database::closeConnection();
+  }
+  
+  // if the cwd option is passed, lets change the current working directory to wherever
+  // the user wants to go before we lift psysh.
+  if ($cwd = drush_get_option('cwd',FALSE)) {
+    chdir($cwd);
   }
 
   $shell->run();


### PR DESCRIPTION
 so that we can change the default working directory.

Hi I love drush and I love the addition of psysh through core-cli. I'd love an option for changing the working directory while I'm working on a custom module or something so I added a cwd option to the core-cli command. This way I can do something like this:

```
drush core-cli --cwd="$(pwd -P)"
```

Now, when the interactive psysh shell is lifted, the current working directory is wherever I am working.

I hope this is useful.
