### PR TITLE
fix - symfony/filesystem wasn't required but was used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     "symfony/config": "^3.4",
     "symfony/console": "^3.4",
     "symfony/event-dispatcher": "^3.4",
+    "symfony/filesystem": "^3.4 || ^4.0",
     "symfony/finder": "^3.4",
     "symfony/process": "^3.4",
     "symfony/var-dumper": "^3.4",


### PR DESCRIPTION
Symfony/FileSystem component is used but isn't required in composer.json file. 

Let's allow 4.0 too because this component isn't a Drupal Core dependency and the usage inside Drush is compatible with it. 