### PR TITLE
Allow multipart aliases with drush sa, 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "consolidation/config": "^1.1.0",
     "consolidation/output-formatters": "^3.1.12",
     "consolidation/robo": "^1.1.5",
-    "consolidation/site-alias": "^1.1.1",
+    "consolidation/site-alias": "^1.1.2",
     "grasmash/yaml-expander": "^1.1.1",
     "league/container": "~2",
     "psr/log": "~1.0",

--- a/scenarios/isolation-phpunit4/composer.json
+++ b/scenarios/isolation-phpunit4/composer.json
@@ -27,7 +27,7 @@
     "php": ">=5.6.0",
     "ext-dom": "*",
     "consolidation/config": "^1.1.0",
-    "consolidation/site-alias": "^1.1.1",
+    "consolidation/site-alias": "^1.1.2",
     "psr/log": "~1.0",
     "sebastian/version": "^1|^2",
     "symfony/finder": "~2.7|^3",

--- a/scenarios/isolation/composer.json
+++ b/scenarios/isolation/composer.json
@@ -27,7 +27,7 @@
     "php": ">=5.6.0",
     "ext-dom": "*",
     "consolidation/config": "^1.1.0",
-    "consolidation/site-alias": "^1.1.1",
+    "consolidation/site-alias": "^1.1.2",
     "psr/log": "~1.0",
     "sebastian/version": "^1|^2",
     "symfony/finder": "~2.7|^3",

--- a/src/Commands/core/SiteCommands.php
+++ b/src/Commands/core/SiteCommands.php
@@ -115,10 +115,11 @@ class SiteCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
      */
     public function siteAlias($site = null, $options = ['format' => 'yaml'])
     {
-        // Check to see if the user provided a specification that matches
+        // First check to see if the user provided a specification that matches
         // multiple sites.
-        $aliasList = $this->siteAliasManager()->getMultiple($site);
-        if (is_array($aliasList)) {
+        list($locationPart, $sitePart) = $this->splitLocationFromSite($site);
+        $aliasList = $this->siteAliasManager()->getMultiple($sitePart, $locationPart);
+        if (is_array($aliasList) && !empty($aliasList)) {
             return new ListDataFromKeys($this->siteAliasExportList($aliasList, $options));
         }
 
@@ -133,6 +134,21 @@ class SiteCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
         } else {
             $this->logger()->success('No site aliases found.');
         }
+    }
+
+    /**
+     * splitLocationFromSite returns the location and the site if the
+     * site alias is in the form '@location.site'. Otherwise it just
+     * returns the site unchanged, without a location.
+     */
+    protected function splitLocationFromSite($site)
+    {
+        $parts = explode('.', ltrim($site, '@'));
+
+        if (count($parts) == 2) {
+            return [$parts[0], '@' . $parts[1]];
+        }
+        return [null, $site];
     }
 
     /**


### PR DESCRIPTION
e.g. @location.site.env or @location.site, in addition to just @location or @site.

A simple bugfix / enhancement that makes Drush 9 sa work more like Drush 8 sa.