### PR TITLE
Allow Symfony Console commands to be used in php:cli.

### DIFF
--- a/src/Psysh/DrushCommand.php
+++ b/src/Psysh/DrushCommand.php
@@ -10,6 +10,7 @@
 namespace Drush\Psysh;
 
 use Consolidation\AnnotatedCommand\AnnotatedCommand;
+use Symfony\Component\Console\Command\Command;
 use Psy\Command\Command as BaseCommand;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,17 +23,17 @@ class DrushCommand extends BaseCommand
 {
 
     /**
-     * @var \Consolidation\AnnotatedCommand\AnnotatedCommand
+     * @var \Symfony\Component\Console\Command\Command
      */
     private $command;
 
     /**
      * DrushCommand constructor.
      *
-     * @param \Consolidation\AnnotatedCommand\AnnotatedCommand $command
-     *   Original (annotated) Drush command.
+     * @param \Symfony\Component\Console\Command\Command $command
+     *   Original Drush command.
      */
-    public function __construct(AnnotatedCommand $command)
+    public function __construct(Command $command)
     {
         $this->command = $command;
         parent::__construct();
@@ -110,14 +111,17 @@ class DrushCommand extends BaseCommand
         $help = wordwrap($this->command->getDescription());
 
         $examples = [];
-        foreach ($this->command->getExampleUsages() as $ex => $def) {
-            // Skip empty examples and things with obvious pipes...
-            if (($ex === '') || (strpos($ex, '|') !== false)) {
-                continue;
-            }
 
-            $ex = preg_replace('/^drush\s+/', '', $ex);
-            $examples[$ex] = $def;
+        if ($this->command instanceof AnnotatedCommand) {
+            foreach ($this->command->getExampleUsages() as $ex => $def) {
+                // Skip empty examples and things with obvious pipes...
+                if (($ex === '') || (strpos($ex, '|') !== false)) {
+                    continue;
+                }
+
+                $ex = preg_replace('/^drush\s+/', '', $ex);
+                $examples[$ex] = $def;
+            }
         }
 
         if (!empty($examples)) {


### PR DESCRIPTION
In `Drush\Drupal\DrushServiceModifier` (https://github.com/drush-ops/drush/blob/2c9a38d1db1f78505ca28cfe44e3db565f02e9e8/src/Drupal/DrushServiceModifier.php#L11-L28), Symfony console commands are recognized by Drush and can be run as normal commands.

However, if you are in a project with a Symfony console command and run `drush php:cli`, you receive this error:
```
 [error]  TypeError: Argument 1 passed to Drush\Psysh\DrushCommand::__construct() must be an instance of Drupal\Console\Core\Command\Command, instance of Consolidation\AnnotatedCommand\AnnotatedCommand [...]
```
I propose that Symfony console commands are allowed to be executed in the CLI, which would avoid this error. I've tested this and it seems to work normally, only one part of the `\Drush\Psysh\DrushCommand` class relied on `Consolidation\AnnotatedCommand\AnnotatedCommand` which I've addressed in the PR.
