### PR TITLE
Improve tests README

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -15,7 +15,7 @@ Docker
 Drush's own tests may be run within provided Docker containers (see docker-compose.yml):
 
 - Start containers: `docker-compose up -d`
-- Run a test: `docker-compose exec php composer functional -- --filter testUserRole`
+- Run a test: `docker-compose exec drupal composer functional -- --filter testUserRole`
 - To change configuration, copy .env.example to .env, edit to taste, and run `docker-compose up -d` again
 - See that .env.example file for help on enabling Xdebug.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,12 +15,12 @@ Docker
 Drush's own tests may be run within provided Docker containers (see docker-compose.yml):
 
 - Start containers: `docker-compose up -d`
-- Run a test: `docker-compose exec php composer functional -- --filter testVersionString`
+- Run a test: `docker-compose exec php composer functional -- --filter testUserRole`
 - To change configuration, copy .env.example to .env, edit to taste, and run `docker-compose up -d` again
 - See that .env.example file for help on enabling Xdebug.
 
 Advanced usage
 ---------
-- Run only tests matching a regex: `composer functional -- --filter testVersionString`
+- Run only tests matching a regex: `composer functional -- --filter testUserRole`
 - Skip slow tests (usually those with network usage): `composer functional -- --exclude-group slow`
 - XML results: `composer functional -- --log-junit results.xml`


### PR DESCRIPTION
- The docker php service name was changed in https://github.com/drush-ops/drush/pull/3728 but not the doc.
- There is no test named `testVersionString`, so when you execute the examples you end up with a `No tests executed!` message. IMO, this is bad for the DX. When I copy paste an example from a doc, I expect it to work. I updated the `--filter` argument with an actually existing test (I chose it randomly).