### PR TITLE
Add a command to check if Drupal has been bootstrapped.

### DIFF
--- a/src/Commands/core/CheckBootstrapCommands.php
+++ b/src/Commands/core/CheckBootstrapCommands.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drush\Commands\core;
+
+use Drush\Drush;
+use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
+use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
+
+class CheckBootstrapCommands extends DrushCommands implements SiteAliasManagerAwareInterface
+{
+    use SiteAliasManagerAwareTrait;
+
+    /**
+     * This command executes successfully if Drupal has been fully bootstrapped.
+     *
+     * @see DRUSH_BOOTSTRAP_DRUPAL_FULL
+     *
+     * @command check-bootstrap:full
+     * @aliases check-bootstrap, cb
+     * @bootstrap max
+     */
+    public function isBootstrapFull()
+    {
+      $this->checkBootstrapPhase(DRUSH_BOOTSTRAP_DRUPAL_FULL);
+    }
+
+    /**
+     * This command executes successfully if Drupal's database has been bootstrapped.
+     *
+     * @see DRUSH_BOOTSTRAP_DRUPAL_DATABASE
+     *
+     * @command check-bootstrap:db
+     * @bootstrap max
+     */
+    public function isBootstrapDatabase()
+    {
+      $this->checkBootstrapPhase(DRUSH_BOOTSTRAP_DRUPAL_DATABASE);
+    }
+
+    /**
+     * This command executes successfully if Drupal's settings.php have been read.
+     *
+     * @see DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION
+     *
+     * @command check-bootstrap:config
+     * @bootstrap max
+     */
+    public function isBootstrapConfiguration()
+    {
+      $this->checkBootstrapPhase(DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION);
+    }
+
+    /**
+     * This command executes successfully if Drupal's settings.php was found.
+     *
+     * @see DRUSH_BOOTSTRAP_DRUPAL_SITE
+     *
+     * @command check-bootstrap:site
+     * @bootstrap max
+     */
+    public function isBootstrapSite()
+    {
+      $this->checkBootstrapPhase(DRUSH_BOOTSTRAP_DRUPAL_SITE);
+    }
+
+    /**
+     * This command executes successfully if a Drupal site was found.
+     *
+     * @see DRUSH_BOOTSTRAP_DRUPAL_ROOT
+     *
+     * @command check-bootstrap:root
+     * @bootstrap max
+     */
+    public function isBootstrapRoot()
+    {
+      $this->checkBootstrapPhase(DRUSH_BOOTSTRAP_DRUPAL_ROOT);
+    }
+
+    protected function checkBootstrapPhase($phase)
+    {
+      if (Drush::bootstrapManager()->hasBootstrapped($phase)) {
+        drush_set_context('DRUSH_EXIT_CODE', DRUSH_SUCCESS);
+      }
+      else {
+        drush_set_context('DRUSH_EXIT_CODE', DRUSH_FRAMEWORK_ERROR);
+      }
+    }
+}


### PR DESCRIPTION
There are many cases where we need to check if Drupal has been installed from scripts, for example:

- In a deployment script, run updates if Drupal is already running, make a clean install otherwise
- In a Kubernetes readiness check, start serving traffic to a pod only when Drupal has been installed

At the moment, there is no dedicated command to check for the bootstrap phase, one needs to run `drush status` and parse the output looking for the "Successful" string, which is not ideal.

This PR adds a set of commands that execute successfully if Drupal has been bootstrapped to a certain level. If not specified the default level is "full", as that's probably the most common use case.

