### PR TITLE
Provide docker-compose for running tests and developing Drush

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# This file is for customizing the Docker environment which is used to develop
+# Drush. If you are just using Drush to run commands, you may ignore this file
+# and docker-compose.yml.
+#
+# Uncomment to change versions of php and DBs
+# POSTGRES_TAG=
+# MARIADB_TAG=
+# PHP_TAG=
+#
+# Uncommnt to run tests against a different DB. Defaults to mysql.
+# UNISH_DB_URL: pgsql://unish:unish@postgres
+# UNISH_DB_URL: sqlite://sut/sites/default/files/.ht.sqlite
+#
+# XDebug defaults to Off in the php container.
+# Uncomment to enable XDebug. See https://wodby.com/stacks/drupal/docs/local/xdebug/.
+# When Xdebug first successfully connects back to PHPStorm, you are prompted to create a Server called unish
+# Then you are prompted to add path mappings (its mandatory).
+# PHP_XDEBUG: 1
+# PHP_XDEBUG_DEFAULT_ENABLE: 1
+# PHP_IDE_CONFIG: serverName=unish
+# PHP_XDEBUG_REMOTE_HOST: host.docker.internal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Drush is built by people like you! Please [join us](https://github.com/drush-ops/drush).
 
 ## Git and Pull requests
-* Contributions are submitted, reviewed, and accepted using GitHub pull requests. [Read this article](https://help.github.com/articles/using-pull-requests) for some details. We use the _Fork and Pull_ model, as described there.
+* Contributions are submitted, reviewed, and accepted using GitHub pull requests.
 * The latest changes are in the `master` branch. PR's should initially target this branch.
 * Try to make clean commits that are easily readable (including descriptive commit messages!)
 * Test before you push. Get familiar with Unish, our test suite. See the test-specific [README.md](tests/README.md). Optionally run tests in the provided Docker containers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Drush is built by people like you! Please [join us](https://github.com/drush-ops
 * Contributions are submitted, reviewed, and accepted using GitHub pull requests. [Read this article](https://help.github.com/articles/using-pull-requests) for some details. We use the _Fork and Pull_ model, as described there.
 * The latest changes are in the `master` branch. PR's should initially target this branch.
 * Try to make clean commits that are easily readable (including descriptive commit messages!)
-* Test before you push. Get familiar with Unish, our test suite. See the test-specific [README.md](tests/README.md)
+* Test before you push. Get familiar with Unish, our test suite. See the test-specific [README.md](tests/README.md). Optionally run tests in the provided Docker containers.
 * We maintain branches named 9.x, 8.x, etc. These are release branches. From these branches, we make new tags for patch and minor versions.
 
 ## Coding style

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Resources
 * Subscribe [this atom feed](https://github.com/drush-ops/drush/releases.atom) to receive notification of new releases. Also, [Version eye](https://www.versioneye.com/).
 * [Drush packages available via Composer](https://packagist.org/search/?type=drupal-drush)
 * [A list of modules that include Drush integration](https://www.drupal.org/project/project_module?f[2]=im_vid_3%3A4654&solrsort=ds_project_latest_release+desc)
-* Drush comes with a [full test suite](https://github.com/drush-ops/drush/blob/master/tests/README.md) powered by [PHPUnit](https://github.com/sebastianbergmann/phpunit). Each commit gets tested by the awesome [Travis CI continuous integration service](https://travis-ci.org/drush-ops/drush).
+* Drush comes with a [full test suite](https://github.com/drush-ops/drush/blob/master/tests/README.md) powered by [PHPUnit](https://github.com/sebastianbergmann/phpunit). Each commit gets tested by our CI bots.
 
 Support
 -----------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3.1"
+
+services:
+  # More info at https://github.com/wodby/mariadb
+  mariadb:
+    image: wodby/mariadb:${MARIADB_TAG-10.1}
+    container_name: ${PROJECT_NAME-unish}_mariadb
+    stop_grace_period: 30s
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+    volumes:
+      - mariadb-datavolume:/var/lib/mysql
+
+  # More info at https://github.com/wodby/php
+  # We don't want their drupal-php image as that ships with a Drush inside.
+  php:
+    image: wodby/php:${PHP_TAG-7.2}
+    container_name: ${PROJECT_NAME-unish}_php
+    environment:
+      PHP_SENDMAIL_PATH: /dev/null
+      UNISH_DB_URL: ${UNISH_DB_URL-mysql://root:password@mariadb}
+      UNISH_NO_TIMEOUTS: y
+      COLUMNS: ${COLUMNS-80} # Set 80 columns for docker exec -it.
+    ## Read instructions at https://wodby.com/stacks/drupal/docs/local/xdebug/
+      PHP_XDEBUG:
+      PHP_XDEBUG_DEFAULT_ENABLE:
+      PHP_IDE_CONFIG:
+      PHP_XDEBUG_REMOTE_HOST:
+    volumes:
+      - ./:/var/www/html:${VOLUME_FLAGS-cached}
+
+  # More info at https://github.com/wodby/postgres
+  postgres:
+    image: wodby/postgres:${POSTGRES_TAG-10.5}
+    container_name: unish_postgres
+    stop_grace_period: 30s
+    environment:
+      POSTGRES_PASSWORD: unish
+      POSTGRES_DB: unish_dev
+      POSTGRES_USER: unish
+    volumes:
+      - postgres-datavolume:/var/lib/postgresql/data
+
+#data volumes https://docs.docker.com/storage/volumes/
+volumes:
+  mariadb-datavolume:
+  postgres-datavolume:
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,4 @@
-Drush's test suite is based on [PHPUnit](http://www.phpunit.de). In order to maintain
+Drush's test suite (aka Unish) is based on [PHPUnit](http://www.phpunit.de). In order to maintain
 high quality, our tests are run on every push. 
 
 - Functional tests at [CircleCi](https://circleci.com/gh/drush-ops/drush) 
@@ -9,6 +9,15 @@ Usage
 --------
 1. Review the configuration settings in [tests/phpunit.xml.dist](phpunit.xml.dist). If customization is needed, copy to phpunit.xml and edit away.
 1. Run test suite: `composer test`
+
+Docker
+----------
+Drush's own tests may be run within provided Docker containers (see docker-compose.yml):
+
+- Start containers: `docker-compose up -d`
+- Run a test: `docker-compose exec php composer functional -- --filter testVersionString`
+- To change configuration, copy .env.example to .env, edit to taste, and run `docker-compose up -d` again
+- See that .env.example file for help on enabling Xdebug.
 
 Advanced usage
 ---------


### PR DESCRIPTION
Allows for tests on mariadb, postgres, sqlite. Includes Xdebug. Includes docs.