### PR TITLE
Propagate option negations to updatedb:status

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -53,6 +53,8 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         $updatedb_options = [
             'entity-updates' => $options['entity-updates'],
             'post-updates' => $options['post-updates'],
+            'no-entity-updates' => $options['no-entity-updates'],
+            'no-post-updates' => $options['no-post-updates'],
         ];
         $process = Drush::drush($this->siteAliasManager()->getSelf(), 'updatedb:status', [], $updatedb_options);
         $process->mustRun();


### PR DESCRIPTION
## Current behavior

When running `drush updb --no-post-updates` one can notice post-update hooks listed among regular update hooks.  Answering `yes` to `Do you wish to run the specified pending updates? (yes/no)` **doesn't run these updates**. 

## Expected behavior

`drush updb --no-post-updates` doesn't show post-update hooks in the update the summary.