### PR TITLE
Set Drupal root context for backward compat.

### DIFF
--- a/src/Boot/DrupalBoot.php
+++ b/src/Boot/DrupalBoot.php
@@ -122,6 +122,8 @@ abstract class DrupalBoot extends BaseBoot
         $drupal_root = $manager->getRoot();
         chdir($drupal_root);
         $this->logger->log(LogLevel::BOOTSTRAP, dt("Change working directory to !drupal_root", ['!drupal_root' => $drupal_root]));
+        // For backward compat purposes, keep setting this context.
+        drush_set_context('DRUSH_DRUPAL_ROOT', $drupal_root);
 
         $core = $this->bootstrapDrupalCore($manager, $drupal_root);
 


### PR DESCRIPTION
Avoids an error with the Acquia Cloud settings include files. And maybe more errors elsewhere.