### PR TITLE
More conservative variation on PR #2002

### DIFF
--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1646,7 +1646,7 @@ function drush_convert_db_from_db_url($db_url) {
       );
       $url = (object)array_map('urldecode', $url);
       $db_spec = array(
-        'driver'   => $url->scheme,
+        'driver'   => $url->scheme == 'mysqli' && extension_loaded('mysql') ? 'mysql' : $url->scheme,
         'username' => $url->user,
         'password' => $url->pass,
         'host' => $url->host,

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -1646,7 +1646,7 @@ function drush_convert_db_from_db_url($db_url) {
       );
       $url = (object)array_map('urldecode', $url);
       $db_spec = array(
-        'driver'   => $url->scheme == 'mysqli' ? 'mysql' : $url->scheme,
+        'driver'   => $url->scheme,
         'username' => $url->user,
         'password' => $url->pass,
         'host' => $url->host,

--- a/lib/Drush/Sql/Sqlmysqli.php
+++ b/lib/Drush/Sql/Sqlmysqli.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drush\Sql;
+
+class Sqlmysqli extends Sqlmysql {
+
+}


### PR DESCRIPTION
See https://github.com/drush-ops/drush/pull/2002#issuecomment-424412519 where I attempted to describe this :-)

This is branched from @eXistenZNL's original PR. I had to rebase it on the 8.x branch for GitHub to say it was mergeable, which I think is why it gives us both credit for his commit. That commit is all his! Not trying to steal credit or anything.

Anyway, this variation should mean that everyone who Drush was working for in the past should keep working (because they have the 'mysql' extension available). And, for everyone that was getting broken (ie. those without the 'mysql' extension) it should start working! So, hopefully this will make the change acceptable.

I tried to run the test suite with Drupal 6 and PHP 7, but it pulls in Drupal 6.38, which is not compatible with PHP 7. The next release of the D6LTS fork of Drupal 6 (probably 6.45) will be compatible! But I don't know how to get the Drush test suite to use it.

But this does allow drush to work with Drupal 6 on PHP 7 in my limited manual testing!