### PR TITLE
Allow symfony/finder 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "symfony/config": "^3.4",
     "symfony/console": "^3.4",
     "symfony/event-dispatcher": "^3.4",
-    "symfony/finder": "^3.4",
+    "symfony/finder": "^3.4 || ^4.0",
     "symfony/process": "^3.4",
     "symfony/var-dumper": "^3.4",
     "symfony/yaml": "^3.4",


### PR DESCRIPTION
The `symfony/finder` component is not a core Drupal dependency. So it not technically locked to `^3.4`.

I have reviewed the usage that is made of this component in drush. The only thing that is used is the `Symfony\Component\Finder\Finder` class.

I have checked every method of this class that is used by drush. Then I have read the CHANGELOG of the component and did not see any obvious impact for drush. Then I made a diff between the `3.4` branch and the `master` branch of this class file and manually checked changes that could break drush usage of this component. I did not find any.

It would be great to accept v4 of this component, so projects that require drush and this component directly can use the latest version.