### PR TITLE
FIXES #3874: Wrap 'pipefail' in "bash -c".

### DIFF
--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -195,13 +195,16 @@ class SqlBase implements ConfigAwareInterface
     }
 
     /**
-     * We have three possibilities for $pipefail:
+     * Handle 'pipefail' option for the specified command.
      *
+     * @param string $cmd Script command to execute; should contain a pipe command
+     * @param string $pipefail Script statements to insert into / wrap around $cmd
+     * @return string Result varies based on value of $pipefail
      *   - empty: Return $cmd unmodified
      *   - simple string: Return $cmd appended to $pipefail
      *   - interpolated: Add slashes to $cmd and insert in $pipefail
      *
-     * The last is particularly for environments such as Ubuntu
+     * Interpolation is particularly for environments such as Ubuntu
      * that use something other than bash as the default shell. To
      * make pipefail work right in this instance, we must wrap it
      * in 'bash -c', since pipefail is a bash feature.


### PR DESCRIPTION
This is almost right.

What we are trying to do here is wrap the 'pipefail' command in "bash -c" so that we can ensure that the shell is bash, since pipefail is a bash feature. We use interpolation on the pipefail string so that it is easy for the caller to alter the template as needed to support other shells.

The default pipefail string is: `bash -c "set -o pipefail; {{cmd}}"`

Also, 'pipefail' doesn't have anything to do with ssh, so I renamed the configuration name from 'ssh.pipefail' to 'sh.pipefail'.

Shortcomings:

1. This works if pipefail is empty, or if it is the default value. However, it is also possible that someone might use something like `set -o pipefail; {{cmd}}`, which for example should work if the user know their default shell is bash. However, at the moment this code always calls `addslashes()` on the contents of `$cmd`, even in instances like this where doing so would be wrong (although you wouldn't notice unless cmd contains quote characters). Perhaps what we need to do is make other interpolation shortcuts that indicate whether the substitution value should be escaped in any way. Maybe `//cmd//` or `{/cmd/}` or something like that for backslash-escaped config values? Do we want to consider shell-escaping at the same time?

2. It might be helpful to pull the 'pipefail' code out into a utility class.