### PR TITLE
fix: process whitelisting of fields correctly

### DIFF
--- a/src/Drupal/Commands/sql/SanitizeUserFieldsCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserFieldsCommands.php
@@ -52,7 +52,7 @@ class SanitizeUserFieldsCommands extends DrushCommands implements SanitizePlugin
         $conn = $this->getDatabase();
         $field_definitions = $this->getEntityManager()->getFieldDefinitions('user', 'user');
         $field_storage = $this->getEntityManager()->getFieldStorageDefinitions('user');
-        foreach (explode(',', $options['whitelist-fields']) as $key => $def) {
+        foreach (explode(',', $options['whitelist-fields']) as $key) {
             unset($field_definitions[$key], $field_storage[$key]);
         }
 


### PR DESCRIPTION
The current logic is unsetting the cardinal index instead.