### PR TITLE
Add a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes     export-ignore
+/.circleci					export-ignore
+/.docker						export-ignore
+/build              export-ignore
+/scenarios          export-ignore
+/sut			          export-ignore
+/tests							export-ignore


### PR DESCRIPTION
Keep things that are only needed for debugging out of Packagist's 'prefer dist' exports.
