### PR TITLE
Use 'Drush::shell()' for commandlines provided as pre-escaped strings…

### DIFF
--- a/.scenarios.lock/php5/composer.json
+++ b/.scenarios.lock/php5/composer.json
@@ -64,7 +64,7 @@
         "consolidation/output-formatters": "^3.3.1",
         "consolidation/robo": "^1.3.4",
         "consolidation/site-alias": "^2.1.1",
-        "consolidation/site-process": "^0.3.0",
+        "consolidation/site-process": "^0.3.1",
         "grasmash/yaml-expander": "^1.1.1",
         "league/container": "~2",
         "psr/log": "~1.0",

--- a/.scenarios.lock/php5/composer.lock
+++ b/.scenarios.lock/php5/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b5dfece43aabb8a7594c0d754b745e5",
+    "content-hash": "a542b3df53007507400856ebb5042f73",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",

--- a/.scenarios.lock/php5/composer.lock
+++ b/.scenarios.lock/php5/composer.lock
@@ -692,16 +692,16 @@
         },
         {
             "name": "consolidation/site-process",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/site-process.git",
-                "reference": "7ddc78bca0c6a547994f3af559a83e6266e5c80d"
+                "reference": "e68741377720d9eb758409af8c10165a3407043d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/site-process/zipball/7ddc78bca0c6a547994f3af559a83e6266e5c80d",
-                "reference": "7ddc78bca0c6a547994f3af559a83e6266e5c80d",
+                "url": "https://api.github.com/repos/consolidation/site-process/zipball/e68741377720d9eb758409af8c10165a3407043d",
+                "reference": "e68741377720d9eb758409af8c10165a3407043d",
                 "shasum": ""
             },
             "require": {
@@ -760,7 +760,7 @@
                 }
             ],
             "description": "A thin wrapper around the Symfony Process Component that allows applications to use the Site Alias library to specify the target for a remote call.",
-            "time": "2019-01-06T01:00:28+00:00"
+            "time": "2019-01-06T16:14:05+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -1544,16 +1544,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b49b1ca166bd109900e6a1683d9bb1115727ef2d"
+                "reference": "c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b49b1ca166bd109900e6a1683d9bb1115727ef2d",
-                "reference": "b49b1ca166bd109900e6a1683d9bb1115727ef2d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde",
+                "reference": "c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde",
                 "shasum": ""
             },
             "require": {
@@ -1590,20 +1590,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:48:54+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "6cf2be5cbd0e87aa35c01f80ae0bf40b6798e442"
+                "reference": "3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/6cf2be5cbd0e87aa35c01f80ae0bf40b6798e442",
-                "reference": "6cf2be5cbd0e87aa35c01f80ae0bf40b6798e442",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e",
+                "reference": "3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e",
                 "shasum": ""
             },
             "require": {
@@ -1639,7 +1639,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:48:54+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1809,16 +1809,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "6867713afe6c50ade2f34ed6435563b065a52145"
+                "reference": "a5f39641bb62e8b74e343467b145331273f615a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6867713afe6c50ade2f34ed6435563b065a52145",
-                "reference": "6867713afe6c50ade2f34ed6435563b065a52145",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/a5f39641bb62e8b74e343467b145331273f615a2",
+                "reference": "a5f39641bb62e8b74e343467b145331273f615a2",
                 "shasum": ""
             },
             "require": {
@@ -1874,7 +1874,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2018-11-20T16:10:26+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "consolidation/output-formatters": "^3.3.1",
     "consolidation/robo": "^1.3.4",
     "consolidation/site-alias": "^2.1.1",
-    "consolidation/site-process": "^0.3.0",
+    "consolidation/site-process": "^0.3.1",
     "grasmash/yaml-expander": "^1.1.1",
     "league/container": "~2",
     "psr/log": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e82e23dd8b8d1c850c24a60ae6d9acf",
+    "content-hash": "2769df20bf6a6fc4781635dd053eaf6e",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",

--- a/composer.lock
+++ b/composer.lock
@@ -692,16 +692,16 @@
         },
         {
             "name": "consolidation/site-process",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/site-process.git",
-                "reference": "7ddc78bca0c6a547994f3af559a83e6266e5c80d"
+                "reference": "e68741377720d9eb758409af8c10165a3407043d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/site-process/zipball/7ddc78bca0c6a547994f3af559a83e6266e5c80d",
-                "reference": "7ddc78bca0c6a547994f3af559a83e6266e5c80d",
+                "url": "https://api.github.com/repos/consolidation/site-process/zipball/e68741377720d9eb758409af8c10165a3407043d",
+                "reference": "e68741377720d9eb758409af8c10165a3407043d",
                 "shasum": ""
             },
             "require": {
@@ -760,7 +760,7 @@
                 }
             ],
             "description": "A thin wrapper around the Symfony Process Component that allows applications to use the Site Alias library to specify the target for a remote call.",
-            "time": "2019-01-06T01:00:28+00:00"
+            "time": "2019-01-06T16:14:05+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -1544,16 +1544,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b49b1ca166bd109900e6a1683d9bb1115727ef2d"
+                "reference": "c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b49b1ca166bd109900e6a1683d9bb1115727ef2d",
-                "reference": "b49b1ca166bd109900e6a1683d9bb1115727ef2d",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde",
+                "reference": "c24ce3d18ccc9bb9d7e1d6ce9330fcc6061cafde",
                 "shasum": ""
             },
             "require": {
@@ -1590,20 +1590,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:48:54+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "6cf2be5cbd0e87aa35c01f80ae0bf40b6798e442"
+                "reference": "3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/6cf2be5cbd0e87aa35c01f80ae0bf40b6798e442",
-                "reference": "6cf2be5cbd0e87aa35c01f80ae0bf40b6798e442",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e",
+                "reference": "3f2a2ab6315dd7682d4c16dcae1e7b95c8b8555e",
                 "shasum": ""
             },
             "require": {
@@ -1639,7 +1639,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:48:54+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1809,16 +1809,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.4.20",
+            "version": "v3.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "6867713afe6c50ade2f34ed6435563b065a52145"
+                "reference": "a5f39641bb62e8b74e343467b145331273f615a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6867713afe6c50ade2f34ed6435563b065a52145",
-                "reference": "6867713afe6c50ade2f34ed6435563b065a52145",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/a5f39641bb62e8b74e343467b145331273f615a2",
+                "reference": "a5f39641bb62e8b74e343467b145331273f615a2",
                 "shasum": ""
             },
             "require": {
@@ -1874,7 +1874,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2018-11-20T16:10:26+00:00"
+            "time": "2019-01-01T13:45:19+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/Commands/DrushCommands.php
+++ b/src/Commands/DrushCommands.php
@@ -11,9 +11,13 @@ use Robo\Contract\ConfigAwareInterface;
 use Robo\Contract\IOAwareInterface;
 use Robo\Common\IO;
 use Symfony\Component\Console\Input\InputOption;
+use Consolidation\SiteProcess\ProcessManagerAwareTrait;
+use Consolidation\SiteProcess\ProcessManagerAwareInterface;
 
-abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, ConfigAwareInterface
+abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, ConfigAwareInterface, ProcessManagerAwareInterface
 {
+    use ProcessManagerAwareTrait;
+
     // This is more readable.
     const REQ=InputOption::VALUE_REQUIRED;
     const OPT=InputOption::VALUE_OPTIONAL;
@@ -86,11 +90,11 @@ abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, 
 
         if (self::input()->isInteractive()) {
             ;
-            $process = Drush::process(['less', $file])->setTty(true);
+            $process = $this->processManager()->process(['less', $file])->setTty(true);
             if ($process->run() === 0) {
                 return;
             } else {
-                $process = Drush::process(['more', $file]);
+                $process = $this->processManager()->process(['more', $file]);
                 if ($process->run() === 0) {
                     return;
                 } else {

--- a/src/Commands/core/EditCommands.php
+++ b/src/Commands/core/EditCommands.php
@@ -59,7 +59,7 @@ class EditCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
 
         // A bit awkward due to backward compat.
         $cmd = sprintf($editor, Escape::shellArg($filepath));
-        $process = Drush::shell($cmd);
+        $process = $this->processManager()->shell($cmd);
         $process->setTty(true);
         $process->mustRun();
     }

--- a/src/Commands/core/EditCommands.php
+++ b/src/Commands/core/EditCommands.php
@@ -59,7 +59,7 @@ class EditCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
 
         // A bit awkward due to backward compat.
         $cmd = sprintf($editor, Escape::shellArg($filepath));
-        $process = Drush::process($cmd);
+        $process = Drush::shell($cmd);
         $process->setTty(true);
         $process->mustRun();
     }

--- a/src/Commands/core/InitCommands.php
+++ b/src/Commands/core/InitCommands.php
@@ -124,7 +124,7 @@ class InitCommands extends DrushCommands implements BuilderAwareInterface, IOAwa
             $editor = drush_get_editor();
             // A bit awkward due to backward compat.
             $cmd = sprintf($editor, Escape::shellArg($drush_config_file));
-            $process = Drush::shell($cmd);
+            $process = $this->processManager()->shell($cmd);
             $process->setTty(true);
             $process->mustRun();
         }

--- a/src/Commands/core/InitCommands.php
+++ b/src/Commands/core/InitCommands.php
@@ -124,7 +124,7 @@ class InitCommands extends DrushCommands implements BuilderAwareInterface, IOAwa
             $editor = drush_get_editor();
             // A bit awkward due to backward compat.
             $cmd = sprintf($editor, Escape::shellArg($drush_config_file));
-            $process = Drush::process($cmd);
+            $process = Drush::shell($cmd);
             $process->setTty(true);
             $process->mustRun();
         }

--- a/src/Commands/core/NotifyCommands.php
+++ b/src/Commands/core/NotifyCommands.php
@@ -90,7 +90,7 @@ class NotifyCommands extends DrushCommands
 
         // Keep backward compat and prepare a string here.
         $cmd = sprintf($cmd, Escape::shellArg($msg));
-        $process = Drush::process($cmd, $msg);
+        $process = Drush::shell($cmd);
         $process->run();
         if (!$process->isSuccessful()) {
             Drush::logger()->warning($error_message);

--- a/src/Commands/core/NotifyCommands.php
+++ b/src/Commands/core/NotifyCommands.php
@@ -90,7 +90,7 @@ class NotifyCommands extends DrushCommands
 
         // Keep backward compat and prepare a string here.
         $cmd = sprintf($cmd, Escape::shellArg($msg));
-        $process = Drush::shell($cmd);
+        $process = $this->processManager()->shell($cmd);
         $process->run();
         if (!$process->isSuccessful()) {
             Drush::logger()->warning($error_message);

--- a/src/Commands/core/RsyncCommands.php
+++ b/src/Commands/core/RsyncCommands.php
@@ -74,7 +74,7 @@ class RsyncCommands extends DrushCommands implements SiteAliasManagerAwareInterf
 
         $ssh_options = Drush::config()->get('ssh.options', '');
         $exec = "rsync -e 'ssh $ssh_options'". ' '. implode(' ', array_filter($parameters));
-        $process = Drush::shell($exec);
+        $process = $this->processManager()->shell($exec);
         $process->run($process->showRealtime());
 
         if ($process->isSuccessful()) {

--- a/src/Commands/core/RsyncCommands.php
+++ b/src/Commands/core/RsyncCommands.php
@@ -74,7 +74,7 @@ class RsyncCommands extends DrushCommands implements SiteAliasManagerAwareInterf
 
         $ssh_options = Drush::config()->get('ssh.options', '');
         $exec = "rsync -e 'ssh $ssh_options'". ' '. implode(' ', array_filter($parameters));
-        $process = Drush::process($exec);
+        $process = Drush::shell($exec);
         $process->run($process->showRealtime());
 
         if ($process->isSuccessful()) {

--- a/src/Commands/generate/Helper/OutputHandler.php
+++ b/src/Commands/generate/Helper/OutputHandler.php
@@ -31,7 +31,7 @@ class OutputHandler extends BaseOutputHandler
         if (defined('DRUPAL_ROOT') && $dumped_files) {
             $exec = drush_get_editor();
             $exec = str_replace('%s', Escape::shellArg(Path::makeAbsolute($dumped_files[0], DRUPAL_ROOT)), $exec);
-            $process = Drush::process($exec);
+            $process = Drush::shell($exec);
             // Use start() in order to get an async fork.
             $process->start();
         }

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -140,7 +140,7 @@ class SqlCommands extends DrushCommands
     public function cli($options = ['extra' => self::REQ])
     {
         $sql = SqlBase::create($options);
-        $process = Drush::shell($sql->connect(), null, $sql->getEnv());
+        $process = $this->processManager()->shell($sql->connect(), null, $sql->getEnv());
         $process->setTty(true);
         $process->mustRun();
     }

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -140,7 +140,7 @@ class SqlCommands extends DrushCommands
     public function cli($options = ['extra' => self::REQ])
     {
         $sql = SqlBase::create($options);
-        $process = Drush::process($sql->connect(), null, $sql->getEnv());
+        $process = Drush::shell($sql->connect(), null, $sql->getEnv());
         $process->setTty(true);
         $process->mustRun();
     }

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -166,10 +166,11 @@ class ConfigCommands extends DrushCommands
         $temp_storage = new FileStorage($temp_dir);
         $temp_storage->write($config_name, $contents);
 
-        //
+        // Note that `drush_get_editor` returns a string that contains a
+        // %s placeholder for the config file path.
         $exec = drush_get_editor();
         $cmd = sprintf($exec, Escape::shellArg($temp_storage->getFilePath($config_name)));
-        $process = Drush::process($cmd);
+        $process = Drush::shell($cmd);
         $process->setTty(true);
         $process->mustRun();
 

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -170,14 +170,14 @@ class ConfigCommands extends DrushCommands
         // %s placeholder for the config file path.
         $exec = drush_get_editor();
         $cmd = sprintf($exec, Escape::shellArg($temp_storage->getFilePath($config_name)));
-        $process = Drush::shell($cmd);
+        $process = $this->processManager()->shell($cmd);
         $process->setTty(true);
         $process->mustRun();
 
         // Perform import operation if user did not immediately exit editor.
         if (!$options['bg']) {
             $redispatch_options = Drush::redispatchOptions()   + ['partial' => true, 'source' => $temp_dir];
-            $process = Drush::drush(Drush::aliasManager()->getSelf(), 'config-import', [], $redispatch_options);
+            $process = $this->processManager()->drush(Drush::aliasManager()->getSelf(), 'config-import', [], $redispatch_options);
             $process->mustRun($process->showRealtime());
         }
     }
@@ -515,7 +515,7 @@ class ConfigCommands extends DrushCommands
             $prefix = ['git', 'diff', '--color=always'];
         }
         $args = array_merge($prefix, ['-u', $temp_destination_dir, $temp_source_dir]);
-        $process = Drush::process($args);
+        $process = $this->processManager()->process($args);
         $process->run();
         return $process->getOutput();
     }

--- a/src/Drupal/Commands/config/ConfigExportCommands.php
+++ b/src/Drupal/Commands/config/ConfigExportCommands.php
@@ -160,18 +160,18 @@ class ConfigExportCommands extends DrushCommands
         if ($options['commit']) {
             // There must be changed files at the destination dir; if there are not, then
             // we will skip the commit step.
-            $process = Drush::process('git status --porcelain .', $destination_dir);
+            $process = Drush::process(['git', 'status', '--porcelain', '.'], $destination_dir);
             $process->mustRun();
             $uncommitted_changes = $process->getOutput();
             if (!empty($uncommitted_changes)) {
-                $process = Drush::process('git add -A .', $destination_dir);
+                $process = Drush::process(['git', 'add', '-A', '.'], $destination_dir);
                 $process->mustRun();
                 $comment_file = drush_save_data_to_temp_file($options['message'] ?: 'Exported configuration.'. $preview);
-                $process = Drush::process(['git commit', "--file=$comment_file"], $destination_dir);
+                $process = Drush::process(['git', 'commit', "--file=$comment_file"], $destination_dir);
                 $process->mustRun();
             }
         } elseif ($options['add']) {
-            Drush::process(['git add -p ',  $destination_dir])->run();
+            Drush::process(['git', 'add', '-p',  $destination_dir])->run();
         }
     }
 

--- a/src/Drupal/Commands/config/ConfigExportCommands.php
+++ b/src/Drupal/Commands/config/ConfigExportCommands.php
@@ -14,7 +14,6 @@ use Webmozart\PathUtil\Path;
 
 class ConfigExportCommands extends DrushCommands
 {
-
     /**
      * @var ConfigManagerInterface
      */
@@ -160,18 +159,18 @@ class ConfigExportCommands extends DrushCommands
         if ($options['commit']) {
             // There must be changed files at the destination dir; if there are not, then
             // we will skip the commit step.
-            $process = Drush::process(['git', 'status', '--porcelain', '.'], $destination_dir);
+            $process = $this->processManager()->process(['git', 'status', '--porcelain', '.'], $destination_dir);
             $process->mustRun();
             $uncommitted_changes = $process->getOutput();
             if (!empty($uncommitted_changes)) {
-                $process = Drush::process(['git', 'add', '-A', '.'], $destination_dir);
+                $process = $this->processManager()->process(['git', 'add', '-A', '.'], $destination_dir);
                 $process->mustRun();
                 $comment_file = drush_save_data_to_temp_file($options['message'] ?: 'Exported configuration.'. $preview);
-                $process = Drush::process(['git', 'commit', "--file=$comment_file"], $destination_dir);
+                $process = $this->processManager()->process(['git', 'commit', "--file=$comment_file"], $destination_dir);
                 $process->mustRun();
             }
         } elseif ($options['add']) {
-            Drush::process(['git', 'add', '-p',  $destination_dir])->run();
+            $this->processManager()->process(['git', 'add', '-p',  $destination_dir])->run();
         }
     }
 

--- a/src/Drush.php
+++ b/src/Drush.php
@@ -343,7 +343,7 @@ class Drush
     public function shell($command, $cwd = null, array $env = null, $input = null, $timeout = 60)
     {
         $processManager = self::service('process.manager');
-        return $processManager->shell($commandline, $cwd, $env, $input, $timeout);
+        return $processManager->shell($command, $cwd, $env, $input, $timeout);
     }
 
     /**

--- a/src/Drush.php
+++ b/src/Drush.php
@@ -91,31 +91,31 @@ class Drush
      */
     public static function getVersion()
     {
-        if (!static::$version) {
-            $drush_info = static::drushReadDrushInfo();
-            static::$version = $drush_info['drush_version'];
+        if (!self::$version) {
+            $drush_info = self::drushReadDrushInfo();
+            self::$version = $drush_info['drush_version'];
         }
-        return static::$version;
+        return self::$version;
     }
 
     public static function getMajorVersion()
     {
-        if (!static::$majorVersion) {
-            $drush_version = static::getVersion();
+        if (!self::$majorVersion) {
+            $drush_version = self::getVersion();
             $version_parts = explode('.', $drush_version);
-            static::$majorVersion = $version_parts[0];
+            self::$majorVersion = $version_parts[0];
         }
-        return static::$majorVersion;
+        return self::$majorVersion;
     }
 
     public static function getMinorVersion()
     {
-        if (!static::$minorVersion) {
-            $drush_version = static::getVersion();
+        if (!self::$minorVersion) {
+            $drush_version = self::getVersion();
             $version_parts = explode('.', $drush_version);
-            static::$minorVersion = $version_parts[1];
+            self::$minorVersion = $version_parts[1];
         }
-        return static::$minorVersion;
+        return self::$minorVersion;
     }
 
     /**
@@ -180,10 +180,10 @@ class Drush
      */
     public static function runner()
     {
-        if (!isset(static::$runner)) {
-            static::$runner = new \Robo\Runner();
+        if (!isset(self::$runner)) {
+            self::$runner = new \Robo\Runner();
         }
-        return static::$runner;
+        return self::$runner;
     }
 
     /**
@@ -201,7 +201,7 @@ class Drush
      */
     public static function service($id)
     {
-        return static::getContainer()->get($id);
+        return self::getContainer()->get($id);
     }
 
     /**
@@ -216,7 +216,7 @@ class Drush
     public static function hasService($id)
     {
         // Check hasContainer() first in order to always return a Boolean.
-        return static::hasContainer() && static::getContainer()->has($id);
+        return self::hasContainer() && self::getContainer()->has($id);
     }
 
     /**
@@ -226,7 +226,7 @@ class Drush
      */
     public static function commandFactory()
     {
-        return static::service('commandFactory');
+        return self::service('commandFactory');
     }
 
     /**
@@ -236,7 +236,7 @@ class Drush
      */
     public static function logger()
     {
-        return static::service('logger');
+        return self::service('logger');
     }
 
     /**
@@ -246,7 +246,7 @@ class Drush
      */
     public static function config()
     {
-        return static::service('config');
+        return self::service('config');
     }
 
     /**
@@ -254,7 +254,7 @@ class Drush
      */
     public static function aliasManager()
     {
-        return static::service('site.alias.manager');
+        return self::service('site.alias.manager');
     }
 
     /**
@@ -264,7 +264,7 @@ class Drush
      */
     public static function input()
     {
-        return static::service('input');
+        return self::service('input');
     }
 
     /**
@@ -274,7 +274,7 @@ class Drush
      */
     public static function output()
     {
-        return static::service('output');
+        return self::service('output');
     }
 
     /**
@@ -375,7 +375,7 @@ class Drush
      */
     public static function affirmative()
     {
-        if (!static::hasService('input')) {
+        if (!self::hasService('input')) {
             throw new \Exception('No input service available.');
         }
         return Drush::input()->getOption('yes') || (Drush::backend() && !Drush::negative());
@@ -386,7 +386,7 @@ class Drush
      */
     public static function negative()
     {
-        if (!static::hasService('input')) {
+        if (!self::hasService('input')) {
             throw new \Exception('No input service available.');
         }
         return Drush::input()->getOption('no');
@@ -397,7 +397,7 @@ class Drush
      */
     public static function verbose()
     {
-        if (!static::hasService('output')) {
+        if (!self::hasService('output')) {
             return false;
         }
         return \Drush\Drush::output()->isVerbose();
@@ -408,7 +408,7 @@ class Drush
      */
     public static function debug()
     {
-        if (!static::hasService('output')) {
+        if (!self::hasService('output')) {
             return false;
         }
         return \Drush\Drush::output()->isDebug();
@@ -421,7 +421,7 @@ class Drush
      */
     public static function bootstrapManager()
     {
-        return static::service('bootstrap.manager');
+        return self::service('bootstrap.manager');
     }
 
     /**
@@ -431,24 +431,24 @@ class Drush
      */
     public static function bootstrap()
     {
-        return static::bootstrapManager()->bootstrap();
+        return self::bootstrapManager()->bootstrap();
     }
 
     public static function redispatchOptions($input = null)
     {
-        $input = $input ?: static::input();
+        $input = $input ?: self::input();
 
         // $input->getOptions() returns an associative array of option => value
         $options = $input->getOptions();
 
         // The 'runtime.options' config contains a list of option names on th cli
-        $optionNamesFromCommandline = static::config()->get('runtime.options');
+        $optionNamesFromCommandline = self::config()->get('runtime.options');
 
         // Remove anything in $options that was not on the cli
         $options = array_intersect_key($options, array_flip($optionNamesFromCommandline));
 
         // Add in the 'runtime.context' items, which includes --include, --alias-path et. al.
-        return $options + array_filter(static::config()->get(PreflightArgs::DRUSH_RUNTIME_CONTEXT_NAMESPACE));
+        return $options + array_filter(self::config()->get(PreflightArgs::DRUSH_RUNTIME_CONTEXT_NAMESPACE));
     }
 
     /**

--- a/src/Drush.php
+++ b/src/Drush.php
@@ -325,10 +325,25 @@ class Drush
      * @return ProcessBase
      *   A wrapper around Symfony Process.
      */
-    public static function process($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = null)
+    public static function process($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60)
     {
         $processManager = self::service('process.manager');
-        return $processManager->process($commandline, $cwd, $env, $input, $timeout, $options);
+        return $processManager->process($commandline, $cwd, $env, $input, $timeout);
+    }
+
+    /**
+     * Create a Process instance from a commandline string.
+     * @param string $command The commandline string to run
+     * @param string|null $cwd     The working directory or null to use the working dir of the current PHP process
+     * @param array|null $env     The environment variables or null to use the same environment as the current PHP process
+     * @param mixed|null $input   The input as stream resource, scalar or \Traversable, or null for no input
+     * @param int|float|null $timeout The timeout in seconds or null to disable
+     * @return Process
+     */
+    public function shell($command, $cwd = null, array $env = null, $input = null, $timeout = 60)
+    {
+        $processManager = self::service('process.manager');
+        return $processManager->shell($commandline, $cwd, $env, $input, $timeout);
     }
 
     /**

--- a/src/Exec/ExecTrait.php
+++ b/src/Exec/ExecTrait.php
@@ -71,7 +71,7 @@ trait ExecTrait
                         $args = ['sleep', $sleep, Shell::op('&&')];
                     }
                     // @todo We implode because quoting is messing up the sleep.
-                    $process = Drush::process(array_merge($args, [$browser, $uri]));
+                    $process = Drush::shell(implode(' ', array_merge($args, [$browser, $uri])));
                     $process->run();
                 }
                 return true;
@@ -88,7 +88,7 @@ trait ExecTrait
      */
     public static function programExists($program)
     {
-        $process = Drush::process(['command', '-v', $program]);
+        $process = Drush::shell("command -v $program");
         $process->run();
         return $process->isSuccessful();
     }

--- a/src/Exec/ExecTrait.php
+++ b/src/Exec/ExecTrait.php
@@ -71,7 +71,7 @@ trait ExecTrait
                         $args = ['sleep', $sleep, Shell::op('&&')];
                     }
                     // @todo We implode because quoting is messing up the sleep.
-                    $process = Drush::process(implode(' ', array_merge($args, [$browser, $uri])));
+                    $process = Drush::process(array_merge($args, [$browser, $uri]));
                     $process->run();
                 }
                 return true;
@@ -88,7 +88,7 @@ trait ExecTrait
      */
     public static function programExists($program)
     {
-        $process = Drush::process("command -v $program");
+        $process = Drush::process(['command', '-v', $program]);
         $process->run();
         return $process->isSuccessful();
     }

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -81,19 +81,33 @@ class ProcessManager extends ConsolidationProcessManager
      * The timeout parameter on this method doesn't work. It exists for compatibility with parent.
      * Call this method to get a Process and then call setters as needed.
      *
-     * @param string|array   $commandline The command line to run
+     * @param array          $commandline The command line to run with arguments as separate items in an array
      * @param string|null    $cwd         The working directory or null to use the working dir of the current PHP process
      * @param array|null     $env         The environment variables or null to use the same environment as the current PHP process
      * @param mixed|null     $input       The input as stream resource, scalar or \Traversable, or null for no input
      * @param int|float|null $timeout     The timeout in seconds or null to disable
-     * @param array          $options     An array of options for proc_open
      *
      * @return ProcessBase
      *   A wrapper around Symfony Process.
      */
-    public function process($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60, array $options = null)
+    public function process($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60)
     {
-        $process = new ProcessBase($commandline, $cwd, $env, $input, $timeout, $options);
+        $process = parent::process($commandline, $cwd, $env, $input, $timeout);
+        return $this->configureProcess($process);
+    }
+
+    /**
+     * Create a Process instance from a commandline string.
+     * @param string $command The commandline string to run
+     * @param string|null $cwd     The working directory or null to use the working dir of the current PHP process
+     * @param array|null $env     The environment variables or null to use the same environment as the current PHP process
+     * @param mixed|null $input   The input as stream resource, scalar or \Traversable, or null for no input
+     * @param int|float|null $timeout The timeout in seconds or null to disable
+     * @return Process
+     */
+    public function shell($command, $cwd = null, array $env = null, $input = null, $timeout = 60)
+    {
+        $process = parent::shell($command, $cwd, $env, $input, $timeout);
         return $this->configureProcess($process);
     }
 

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -183,7 +183,7 @@ class SqlBase implements ConfigAwareInterface
             $cmd .= ' > ' . Escape::shellArg($file);
         }
 
-        $process = Drush::process($cmd, null, $this->getEnv());
+        $process = Drush::shell($cmd, null, $this->getEnv());
         // Avoid the php memory of saving stdout.
         $process->disableOutput();
         // Show dump in real-time on stdout, for backward compat.
@@ -313,7 +313,7 @@ class SqlBase implements ConfigAwareInterface
         // We show the query when --debug is used and this function created the temp file.
         $this->logQueryInDebugMode($query, $input_file_original);
 
-        $process = Drush::process($exec, null, $this->getEnv());
+        $process = Drush::shell($exec, null, $this->getEnv());
         $process->setSimulated(false);
         $process->run();
         $success = $process->isSuccessful();

--- a/src/Sql/SqlPgsql.php
+++ b/src/Sql/SqlPgsql.php
@@ -97,7 +97,7 @@ class SqlPgsql extends SqlBase
         unset($db_spec_no_db['database']);
         $sql_no_db = new SqlPgsql($db_spec_no_db, $this->getOptions());
         $query = "SELECT 1 AS result FROM pg_database WHERE datname='$database'";
-        $process = Drush::process($sql_no_db->connect() . ' -t -c ' . $query, null, $this->getEnv());
+        $process = Drush::shell($sql_no_db->connect() . ' -t -c ' . $query, null, $this->getEnv());
         $process->setSimulated(false);
         $process->run();
         return $process->isSuccessful();

--- a/tests/functional/UpdateDBTest.php
+++ b/tests/functional/UpdateDBTest.php
@@ -18,9 +18,9 @@ class UpdateDBTest extends CommandUnishTestCase
     {
         $this->setUpDrupal(1, true);
         $this->drush('pm:enable', ['devel']);
-        $this->drush('updatedb:status', [], ['format' => 'json']);
-        $out = $this->getOutputFromJSON();
-        $this->assertNull($out);
+        $this->drush('updatedb:status');
+        $err = $this->getErrorOutput();
+        $this->assertEquals('[success] No database updates required.', $err);
 
         // Force a pending update.
         $this->drush('php-script', ['updatedb_script'], ['script-path' => __DIR__ . '/resources']);
@@ -34,9 +34,9 @@ class UpdateDBTest extends CommandUnishTestCase
         $this->drush('updatedb', []);
 
         // Assert that we ran hook_update_n properly
-        $this->drush('updatedb:status', [], ['format' => 'json']);
-        $out = $this->getOutputFromJSON();
-        $this->assertNull($out);
+        $this->drush('updatedb:status');
+        $err = $this->getErrorOutput();
+        $this->assertEquals('[success] No database updates required.', $err);
 
         // Assure that a pending post-update is reported.
         $this->pathPostUpdate = Path::join($this->webroot(), 'modules/unish/devel/devel.post_update.php');
@@ -266,9 +266,9 @@ YAML_FRAGMENT;
         $this->drush('updatedb');
 
         // Assert that the updates were run correctly.
-        $this->drush('updatedb:status', [], ['format' => 'json']);
-        $out = $this->getOutputFromJSON();
-        $this->assertNull($out);
+        $this->drush('updatedb:status');
+        $err = $this->getErrorOutput();
+        $this->assertEquals('[success] No database updates required.', $err);
     }
 
     /**

--- a/tests/integration/CoreTest.php
+++ b/tests/integration/CoreTest.php
@@ -16,16 +16,15 @@ class CoreTest extends UnishIntegrationTestCase
     {
         $root = $this->webroot();
         $options = [
-        'pipe' => null,
         'ignore' => 'cron,http requests,update,update_core,trusted_host_patterns', // no network access when running in tests, so ignore these
         // 'strict' => 0, // invoke from script: do not verify options
         ];
         // Verify that there are no severity 2 items in the status report
-        $this->drush('core-requirements', [], $options + ['severity' => '2']);
+        $this->drush('core-requirements', [], $options + ['severity' => '2', 'pipe' => true]);
         $output = $this->getOutput();
         $this->assertEquals('', $output);
 
-        $this->drush('core-requirements', [], $options);
+        $this->drush('core-requirements', [], $options + ['format' => 'json']);
         $loaded = $this->getOutputFromJSON();
         // Pick a subset that are valid for D6/D7/D8.
         $expected = [

--- a/tests/unish/Utils/OutputUtilsTrait.php
+++ b/tests/unish/Utils/OutputUtilsTrait.php
@@ -128,7 +128,11 @@ trait OutputUtilsTrait
      */
     public function getOutputFromJSON($key = null)
     {
-        $json = json_decode($this->getOutput());
+        $output = $this->getOutput();
+        $json = json_decode($output);
+        if (!$json) {
+            throw new \Exception("No json output received.\n\nOutput:\n\n$output\n\nStderr:\n\n" . $this->getErrorOutput());
+        }
         if (isset($key)) {
             $json = $json->{$key}; // http://stackoverflow.com/questions/2925044/hyphens-in-keys-of-object
         }


### PR DESCRIPTION
…, and 'Drush::process()' for commandlines provided as arrays of arguments that need to be escaped