### PR TITLE
Backport #3687: preserve 'contrib' and 'custom' dir placements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "php": ">=5.4.5",
     "psr/log": "~1.0",
     "psy/psysh": "~0.6",
-    "consolidation/annotated-command": "^2.8.1",
+    "consolidation/annotated-command": "^2.9.1",
     "consolidation/output-formatters": "~3",
     "symfony/yaml": "~2.3|^3",
     "symfony/var-dumper": "~2.7|^3",

--- a/composer.lock
+++ b/composer.lock
@@ -1,36 +1,37 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f964f597be5b57a32e5078444ed7d0f4",
+    "content-hash": "212f332e747566b2707730cb23824682",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "2.8.1",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "7f94009d732922d61408536f9228aca8f22e9135"
+                "reference": "4bdbb8fa149e1cc1511bd77b0bc4729fd66bccac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/7f94009d732922d61408536f9228aca8f22e9135",
-                "reference": "7f94009d732922d61408536f9228aca8f22e9135",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/4bdbb8fa149e1cc1511bd77b0bc4729fd66bccac",
+                "reference": "4bdbb8fa149e1cc1511bd77b0bc4729fd66bccac",
                 "shasum": ""
             },
             "require": {
                 "consolidation/output-formatters": "^3.1.12",
                 "php": ">=5.4.0",
                 "psr/log": "^1",
-                "symfony/console": "^2.8|~3",
-                "symfony/event-dispatcher": "^2.5|^3",
-                "symfony/finder": "^2.5|^3"
+                "symfony/console": "^2.8|^3|^4",
+                "symfony/event-dispatcher": "^2.5|^3|^4",
+                "symfony/finder": "^2.5|^3|^4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8",
-                "satooshi/php-coveralls": "^1.0",
+                "g1a/composer-test-scenarios": "^2",
+                "phpunit/phpunit": "^6",
+                "satooshi/php-coveralls": "^2",
                 "squizlabs/php_codesniffer": "^2.7"
             },
             "type": "library",
@@ -55,32 +56,38 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2017-10-17T01:48:51+00:00"
+            "time": "2018-09-19T17:47:18+00:00"
         },
         {
             "name": "consolidation/output-formatters",
-            "version": "3.1.12",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "88ef346a1cefb92aab8b57a3214a6d5fc63f5d2a"
+                "reference": "d78ef59aea19d3e2e5a23f90a055155ee78a0ad5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/88ef346a1cefb92aab8b57a3214a6d5fc63f5d2a",
-                "reference": "88ef346a1cefb92aab8b57a3214a6d5fc63f5d2a",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/d78ef59aea19d3e2e5a23f90a055155ee78a0ad5",
+                "reference": "d78ef59aea19d3e2e5a23f90a055155ee78a0ad5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "symfony/console": "^2.8|~3",
-                "symfony/finder": "~2.5|~3.0"
+                "symfony/console": "^2.8|^3|^4",
+                "symfony/finder": "^2.5|^3|^4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8",
-                "satooshi/php-coveralls": "^1.0",
+                "g1a/composer-test-scenarios": "^2",
+                "phpunit/phpunit": "^5.7.27",
+                "satooshi/php-coveralls": "^2",
                 "squizlabs/php_codesniffer": "^2.7",
+                "symfony/console": "3.2.3",
+                "symfony/var-dumper": "^2.8|^3|^4",
                 "victorjonsson/markdowndocs": "^1.3"
+            },
+            "suggest": {
+                "symfony/var-dumper": "For using the var_dump formatter"
             },
             "type": "library",
             "extra": {
@@ -104,7 +111,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2017-10-12T19:38:03+00:00"
+            "time": "2018-05-25T18:02:34+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -381,31 +388,32 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.8.14",
+            "version": "v0.9.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "91e53c16560bdb8b9592544bb38429ae00d6baee"
+                "reference": "ed3c32c4304e1a678a6e0f9dc11dd2d927d89555"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/91e53c16560bdb8b9592544bb38429ae00d6baee",
-                "reference": "91e53c16560bdb8b9592544bb38429ae00d6baee",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/ed3c32c4304e1a678a6e0f9dc11dd2d927d89555",
+                "reference": "ed3c32c4304e1a678a6e0f9dc11dd2d927d89555",
                 "shasum": ""
             },
             "require": {
                 "dnoegel/php-xdg-base-dir": "0.1",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
                 "jakub-onderka/php-console-highlighter": "0.3.*",
-                "nikic/php-parser": "~1.3|~2.0|~3.0",
-                "php": ">=5.3.9",
-                "symfony/console": "~2.3.10|^2.4.2|~3.0",
-                "symfony/var-dumper": "~2.7|~3.0"
+                "nikic/php-parser": "~1.3|~2.0|~3.0|~4.0",
+                "php": ">=5.4.0",
+                "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0",
+                "symfony/var-dumper": "~2.7|~3.0|~4.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~1.11",
-                "hoa/console": "~3.16|~1.14",
-                "phpunit/phpunit": "~4.4|~5.0",
-                "symfony/finder": "~2.1|~3.0"
+                "bamarni/composer-bin-plugin": "^1.2",
+                "hoa/console": "~2.15|~3.16",
+                "phpunit/phpunit": "~4.8.35|~5.0|~6.0|~7.0"
             },
             "suggest": {
                 "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
@@ -420,15 +428,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-develop": "0.8.x-dev"
+                    "dev-develop": "0.9.x-dev"
                 }
             },
             "autoload": {
                 "files": [
-                    "src/Psy/functions.php"
+                    "src/functions.php"
                 ],
                 "psr-4": {
-                    "Psy\\": "src/Psy/"
+                    "Psy\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -450,20 +458,20 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2017-11-04T16:06:49+00:00"
+            "time": "2018-09-05T11:40:09+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.28",
+            "version": "v2.8.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f81549d2c5fdee8d711c9ab3c7e7362353ea5853"
+                "reference": "0c1fcbb9afb5cff992c982ff99c0434f0146dcfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f81549d2c5fdee8d711c9ab3c7e7362353ea5853",
-                "reference": "f81549d2c5fdee8d711c9ab3c7e7362353ea5853",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0c1fcbb9afb5cff992c982ff99c0434f0146dcfc",
+                "reference": "0c1fcbb9afb5cff992c982ff99c0434f0146dcfc",
                 "shasum": ""
             },
             "require": {
@@ -477,7 +485,7 @@
                 "symfony/process": "~2.1|~3.0.0"
             },
             "suggest": {
-                "psr/log": "For using the console logger",
+                "psr/log-implementation": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/process": ""
             },
@@ -511,20 +519,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-01T21:00:16+00:00"
+            "time": "2018-07-26T11:13:39+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.28",
+            "version": "v2.8.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "eaaec993ca5e8067e204b2ee653cdd142961f33e"
+                "reference": "cbb8a5f212148964efbc414838c527229f9951b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/eaaec993ca5e8067e204b2ee653cdd142961f33e",
-                "reference": "eaaec993ca5e8067e204b2ee653cdd142961f33e",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/cbb8a5f212148964efbc414838c527229f9951b7",
+                "reference": "cbb8a5f212148964efbc414838c527229f9951b7",
                 "shasum": ""
             },
             "require": {
@@ -568,20 +576,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-01T21:00:16+00:00"
+            "time": "2018-08-03T09:45:57+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.28",
+            "version": "v2.8.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "7fe089232554357efb8d4af65ce209fc6e5a2186"
+                "reference": "84ae343f39947aa084426ed1138bb96bf94d1f12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7fe089232554357efb8d4af65ce209fc6e5a2186",
-                "reference": "7fe089232554357efb8d4af65ce209fc6e5a2186",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/84ae343f39947aa084426ed1138bb96bf94d1f12",
+                "reference": "84ae343f39947aa084426ed1138bb96bf94d1f12",
                 "shasum": ""
             },
             "require": {
@@ -628,20 +636,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-01T21:00:16+00:00"
+            "time": "2018-07-26T09:03:18+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.28",
+            "version": "v2.8.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "a945724b201f74d543e356f6059c930bb8d10c92"
+                "reference": "f0de0b51913eb2caab7dfed6413b87e14fca780e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/a945724b201f74d543e356f6059c930bb8d10c92",
-                "reference": "a945724b201f74d543e356f6059c930bb8d10c92",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/f0de0b51913eb2caab7dfed6413b87e14fca780e",
+                "reference": "f0de0b51913eb2caab7dfed6413b87e14fca780e",
                 "shasum": ""
             },
             "require": {
@@ -677,20 +685,78 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-01T21:00:16+00:00"
+            "time": "2018-07-26T11:13:39+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.6.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
-                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
                 "shasum": ""
             },
             "require": {
@@ -702,7 +768,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -736,20 +802,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-10-11T12:05:26+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v2.8.28",
+            "version": "v2.8.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "3e34c94f44d7bf8db1569b4bcb4b45065ccf388e"
+                "reference": "4f935cf61c3733ca662628425eac69b38c2bbb4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/3e34c94f44d7bf8db1569b4bcb4b45065ccf388e",
-                "reference": "3e34c94f44d7bf8db1569b4bcb4b45065ccf388e",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/4f935cf61c3733ca662628425eac69b38c2bbb4c",
+                "reference": "4f935cf61c3733ca662628425eac69b38c2bbb4c",
                 "shasum": ""
             },
             "require": {
@@ -804,24 +870,25 @@
                 "debug",
                 "dump"
             ],
-            "time": "2017-09-15T16:59:28+00:00"
+            "time": "2018-07-26T11:13:39+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.28",
+            "version": "v2.8.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "842fb6df22180244b4c65935ce1a88d324e5ff9e"
+                "reference": "fbf876678e29dc634430dcf0096e216eb0004467"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/842fb6df22180244b4c65935ce1a88d324e5ff9e",
-                "reference": "842fb6df22180244b4c65935ce1a88d324e5ff9e",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/fbf876678e29dc634430dcf0096e216eb0004467",
+                "reference": "fbf876678e29dc634430dcf0096e216eb0004467",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
@@ -853,20 +920,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-05T14:38:30+00:00"
+            "time": "2018-07-26T09:03:18+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -903,7 +970,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -1058,33 +1125,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -1117,7 +1184,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1183,16 +1250,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -1226,7 +1293,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1320,16 +1387,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.11",
+            "version": "1.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
-                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
                 "shasum": ""
             },
             "require": {
@@ -1365,7 +1432,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-12-04T08:55:13+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1869,16 +1936,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.35",
+            "version": "v2.7.49",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "601b7d86103ae1ad374343725e899f905680f919"
+                "reference": "df9e3c66fb62a1ee93002e8ec9cd4d831236f494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/601b7d86103ae1ad374343725e899f905680f919",
-                "reference": "601b7d86103ae1ad374343725e899f905680f919",
+                "url": "https://api.github.com/repos/symfony/process/zipball/df9e3c66fb62a1ee93002e8ec9cd4d831236f494",
+                "reference": "df9e3c66fb62a1ee93002e8ec9cd4d831236f494",
                 "shasum": ""
             },
             "require": {
@@ -1914,7 +1981,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-09-30T14:00:25+00:00"
+            "time": "2018-05-15T08:20:41+00:00"
         }
     ],
     "aliases": [],

--- a/includes/annotationcommand_adapter.inc
+++ b/includes/annotationcommand_adapter.inc
@@ -30,6 +30,10 @@ function annotationcommand_adapter_get_discovery() {
     $discovery = new CommandFileDiscovery();
     $discovery
       ->setIncludeFilesAtBase(false)
+      ->setSearchDepth(3)
+      ->ignoreNamespacePart('contrib', 'Commands')
+      ->ignoreNamespacePart('custom', 'Commands')
+      ->ignoreNamespacePart('src')
       ->setSearchLocations(['Commands'])
       ->setSearchPattern('#.*Commands.php$#');
   }
@@ -265,10 +269,14 @@ function annotationcommand_adapter_get_commands($annotation_commandfiles) {
   //   'modules/default_content/src/CliTools/DefaultContentCommands.php' =>
   //   '\\Drupal\\default_content\\CliTools\\DefaultContentCommands',
   foreach ($annotation_commandfiles as $commandfile_path => $commandfile_class) {
-    if (file_exists($commandfile_path)) {
-      $commandhandler = annotationcommand_adapter_create_commandfile_instance($commandfile_path, $commandfile_class);
-      $commands_for_this_commandhandler = annotationcommand_adapter_get_commands_for_commandhandler($commandhandler, $commandfile_path);
-      $commands = array_merge($commands, $commands_for_this_commandhandler);
+    $class = new \ReflectionClass($commandfile_class);
+    if (file_exists($commandfile_path) && ($class && !$class->isAbstract())) {
+      try {
+        $commandhandler = annotationcommand_adapter_create_commandfile_instance($commandfile_path, $commandfile_class);
+        $commands_for_this_commandhandler = annotationcommand_adapter_get_commands_for_commandhandler($commandhandler, $commandfile_path);
+        $commands = array_merge($commands, $commands_for_this_commandhandler);
+      }
+      catch (\Exception $e) {}
     }
   }
   return $commands;
@@ -368,6 +376,32 @@ function annotationcommand_adapter_get_command_for_console_command($console_comm
   return $commands;
 }
 
+function annotationcommand_adapter_bootstrap_phase_index($phase)
+{
+  $phaseMap = annotationcommand_adapter_bootstrap_phase_map();
+  if (isset($phaseMap[$phase])) {
+    return $phaseMap[$phase];
+  }
+
+  if ((substr($phase, 0, 16) != 'DRUSH_BOOTSTRAP_') || (!defined($phase))) {
+    return;
+  }
+  return constant($phase);
+}
+
+function annotationcommand_adapter_bootstrap_phase_map()
+{
+  return [
+    'root' => DRUSH_BOOTSTRAP_DRUPAL_ROOT,
+    'site' => DRUSH_BOOTSTRAP_DRUPAL_SITE,
+    'config' => DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION,
+    'configuration' => DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION,
+    'db' => DRUSH_BOOTSTRAP_DRUPAL_DATABASE,
+    'database' => DRUSH_BOOTSTRAP_DRUPAL_DATABASE,
+    'full' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+  ];
+}
+
 /**
  * Convert an annotated command command handler object into a Drush $command record.
  *
@@ -378,6 +412,9 @@ function annotationcommand_adapter_get_command_for_console_command($console_comm
  * @return array Drush $command record
  */
 function annotationcommand_adapter_get_commands_for_commandhandler($commandhandler, $commandfile_path, $includeAllPublicMethods = true) {
+  if (!$commandhandler) {
+    return [];
+  }
   $cache =& drush_get_context('DRUSH_ANNOTATION_COMMANDS_FOR_COMMANDFILE');
   if (isset($cache[$commandfile_path])) {
     return $cache[$commandfile_path];
@@ -401,7 +438,8 @@ function annotationcommand_adapter_get_commands_for_commandhandler($commandhandl
     $handle_remote_commands = $commandinfo->getAnnotation('handle-remote-commands') == 'true';
     // TODO: if there is no 'bootstrap' annotation, maybe we should default to NONE instead of FULL?
     if ($bootstrap = $commandinfo->getAnnotation('bootstrap')) {
-      $bootstrap = constant($bootstrap);
+      // Convert from the bootstrap string to the appropriate bootstrap phase index
+      $bootstrap = annotationcommand_adapter_bootstrap_phase_map($bootstrap);
     }
     $command = [
       'name' => $command_name,

--- a/includes/annotationcommand_adapter.inc
+++ b/includes/annotationcommand_adapter.inc
@@ -391,6 +391,7 @@ function annotationcommand_adapter_bootstrap_phase_index($phase)
 function annotationcommand_adapter_bootstrap_phase_map()
 {
   return [
+    'none' => DRUSH_BOOTSTRAP_NONE,
     'root' => DRUSH_BOOTSTRAP_DRUPAL_ROOT,
     'site' => DRUSH_BOOTSTRAP_DRUPAL_SITE,
     'config' => DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION,
@@ -438,7 +439,7 @@ function annotationcommand_adapter_get_commands_for_commandhandler($commandhandl
     // TODO: if there is no 'bootstrap' annotation, maybe we should default to NONE instead of FULL?
     if ($bootstrap = $commandinfo->getAnnotation('bootstrap')) {
       // Convert from the bootstrap string to the appropriate bootstrap phase index
-      $bootstrap = annotationcommand_adapter_bootstrap_phase_map($bootstrap);
+      $bootstrap = annotationcommand_adapter_bootstrap_phase_index($bootstrap);
     }
     $command = [
       'name' => $command_name,

--- a/includes/annotationcommand_adapter.inc
+++ b/includes/annotationcommand_adapter.inc
@@ -269,15 +269,15 @@ function annotationcommand_adapter_get_commands($annotation_commandfiles) {
   //   'modules/default_content/src/CliTools/DefaultContentCommands.php' =>
   //   '\\Drupal\\default_content\\CliTools\\DefaultContentCommands',
   foreach ($annotation_commandfiles as $commandfile_path => $commandfile_class) {
-    $class = new \ReflectionClass($commandfile_class);
-    if (file_exists($commandfile_path) && ($class && !$class->isAbstract())) {
-      try {
+    try {
+      $class = new \ReflectionClass($commandfile_class);
+      if (file_exists($commandfile_path) && (!$class->isAbstract())) {
         $commandhandler = annotationcommand_adapter_create_commandfile_instance($commandfile_path, $commandfile_class);
         $commands_for_this_commandhandler = annotationcommand_adapter_get_commands_for_commandhandler($commandhandler, $commandfile_path);
         $commands = array_merge($commands, $commands_for_this_commandhandler);
       }
-      catch (\Exception $e) {}
     }
+    catch (\Exception $e) {}
   }
   return $commands;
 }

--- a/includes/annotationcommand_adapter.inc
+++ b/includes/annotationcommand_adapter.inc
@@ -270,8 +270,7 @@ function annotationcommand_adapter_get_commands($annotation_commandfiles) {
   //   '\\Drupal\\default_content\\CliTools\\DefaultContentCommands',
   foreach ($annotation_commandfiles as $commandfile_path => $commandfile_class) {
     try {
-      $class = new \ReflectionClass($commandfile_class);
-      if (file_exists($commandfile_path) && (!$class->isAbstract())) {
+      if (file_exists($commandfile_path) && ($commandfile_class != '\Drush\Commands\DrushCommands')) {
         $commandhandler = annotationcommand_adapter_create_commandfile_instance($commandfile_path, $commandfile_class);
         $commands_for_this_commandhandler = annotationcommand_adapter_get_commands_for_commandhandler($commandhandler, $commandfile_path);
         $commands = array_merge($commands, $commands_for_this_commandhandler);

--- a/includes/annotationcommand_adapter.inc
+++ b/includes/annotationcommand_adapter.inc
@@ -235,6 +235,7 @@ function annotationcommand_adapter_process_command() {
 
   $input = new DrushInputAdapter($args, annotationcommand_adapter_get_options($command), $command['command']);
   $output = new DrushOutputAdapter();
+  annotationcommand_adapter_input($input);
   $annotationData = $command['annotations'];
   $commandData = new CommandData(
     $annotationData,
@@ -253,6 +254,14 @@ function annotationcommand_adapter_process_command() {
   );
 
   return $result;
+}
+
+function annotationcommand_adapter_input($setInput = null) {
+  static $cacheInput = null;
+  if ($setInput != null) {
+    $cacheInput = $setInput;
+  }
+  return $cacheInput;
 }
 
 /**

--- a/lib/Drush/Commands/DrushCommands.php
+++ b/lib/Drush/Commands/DrushCommands.php
@@ -1,0 +1,41 @@
+<?php
+namespace Drush\Commands;
+
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+abstract class DrushCommands implements LoggerAwareInterface
+{
+    // This is more readable.
+    const REQ=InputOption::VALUE_REQUIRED;
+    const OPT=InputOption::VALUE_OPTIONAL;
+
+    use LoggerAwareTrait;
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * Returns a logger object.
+     *
+     * @return LoggerInterface
+     */
+    protected function logger()
+    {
+        return $this->logger;
+    }
+
+    /**
+     * Print the contents of a file.
+     *
+     * @param string $file
+     *   Full path to a file.
+     */
+    protected function printFile($file)
+    {
+        drush_print_file($file);
+    }
+}

--- a/lib/Drush/Commands/DrushCommands.php
+++ b/lib/Drush/Commands/DrushCommands.php
@@ -5,7 +5,22 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Drush\Command\DrushInputAdapter;
+use Drush\Command\DrushOutputAdapter;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\OutputInterface;
+use Drush\DrushConfig;
 
+/**
+ * DrushCommands provides access to configuration, IO and the logger,
+ * and also provides a "printFile" convenience method for displaying
+ * the contents of a file with a pager.
+ *
+ * Drush extensions that use ONLY the facilities provided by this class,
+ * plus any APIs provided by Drupal core and the module they are bundled
+ * with should work with both Drush 8 and Drush 9.
+ */
 abstract class DrushCommands implements LoggerAwareInterface
 {
     // This is more readable.
@@ -14,8 +29,45 @@ abstract class DrushCommands implements LoggerAwareInterface
 
     use LoggerAwareTrait;
 
+    protected $io;
+
     public function __construct()
     {
+    }
+
+    /**
+     * Return an object that has the same signature as a Consolidation\Config\ConfigInterface
+     */
+    protected function getConfig()
+    {
+        return new DrushConfig();
+    }
+
+    /**
+     * @return SymfonyStyle
+     */
+    protected function io()
+    {
+        if (!$this->io) {
+            $this->io = new SymfonyStyle($this->input(), $this->output());
+        }
+        return $this->io;
+    }
+
+    /**
+     * @return InputInterface
+     */
+    protected function input()
+    {
+        return annotationcommand_adapter_input();
+    }
+
+    /**
+     * @return OutputInterface
+     */
+    protected function output()
+    {
+        return new DrushOutputAdapter();
     }
 
     /**

--- a/lib/Drush/DrushConfig.php
+++ b/lib/Drush/DrushConfig.php
@@ -1,0 +1,94 @@
+<?php
+namespace Drush;
+
+/**
+ * Provides minimal access to Drush configuration in a way that is
+ * forward-compatible with the Consolidation\Config classes used
+ * in Drush 9.
+ */
+class DrushConfig
+{
+    /**
+     * Determine if a non-default config value exists in a non-default context.
+     */
+    public function has($key)
+    {
+        $contexts = drush_context_names();
+        $contexts = array_filter($contexts, function ($item) { return $item != 'default'; });
+
+        foreach ($contexts as $context) {
+            $value = _drush_get_option($option, drush_get_context($context));
+
+            if ($value !== NULL) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Fetch a configuration value
+     *
+     * @param string $key Which config item to look up
+     * @param string|null $default Value to use when $key does not exist
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        return drush_get_option($key, $default);
+    }
+
+    /**
+     * Set a config value
+     *
+     * @param string $key
+     * @param mixed $value
+     *
+     * @return $this
+     */
+    public function set($key, $value)
+    {
+        drush_set_option($key, $value);
+    }
+
+    /**
+     * Return the default value for a given configuration item.
+     *
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function hasDefault($key)
+    {
+        $value = $this->getDefault($key);
+        return $value != null;
+    }
+
+    /**
+     * Return the default value for a given configuration item.
+     *
+     * @param string $key
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getDefault($key, $default = null)
+    {
+        return drush_get_option($key, $default, 'default');
+    }
+
+    /**
+     * Set the default value for a configuration setting. This allows us to
+     * set defaults either before or after more specific configuration values
+     * are loaded. Keeping defaults separate from current settings also
+     * allows us to determine when a setting has been overridden.
+     *
+     * @param string $key
+     * @param string $value
+     */
+    public function setDefault($key, $value)
+    {
+        drush_set_default($key, $value);
+    }
+}


### PR DESCRIPTION
Use new features of the commandfile discovery class in the new version of the annotated command library, 2.9.1 to allow site-wide Drush extensions to be placed in contrib/custom directories without adding those names to the namespace, so the namespace of a command does not change if it moves from 'contrib' to 'custom'.

I managed to make a version of the Behat Drush Endpoint that works with both Drush 8 and Drush 9. I'd like to backport #3687 so that the Drush 9 version of the same command can also work in Drush 8. Drush commands (site-wide or bundled with modules) could be made to work with both if they limited themselves to using only Drupal core APIs + the APIs of the module they are attached to + limited Drush features such as the logger and output formatters. A standalone project that provides test traits to make it easy to test this functionality would also be helpful.