### PR TITLE
Make the link to example commands absolute so it works from docs.drush.org

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -59,7 +59,7 @@ For an example, see the alterer class provided by the testing 'woot' module: `te
 Global Drush Commands
 ==============================
 
-Commandfiles that don't ship inside Drupal modules are called 'global' commandfiles. See the [examples/Commands](/examples/Commands) folder for examples. In general, it's better to use modules to carry your Drush commands. If you still prefer using a global commandfiles, here are two examples of valid commandfile names and namespaces:
+Commandfiles that don't ship inside Drupal modules are called 'global' commandfiles. See the [examples/Commands](https://github.com/drush-ops/drush/tree/master/examples/Commands) folder for examples. In general, it's better to use modules to carry your Drush commands. If you still prefer using a global commandfiles, here are two examples of valid commandfile names and namespaces:
 
 1. Simple
      - Filename: $PROJECT_ROOT/drush/Commands/ExampleCommands.php


### PR DESCRIPTION
The link to example commands is broken on docs.drush.org.

Steps to replicate:

1. Navigate to http://docs.drush.org/en/master/commands/#global-drush-commands
2. Click the _examples/Commands_ link

