### PR TITLE
Remove context.inc usage in Boot classes

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -57,6 +57,7 @@
  * drush_backend_get_result().
  */
 
+use Drush\Drush;
 use Drush\Log\LogLevel;
 use Drush\Preflight\PreflightArgs;
 
@@ -848,8 +849,8 @@ function drush_backend_invoke_concurrent($invocations, $common_options = [], $co
     $is_remote = array_key_exists('remote-host', $site_record);
     $is_different_site =
       $is_remote ||
-      (isset($site_record['root']) && ($site_record['root'] != drush_get_context('DRUSH_DRUPAL_ROOT'))) ||
-      (isset($site_record['uri']) && ($site_record['uri'] != drush_get_context('DRUSH_SELECTED_URI')));
+      (isset($site_record['root']) && ($site_record['root'] != Drush::bootstrapManager()->getRoot())) ||
+      (isset($site_record['uri']) && ($site_record['uri'] != Drush::bootstrapManager()->getUri()));
     $os = drush_os($site_record);
     // If the caller did not pass in a specific path to drush, then we will
     // use a default value.  For commands that are being executed on the same

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -92,6 +92,7 @@ define('DRUSH_BOOTSTRAP_DRUPAL_FULL', 5);
  * Helper function to store any context settings that are being validated.
  *
  * @deprecated
+ *   No longer used in Drush core.
  */
 function drush_bootstrap_value($context, $value = null) {
   $values =& drush_get_context('DRUSH_BOOTSTRAP_VALUES', []);
@@ -112,6 +113,7 @@ function drush_bootstrap_value($context, $value = null) {
  * Always returns FALSE, for convenience.
  *
  * @deprecated
+ *   No longer used in Drush core.
  */
 function drush_bootstrap_error($code, $message = null) {
   $errors = drush_get_context('DRUSH_BOOTSTRAP_ERRORS');

--- a/includes/cache.inc
+++ b/includes/cache.inc
@@ -11,6 +11,7 @@
  * option in drushrc.php.
  */
 
+use Drush\Cache\JSONCache;
 use Drush\Drush;
 use Drush\Log\LogLevel;
 
@@ -45,11 +46,7 @@ function _drush_cache_get_object($bin) {
   static $cache_objects;
 
   if (!isset($cache_objects[$bin])) {
-    $class = drush_get_option('cache-class-' . $bin, NULL);
-    if (!isset($class)) {
-      $class = drush_get_option('cache-default-class', '\Drush\Cache\JSONCache');
-    }
-    $cache_objects[$bin] = new $class($bin);
+    $cache_objects[$bin] = new JSONCache($bin);
   }
   return $cache_objects[$bin];
 }

--- a/includes/cache.inc
+++ b/includes/cache.inc
@@ -184,6 +184,8 @@ function drush_cache_get_bins() {
  *
  * @return
  *   A cache id string.
+ *
+ * @deprecated
  */
 function drush_get_cid($prefix, $contexts = [], $params = []) {
   $cid = [];

--- a/includes/drupal.inc
+++ b/includes/drupal.inc
@@ -22,7 +22,7 @@ function drush_drupal_version($drupal_root = NULL) {
   static $version = FALSE;
 
   if (!$version) {
-    if (($drupal_root != NULL) || ($drupal_root = drush_get_context('DRUSH_DRUPAL_ROOT'))) {
+    if (($drupal_root != NULL) || ($drupal_root = Drush::bootstrapManager()->getRoot())) {
       $bootstrap = Drush::bootstrapManager()->bootstrapObjectForRoot($drupal_root);
       if ($bootstrap) {
         $version = $bootstrap->getVersion($drupal_root);

--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -132,10 +132,7 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
         if (!isset($root)) {
             $root = $this->getConfig()->cwd();
         }
-        if (!$this->drupalFinder()->locateRoot($root)) {
-            //    echo ' Drush must be executed within a Drupal site.'. PHP_EOL;
-            //    exit(1);
-        }
+        $this->drupalFinder()->locateRoot($root);
     }
 
     /**

--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -362,11 +362,8 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
         static $result_cache = [];
 
         if (!array_key_exists($phase, $result_cache)) {
-            drush_set_context('DRUSH_BOOTSTRAP_ERRORS', []);
-            drush_set_context('DRUSH_BOOTSTRAP_VALUES', []);
-
+            $validated_phase = -1;
             foreach ($phases as $phase_index => $current_phase) {
-                $validated_phase = drush_get_context('DRUSH_BOOTSTRAP_VALIDATION_PHASE', -1);
                 if ($phase_index > $phase) {
                     break;
                 }
@@ -377,7 +374,7 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
                     } else {
                         $result_cache[$phase_index] = true;
                     }
-                    drush_set_context('DRUSH_BOOTSTRAP_VALIDATION_PHASE', $phase_index);
+                    $validated_phase = $phase_index;
                 }
             }
         }

--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -295,7 +295,7 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
         // phases, it means that the command requires bootstrap to a certain
         // level, but no site root could be found.
         if (!isset($phases[$phase])) {
-            $result = drush_bootstrap_error('DRUSH_NO_SITE', dt("We could not find an applicable site for that command."));
+            throw new \Exception(dt("We could not find an applicable site for that command."));
         }
 
         // Once we start bootstrapping past the DRUSH_BOOTSTRAP_DRUSH phase, we
@@ -317,12 +317,6 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
                     }
                     $this->setPhase($phase_index);
                 }
-            }
-        }
-        if (!$result || drush_get_error()) {
-            $errors = drush_get_context('DRUSH_BOOTSTRAP_ERRORS', []);
-            foreach ($errors as $code => $message) {
-                drush_set_error($code, $message);
             }
         }
         return !drush_get_error();

--- a/src/Boot/DrupalBoot.php
+++ b/src/Boot/DrupalBoot.php
@@ -124,15 +124,13 @@ abstract class DrupalBoot extends BaseBoot
         $drupal_root = Drush::bootstrapManager()->getRoot();
         chdir($drupal_root);
         $this->logger->log(LogLevel::BOOTSTRAP, dt("Change working directory to !drupal_root", ['!drupal_root' => $drupal_root]));
-        $version = drush_drupal_version();
-        $major_version = drush_drupal_major_version();
 
         $core = $this->bootstrapDrupalCore($drupal_root);
 
         // DRUSH_DRUPAL_CORE should point to the /core folder in Drupal 8+.
         define('DRUSH_DRUPAL_CORE', $core);
 
-        $this->logger->log(LogLevel::BOOTSTRAP, dt("Initialized Drupal !version root directory at !drupal_root", ["!version" => $version, '!drupal_root' => $drupal_root]));
+        $this->logger->log(LogLevel::BOOTSTRAP, dt("Initialized Drupal !version root directory at !drupal_root", ["!version" => Drush::bootstrap()->getVersion($drupal_root), '!drupal_root' => $drupal_root]));
     }
 
     /**

--- a/src/Boot/DrupalBoot.php
+++ b/src/Boot/DrupalBoot.php
@@ -55,7 +55,6 @@ abstract class DrupalBoot extends BaseBoot
 
     public function confPath($require_settings = true, $reset = false)
     {
-        return confPath($require_settings, $reset);
     }
 
     /**
@@ -244,7 +243,7 @@ abstract class DrupalBoot extends BaseBoot
     }
 
     /**
-     * Boostrap the Drupal database.
+     * Bootstrap the Drupal database.
      */
     public function bootstrapDrupalDatabase()
     {

--- a/src/Boot/DrupalBoot.php
+++ b/src/Boot/DrupalBoot.php
@@ -101,36 +101,11 @@ abstract class DrupalBoot extends BaseBoot
      * Validate the DRUSH_BOOTSTRAP_DRUPAL_ROOT phase.
      *
      * In this function, we will check if a valid Drupal directory is available.
-     * We also determine the value that will be stored in the DRUSH_DRUPAL_ROOT
-     * context and DRUPAL_ROOT constant if it is considered a valid option.
      */
     public function bootstrapDrupalRootValidate()
     {
         $drupal_root = Drush::bootstrapManager()->getRoot();
-
-        if (empty($drupal_root)) {
-            return drush_bootstrap_error('DRUSH_NO_DRUPAL_ROOT', dt("A Drupal installation directory could not be found"));
-        }
-        // TODO: Perhaps $drupal_root is now ALWAYS valid by the time we get here.
-        if (!$this->legacyValidRootCheck($drupal_root)) {
-            return drush_bootstrap_error('DRUSH_INVALID_DRUPAL_ROOT', dt("The directory !drupal_root does not contain a valid Drupal installation", ['!drupal_root' => $drupal_root]));
-        }
-
-        $version = drush_drupal_version($drupal_root);
-        $major_version = drush_drupal_major_version($drupal_root);
-        if ($major_version <= 6) {
-            return drush_set_error('DRUSH_DRUPAL_VERSION_UNSUPPORTED', dt('Drush !drush_version does not support Drupal !major_version.', ['!drush_version' => Drush::getMajorVersion(), '!major_version' => $major_version]));
-        }
-
-        drush_bootstrap_value('drupal_root', $drupal_root);
-
-        return true;
-    }
-
-    protected function legacyValidRootCheck($root)
-    {
-        $bootstrap_class = Drush::bootstrapManager()->bootstrapObjectForRoot($root);
-        return $bootstrap_class != null;
+        return (bool) $drupal_root;
     }
 
     /**
@@ -146,7 +121,7 @@ abstract class DrupalBoot extends BaseBoot
     public function bootstrapDrupalRoot()
     {
 
-        $drupal_root = drush_set_context('DRUSH_DRUPAL_ROOT', drush_bootstrap_value('drupal_root'));
+        $drupal_root = Drush::bootstrapManager()->getRoot();
         chdir($drupal_root);
         $this->logger->log(LogLevel::BOOTSTRAP, dt("Change working directory to !drupal_root", ['!drupal_root' => $drupal_root]));
         $version = drush_drupal_version();
@@ -168,19 +143,6 @@ abstract class DrupalBoot extends BaseBoot
      */
     public function bootstrapDrupalSiteValidate()
     {
-    }
-
-    /**
-     * Called by bootstrapDrupalSite to do the main work
-     * of the drush drupal site bootstrap.
-     */
-    public function bootstrapDoDrupalSite()
-    {
-        drush_set_context('DRUSH_URI', $this->uri);
-        $site = drush_set_context('DRUSH_DRUPAL_SITE', drush_bootstrap_value('site'));
-        $confPath = drush_set_context('DRUSH_DRUPAL_SITE_ROOT', drush_bootstrap_value('confPath'));
-
-        $this->logger->log(LogLevel::BOOTSTRAP, dt("Initialized Drupal site !site at !site_root", ['!site' => $site, '!site_root' => $confPath]));
     }
 
     /**

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -129,9 +129,18 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         ];
         $request = Request::create($this->uri, 'GET', [], [], [], $server);
         $this->setRequest($request);
+        // @todo.
         $confPath = drush_bootstrap_value('confPath', $this->confPath(true, true));
-        drush_bootstrap_value('site', $request->getHttpHost());
         return true;
+    }
+
+    /**
+     * Called by bootstrapDrupalSite to do the main work
+     * of the drush drupal site bootstrap.
+     */
+    public function bootstrapDoDrupalSite()
+    {
+        $this->logger->log(LogLevel::BOOTSTRAP, dt("Initialized Drupal site !site at !site_root", ['!site' => $this->getRequest()->getHttpHost(), '!site_root' => $this->confPath()]));
     }
 
     public function bootstrapDrupalConfigurationValidate()

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -11,6 +11,7 @@ use Drush\Drush;
 use Drush\Drupal\DrushServiceModifier;
 
 use Drush\Log\LogLevel;
+use Webmozart\PathUtil\Path;
 
 class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
 {
@@ -104,9 +105,7 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
 
     public function bootstrapDrupalCore($drupal_root)
     {
-        $core = DRUPAL_ROOT . '/core';
-
-        return $core;
+        return Path::join($drupal_root, 'core');
     }
 
     public function bootstrapDrupalSiteValidate()
@@ -129,8 +128,6 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         ];
         $request = Request::create($this->uri, 'GET', [], [], [], $server);
         $this->setRequest($request);
-        // @todo.
-        $confPath = drush_bootstrap_value('confPath', $this->confPath(true, true));
         return true;
     }
 

--- a/src/Log/Logger.php
+++ b/src/Log/Logger.php
@@ -25,6 +25,7 @@
 
 namespace Drush\Log;
 
+use Drush\Drush;
 use Drush\Log\LogLevel;
 use Robo\Log\RoboLogger;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -69,7 +70,7 @@ class Logger extends RoboLogger
         }
 
         $verbose = \Drush\Drush::verbose();
-        $debug = drush_get_context('DRUSH_DEBUG');
+        $debug = Drush::debug();
         $debugnotify = drush_get_context('DRUSH_DEBUG_NOTIFY');
 
         $oldStyleEarlyExit = drush_get_context('DRUSH_LEGACY_CONTEXT');

--- a/tests/functional/AnnotatedCommandTest.php
+++ b/tests/functional/AnnotatedCommandTest.php
@@ -99,9 +99,6 @@ class AnnotatedCommandCase extends CommandUnishTestCase
         $output = $this->getOutput();
         $this->assertEquals('alphabet', $output);
 
-        // drush my-cat bet alpha --flip
-        $this->drush('my-cat', ['bet', 'alpha'], ['flip' => null], null, null, self::EXIT_ERROR);
-
         $this->drush('try-formatters');
         $output = $this->getOutput();
         $expected = <<<EOT

--- a/tests/functional/AnnotatedCommandTest.php
+++ b/tests/functional/AnnotatedCommandTest.php
@@ -100,7 +100,7 @@ class AnnotatedCommandCase extends CommandUnishTestCase
         $this->assertEquals('alphabet', $output);
 
         // drush my-cat bet alpha --flip
-        $this->drush('my-cat', ['bet', 'alpha'], ['flip' => null, 'ignored-modules' => 'woot'], null, null, self::EXIT_ERROR);
+        $this->drush('my-cat', ['bet', 'alpha'], ['flip' => null], null, null, self::EXIT_ERROR);
 
         $this->drush('try-formatters');
         $output = $this->getOutput();
@@ -212,12 +212,6 @@ EOT;
         // $this->assertContains('--fields=<first, second, third>', $output);
         $this->assertContains('Available fields:', $output);
         $this->assertContains('[default: "table"]', $output);
-
-        $this->markTestSkipped('--ignored-modules not supported yet');
-
-        // TODO: Support --ignored-modules
-        // drush woot --help with the 'woot' module ignored
-        $this->drush('woot', [], ['help' => null, 'ignored-modules' => 'woot'], null, null, self::EXIT_ERROR);
     }
 
     public function setupGlobalExtensionsForTests()


### PR DESCRIPTION
Main change is that the bootstrap phase is now tracked with a property on the Boot class.

This builds upon the other PR from today #3794 

