### PR TITLE
Fixes #3859: Allow input to be piped to sql:cli

### DIFF
--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -9,6 +9,7 @@ use Drush\Exceptions\UserAbortException;
 use Drush\Exec\ExecTrait;
 use Drush\Sql\SqlBase;
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
+use Symfony\Component\Console\Input\InputInterface;
 
 class SqlCommands extends DrushCommands
 {
@@ -137,11 +138,13 @@ class SqlCommands extends DrushCommands
      * @remote-tty
      * @bootstrap max configuration
      */
-    public function cli($options = ['extra' => self::REQ])
+    public function cli(InputInterface $input, $options = ['extra' => self::REQ])
     {
         $sql = SqlBase::create($options);
         $process = $this->processManager()->shell($sql->connect(), null, $sql->getEnv());
-        $process->setTty(true);
+        $process->setTty($this->getConfig()->get('ssh.tty', $input->isInteractive()));
+        $process->setInput(STDIN);
+        $process->mustRun($process->showRealtime());
         $process->mustRun();
     }
 

--- a/src/Runtime/RedispatchHook.php
+++ b/src/Runtime/RedispatchHook.php
@@ -97,6 +97,7 @@ class RedispatchHook implements InitializeHookInterface, ConfigAwareInterface, S
         $aliasRecord = $this->siteAliasManager()->getSelf();
         $process = $this->processManager->drushSiteProcess($aliasRecord, $redispatchArgs, $redispatchOptions);
         $process->setTty($this->getConfig()->get('ssh.tty', $input->isInteractive()));
+        $process->setInput(STDIN);
         $process->mustRun($process->showRealtime());
 
         return $this->exitEarly($process->getExitCode());


### PR DESCRIPTION
When using the Symfony Process component, it is necessary to call `setTty(true)` when an interactive program is called; however, if input is redirected, then it is important to not set tty mode to true. `setInput` must also be set, and it is possible to pass any resource stream, e.g. STDIN, to this API call.

Replaces #3865 (or at least a subset of it).