### PR TITLE
Replace drush_set_error() and drush_log() via Drush::logger()

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -39,7 +39,7 @@ use Drush\Log\LogLevel;
 class DrushBatchContext extends ArrayObject {
   function offsetSet($name, $value) {
     if ($name == 'message') {
-      drush_log(strip_tags($value), LogLevel::OK);
+      Drush::logger()->info(strip_tags($value));
     }
     elseif ($name == 'error_message') {
       Drush::logger()->error(strip_tags($value));
@@ -282,7 +282,7 @@ function _drush_batch_worker() {
 
     // If we are in progressive mode, break processing after 1 second.
     if (drush_memory_limit() > 0 && (memory_get_usage() * 2) >= drush_memory_limit()) {
-      drush_log(dt("Batch process has consumed in excess of 50% of available memory. Starting new thread"), LogLevel::BATCH);
+      Drush::logger()->notice(dt("Batch process has consumed in excess of 50% of available memory. Starting new thread"), LogLevel::BATCH);
       // Record elapsed wall clock time.
       $current_set['elapsed'] = round((microtime(TRUE) - $current_set['start']) * 1000, 2);
       break;

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -42,7 +42,7 @@ class DrushBatchContext extends ArrayObject {
       drush_log(strip_tags($value), LogLevel::OK);
     }
     elseif ($name == 'error_message') {
-      drush_set_error('DRUSH_BATCH_ERROR', strip_tags($value));
+      Drush::logger()->error(strip_tags($value));
     }
     parent::offsetSet($name, $value);
   }

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -39,7 +39,7 @@ use Drush\Log\LogLevel;
 class DrushBatchContext extends ArrayObject {
   function offsetSet($name, $value) {
     if ($name == 'message') {
-      Drush::logger()->info(strip_tags($value));
+      Drush::logger()->notice(strip_tags($value));
     }
     elseif ($name == 'error_message') {
       Drush::logger()->error(strip_tags($value));

--- a/includes/cache.inc
+++ b/includes/cache.inc
@@ -70,7 +70,7 @@ function _drush_cache_get_object($bin) {
 function drush_cache_get($cid, $bin = 'default') {
   $ret = _drush_cache_get_object($bin)->get($cid);
   $mess = $ret ? "HIT" : "MISS";
-  drush_log(dt("Cache !mess cid: !cid", ['!mess' => $mess, '!cid' => $cid]), LogLevel::DEBUG);
+  Drush::logger()->debug(dt("Cache !mess cid: !cid", ['!mess' => $mess, '!cid' => $cid]));
   return $ret;
 }
 
@@ -112,9 +112,10 @@ function drush_cache_get_multiple(array &$cids, $bin = 'default') {
  * @return bool
  */
 function drush_cache_set($cid, $data, $bin = 'default', $expire = DRUSH_CACHE_PERMANENT) {
-  $ret = _drush_cache_get_object($bin)->set($cid, $data, $expire);
-  if ($ret) drush_log(dt("Cache SET cid: !cid", ['!cid' => $cid]), LogLevel::DEBUG);
-  return $ret;
+  if ($ret = _drush_cache_get_object($bin)->set($cid, $data, $expire)) {
+    Drush::logger()->debug(dt("Cache SET cid: !cid", ['!cid' => $cid]));
+    return $ret;
+  }
 }
 
 /**

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -203,13 +203,8 @@ function drush_op($callable) {
     }
   }
 
-  // Special checking for drush_op('system')
-  if ($callable == 'system') {
-    drush_log(dt("Do not call drush_op('system'); use drush_op_system instead"), LogLevel::DEBUG);
-  }
-
   if (\Drush\Drush::verbose() || \Drush\Drush::simulate()) {
-    drush_log(sprintf("Calling %s(%s)", $callable_string, implode(", ", $args_printed)), LogLevel::DEBUG);
+    Drush::logger()->debug('Calling %s(%s)', [$callable_string, implode(", ", $args_printed)]);
   }
 
   if (\Drush\Drush::simulate()) {
@@ -275,7 +270,7 @@ function drush_attempt_mime_content_type($filename) {
     $finfo = new finfo(FILEINFO_MIME_TYPE);
     $content_type = $finfo->file($filename);
     if ($content_type == 'application/octet-stream') {
-      drush_log(dt('Mime type for !file is application/octet-stream.', ['!file' => $filename]), LogLevel::DEBUG);
+      Drush::logger()->debug(dt('Mime type for !file is application/octet-stream.', ['!file' => $filename]));
       $content_type = FALSE;
     }
   }
@@ -284,7 +279,7 @@ function drush_attempt_mime_content_type($filename) {
   // archives as octet-stream for other reasons) we'll detect mime types on our
   //  own by examing the file's magic header bytes.
   if (!$content_type) {
-    drush_log(dt('Examining !file headers.', ['!file' => $filename]), LogLevel::DEBUG);
+    Drush::logger()->debug(dt('Examining !file headers.', ['!file' => $filename]));
     if ($file = fopen($filename, 'rb')) {
       $first = fread($file, 2);
       fclose($file);
@@ -312,23 +307,23 @@ function drush_attempt_mime_content_type($filename) {
             break;
 
           default:
-            drush_log(dt('Unable to determine mime type from header bytes 0x!hex of !file.', ['!hex' => dechex($data[1]), '!file' => $filename,]), LogLevel::DEBUG);
+            Drush::logger()->debug(dt('Unable to determine mime type from header bytes 0x!hex of !file.', ['!hex' => dechex($data[1]), '!file' => $filename,]));
         }
       }
       else {
-        drush_log(dt('Unable to read !file.', ['!file' => $filename]), LogLevel::WARNING);
+        Drush::logger()->warning(dt('Unable to read !file.', ['!file' => $filename]));
       }
     }
     else {
-      drush_log(dt('Unable to open !file.', ['!file' => $filename]), LogLevel::WARNING);
+      Drush::logger()->warning(dt('Unable to open !file.', ['!file' => $filename]));
     }
   }
 
   // 3. Lastly if above methods didn't work, try to guess the mime type from
-  // the file extension. This is useful if the file has no identificable magic
+  // the file extension. This is useful if the file has no identifiable magic
   // header bytes (for example tarballs).
   if (!$content_type) {
-    drush_log(dt('Examining !file extension.', ['!file' => $filename]), LogLevel::DEBUG);
+    Drush::logger()->debug(dt('Examining !file extension.', ['!file' => $filename]));
 
     // Remove querystring from the filename, if present.
     $filename = basename(current(explode('?', $filename, 2)));
@@ -507,7 +502,7 @@ function drush_get_log() {
  * Run print_r on a variable and log the output.
  */
 function dlm($object) {
-  drush_log(print_r($object, TRUE));
+  Drush::logger()->notice(print_r($object, TRUE));
 }
 
 // Copy of format_size() in Drupal.

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -252,16 +252,17 @@ function drush_call_user_func_array($function, $args = []) {
  *
  * If mime type can't be obtained, an error will be set.
  *
- * @return mixed
+ * @return string|bool
  *   The MIME content type of the file or FALSE.
  */
 function drush_mime_content_type($filename) {
   $content_type = drush_attempt_mime_content_type($filename);
   if ($content_type) {
-    drush_log(dt('Mime type for !file is !mt', ['!file' => $filename, '!mt' => $content_type]), LogLevel::INFO);
+    Drush::logger()->info(dt('Mime type for !file is !mt', ['!file' => $filename, '!mt' => $content_type]));
     return $content_type;
   }
-  return drush_set_error('MIME_CONTENT_TYPE_UNKNOWN', dt('Unable to determine mime type for !file.', ['!file' => $filename]));
+  Drush::logger()->error(dt('Unable to determine mime type for !file.', ['!file' => $filename]));
+  return false;
 }
 
 /**

--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -44,10 +44,10 @@ function drush_error_handler($errno, $message, $filename, $line) {
       $type = LogLevel::WARNING;
     }
 
-    drush_log($message . ' ' . basename($filename) . ':' . $line, $type);
+    Drush::logger()->log($type, $message . ' ' . basename($filename) . ':' . $line);
 
     if ($errno == E_RECOVERABLE_ERROR && $halt_on_error) {
-      drush_log(dt('E_RECOVERABLE_ERROR encountered; aborting. To ignore recoverable errors, run again with --no-halt-on-error'), 'error');
+      Drush::logger()->error(dt('E_RECOVERABLE_ERROR encountered; aborting. To ignore recoverable errors, run again with --no-halt-on-error'));
       exit(DRUSH_APPLICATION_ERROR);
     }
 

--- a/includes/exec.inc
+++ b/includes/exec.inc
@@ -160,7 +160,7 @@ function _drush_shell_exec($args, $interactive = FALSE, $simulate = false) {
     $command = call_user_func_array('sprintf', $args);
   }
 
-  drush_log('Executing: ' . $command, LogLevel::INFO);
+  Drush::logger()->info('Executing: ' . $command);
   if (!$simulate) {
     if ($interactive) {
       $result = drush_shell_proc_open($command);

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -229,8 +229,7 @@ class SqlCommands extends DrushCommands
         $return = $sql->dump();
         if ($return === false) {
             throw new \Exception('Unable to dump database. Rerun with --debug to see any error message.');
-        }
-        elseif ($return) {
+        } elseif ($return) {
             $this->logger()->success(dt('Database dump saved to !path', ['!path' => $return]));
         }
         return new PropertyList(['path' => $return]);

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -230,6 +230,9 @@ class SqlCommands extends DrushCommands
         if ($return === false) {
             throw new \Exception('Unable to dump database. Rerun with --debug to see any error message.');
         }
+        elseif ($return) {
+            $this->logger()->success(dt('Database dump saved to !path', ['!path' => $return]));
+        }
         return new PropertyList(['path' => $return]);
     }
 

--- a/src/Drupal/DrupalKernelTrait.php
+++ b/src/Drupal/DrupalKernelTrait.php
@@ -24,7 +24,7 @@ trait DrupalKernelTrait
      */
     public function addServiceModifier(ServiceModifierInterface $serviceModifier)
     {
-        drush_log(dt("Add service modifier"), LogLevel::DEBUG);
+        Drush::logger()->debug((dt("Add service modifier")));
         $this->serviceModifiers[] = $serviceModifier;
     }
 
@@ -33,7 +33,7 @@ trait DrupalKernelTrait
      */
     protected function getContainerBuilder()
     {
-        drush_log(dt("Get container builder"), LogLevel::DEBUG);
+        Drush::logger()->debug(dt("Get container builder"));
         $container = parent::getContainerBuilder();
         foreach ($this->serviceModifiers as $serviceModifier) {
             $serviceModifier->alter($container);
@@ -145,7 +145,7 @@ trait DrupalKernelTrait
         if (!file_exists($result)) {
             return;
         }
-        drush_log(dt("!module should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file.", ['!module' => $module]), LogLevel::DEBUG);
+        Drush::logger()->debug(dt("!module should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file.", ['!module' => $module]));
         return $result;
     }
 
@@ -174,7 +174,7 @@ trait DrupalKernelTrait
         $composerJsonContents = file_get_contents($composerJsonPath);
         $info = json_decode($composerJsonContents, true);
         if (!$info) {
-            drush_log(dt('Invalid json in {composer}', ['composer' => $composerJsonPath]), LogLevel::WARNING);
+            Drush::logger()->warning(dt('Invalid json in {composer}', ['composer' => $composerJsonPath]));
             return false;
         }
         if (!isset($info['extra']['drush']['services'])) {
@@ -189,11 +189,11 @@ trait DrupalKernelTrait
         foreach ($services as $serviceYmlPath => $versionConstraint) {
             $version = preg_replace('#-dev.*#', '', $version);
             if (Semver::satisfies($version, $versionConstraint)) {
-                drush_log(dt('Found {services} for {module} Drush commands', ['module' => $module, 'services' => $serviceYmlPath]), LogLevel::DEBUG);
+                Drush::logger()->debug(dt('Found {services} for {module} Drush commands', ['module' => $module, 'services' => $serviceYmlPath]));
                 return $dir . '/' . $serviceYmlPath;
             }
         }
-        drush_log(dt('{module} has Drush commands, but none of {constraints} match the current Drush version "{version}"', ['module' => $module, 'constraints' => implode(',', $services), 'version' => $version]), LogLevel::DEBUG);
+        Drush::logger()->debug(dt('{module} has Drush commands, but none of {constraints} match the current Drush version "{version}"', ['module' => $module, 'constraints' => implode(',', $services), 'version' => $version]));
         return false;
     }
 

--- a/src/Drupal/DrushServiceModifier.php
+++ b/src/Drupal/DrushServiceModifier.php
@@ -2,6 +2,7 @@
 
 namespace Drush\Drupal;
 
+use Drush\Drush;
 use Drush\Log\LogLevel;
 use Drupal\Core\DependencyInjection\ServiceModifierInterface;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
@@ -22,7 +23,7 @@ class DrushServiceModifier implements ServiceModifierInterface
      */
     public function alter(ContainerBuilder $container)
     {
-        drush_log(dt("Service modifier alter."), LogLevel::DEBUG_NOTIFY);
+        Drush::logger()->log(LogLevel::DEBUG_NOTIFY, dt("Service modifier alter."));
         // http://symfony.com/doc/2.7/components/dependency_injection/tags.html#register-the-pass-with-the-container
         $container->register(self::DRUSH_CONSOLE_SERVICES, 'Drush\Command\ServiceCommandlist');
         $container->addCompilerPass(new FindCommandsCompilerPass(self::DRUSH_CONSOLE_SERVICES, 'console.command'));

--- a/src/Drupal/FindCommandsCompilerPass.php
+++ b/src/Drupal/FindCommandsCompilerPass.php
@@ -1,6 +1,7 @@
 <?php
 namespace Drush\Drupal;
 
+use Drush\Drush;
 use Drush\Log\LogLevel;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -43,12 +44,12 @@ class FindCommandsCompilerPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
-        drush_log(dt("process !storage !tag", ['!storage' => $this->storageClassId, '!tag' => $this->tagId]), LogLevel::DEBUG);
+        Drush::logger()->debug(dt("process !storage !tag", ['!storage' => $this->storageClassId, '!tag' => $this->tagId]));
         // We expect that our called registered the storage
         // class under the storage class id before adding this
         // compiler pass, but we will test this presumption to be sure.
         if (!$container->has($this->storageClassId)) {
-            drush_log(dt("storage class not registered"), LogLevel::DEBUG);
+            Drush::logger()->debug(dt("storage class not registered"));
             return;
         }
 
@@ -60,7 +61,7 @@ class FindCommandsCompilerPass implements CompilerPassInterface
             $this->tagId
         );
         foreach ($taggedServices as $id => $tags) {
-            drush_log(dt("Found tagged service !id", ['!id' => $id]), LogLevel::DEBUG_NOTIFY);
+            Drush::logger()->log(LogLevel::DEBUG_NOTIFY, dt("Found tagged service !id", ['!id' => $id]));
             $definition->addMethodCall(
                 'addCommandReference',
                 [new Reference($id)]

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -149,8 +149,8 @@ class SqlBase implements ConfigAwareInterface
     /*
      * Execute a SQL dump and return the path to the resulting dump file.
      *
-     * @return bool|null
-     *   Returns null, or false on failure.
+     * @return string|bool|null
+     *   Returns path to dump file, null, or false on failure.
      */
     public function dump()
     {
@@ -175,14 +175,7 @@ class SqlBase implements ConfigAwareInterface
         $process->disableOutput();
         // Show dump in real-time on stdout, for backward compat.
         $process->run($process->showRealtime());
-        if ($process->isSuccessful()) {
-            if ($file) {
-                drush_log(dt('Database dump saved to !path', ['!path' => $file]), LogLevel::SUCCESS);
-                return $file;
-            }
-        } else {
-            return drush_set_error('DRUSH_SQL_DUMP_FAIL', 'Database dump failed');
-        }
+        return $process->isSuccessful() ? $file : false;
     }
 
     /*
@@ -276,7 +269,8 @@ class SqlBase implements ConfigAwareInterface
             if ($process->isSuccessful()) {
                 $input_file = trim($input_file, '.gz');
             } else {
-                return drush_set_error(dt('Failed to decompress input file.'));
+                Drush::logger()->error(dt('Failed to decompress input file.'));
+                return false;
             }
         }
 

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -318,11 +318,11 @@ class SqlBase implements ConfigAwareInterface
      */
     protected function logQueryInDebugMode($query, $input_file_original)
     {
-        // In --verbose mode, drush_shell_exec() will show the call to mysql/psql/sqlite,
+        // In --verbose mode, Drush::process() will show the call to mysql/psql/sqlite,
         // but the sql query itself is stored in a temp file and not displayed.
         // We show the query when --debug is used and this function created the temp file.
         if ((Drush::debug() || Drush::simulate()) && empty($input_file_original)) {
-            drush_log('sql:query: ' . $query, LogLevel::INFO);
+            Drush::logger()->info('sql:query: ' . $query);
         }
     }
 

--- a/src/Sql/SqlOracle.php
+++ b/src/Sql/SqlOracle.php
@@ -2,6 +2,7 @@
 
 namespace Drush\Sql;
 
+use Drush\Drush;
 use Drush\Log\LogLevel;
 
 class SqlOracle extends SqlBase
@@ -29,7 +30,8 @@ class SqlOracle extends SqlBase
 
     public function createdbSql($dbname)
     {
-        return drush_log("Unable to generate CREATE DATABASE sql for $dbname", LogLevel::ERROR);
+        Drush::logger()->error("Unable to generate CREATE DATABASE sql for $dbname");
+        return false;
     }
 
     // @todo $suffix = '.sql';

--- a/src/Sql/SqlSqlite.php
+++ b/src/Sql/SqlSqlite.php
@@ -2,6 +2,7 @@
 
 namespace Drush\Sql;
 
+use Drush\Drush;
 use Drush\Log\LogLevel;
 
 class SqlSqlite extends SqlBase
@@ -35,20 +36,17 @@ class SqlSqlite extends SqlBase
     {
         $file = $this->getDbSpec()['database'];
         if (file_exists($file)) {
-            drush_log("SQLITE: Deleting existing database '$file'", LogLevel::DEBUG);
+            Drush::logger()->debug("SQLITE: Deleting existing database '$file'");
             drush_delete_dir($file, true);
         }
 
         // Make sure sqlite can create file
         $path = dirname($file);
-        drush_log("SQLITE: creating '$path' for creating '$file'", LogLevel::DEBUG);
-        drush_mkdir($path);
-        if (!file_exists($path)) {
-            drush_log("SQLITE: Cannot create $path", LogLevel::ERROR);
-            return false;
-        } else {
-            return true;
+        Drush::logger()->debug("SQLITE: creating '$path' for creating '$file'");
+        if (!drush_mkdir($path)) {
+            Drush::logger()->error("SQLITE: Cannot create $path");
         }
+        return file_exists($path);
     }
 
     public function dbExists()

--- a/tests/functional/UpdateDBTest.php
+++ b/tests/functional/UpdateDBTest.php
@@ -113,7 +113,7 @@ LOG
                 <<<LOG
 > [notice] Update started: woot_update_8101
 > [notice] This is the update message from woot_update_8101
-> [ok] Update completed: woot_update_8101
+> [notice] Update completed: woot_update_8101
 > [notice] Update started: woot_update_8102
 > [error] This is the exception message thrown in woot_update_8102
 > [error] Update failed: woot_update_8102
@@ -192,10 +192,10 @@ LOG;
         $expected_error_output =
         '> [notice] Update started: woot_update_8104
 > [notice] This is the update message from woot_update_8104
-> [ok] Update completed: woot_update_8104
+> [notice] Update completed: woot_update_8104
 > [notice] Update started: woot_post_update_a
 > [notice] This is the update message from woot_post_update_a
-> [ok] Update completed: woot_post_update_a
+> [notice] Update completed: woot_post_update_a
 > [notice] Update started: woot_post_update_failing
 > [error] This is the exception message thrown in woot_post_update_failing
 > [error] Update failed: woot_post_update_failing
@@ -309,12 +309,12 @@ LOG;
         $expected_error_output = <<<LOG
 > [notice] Update started: woot_update_8104
 > [notice] This is the update message from woot_update_8104
-> [ok] Update completed: woot_update_8104
+> [notice] Update completed: woot_update_8104
 > [notice] Update started: woot_post_update_a
 > [notice] This is the update message from woot_post_update_a
-> [ok] Update completed: woot_post_update_a
+> [notice] Update completed: woot_post_update_a
 > [notice] Update started: woot_post_update_render
-> [ok] Update completed: woot_post_update_render
+> [notice] Update completed: woot_post_update_render
 [success] Finished performing updates.
 LOG;
 


### PR DESCRIPTION
All instances in non-deprecated code are replaced.