### PR TITLE
Stop using 'remote-host' in redispatch hook.

### DIFF
--- a/src/Runtime/RedispatchHook.php
+++ b/src/Runtime/RedispatchHook.php
@@ -57,10 +57,9 @@ class RedispatchHook implements InitializeHookInterface, ConfigAwareInterface, S
      */
     public function redispatchIfRemote(InputInterface $input)
     {
+        $aliasRecord = $this->siteAliasManager()->getSelf();
         // Determine if this is a remote command.
-        // n.b. 'hasOption' only means that the option definition exists, so don't use that here.
-        $remote = $input->getOption('remote-host');
-        if (!empty($remote)) {
+        if (!$aliasRecord->isLocal()) {
             return $this->redispatch($input);
         }
     }


### PR DESCRIPTION
Use $aliasRecord->isLocal() rather than getOption('remote-host') to determine whether to redispatch.

Merge this into #3835 , and then it shouldn't be necessary to [remap docker.service](https://github.com/consolidation/site-alias/pull/30/files/016f5a8c77bb455038d29696d0c0e94c7b00e230..ed6d1fb2e5a939297964cf088c13d322df789818#diff-61c9423e4386ba78d1b3d7d9523ce5e9R268) in https://github.com/consolidation/site-alias/pull/30.

Presuming tests pass here, anyway.