### PR TITLE
Add array type hint to QueueCommands::run

### DIFF
--- a/src/Drupal/Commands/core/QueueCommands.php
+++ b/src/Drupal/Commands/core/QueueCommands.php
@@ -58,7 +58,7 @@ class QueueCommands extends DrushCommands
      * @validate-queue name
      * @option time-limit The maximum number of seconds allowed to run the queue
      */
-    public function run($name, $options = ['time-limit' => self::REQ])
+    public function run($name, array $options = ['time-limit' => self::REQ])
     {
         $time_limit = (int) $options['time-limit'];
         $start = microtime(true);


### PR DESCRIPTION
Ok, so I realize this is a bit of an edge case.

I have added a command file that extends a drush core command (QueueCommands). It lives in a custom module. I override the ::run method for some very specific reason.

As with most projects, I am doing code style checking of all custom code. Against Drupal coding standards. So including this new file. And it would require me to add a type hint to the $options parameter to pass. Which would then give a warning, because the overriding class now changes the function signature of run.

So here is a quick PR just for my very narrow use case :)