### PR TITLE
Fix #3730. Remove patch to drupal/core 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,11 +125,6 @@
       "sut/themes/contrib/{$name}": ["type:drupal-theme"],
       "sut/drush/contrib/{$name}": ["type:drupal-drush"]
     },
-    "patches": {
-      "drupal/core": {
-        "Allow updating modules with new service dependencies https://www.drupal.org/project/drupal/issues/2863986": "https://www.drupal.org/files/issues/2863986-2-49.patch"
-      }
-    },
     "branch-alias": {
         "dev-master": "9.x-dev"
     }

--- a/scenarios/isolation-phpunit4/composer.json
+++ b/scenarios/isolation-phpunit4/composer.json
@@ -105,11 +105,6 @@
       "sut/themes/contrib/{$name}": ["type:drupal-theme"],
       "sut/drush/contrib/{$name}": ["type:drupal-drush"]
     },
-    "patches": {
-      "drupal/core": {
-        "Allow updating modules with new service dependencies https://www.drupal.org/project/drupal/issues/2863986": "https://www.drupal.org/files/issues/2863986-2-49.patch"
-      }
-    },
     "branch-alias": {
         "dev-master": "9.x-dev"
     }

--- a/scenarios/isolation/composer.json
+++ b/scenarios/isolation/composer.json
@@ -105,11 +105,6 @@
       "sut/themes/contrib/{$name}": ["type:drupal-theme"],
       "sut/drush/contrib/{$name}": ["type:drupal-drush"]
     },
-    "patches": {
-      "drupal/core": {
-        "Allow updating modules with new service dependencies https://www.drupal.org/project/drupal/issues/2863986": "https://www.drupal.org/files/issues/2863986-2-49.patch"
-      }
-    },
     "branch-alias": {
         "dev-master": "9.x-dev"
     }

--- a/tests/UpdateDBTest.php
+++ b/tests/UpdateDBTest.php
@@ -219,6 +219,9 @@ LOG;
      */
     public function testUpdateModuleWithServiceDependency()
     {
+
+        $this->markTestSkipped('Requires a patched Drupal. See https://github.com/drush-ops/drush/pull/3735.');
+
         $root = $this->webroot();
         $this->setUpDrupal(1, true);
         $options = [


### PR DESCRIPTION
The offending patch used to only be applied to our test system but I inadvertently made it so that Drupal installs that have extra config enable_patching: true in their composer.json extra config get the patch too. 

For now removing the patch and the test that depends on it. We'll find a better way. I made a [quick feature request in cweagans/composer-patches](https://github.com/cweagans/composer-patches/issues/237)