### PR TITLE
Make Log message status transparent

### DIFF
--- a/src/Log/Logger.php
+++ b/src/Log/Logger.php
@@ -103,9 +103,9 @@ class Logger extends RoboLogger
         }
 
         if ($this->output->isDecorated()) {
-            $red = "\033[31;40m\033[1m[%s]\033[0m";
-            $yellow = "\033[1;33;40m\033[1m[%s]\033[0m";
-            $green = "\033[1;32;40m\033[1m[%s]\033[0m";
+            $red = "\033[31m\033[1m[%s]\033[0m";
+            $yellow = "\033[1;33m\033[1m[%s]\033[0m";
+            $green = "\033[1;32m\033[1m[%s]\033[0m";
         } else {
             $red = "[%s]";
             $yellow = "[%s]";


### PR DESCRIPTION
I've noticed that colored log statuses have a black background, which looks ugly on semi-transparent terminals (I guess on all terminals with a different background color as well). Is there a reason to force the bg color?