### PR TITLE
Move some methods from Drush:: to DrushConfig::

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -9,7 +9,7 @@ use Consolidation\SiteAlias\SiteAliasManager;
 use Drush\Log\LogLevel;
 use Drush\Command\RemoteCommandProxy;
 use Drush\Runtime\RedispatchHook;
-use Robo\Common\ConfigAwareTrait;
+use Drush\Config\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -544,6 +544,9 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
         if ($object instanceof \Consolidation\SiteAlias\SiteAliasManagerAwareInterface) {
             $object->setSiteAliasManager($container->get('site.alias.manager'));
         }
+        if ($object instanceof \Consolidation\SiteProcess\ProcessManagerAwareInterface) {
+            $object->setProcessManager($container->get('process.manager'));
+        }
         if ($object instanceof \Consolidation\AnnotatedCommand\Input\StdinAwareInterface) {
             $object->setStdinHandler($container->get('stdinHandler'));
         }

--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -9,7 +9,7 @@ use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
-use Robo\Common\ConfigAwareTrait;
+use Drush\Config\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 
 class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface, ConfigAwareInterface, ContainerAwareInterface

--- a/src/Commands/DrushCommands.php
+++ b/src/Commands/DrushCommands.php
@@ -6,7 +6,7 @@ use Drush\Style\DrushStyle;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
-use Robo\Common\ConfigAwareTrait;
+use Drush\Config\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 use Robo\Contract\IOAwareInterface;
 use Robo\Common\IO;
@@ -27,10 +27,7 @@ abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, 
     const EXIT_FAILURE = 1;
 
     use LoggerAwareTrait;
-    use ConfigAwareTrait {
-        // Move aside this method so we can replace. See https://stackoverflow.com/a/37687295.
-        getConfig as ConfigAwareGetConfig;
-    }
+    use ConfigAwareTrait;
     use IO {
         io as roboIo;
     }
@@ -59,19 +56,6 @@ abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, 
             $this->io = new DrushStyle($this->input(), $this->output());
         }
         return $this->io;
-    }
-
-    /**
-     * Replaces same method in ConfigAwareTrait in order to provide a
-     * DrushConfig as return type. Helps with IDE completion.
-     *
-     * @see https://stackoverflow.com/a/37687295.
-     *
-     * @return \Drush\Config\DrushConfig
-     */
-    public function getConfig()
-    {
-        return $this->ConfigAwareGetConfig();
     }
 
     /**

--- a/src/Commands/config/ConfigPullCommands.php
+++ b/src/Commands/config/ConfigPullCommands.php
@@ -49,10 +49,10 @@ class ConfigPullCommands extends DrushCommands implements SiteAliasManagerAwareI
             'format' => 'string',
         ];
         $this->logger()->notice(dt('Starting to export configuration on :destination.', [':destination' => $destination]));
-        $process = Drush::drush($sourceRecord, 'config-export', [], $export_options + $global_options);
+        $process = $this->processManager()->drush($sourceRecord, 'config-export', [], $export_options + $global_options);
         $process->mustRun();
         // Trailing slash assures that we transfer files and not the containing dir.
-        $export_path = Drush::simulate() ? '/simulated/path' : trim($process->getOutput()) . '/';
+        $export_path = $this->getConfig()->simulate() ? '/simulated/path' : trim($process->getOutput()) . '/';
 
         if (strpos($destination, ':') === false) {
             $destination .= ':%config-' . $options['label'];
@@ -74,7 +74,7 @@ class ConfigPullCommands extends DrushCommands implements SiteAliasManagerAwareI
             'delete' => true,
             'exclude' => '.htaccess',
         ];
-        $process = Drush::drush($runner, 'core-rsync', $args, ['yes' => true, 'debug' => true], $options_double_dash);
+        $process = $this->processManager()->drush($runner, 'core-rsync', $args, ['yes' => true, 'debug' => true], $options_double_dash);
         $process->mustRun();
         drush_backend_set_result($destinationHostPath->getOriginal());
         return new PropertyList(['path' => $destinationHostPath->getOriginal()]);
@@ -87,7 +87,7 @@ class ConfigPullCommands extends DrushCommands implements SiteAliasManagerAwareI
     {
         if ($commandData->input()->getOption('safe')) {
             $destinationRecord = $this->siteAliasManager()->get($commandData->input()->getArgument('destination'));
-            $process = Drush::siteProcess($destinationRecord, ['git', 'diff', '--quiet']);
+            $process = $this->processManager()->siteProcess($destinationRecord, ['git', 'diff', '--quiet']);
             $process->chdirToSiteRoot();
             $process->run();
             if (!$process->isSuccessful()) {

--- a/src/Commands/core/BrowseCommands.php
+++ b/src/Commands/core/BrowseCommands.php
@@ -38,7 +38,7 @@ class BrowseCommands extends DrushCommands implements SiteAliasManagerAwareInter
         // Redispatch if called against a remote-host so a browser is started on the
         // the *local* machine.
         if (!$aliasRecord->isLocal()) {
-            $process = Drush::drush($aliasRecord, 'browse', [$path], Drush::redispatchOptions());
+            $process = $this->processManager()->drush($aliasRecord, 'browse', [$path], Drush::redispatchOptions());
             $process->mustRun();
             $link = $process->getOutput();
         } else {

--- a/src/Commands/core/BrowseCommands.php
+++ b/src/Commands/core/BrowseCommands.php
@@ -37,7 +37,7 @@ class BrowseCommands extends DrushCommands implements SiteAliasManagerAwareInter
         $aliasRecord = $this->siteAliasManager()->getSelf();
         // Redispatch if called against a remote-host so a browser is started on the
         // the *local* machine.
-        if (!$aliasRecord->isLocal()) {
+        if ($this->processManager()->hasTransport($aliasRecord)) {
             $process = $this->processManager()->drush($aliasRecord, 'browse', [$path], Drush::redispatchOptions());
             $process->mustRun();
             $link = $process->getOutput();

--- a/src/Commands/core/EditCommands.php
+++ b/src/Commands/core/EditCommands.php
@@ -81,7 +81,7 @@ class EditCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
             }
         }
 
-        if ($rcs = Drush::config()->get('runtime.config.paths')) {
+        if ($rcs = $this->getConfig()->configPaths()) {
             // @todo filter out any files that are within Drush.
             $rcs = array_combine($rcs, $rcs);
             if ($headers) {
@@ -135,7 +135,7 @@ class EditCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
     public static function bashFiles()
     {
         $bashFiles = [];
-        $home = Drush::config()->home();
+        $home = $this->getConfig()->home();
         if ($bashrc = self::findBashrc($home)) {
             $bashFiles[$bashrc] = $bashrc;
         }

--- a/src/Commands/core/LoginCommands.php
+++ b/src/Commands/core/LoginCommands.php
@@ -40,7 +40,7 @@ class LoginCommands extends DrushCommands implements SiteAliasManagerAwareInterf
         // the *local* machine.
         $aliasRecord = $this->siteAliasManager()->getSelf();
         if (!$aliasRecord->isLocal()) {
-            $process = Drush::drush($aliasRecord, 'user-login', [$path], Drush::redispatchOptions());
+            $process = $this->processManager()->drush($aliasRecord, 'user-login', [$path], Drush::redispatchOptions());
             $process->mustRun();
             $link = $process->getOutput();
         } else {

--- a/src/Commands/core/LoginCommands.php
+++ b/src/Commands/core/LoginCommands.php
@@ -39,7 +39,7 @@ class LoginCommands extends DrushCommands implements SiteAliasManagerAwareInterf
         // Redispatch if called against a remote-host so a browser is started on the
         // the *local* machine.
         $aliasRecord = $this->siteAliasManager()->getSelf();
-        if (!$aliasRecord->isLocal()) {
+        if ($this->processManager()->hasTransport($aliasRecord)) {
             $process = $this->processManager()->drush($aliasRecord, 'user-login', [$path], Drush::redispatchOptions());
             $process->mustRun();
             $link = $process->getOutput();

--- a/src/Commands/core/NotifyCommands.php
+++ b/src/Commands/core/NotifyCommands.php
@@ -90,10 +90,10 @@ class NotifyCommands extends DrushCommands
 
         // Keep backward compat and prepare a string here.
         $cmd = sprintf($cmd, Escape::shellArg($msg));
-        $process = $this->processManager()->shell($cmd);
+        $process = Drush::shell($cmd);
         $process->run();
         if (!$process->isSuccessful()) {
-            $this->logger()->warning($error_message);
+            Drush::logger()->warning($error_message);
         }
 
         return true;

--- a/src/Commands/core/NotifyCommands.php
+++ b/src/Commands/core/NotifyCommands.php
@@ -33,7 +33,7 @@ class NotifyCommands extends DrushCommands
             return;
         }
 
-        if (Drush::config()->get('notify.duration')) {
+        if ($this->getConfig()->get('notify.duration')) {
             if (self::isAllowed()) {
                 $msg = dt("Command '!command' completed.", ['!command' => $cmd]);
                 self::shutdownSend($msg, $commandData);
@@ -93,7 +93,7 @@ class NotifyCommands extends DrushCommands
         $process = $this->processManager()->shell($cmd);
         $process->run();
         if (!$process->isSuccessful()) {
-            Drush::logger()->warning($error_message);
+            $this->logger()->warning($error_message);
         }
 
         return true;

--- a/src/Commands/core/RsyncCommands.php
+++ b/src/Commands/core/RsyncCommands.php
@@ -60,7 +60,7 @@ class RsyncCommands extends DrushCommands implements SiteAliasManagerAwareInterf
     public function rsync($source, $target, array $extra, $options = ['exclude-paths' => self::REQ, 'include-paths' => self::REQ, 'mode' => 'akz'])
     {
         // Prompt for confirmation. This is destructive.
-        if (!\Drush\Drush::simulate()) {
+        if (!$this->getConfig()->simulate()) {
             $replacements = ['!source' => $this->sourceEvaluatedPath->fullyQualifiedPathPreservingTrailingSlash(), '!target' => $this->targetEvaluatedPath->fullyQualifiedPath()];
             if (!$this->io()->confirm(dt("Replace files in !target with !source?", $replacements))) {
                 throw new UserAbortException();
@@ -72,7 +72,7 @@ class RsyncCommands extends DrushCommands implements SiteAliasManagerAwareInterf
         $parameters[] = $this->sourceEvaluatedPath->fullyQualifiedPathPreservingTrailingSlash();
         $parameters[] = $this->targetEvaluatedPath->fullyQualifiedPath();
 
-        $ssh_options = Drush::config()->get('ssh.options', '');
+        $ssh_options = $this->getConfig()->get('ssh.options', '');
         $exec = "rsync -e 'ssh $ssh_options'". ' '. implode(' ', array_filter($parameters));
         $process = $this->processManager()->shell($exec);
         $process->run($process->showRealtime());

--- a/src/Commands/core/RunserverCommands.php
+++ b/src/Commands/core/RunserverCommands.php
@@ -74,8 +74,8 @@ class RunserverCommands extends DrushCommands
         }
         // Start the server using 'php -S'.
         $router = Path::join(DRUSH_BASE_PATH, '/misc/d8-rs-router.php');
-        $php = Drush::config()->get('php', 'php');
-        $process = Drush::process([$php, '-S', $addr . ':' . $uri['port'], $router]);
+        $php = $this->getConfig()->get('php', 'php');
+        $process = $this->processManager()->process([$php, '-S', $addr . ':' . $uri['port'], $router]);
         $process->setWorkingDirectory(Drush::bootstrapManager()->getRoot());
         $process->setTty(true);
         if ($options['quiet']) {

--- a/src/Commands/core/SiteCommands.php
+++ b/src/Commands/core/SiteCommands.php
@@ -173,7 +173,7 @@ class SiteCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
         $discovery->depth('< 9');
         $legacyAliasConverter = new LegacyAliasConverter($discovery);
         $legacyAliasConverter->setTargetDir($destination);
-        $legacyAliasConverter->setSimulate(Drush::simulate());
+        $legacyAliasConverter->setSimulate($this->getConfig()->simulate());
 
         // Find and convert.
         drush_mkdir($destination, true);

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -214,10 +214,10 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
             $options = ['yes' => true];
             $selfRecord = $this->siteAliasManager()->getSelf();
 
-            $process = Drush::drush($selfRecord, 'config-set', ['system.site', 'uuid', $source_storage->read('system.site')['uuid']], $options);
+            $process = $this->processManager()->drush($selfRecord, 'config-set', ['system.site', 'uuid', $source_storage->read('system.site')['uuid']], $options);
             $process->mustRun();
 
-            $process = Drush::drush($selfRecord, 'config-import', [], ['source' => $config] + $options);
+            $process = $this->processManager()->drush($selfRecord, 'config-import', [], ['source' => $config] + $options);
             $process->mustRun($process->showRealtime());
         }
     }
@@ -332,7 +332,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
 
         // Can't install without sites subdirectory and settings.php.
         if (!file_exists($confPath)) {
-            if (!drush_mkdir($confPath) && !Drush::simulate()) {
+            if (!drush_mkdir($confPath) && !$this->getConfig()->simulate()) {
                 throw new \Exception(dt('Failed to create directory @confPath', ['@confPath' => $confPath]));
             }
         } else {
@@ -340,14 +340,14 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
         }
 
         if (!drush_file_not_empty($settingsfile)) {
-            if (!drush_op('copy', 'sites/default/default.settings.php', $settingsfile) && !Drush::simulate()) {
+            if (!drush_op('copy', 'sites/default/default.settings.php', $settingsfile) && !$this->getConfig()->simulate()) {
                 throw new \Exception(dt('Failed to copy sites/default/default.settings.php to @settingsfile', ['@settingsfile' => $settingsfile]));
             }
         }
 
         // Write an empty sites.php if we using multi-site.
         if ($sitesfile_write) {
-            if (!drush_op('copy', 'sites/example.sites.php', $sitesfile) && !Drush::simulate()) {
+            if (!drush_op('copy', 'sites/example.sites.php', $sitesfile) && !$this->getConfig()->simulate()) {
                 throw new \Exception(dt('Failed to copy sites/example.sites.php to @sitesfile', ['@sitesfile' => $sitesfile]));
             }
         }

--- a/src/Commands/core/SshCommands.php
+++ b/src/Commands/core/SshCommands.php
@@ -49,7 +49,7 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
             $args = explode(' ', $args[0]);
         }
 
-        $process = Drush::siteProcess($alias, $args);
+        $process = $this->processManager()->siteProcess($alias, $args);
         $process->setTty($options['tty']);
         $process->chdirToSiteRoot($options['cd']);
         $process->mustRun($process->showRealtime());

--- a/src/Commands/core/StatusCommands.php
+++ b/src/Commands/core/StatusCommands.php
@@ -140,7 +140,7 @@ class StatusCommands extends DrushCommands implements SiteAliasManagerAwareInter
         $status_table['drush-version'] = Drush::getVersion();
         $status_table['drush-temp'] = $this->getConfig()->tmp();
         $status_table['drush-cache-directory'] = $this->getConfig()->cache();
-        $status_table['drush-conf'] = Drush::config()->get('runtime.config.paths');
+        $status_table['drush-conf'] = $this->getConfig()->configPaths();
         // List available alias files
         $alias_files = $this->siteAliasManager()->listAllFilePaths();
         sort($alias_files);

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -201,17 +201,17 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
                     Database::startLog($function);
                 }
 
-                $this->logger()->notice("Update started: $function");
+                Drush::logger()->notice("Update started: $function");
                 $ret['results']['query'] = $function($context['sandbox']);
                 $ret['results']['success'] = true;
             } catch (\Throwable $e) {
                 // PHP 7 introduces Throwable, which covers both Error and Exception throwables.
                 $ret['#abort'] = ['success' => false, 'query' => $e->getMessage()];
-                $this->logger()->error($e->getMessage());
+                Drush::logger()->error($e->getMessage());
             } catch (\Exception $e) {
                 // In order to be compatible with PHP 5 we also catch regular Exceptions.
                 $ret['#abort'] = ['success' => false, 'query' => $e->getMessage()];
-                $this->logger()->error($e->getMessage());
+                Drush::logger()->error($e->getMessage());
             }
 
             if ($context['log']) {
@@ -219,7 +219,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
             }
         } else {
             $ret['#abort'] = ['success' => false];
-            $this->logger()->warning(dt('Update function @function not found', ['@function' => $function]));
+            Drush::logger()->warning(dt('Update function @function not found', ['@function' => $function]));
         }
 
         if (isset($context['sandbox']['#finished'])) {
@@ -237,7 +237,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
 
         // Log the message that was returned.
         if (!empty($ret['results']['query'])) {
-            $this->logger()->notice(strip_tags((string) $ret['results']['query']));
+            Drush::logger()->notice(strip_tags((string) $ret['results']['query']));
         }
 
         if (!empty($ret['#abort'])) {
@@ -283,7 +283,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         list($module, $name) = explode('_post_update_', $function, 2);
         module_load_include('php', $module, $module . '.post_update');
         if (function_exists($function)) {
-            $this->logger()->notice("Update started: $function");
+            Drush::logger()->notice("Update started: $function");
             try {
                 $ret['results']['query'] = $function($context['sandbox']);
                 $ret['results']['success'] = true;
@@ -296,7 +296,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
                 // types, but for now we'll just log the exception and return the message
                 // for printing.
                 // @see https://www.drupal.org/node/2564311
-                $this->logger()->error($e->getMessage());
+                Drush::logger()->error($e->getMessage());
 
                 $variables = Error::decodeException($e);
                 unset($variables['backtrace']);
@@ -318,7 +318,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
 
         // Log the message that was returned.
         if (!empty($ret['results']['query'])) {
-            $this->logger()->notice(strip_tags((string) $ret['results']['query']));
+            Drush::logger()->notice(strip_tags((string) $ret['results']['query']));
         }
 
         if (!empty($ret['#abort'])) {

--- a/src/Commands/core/XhprofCommands.php
+++ b/src/Commands/core/XhprofCommands.php
@@ -51,7 +51,7 @@ class XhprofCommands extends DrushCommands
         if (self::xhprofIsEnabled()) {
             $namespace = 'Drush';
             $run_id = self::xhprofFinishRun($namespace);
-            $url = Drush::config()->get('xh.link') . '/index.php?run=' . urlencode($run_id) . '&source=' . urlencode($namespace);
+            $url = $this->getConfig()->get('xh.link') . '/index.php?run=' . urlencode($run_id) . '&source=' . urlencode($namespace);
             $this->logger()->notice(dt('XHProf run saved. View report at !url', ['!url' => $url]));
         }
     }
@@ -64,7 +64,7 @@ class XhprofCommands extends DrushCommands
     public function xhprofInitialize(InputInterface $input, AnnotationData $annotationData)
     {
         if (self::xhprofIsEnabled()) {
-            $config = Drush::config()->get('xh');
+            $config = $this->getConfig()->get('xh');
             $flags = self::xhprofFlags($config);
             self::xhprofEnable($flags);
         }

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -86,7 +86,7 @@ class SqlCommands extends DrushCommands
         $sql = SqlBase::create($options);
         $db_spec = $sql->getDbSpec();
         // Prompt for confirmation.
-        if (!Drush::simulate()) {
+        if (!$this->getConfig()->simulate()) {
             // @todo odd - maybe for sql-sync.
             $txt_destination = (isset($db_spec['remote-host']) ? $db_spec['remote-host'] . '/' : '') . $db_spec['database'];
             $this->output()->writeln(dt("Creating database !target. Any existing database will be dropped!", ['!target' => $txt_destination]));
@@ -176,7 +176,7 @@ class SqlCommands extends DrushCommands
         if ($options['db-prefix']) {
             Drush::bootstrapManager()->bootstrapMax(DRUSH_BOOTSTRAP_DRUPAL_DATABASE);
         }
-        if (Drush::simulate()) {
+        if ($this->getConfig()->simulate()) {
             if ($query) {
                 $this->output()->writeln(dt('Simulating sql:query: !q', ['!q' => $query]));
             } else {

--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -109,7 +109,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
 
     public function databaseName(AliasRecord $record)
     {
-        if (!$record->isLocal() && $this->getConfig()->simulate()) {
+        if ($this->processManager()->hasTransport($record) && $this->getConfig()->simulate()) {
             return 'simulated_db';
         }
 

--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -52,7 +52,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
         // Create target DB if needed.
         if ($options['create-db']) {
             $this->logger()->notice(dt('Starting to create database on target.'));
-            $process = Drush::drush($targetRecord, 'sql-create', [], $global_options);
+            $process = $this->processManager()->drush($targetRecord, 'sql-create', [], $global_options);
             $process->mustRun();
         }
 
@@ -96,7 +96,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
             throw new \Exception(dt('The --target-dump option must be supplied when --no-sync is specified.'));
         }
 
-        if (!Drush::simulate()) {
+        if (!$this->getConfig()->simulate()) {
             $this->output()->writeln(dt("You will destroy data in !target and replace with data from !source.", [
                 '!source' => $txt_source,
                 '!target' => $txt_target
@@ -109,11 +109,11 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
 
     public function databaseName(AliasRecord $record)
     {
-        if (!$record->isLocal() && Drush::simulate()) {
+        if (!$record->isLocal() && $this->getConfig()->simulate()) {
             return 'simulated_db';
         }
 
-        $process = Drush::drush($record, 'core-status', ['db-name'], ['format' => 'string']);
+        $process = $this->processManager()->drush($record, 'core-status', ['db-name'], ['format' => 'string']);
         $process->setSimulated(false);
         $process->mustRun();
         return trim($process->getOutput());
@@ -140,10 +140,10 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
             $this->logger()->notice(dt('Starting to dump database on source.'));
             // Set --backend=json. Drush 9.6+ changes that to --format=json. See \Drush\Preflight\PreflightArgs::setBackend.
             // Drush 9.5- handles this as --backend.
-            $process = Drush::drush($sourceRecord, 'sql-dump', [], $dump_options + ['backend' => 'json']);
+            $process = $this->processManager()->drush($sourceRecord, 'sql-dump', [], $dump_options + ['backend' => 'json']);
             $process->mustRun();
 
-            if (Drush::simulate()) {
+            if ($this->getConfig()->simulate()) {
                 $source_dump_path = '/simulated/path/to/dump.tgz';
             } else {
                 // First try a Drush 9.6+ return format.
@@ -189,7 +189,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
         } else {
             $tmp = '/tmp'; // Our fallback plan.
             $this->logger()->notice(dt('Starting to discover temporary files directory on target.'));
-            $process = Drush::drush($targetRecord, 'core-status', ['drush-temp'], ['format' => 'string']);
+            $process = $this->processManager()->drush($targetRecord, 'core-status', ['drush-temp'], ['format' => 'string']);
             $process->setSimulated(false);
             $process->run();
 
@@ -215,7 +215,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
                 $runner = $targetRecord;
             }
             $this->logger()->notice(dt('Copying dump file from source to target.'));
-            $process = Drush::drush($runner, 'core-rsync', [$sourceRecord->name() . ":$source_dump_path", $targetRecord->name() . ":$target_dump_path"], [], $double_dash_options);
+            $process = $this->processManager()->drush($runner, 'core-rsync', [$sourceRecord->name() . ":$source_dump_path", $targetRecord->name() . ":$target_dump_path"], [], $double_dash_options);
             $process->mustRun($process->showRealtime());
         }
         return $target_dump_path;
@@ -235,7 +235,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
             'file' => $target_dump_path,
             'file-delete' => true,
         ];
-        $process = Drush::drush($targetRecord, 'sql-query', [], $query_options);
+        $process = $this->processManager()->drush($targetRecord, 'sql-query', [], $query_options);
         $process->mustRun();
     }
 }

--- a/src/Config/ConfigAwareTrait.php
+++ b/src/Config/ConfigAwareTrait.php
@@ -1,0 +1,22 @@
+<?php
+namespace Drush\Config;
+
+trait ConfigAwareTrait
+{
+    use \Robo\Common\ConfigAwareTrait {
+        \Robo\Common\ConfigAwareTrait::getConfig as parentGetConfig;
+    }
+
+    /**
+     * Replaces same method in ConfigAwareTrait in order to provide a
+     * DrushConfig as return type. Helps with IDE completion.
+     *
+     * @see https://stackoverflow.com/a/37687295.
+     *
+     * @return \Drush\Config\DrushConfig
+     */
+    public function getConfig()
+    {
+        return $this->parentGetConfig();
+    }
+}

--- a/src/Config/DrushConfig.php
+++ b/src/Config/DrushConfig.php
@@ -50,7 +50,7 @@ class DrushConfig extends ConfigOverlay
     }
 
     /**
-     * Return 'true' if we are in simulated mode
+     * Return 'true' if we are in simulated mode.
      */
     public function simulate()
     {
@@ -58,11 +58,20 @@ class DrushConfig extends ConfigOverlay
     }
 
     /**
-     * Return 'true' if we are in backend mode
+     * Return 'true' if we are in backend mode.
      */
     public function backend()
     {
         return $this->get(PreflightArgs::BACKEND);
+    }
+
+    /**
+     * Return the list of paths to active Drush configuration files.
+     * @return array
+     */
+    public function configPaths()
+    {
+        return $this->get('runtime.config.paths', []);
     }
 
     public function cache()

--- a/src/Config/DrushConfig.php
+++ b/src/Config/DrushConfig.php
@@ -6,6 +6,11 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
+// TODO: Not sure if we should have a reference to PreflightArgs here.
+// Maybe these constants should be in config, and PreflightArgs can
+// reference them from there as well.
+use Drush\Preflight\PreflightArgs;
+
 /**
  * Accessors for common Drush config keys.
  */
@@ -34,6 +39,30 @@ class DrushConfig extends ConfigOverlay
     public function tmp()
     {
         return $this->get('env.tmp');
+    }
+
+    /**
+     * Return the path to this Drush
+     */
+    public function drushScript()
+    {
+        return $this->get('runtime.drush-script', 'drush');
+    }
+
+    /**
+     * Return 'true' if we are in simulated mode
+     */
+    public function simulate()
+    {
+        return $this->get(\Robo\Config\Config::SIMULATE);
+    }
+
+    /**
+     * Return 'true' if we are in backend mode
+     */
+    public function backend()
+    {
+        return $this->get(PreflightArgs::BACKEND);
     }
 
     public function cache()

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -130,7 +130,7 @@ class ConfigCommands extends DrushCommands
             } elseif ($this->io()->confirm(dt('Do you want to update !key key in !name config?', ['!key' => $key, '!name' => $config_name]))) {
                 $confirmed = true;
             }
-            if ($confirmed && !\Drush\Drush::simulate()) {
+            if ($confirmed && !$this->getConfig()->simulate()) {
                 return $config->set($key, $data)->save();
             }
         }

--- a/src/Drupal/Commands/core/RoleCommands.php
+++ b/src/Drupal/Commands/core/RoleCommands.php
@@ -77,7 +77,7 @@ class RoleCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
         $perms = StringUtils::csvToArray($permissions);
         user_role_grant_permissions($machine_name, $perms);
         $this->logger()->success(dt('Added "!permissions" to "!role"', ['!permissions' => $permissions, '!role' => $machine_name]));
-        Drush::drush($this->siteAliasManager()->getSelf(), 'cache-rebuild');
+        $this->processManager()->drush($this->siteAliasManager()->getSelf(), 'cache-rebuild');
     }
 
     /**
@@ -97,7 +97,7 @@ class RoleCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
         $perms = StringUtils::csvToArray($permissions);
         user_role_revoke_permissions($machine_name, $perms);
         $this->logger()->success(dt('Removed "!permissions" to "!role"', ['!permissions' => $permissions, '!role' => $machine_name]));
-        Drush::drush($this->siteAliasManager()->getSelf(), 'cache-rebuild');
+        $this->processManager()->drush($this->siteAliasManager()->getSelf(), 'cache-rebuild');
     }
 
     /**

--- a/src/Drupal/Commands/core/UserCommands.php
+++ b/src/Drupal/Commands/core/UserCommands.php
@@ -231,7 +231,7 @@ class UserCommands extends DrushCommands
             'access' => '0',
             'status' => 1,
         ];
-        if (!Drush::simulate()) {
+        if (!$this->getConfig()->simulate()) {
             if ($account = User::create($new_user)) {
                 $account->save();
                 drush_backend_set_result($this->infoArray($account));
@@ -308,7 +308,7 @@ class UserCommands extends DrushCommands
     public function password($name, $password)
     {
         if ($account = user_load_by_name($name)) {
-            if (!Drush::simulate()) {
+            if (!$this->getConfig()->simulate()) {
                 $account->setpassword($password);
                 $account->save();
                 $this->logger()->success(dt('Changed password for !name.', ['!name' => $name]));

--- a/src/Drush.php
+++ b/src/Drush.php
@@ -347,27 +347,33 @@ class Drush
     }
 
     /**
-     * Return the path to this Drush
+     * Return the path to this Drush.
+     *
+     * @deprecated Inject configuration and use $this->getConfig()->drushScript().
      */
     public static function drushScript()
     {
-        return \Drush\Drush::config()->get('runtime.drush-script', 'drush');
+        return \Drush\Drush::config()->drushScript();
     }
 
     /**
      * Return 'true' if we are in simulated mode
+     *
+     * @deprecated Inject configuration and use $this->getConfig()->simulate().
      */
     public static function simulate()
     {
-        return \Drush\Drush::config()->get(\Robo\Config\Config::SIMULATE);
+        return \Drush\Drush::config()->simulate();
     }
 
     /**
      * Return 'true' if we are in backend mode
+     *
+     * @deprecated Inject configuration and use $this->getConfig()->backend().
      */
     public static function backend()
     {
-        return \Drush\Drush::config()->get(PreflightArgs::BACKEND);
+        return \Drush\Drush::config()->backend();
     }
 
     /**

--- a/src/Drush.php
+++ b/src/Drush.php
@@ -286,6 +286,8 @@ class Drush
      * @param array $options
      * @param array $options_double_dash
      * @return SiteProcess
+     *
+     * @deprecated Use injected process manager instead.
      */
     public static function drush(AliasRecord $siteAlias, $command, $args = [], $options = [], $options_double_dash = [])
     {
@@ -302,6 +304,8 @@ class Drush
      * @param array $options
      * @param array $options_double_dash
      * @return ProcessBase
+     *
+     * @deprecated Use injected process manager instead.
      */
     public static function siteProcess(AliasRecord $siteAlias, $args = [], $options = [], $options_double_dash = [])
     {
@@ -324,6 +328,8 @@ class Drush
      *
      * @return ProcessBase
      *   A wrapper around Symfony Process.
+     *
+     * @deprecated Use injected process manager instead.
      */
     public static function process($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60)
     {
@@ -339,6 +345,8 @@ class Drush
      * @param mixed|null $input   The input as stream resource, scalar or \Traversable, or null for no input
      * @param int|float|null $timeout The timeout in seconds or null to disable
      * @return Process
+     *
+     * @deprecated Use injected process manager instead.
      */
     public function shell($command, $cwd = null, array $env = null, $input = null, $timeout = 60)
     {

--- a/src/Runtime/RedispatchHook.php
+++ b/src/Runtime/RedispatchHook.php
@@ -10,7 +10,7 @@ use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 use Consolidation\SiteProcess\ProcessManager;
 use Drush\Drush;
 use Drush\Log\LogLevel;
-use Robo\Common\ConfigAwareTrait;
+use Drush\Config\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 use Symfony\Component\Console\Input\InputInterface;
 

--- a/src/Runtime/TildeExpansionHook.php
+++ b/src/Runtime/TildeExpansionHook.php
@@ -5,7 +5,7 @@ namespace Drush\Runtime;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\Hooks\ValidatorInterface;
 use Drush\Utils\StringUtils;
-use Robo\Common\ConfigAwareTrait;
+use Drush\Config\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 
 /**

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -12,7 +12,7 @@ use Drush\Style\DrushStyle;
 use Consolidation\SiteProcess\ProcessBase;
 use Consolidation\SiteProcess\SiteProcess;
 use Webmozart\PathUtil\Path;
-use Robo\Common\ConfigAwareTrait;
+use Drush\Config\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 
 /**

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -6,7 +6,7 @@ use Consolidation\SiteProcess\Util\Escape;
 use Drupal\Core\Database\Database;
 use Drush\Drush;
 use Drush\Utils\FsUtils;
-use Robo\Common\ConfigAwareTrait;
+use Drush\Config\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;


### PR DESCRIPTION
Depend on injected config object rather than static `Drush::` methods wherever possible.