### PR TITLE
Fixed config location prompt has an unnecessary full stop

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -427,7 +427,7 @@ class ConfigCommands extends DrushCommands
             $choices = drush_map_assoc(array_keys($config_directories));
             unset($choices[CONFIG_ACTIVE_DIRECTORY]);
             if (count($choices) >= 2) {
-                $label = $this->io()->choice('Choose a '. $option_name. '.', $choices);
+                $label = $this->io()->choice('Choose a '. $option_name, $choices);
                 $input->setArgument('label', $label);
             }
         }


### PR DESCRIPTION
There should not be a full stop here, as the framework adds a colon:

```
 Choose a source.:
  [0] Cancel
  [1] sync
  [2] vcs
```