### PR TITLE
D7: file_get_stream_wrappers cache poisoning in update_check_requirements()

### DIFF
--- a/commands/core/drupal/update_7.inc
+++ b/commands/core/drupal/update_7.inc
@@ -199,6 +199,11 @@ function update_main_prepare() {
   // @see https://github.com/drush-ops/drush/pull/399
   module_implements('', FALSE, TRUE);
 
+  // Ensure we re-evaluate the stream wrappers on full bootstrap.
+  // update_check_requirements() invokes a writeable check and hence loads the
+  // stream wrappers while not all modules are available.
+  drupal_static_reset('file_get_stream_wrappers');
+  
   // Now proceed with a full bootstrap.
 
   drush_bootstrap(DRUSH_BOOTSTRAP_DRUPAL_FULL);


### PR DESCRIPTION
Currently  `update_check_requirements()` runs `update_check_requirements()` before a full bootstrap. And `update_check_requirements()` performs a writeable check on the filesystem - which invokes the file stream wrapper handling.
This fills a the static cache of `file_get_stream_wrappers` and because of the low bootstrap level not all available stream wrappers will be registered.

This can lead to missing stream wrappers in update hooks.

We should reset the file_get_stream_wrappers static cache before running the full bootstrap which then will re-evaluate the available stream wrappers.