### PR TITLE
Allow symfony/var-dumper 4 again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "symfony/event-dispatcher": "^3.4",
     "symfony/finder": "^3.4",
     "symfony/process": "^3.4",
-    "symfony/var-dumper": "^3.4",
+    "symfony/var-dumper": "^3.4 || ^4.0",
     "symfony/yaml": "^3.4",
     "webflo/drupal-finder": "^1.1",
     "webmozart/path-util": "^2.1.0"

--- a/scenarios/isolation-phpunit4/composer.json
+++ b/scenarios/isolation-phpunit4/composer.json
@@ -36,7 +36,7 @@
     "consolidation/site-alias": "^1.1.5",
     "psr/log": "~1.0",
     "symfony/finder": "^3.4",
-    "symfony/var-dumper": "^3.4",
+    "symfony/var-dumper": "^3.4 || ^4.0",
     "webflo/drupal-finder": "^1.1",
     "webmozart/path-util": "^2.1.0"
   },

--- a/scenarios/isolation/composer.json
+++ b/scenarios/isolation/composer.json
@@ -36,7 +36,7 @@
     "consolidation/site-alias": "^1.1.5",
     "psr/log": "~1.0",
     "symfony/finder": "^3.4",
-    "symfony/var-dumper": "^3.4",
+    "symfony/var-dumper": "^3.4 || ^4.0",
     "webflo/drupal-finder": "^1.1",
     "webmozart/path-util": "^2.1.0"
   },


### PR DESCRIPTION
This change was accepted in https://github.com/drush-ops/drush/pull/3578 but was mistakenly reverted (I guess ? @weitzman) in https://github.com/drush-ops/drush/pull/3697.

