### PR TITLE
Fix bug where pm:security misses required security updates.

### DIFF
--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -136,7 +136,7 @@ class SecurityUpdateCommands extends DrushCommands
      */
     protected function registerAllSecurityUpdates($composer_lock_data, $security_advisories_composer_json)
     {
-        $both = $composer_lock_data['packages-dev'] + $composer_lock_data['packages'];
+        $both = array_merge($composer_lock_data['packages-dev'], $composer_lock_data['packages']);
         foreach ($both as $package) {
             $name = $package['name'];
             $this->registerPackageSecurityUpdates($security_advisories_composer_json, $name, $package);


### PR DESCRIPTION
The bug here is that 'packages-dev' and 'packages' are both arrays with
numeric keys. Using the '+' operator on them, according to PHP's
documentation (https://secure.php.net/manual/en/language.operators.array.php),
means that if a key exists in both, whatever array is on the right-hand side
will have that key's value ignored and the left-hand side's value will be
used.

To ensure that the 'packages' array is appended to the 'packages-dev' array,
we have to use array_merge, which always appends numeric keys
(https://secure.php.net/manual/en/function.array-merge.php).