### PR TITLE
“git” is now the only supported username for SSH Git clones

### DIFF
--- a/commands/pm/package_handler/git_drupalorg.inc
+++ b/commands/pm/package_handler/git_drupalorg.inc
@@ -49,7 +49,7 @@ function package_handler_validate() {
 function package_handler_download_project(&$request, $release) {
   if ($username = drush_get_option('gitusername')) {
     // Uses SSH, which enables pushing changes back to git.drupal.org.
-    $repository = $username . '@git.drupal.org:project/' . $request['name'] . '.git';
+    $repository = 'git@git.drupal.org:project/' . $request['name'] . '.git';
   }
   else {
     $repository = 'git://git.drupal.org/project/' . $request['name'] . '.git';


### PR DESCRIPTION
See https://www.drupal.org/gitauth

This is a change in preparation for Drupal.org’s move to GitLab, which does not support arbitrary usernames for SSH clones. Our current Git daemon also supports authenticating with git@… as long as you have SSH keys set up.