### PR TITLE
Set a non-zero exit status for "sql-create" on failure

### DIFF
--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -240,7 +240,11 @@ function drush_sql_create() {
     }
   }
 
-  return $sql->createdb(TRUE);
+  $result = $sql->createdb(TRUE);
+  if (!result) {
+    drush_set_error('DRUSH_SQL_CREATE_ERROR', dt('SQL create database error occurred.'));
+  }
+  return $result;
 }
 
 

--- a/commands/sql/sql.drush.inc
+++ b/commands/sql/sql.drush.inc
@@ -241,7 +241,7 @@ function drush_sql_create() {
   }
 
   $result = $sql->createdb(TRUE);
-  if (!result) {
+  if (!$result) {
     drush_set_error('DRUSH_SQL_CREATE_ERROR', dt('SQL create database error occurred.'));
   }
   return $result;


### PR DESCRIPTION
This PR ensures `drush sql-create` returns a non-zero status when it fails.  See https://github.com/drush-ops/drush/pull/3732 and https://github.com/drush-ops/drush/pull/2925.