### PR TITLE
Fix ssh to site alias

### DIFF
--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -613,7 +613,7 @@ function drush_preflight_command_dispatch() {
     $local_drush = find_wrapper_or_launcher($root);
   }
   $is_local = drush_get_option('local');
-  $must_use_site_local = !empty($root) && !empty($local_drush) && empty($is_local);
+  $must_use_site_local = !empty($root) && !empty($local_drush) && !empty($is_local);
   // If the command sets the 'handle-remote-commands' flag, then we will short-circuit
   // remote command dispatching and site-list command dispatching, and always let
   // the command handler run on the local machine.


### PR DESCRIPTION
There have been many reports of ssh issues with 8.1.17. See #3725. I believe the changes in #3428 are the source of the breakage.

I'm able to connect successfully if I use `--local`: `drush --local @alias ssh`. I'm also able to connect if I use only a global drush. The combination of a global drush calling a local drush breaks.

I find myself very confused with the variable names. The command setting `handle-remote-commands` sounds to me like it should run the command remotely, but the docs say ```set to TRUE if `drush @remote mycommand` should be executed locally rather than remotely dispatched```.

The `ssh` command has `handle-remote-commands` set to `TRUE` so it should always be executed locally.

In the changes for #3428, a new variable `$must_use_site_local` is defined. To me it sounds like that means the command must be executed locally, but the code checks that drush `--local` is **not** set.

Based on the "global+local drush" case, the previous code and the variable names, I believe the bug is a missing `!` check. The `$must_use_site_local` should check that `--local` is `!empty()` instead of `empty()`.

I will provide test setup details and logs of 8.1.16 working and 8.1.17 broken in the first comment.