### PR TITLE
Fixes #3672: Call Boot::terminate() in a shutdown handler.

### DIFF
--- a/src/Boot/BaseBoot.php
+++ b/src/Boot/BaseBoot.php
@@ -21,6 +21,7 @@ abstract class BaseBoot implements Boot, LoggerAwareInterface, ContainerAwareInt
 
     public function __construct()
     {
+        register_shutdown_function([$this, 'terminate']);
     }
 
     public function findUri($root, $uri)


### PR DESCRIPTION
Not sure if this is effective, but it at least does not crash.