### PR TITLE
Make drush_error_handler's fifth argument optional.

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -18,7 +18,7 @@ use Webmozart\PathUtil\Path;
  * Log PHP errors to the Drush log. This is in effect until Drupal's error
  * handler takes over.
  */
-function drush_error_handler($errno, $message, $filename, $line, $context) {
+function drush_error_handler($errno, $message, $filename, $line) {
   // E_DEPRECATED was added in PHP 5.3. Drupal 6 will not fix all the
   // deprecated errors, but suppresses them. So we suppress them as well.
   if (defined('E_DEPRECATED')) {


### PR DESCRIPTION
Since set_error_handler was introduced, the fifth argument has been optional. In
PHP 7.2 it has been deprecated. The argument is not even used in the function.
