### PR TITLE
Generate full path for rsync only if alias is remote.

### DIFF
--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -204,9 +204,14 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
             if (($runner == 'target') || ($runner == 'destination')) {
                 $runner = $targetRecord;
             }
+
+            // Generate full path for rsync, including site alias (if remote) or without alias (if local)
+            $source_full_path = ($sourceRecord->isRemote() ? $sourceRecord->name() . ':' . $source_dump_path : $source_dump_path);
+            $target_full_path = ($targetRecord->isRemote() ? $targetRecord->name() . ':' . $target_dump_path : $target_dump_path);
+
             // Since core-rsync is a strict-handling command and drush_invoke_process() puts options at end, we can't send along cli options to rsync.
             // Alternatively, add options like ssh.options to a site alias (usually on the machine that initiates the sql-sync).
-            $return = drush_invoke_process($runner, 'core-rsync', array_merge([$sourceRecord->name() . ":$source_dump_path", $targetRecord->name() . ":$target_dump_path", '--'], $rsync_options), [], $backend_options);
+            $return = drush_invoke_process($runner, 'core-rsync', array_merge([$source_full_path, $target_full_path, '--'], $rsync_options), [], $backend_options);
             $this->logger()->notice(dt('Copying dump file from source to target.'));
             if ($return['error_status']) {
                 throw new \Exception(dt('core-rsync failed.'));


### PR DESCRIPTION
This should fix drush sql:sync if the local alias is different from @self (needed for most of drupal multisite project where each site uses different alias but they are all in fact in local). It should be also starting point to support sync between two remotes (possible, with tunnelling rsync transfer through local).

This is related to the discussion in https://github.com/drush-ops/drush/issues/3408 , where I will write the closer comment.

Please forgive my ignorance but it was not in my time possibilities to set up the test suite and it is very likely the SqlSyncTest.php will need to be updated as well. I would appreciate if someone from drush authors could take over that.