### PR TITLE
More gentle exit() reporting.

### DIFF
--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -23,7 +23,7 @@ function drush_main() {
  * will return a json string containing the options and log information
  * used by the script.
  *
- * The command will exit with '1' if it was successfully executed, and the
+ * The command will exit with '0' if it was successfully executed, and the
  * result of drush_get_error() if it wasn't.
  */
 function drush_shutdown() {
@@ -33,7 +33,7 @@ function drush_shutdown() {
   }
 
   if (!Drush::config()->get(Runtime::DRUSH_RUNTIME_COMPLETED_NAMESPACE)) {
-      throw new RuntimeException('Drush command terminated abnormally. Check for an exit() in your Drupal site.');
+      Drush::logger()->warning('Drush command terminated abnormally. Check for an exit() in your Drupal site.');
   }
 
   if (Drush::backend()) {


### PR DESCRIPTION
The exception was printing another backtrace which clutterred things. Use regular log message instead.

However, I still think we are printing too often here. If there is a fatal error anywhere in the request we write the message about exit(). A much more relevant message has already been reported. I think we need more criteria around this log message.