### PR TITLE
Unset _style during encode/decode of backend packets to avoid type mismatch errors

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -213,6 +213,9 @@ function drush_backend_output_discard($string) {
 function drush_backend_packet($packet, $data) {
   if (\Drush\Drush::backend()) {
     $data['packet'] = $packet;
+    // Ensure $data['_style'] isn't encoded, to avoid errors during decode and
+    // subsequent logging.
+    unset($data['_style']);
     $data = json_encode($data);
     // We use 'fwrite' instead of 'drush_print' here because
     // this backend packet is out-of-band data.
@@ -536,6 +539,8 @@ function drush_backend_parse_packets(&$string, &$remainder, $backend_options) {
     drush_set_context('DRUSH_RECEIVED_BACKEND_PACKETS', TRUE);
     foreach ($match[1] as $packet_data) {
       $entry = (array) json_decode($packet_data);
+      // Ensure $entry['_style'] isn't set to avoid type mismatch errors.
+      unset($entry['_style']);
       if (is_array($entry) && isset($entry['packet'])) {
         $function = 'drush_backend_packet_' . $entry['packet'];
         if (function_exists($function)) {


### PR DESCRIPTION
If a drush command uses a Robo collection (or perhaps just a Robo task—untested), and that command is invoked as a backend process, and that command fails, you may see an error like this:

```
 [error]  Drush command terminated abnormally due to an unrecoverable error.
Error: Uncaught Error: Unsupported operand types in /app/vendor/consolidation/log/src/LogOutputStyler.php:66
Stack trace:
#0 /app/vendor/consolidation/log/src/Logger.php(186): Consolidation\Log\LogOutputStyler->style(Array)
#1 /app/vendor/consolidation/log/src/Logger.php(171): Consolidation\Log\Logger->doLog(Object(Symfony\Component\Console\Output\StreamOutput), 'error', '', Array)
#2 /app/vendor/drush/drush/src/Log/Logger.php(174): Consolidation\Log\Logger->log('error', '', Array)
#3 /app/vendor/drush/drush/includes/drush.inc(454): Drush\Log\Logger->log('error', '', Array)
#4 /app/vendor/drush/drush/includes/drush.inc(428): _drush_log_to_logger(Object(Drush\Log\Logger), Array)
#5 /app/vendor/drush/drush/includes/drush.inc(488): _drush_log(Array)
#6 /app/vendor/drush/drush/includes/backend.inc(542): drush_backend_packet_log(Array, Array)
#7 /app/vendor/drush/drush/includes/backend.inc(454): drush_backend_parse_packets('\x00DRUSH_BACKEND:...', '', Array)
#8 /app/vendor/drush/drush/includes/backend.inc(1040): _drush_b in /app/vendor/consolidation/log/src/LogOutputStyler.php, line 66
```

After some debugging, it turns out this is because [`Robo\Log\ResultPrinter`](https://github.com/consolidation/Robo/blob/bba85cdd6ba5dc1b035338fc723cec84114764b3/src/Log/ResultPrinter.php#L68) sets `['_style']['message']` to an empty string, which then gets encoded to json. When the "frontend" process then decodes this json, `['_style']` is decoded as a `stdClass`. This subsequently results in an unsupported operand error in [`Consolidation\Log\LogOutputStyler::style()`](https://github.com/consolidation/log/blob/35f6c653037de312f0d8834c9f0dd41f2ff76ebf/src/LogOutputStyler.php#L66) as that function expects `_style` to be an array.

The attached patch strips `_style` from the packet prior to encoded and subsequent to decoding. You may wonder why the latter is necessary if the former is done, but remember that different versions of drush may be involved, so an older version of drush may happily send along the `_style` and recreate the same error on a newer version of drush. Cleaning up in both places should avoid this possibility.