### PR TITLE
Continue #3166/2. Fix script name when Drupal uses a domain + subdir without scheme.

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -141,8 +141,8 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
 
         // Account for users who omit the http:// prefix.
         if (empty($parsed_url['scheme'])) {
-            $this->uri = 'http://' . $uri;
-            $parsed_url = parse_url($this->uri);
+            $this->uri = 'http://' . $this->uri;
+            $parsed_url = parse_url('http://' . $uri);
         }
 
         $server = [

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -141,7 +141,7 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
 
         // Account for users who omit the http:// prefix.
         if (empty($parsed_url['scheme'])) {
-            $this->uri = 'http://' . $this->uri;
+            $this->uri = 'http://' . $uri;
             $parsed_url = parse_url($this->uri);
         }
 


### PR DESCRIPTION
This is an addition to #3553 (committed just before Drush 9.3.0, https://github.com/drush-ops/drush/pull/3553/commits/3f18f8138e9174e700b22892ef4dd8d7bcca78ef) which continued #3166.

This PR fixed the situation for --uri=http://domain.com/subdir and for --uri=domain.com/subdir/, but not for --uri=domain.com/subdir . (This is a regression from Drush 8 and has caused some emergency work on an existing Drupal-using project. Not sure if this ever worked with Drush9; I only tested 9.2.3, which obviously doesn't work because... above referenced code is missing.)

In the latter case, $_SERVER['SCRIPT_NAME'] will contain 'subdirindex.php' (i.e. missing slash) ... which makes DrupalKernel::findSitePath() return "sites/default" instead of the correct directory in $sites.

I believe the fix, and the fact that this doesn't introduce new regressions, is self evident when comparing it with the above referenced commit.