### PR TITLE
git:// is discontinued on drupal.org - use https://

### DIFF
--- a/commands/pm/package_handler/git_drupalorg.inc
+++ b/commands/pm/package_handler/git_drupalorg.inc
@@ -52,7 +52,7 @@ function package_handler_download_project(&$request, $release) {
     $repository = $username . '@git.drupal.org:project/' . $request['name'] . '.git';
   }
   else {
-    $repository = 'git://git.drupal.org/project/' . $request['name'] . '.git';
+    $repository = 'https://git.drupal.org/project/' . $request['name'] . '.git';
   }
   $request['repository'] = $repository;
   $tag = $release['tag'];


### PR DESCRIPTION
https://twitter.com/drupal_infra/status/1088571024918994945