### PR TITLE
Pin consolidation/site-alias to 1.1.5 until Drush supports 1.1.6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "consolidation/config": "^1.1.0",
     "consolidation/output-formatters": "^3.1.12",
     "consolidation/robo": "^1.1.5",
-    "consolidation/site-alias": "^1.1.5",
+    "consolidation/site-alias": "1.1.5",
     "grasmash/yaml-expander": "^1.1.1",
     "league/container": "~2",
     "psr/log": "~1.0",


### PR DESCRIPTION
Drush 9.5.2 can install consolidation/site-alias 1.1.6, which is incompatible. We can pin the version until those changes go in to a Drush release.

See https://github.com/consolidation/site-alias/pull/11#issuecomment-433678408