### PR TITLE
Use Drupal DB during bootstrap instead of CLI

### DIFF
--- a/src/Boot/DrupalBoot.php
+++ b/src/Boot/DrupalBoot.php
@@ -169,34 +169,6 @@ abstract class DrupalBoot extends BaseBoot
      */
     public function bootstrapDrupalDatabaseValidate()
     {
-        // Drupal requires PDO, and Drush requires php 5.6+ which ships with PDO
-        // but PHP may be compiled with --disable-pdo.
-        if (!class_exists('\PDO')) {
-            $this->logger->log(LogLevel::BOOTSTRAP, dt('PDO support is required.'));
-            return false;
-        }
-        try {
-            $sql = SqlBase::create();
-            // Drush requires a database client program during its Drupal bootstrap.
-            $command = $sql->command();
-            if (drush_program_exists($command) === false) {
-                $this->logger->warning(dt('The command \'!command\' is required for preflight but cannot be found. Please install it and retry.', ['!command' => $command]));
-                return false;
-            }
-            if (!$sql->query('SELECT 1;', null, drush_bit_bucket())) {
-                $message = dt("Drush was not able to start (bootstrap) the Drupal database.\n");
-                $message .= dt("Hint: This may occur when Drush is trying to:\n");
-                $message .= dt(" * bootstrap a site that has not been installed or does not have a configured database. In this case you can select another site with a working database setup by specifying the URI to use with the --uri parameter on the command line. See `drush topic docs-aliases` for details.\n");
-                $message .= dt(" * connect the database through a socket. The socket file may be wrong or the php-cli may have no access to it in a jailed shell. See http://drupal.org/node/1428638 for details.\n");
-                $message .= dt('More information may be available by running `drush status`');
-                $this->logger->log(LogLevel::BOOTSTRAP, $message);
-                return false;
-            }
-        } catch (\Exception $e) {
-            $this->logger->log(LogLevel::DEBUG, dt('Unable to validate DB: @e', ['@e' => $e->getMessage()]));
-            return false;
-        }
-        return true;
     }
 
     /**
@@ -221,6 +193,9 @@ abstract class DrupalBoot extends BaseBoot
      *   Array of table names, or string with one table name
      *
      * @return TRUE if all required tables exist in the database.
+     *
+     * @deprecated
+     *   No longer used by Drush core.
      */
     public function bootstrapDrupalDatabaseHasTable($required_tables)
     {

--- a/src/Boot/DrupalBoot.php
+++ b/src/Boot/DrupalBoot.php
@@ -172,52 +172,6 @@ abstract class DrupalBoot extends BaseBoot
     }
 
     /**
-     * Test to see if the Drupal database has a specified
-     * table or tables.
-     *
-     * This is a bootstrap helper function designed to be called
-     * from the bootstrapDrupalDatabaseValidate() methods of
-     * derived DrupalBoot classes.  If a database exists, but is
-     * empty, then the Drupal database bootstrap will fail.  To
-     * prevent this situation, we test for some table that is needed
-     * in an ordinary bootstrap, and return FALSE from the validate
-     * function if it does not exist, so that we do not attempt to
-     * start the database bootstrap.
-     *
-     * Note that we must manually do our own prefix testing here,
-     * because the existing wrappers we have for handling prefixes
-     * depend on bootstrapping to the "database" phase, and therefore
-     * are not available to validate this same phase.
-     *
-     * @param $required_tables
-     *   Array of table names, or string with one table name
-     *
-     * @return TRUE if all required tables exist in the database.
-     *
-     * @deprecated
-     *   No longer used by Drush core.
-     */
-    public function bootstrapDrupalDatabaseHasTable($required_tables)
-    {
-
-        $sql = SqlBase::create();
-        $spec = $sql->getDbSpec();
-        $prefix = isset($spec['prefix']) ? $spec['prefix'] : null;
-        if (!is_array($prefix)) {
-            $prefix = ['default' => $prefix];
-        }
-        foreach ((array)$required_tables as $required_table) {
-            $prefix_key = array_key_exists($required_table, $prefix) ? $required_table : 'default';
-            $table_name = $prefix[$prefix_key] . $required_table;
-            if (!$sql->alwaysQuery("SELECT 1 FROM $table_name LIMIT 1;", null, drush_bit_bucket())) {
-                $this->logger->notice('Missing database table: '. $table_name);
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
      * Bootstrap the Drupal database.
      */
     public function bootstrapDrupalDatabase()

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -170,9 +170,7 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
             $this->logger->log(LogLevel::BOOTSTRAP, 'Unable to connect to database. More information may be available by running `drush status`. This may occur when Drush is trying to bootstrap a site that has not been installed or does not have a configured database. In this case you can select another site with a working database setup by specifying the URI to use with the --uri parameter on the command line. See `drush topic docs-aliases` for details.');
             return false;
         }
-        try {
-            $connection->schema()->tableExists('key_value');
-        } catch (\Exception $e) {
+        if (!$connection->schema()->tableExists('key_value')) {
             $this->logger->log(LogLevel::BOOTSTRAP, 'key_value table not found. Database may be empty.');
             return false;
         }

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -171,7 +171,7 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
             return false;
         }
         try {
-            $connection->query('SELECT * from {key_value};');
+            $connection->schema()->tableExists('key_value');
         } catch (\Exception $e) {
             $this->logger->log(LogLevel::BOOTSTRAP, 'key_value table not found. Database may be empty.');
             return false;

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -163,12 +163,12 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         }
 
         try {
-            // @todo Log queries or log failure messages?
+            // @todo Log queries in addition to logging failure messages?
             $connection = Database::getConnection();
             $connection->query('SELECT 1;');
         } catch (\Exception $e) {
             $this->logger->log(LogLevel::BOOTSTRAP, 'Unable to connect to database. More information may be available by running `drush status`. This may occur when Drush is trying to bootstrap a site that has not been installed or does not have a configured database. In this case you can select another site with a working database setup by specifying the URI to use with the --uri parameter on the command line. See `drush topic docs-aliases` for details.');
-            return FALSE;
+            return false;
         }
         try {
             $connection->query('SELECT * from {key_value};');

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -3,6 +3,7 @@
 namespace Drush\Boot;
 
 use Consolidation\AnnotatedCommand\AnnotationData;
+use Drupal\Core\Database\Database;
 use Drush\Log\DrushLog;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -154,7 +155,28 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
 
     public function bootstrapDrupalDatabaseValidate()
     {
-        return parent::bootstrapDrupalDatabaseValidate() && $this->bootstrapDrupalDatabaseHasTable('key_value');
+        // Drupal requires PDO, and Drush requires php 5.6+ which ships with PDO
+        // but PHP may be compiled with --disable-pdo.
+        if (!class_exists('\PDO')) {
+            $this->logger->log(LogLevel::BOOTSTRAP, dt('PDO support is required.'));
+            return false;
+        }
+
+        try {
+            // @todo Log queries or log failure messages?
+            $connection = Database::getConnection();
+            $connection->query('SELECT 1;');
+        } catch (\Exception $e) {
+            $this->logger->log(LogLevel::BOOTSTRAP, 'Unable to connect to database. More information may be available by running `drush status`. This may occur when Drush is trying to bootstrap a site that has not been installed or does not have a configured database. In this case you can select another site with a working database setup by specifying the URI to use with the --uri parameter on the command line. See `drush topic docs-aliases` for details.');
+            return FALSE;
+        }
+        try {
+            $connection->query('SELECT * from {key_value};');
+        } catch (\Exception $e) {
+            $this->logger->log(LogLevel::BOOTSTRAP, 'key_value table not found. Database may be empty.');
+            return false;
+        }
+        return true;
     }
 
     public function bootstrapDrupalDatabase()


### PR DESCRIPTION
Removes a dependency on the SQL classes and Drush users may no skip installation of `mysql` CLI client if they don't want to run sql commands. This is nice for mnimalist Docker pwoered environments.