### PR TITLE
set a general error for drush commands that return false

### DIFF
--- a/includes/command.inc
+++ b/includes/command.inc
@@ -230,6 +230,10 @@ function drush_command() {
   if (!drush_get_error()) {
     $result = _drush_invoke_hooks($command, $args);
   }
+  
+  if ($result === FALSE && !drush_get_error()) {
+    drush_set_error('DRUSH_COMMAND_FAILED', dt('The Drush command ' . $command['command'] . ' failed.'));
+  }
 
   if (!drush_get_error()) {
     foreach (drush_command_implements('drush_exit') as $name) {


### PR DESCRIPTION
We have noticed that `drush sql-create` and `sql-drop` don't return a non-zero status when they fail.  This changes `drush_command()` to set a generic "command failed" error for any command that returns `FALSE` without setting a Drush error.

There was a similar issue with `drush sql-query`: https://github.com/drush-ops/drush/issues/34#issuecomment-326548684