### PR TITLE
Bring back legacy support for space-separated commands in 'drush ssh'

### DIFF
--- a/src/Commands/core/SshCommands.php
+++ b/src/Commands/core/SshCommands.php
@@ -27,7 +27,7 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
      * @aliases ssh,site-ssh
      * @topics docs:aliases
      */
-    public function ssh(array $args, $options = ['cd' => true, 'tty' => false])
+    public function ssh(array $args, $options = ['cd' => true, 'tty' => false, 'legacy' => true])
     {
         $alias = $this->siteAliasManager()->getSelf();
         if ($alias->isNone()) {
@@ -43,9 +43,15 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
             $options['tty'] = true;
         }
 
+        // Legacy support: if there is only one argument provided, then
+        // explode it. This may be disabled via the --no-legacy option.
+        if ((count($args) == 1) && $options['legacy']) {
+            $args = explode(' ', $args[0]);
+        }
+
         $process = Drush::siteProcess($alias, $args);
         $process->setTty($options['tty']);
         $process->chdirToSiteRoot($options['cd']);
-        $process->mustRun();
+        $process->mustRun($process->showRealtime());
     }
 }

--- a/tests/functional/SiteSshTest.php
+++ b/tests/functional/SiteSshTest.php
@@ -11,9 +11,9 @@ namespace Unish;
 class SiteSshCase extends CommandUnishTestCase
 {
 
-  /**
-   * Test drush ssh --simulate. No additional bash passed.
-   */
+    /**
+     * Test drush ssh --simulate. No additional bash passed.
+     */
     public function testInteractive()
     {
         if ($this->isWindows()) {
@@ -21,7 +21,7 @@ class SiteSshCase extends CommandUnishTestCase
         }
 
         $options = [
-        'simulate' => null,
+            'simulate' => true,
         ];
         $this->drush('ssh', [], $options, 'user@server/path/to/drupal#sitename');
         $output = $this->getErrorOutput();
@@ -29,16 +29,16 @@ class SiteSshCase extends CommandUnishTestCase
         $this->assertContains($expected, $output);
     }
 
-  /**
-   * Test drush ssh --simulate 'date'.
-   * @todo Run over a site list. drush_sitealias_get_record() currently cannot
-   * handle a site list comprised of longhand site specifications.
-   */
+    /**
+     * Test drush ssh --simulate 'date'.
+     * @todo Run over a site list. drush_sitealias_get_record() currently cannot
+     * handle a site list comprised of longhand site specifications.
+     */
     public function testNonInteractive()
     {
         $options = [
-        'cd' => '0',
-        'simulate' => null,
+            'cd' => '0',
+            'simulate' => true,
         ];
         $this->drush('ssh', ['date'], $options, 'user@server/path/to/drupal#sitename');
         $output = $this->getErrorOutput();
@@ -46,14 +46,14 @@ class SiteSshCase extends CommandUnishTestCase
         $this->assertContains($expected, $output);
     }
 
-  /**
-  * Test drush ssh with multiple arguments (preferred form).
-  */
+    /**
+    * Test drush ssh with multiple arguments (preferred form).
+    */
     public function testSshMultipleArgs()
     {
         $options = [
-        'cd' => '0',
-        'simulate' => null,
+            'cd' => '0',
+            'simulate' => true,
         ];
         $this->drush('ssh', ['ls', '/path1', '/path2'], $options, 'user@server/path/to/drupal#sitename');
         $output = $this->getSimplifiedErrorOutput();
@@ -61,17 +61,14 @@ class SiteSshCase extends CommandUnishTestCase
         $this->assertContains($expected, $output);
     }
 
-  /**
-   * Test drush ssh with multiple arguments (legacy form).
-   */
+    /**
+     * Test drush ssh with multiple arguments (legacy form).
+     */
     public function testSshMultipleArgsLegacy()
     {
-        // @TODO: Bring this back?
-        $this->markTestSkipped('Legacy ssh form, where first element of commandline contains both program and arguments is not supported.');
-
         $options = [
-        'cd' => '0',
-         'simulate' => null,
+            'cd' => '0',
+            'simulate' => true,
         ];
         $this->drush('ssh', ['ls /path1 /path2'], $options, 'user@server/path/to/drupal#sitename');
         $expected = "[notice] Simulating: ssh -o PasswordAuthentication=no user@server 'ls /path1 /path2'";


### PR DESCRIPTION
(supported in Drush 9.5.2).

Fix bug with lack of echo'ed output in 'drush @site ssh cmd'.

n.b. `simulate` mode not working in integration tests at the moment. Moving this to be an integration test wouldn't be much of a time savings in the test, since these tests do not set up a Drupal site.