### PR TITLE
Fix undefined variable preflightArgs notice

### DIFF
--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -294,7 +294,7 @@ class Preflight
             // when preflightArgs->alias() returns an alias name. In all other
             // instances we will get an alias record, even if it is only a
             // placeholder 'self' with the root holding the cwd.
-            $aliasName = $preflightArgs->alias();
+            $aliasName = $this->preflightArgs->alias();
             throw new \Exception("The alias $aliasName could not be found.");
         }
 


### PR DESCRIPTION
- Fixed PHP notice:

PHP Notice:  Undefined variable: preflightArgs in /var/www/html/vendor/drush/drush/src/Preflight/Preflight.php on line 297