### PR TITLE
Allow symfony/config 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "league/container": "~2",
     "psr/log": "~1.0",
     "psy/psysh": "~0.6",
-    "symfony/config": "^3.4",
+    "symfony/config": "^3.4 || ^4.0",
     "symfony/console": "^3.4",
     "symfony/event-dispatcher": "^3.4",
     "symfony/finder": "^3.4",


### PR DESCRIPTION
The `symfony/config` component is not a core Drupal dependency. So it not technically locked to `^3.4`.

I have reviewed the usage that is made of this component in drush. The only thing that is used is the `Symfony\Component\Config\Definition\Exception\Exception` class. This class did not change at all in the version 4 so it is a safe update.

It would be great to accept v4 of this component, so projects that require drush and this component directly can use the latest version.
