### PR TITLE
Fixes #3761. Taking into account unreadable output of 'stty size' when...

### DIFF
--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -441,7 +441,7 @@ function _drush_preflight_columns() {
   if (!($columns = getenv('COLUMNS') ?: 0)) {
     // Trying to export the columns using stty.
     exec('stty size 2>&1', $columns_output, $columns_status);
-    if (!$columns_status) $columns = preg_replace('/\d+\s(\d+)/', '$1', $columns_output[0], -1, $columns_count);
+    if (!$columns_status && is_numeric($columns_output[0])) $columns = preg_replace('/\d+\s(\d+)/', '$1', $columns_output[0], -1, $columns_count);
 
     // If stty fails and Drush us running on Windows are we trying with mode con.
     if (($columns_status || !$columns_count) && drush_is_windows()) {


### PR DESCRIPTION
…determining number of columns, to avoid unreadable tables.

It just makes additional check for already existing assumption. Without it, we are getting unexpected state which in some situations causes COLUMNS to be assumed to be 0, which breaks display of tables.