### PR TITLE
Compatibility with new Tideways XHProf extension.

### DIFF
--- a/src/Commands/core/XhprofCommands.php
+++ b/src/Commands/core/XhprofCommands.php
@@ -37,7 +37,7 @@ class XhprofCommands extends DrushCommands
     {
         if (self::xhprofIsEnabled()) {
             $namespace = 'Drush';
-            $run_id = self::xhprof_finish_run($namespace);
+            $run_id = self::xhprofFinishRun($namespace);
             $url = Drush::config()->get('xh.link') . '/index.php?run=' . urlencode($run_id) . '&source=' . urlencode($namespace);
             $this->logger()->notice(dt('XHProf run saved. View report at !url', ['!url' => $url]));
         }
@@ -53,7 +53,7 @@ class XhprofCommands extends DrushCommands
         if (self::xhprofIsEnabled()) {
             $config = Drush::config()->get('xh');
             $flags = self::xhprofFlags($config);
-            self::xhprof_enable($flags);
+            self::xhprofEnable($flags);
         }
     }
 
@@ -90,11 +90,11 @@ class XhprofCommands extends DrushCommands
     /**
      * Enable profiling.
      */
-    public static function xhprof_enable($flags) {
+    public static function xhprofEnable($flags)
+    {
         if (extension_loaded('tideways_xhprof')) {
             \tideways_xhprof_enable(TIDEWAYS_XHPROF_FLAGS_MEMORY | TIDEWAYS_XHPROF_FLAGS_CPU);
-        }
-        else {
+        } else {
             \xhprof_enable($flags);
         }
     }
@@ -102,15 +102,15 @@ class XhprofCommands extends DrushCommands
     /**
      * Disable profiling and save results.
      */
-    public static function xhprof_finish_run($namespace) {
+    public static function xhprofFinishRun($namespace)
+    {
         if (extension_loaded('tideways_xhprof')) {
             $data = \tideways_xhprof_disable();
             $dir = sys_get_temp_dir();
             $run_id = uniqid();
             file_put_contents($dir . DIRECTORY_SEPARATOR . $run_id . '.' . $namespace . '.xhprof', serialize($data));
             return $run_id;
-        }
-        else {
+        } else {
             $xhprof_data = \xhprof_disable();
             $xhprof_runs = new \XHProfRuns_Default();
             return $xhprof_runs->save_run($xhprof_data, $namespace);

--- a/src/Commands/core/XhprofCommands.php
+++ b/src/Commands/core/XhprofCommands.php
@@ -8,6 +8,19 @@ use Drush\Drush;
 use Symfony\Component\Console\Input\InputInterface;
 use Drush\Commands\DrushCommands;
 
+/**
+ * Class XhprofCommands
+ * @package Drush\Commands\core
+ *
+ * Supports profiling Drush commands using either XHProf or Tideways XHProf.
+ *
+ * Note that XHProf is only compatible with PHP 5.6. For PHP 7+, you must use
+ * the Tideways XHProf fork. The Tideways XHProf extension recently underwent a
+ * major refactor; Drush is only compatible with the newer version.
+ * @see https://tideways.com/profiler/blog/releasing-new-tideways-xhprof-extension
+ *
+ * @todo Remove support for XHProf extension once PHP 5.6 is EOL.
+ */
 class XhprofCommands extends DrushCommands
 {
 
@@ -61,10 +74,15 @@ class XhprofCommands extends DrushCommands
     {
         if (Drush::config()->get('xh.link')) {
             if (!extension_loaded('xhprof') && !extension_loaded('tideways_xhprof')) {
-                throw new \Exception(dt('You must enable the xhprof or tideways PHP extensions in your CLI PHP in order to profile.'));
+                if (extension_loaded('tideways')) {
+                    throw new \Exception(dt('You are using an older incompatible version of the tideways extension. Please upgrade to the new tideways_xhprof extension.'));
+                } else {
+                    throw new \Exception(dt('You must enable the xhprof or tideways_xhprof PHP extensions in your CLI PHP in order to profile.'));
+                }
             }
             return true;
         }
+        return false;
     }
 
     /**

--- a/src/Commands/core/XhprofCommands.php
+++ b/src/Commands/core/XhprofCommands.php
@@ -102,11 +102,11 @@ class XhprofCommands extends DrushCommands
     /**
      * Disable profiling and save results.
      */
-    public static function xhprofFinishRun($namespace)
+    public function xhprofFinishRun($namespace)
     {
         if (extension_loaded('tideways_xhprof')) {
             $data = \tideways_xhprof_disable();
-            $dir = sys_get_temp_dir();
+            $dir = $this->getConfig()->tmp();
             $run_id = uniqid();
             file_put_contents($dir . DIRECTORY_SEPARATOR . $run_id . '.' . $namespace . '.xhprof', serialize($data));
             return $run_id;


### PR DESCRIPTION
Drush includes built-in functionality to profile commands using XHProf or Tideways.

Tideways recently went through a [pretty significant refactoring](https://tideways.com/profiler/blog/releasing-new-tideways-xhprof-extension), which changed the extension name and apparently some of the internals as well, although the data format is still compatible with the XHProf UI. This requires Drush to update its integration as well.

I could think of ways to improve this approach, but I wanted to get at least a working PoC for maintainers to review before putting more work into it. Primarily, it would be nice to support flags, which are now also named differently in Tideways. Also, maybe use an abstract "profiler" interface to support either XHProf or Tideways (or even different versions of Tideways), without having to use so many conditionals... maybe that's overkill.