### PR TITLE
Remove set_error_handler('drush_error_handler') from cache:rebuild.

### DIFF
--- a/src/Commands/core/CacheCommands.php
+++ b/src/Commands/core/CacheCommands.php
@@ -200,9 +200,6 @@ class CacheCommands extends DrushCommands implements CustomEventAwareInterface, 
         $site_path = DrupalKernel::findSitePath($request);
         Settings::initialize($root, $site_path, $autoloader);
 
-        // Use our error handler since _drupal_log_error() depends on an unavailable theme system (ugh).
-        set_error_handler('drush_error_handler');
-
         // drupal_rebuild() calls drupal_flush_all_caches() itself, so we don't do it manually.
         drupal_rebuild($autoloader, $request);
         $this->logger()->success(dt('Cache rebuild complete.'));


### PR DESCRIPTION
Fixes #3836.

It looks like _drupal_log_error() no longer themes error messages form CLI requests. So lets remove this code. 