### PR TITLE
Replace http with https for git.drupal.org URLs

### DIFF
--- a/commands/make/make.download.inc
+++ b/commands/make/make.download.inc
@@ -253,7 +253,7 @@ function make_download_git($name, $type, $download, $download_location) {
   $wc = _get_working_copy_option($download);
   $checkout_after_clone = TRUE;
   // If no download URL specified, assume anonymous clone from git.drupal.org.
-  $download['url'] = isset($download['url']) ? $download['url'] : "http://git.drupal.org/project/$name.git";
+  $download['url'] = isset($download['url']) ? $download['url'] : "https://git.drupal.org/project/$name.git";
   // If no working-copy download URL specified, assume it is the same.
   $download['wc_url'] = isset($download['wc_url']) ? $download['wc_url'] : $download['url'];
 

--- a/docs/make.md
+++ b/docs/make.md
@@ -484,7 +484,7 @@ Properties in the includer takes precedence over the includee.
         type: "module"
         download:
           type: "git"
-          url: "http://git.drupal.org/project/views.git"
+          url: "https://git.drupal.org/project/views.git"
 
 A project or library entry of an included makefile can be removed entirely by
 setting the corresponding key to NULL:

--- a/examples/example.make
+++ b/examples/example.make
@@ -36,7 +36,7 @@ api = 2
 ; Git clone of Drupal 7.x. Requires the `core` property to be set to 7.x.
 ; projects[drupal][type] = "core"
 ; projects[drupal][download][type] = git
-; projects[drupal][download][url] = http://git.drupal.org/project/drupal.git
+; projects[drupal][download][url] = https://git.drupal.org/project/drupal.git
 
 projects[] = drupal
 
@@ -69,7 +69,7 @@ projects[ctools][version] = 1.3
 
 projects[data][type] = module
 projects[data][download][type] = git
-projects[data][download][url] = http://git.drupal.org/project/views.git
+projects[data][download][url] = https://git.drupal.org/project/views.git
 projects[data][download][revision] = DRUPAL-6--3
 
 ; For projects on drupal.org, some shorthand is available. If any

--- a/examples/example.make.yml
+++ b/examples/example.make.yml
@@ -40,7 +40,7 @@ api: 2
 #   drupal:
 #     type: "core"
 #     download:
-#       url: "http://git.drupal.org/project/drupal.git"
+#       url: "https://git.drupal.org/project/drupal.git"
 
 projects:
   drupal:
@@ -80,7 +80,7 @@ projects:
     type: "module"
     download:
       type: "git" # Note, 'git' is the default, no need to specify.
-      url: "http://git.drupal.org/project/views.git"
+      url: "https://git.drupal.org/project/views.git"
       revision: "7.x-3.x"
 
   # For projects on drupal.org, some shorthand is available. If any

--- a/tests/makeTest.php
+++ b/tests/makeTest.php
@@ -319,7 +319,7 @@ class makeMakefileCase extends CommandUnishTestCase {
 
     // Verify that a reference cache was created.
     $cache_dir = UNISH_CACHE . DIRECTORY_SEPARATOR . 'cache';
-    $this->assertFileExists($cache_dir . '/git/cck_signup-' . md5('http://git.drupal.org/project/cck_signup.git'));
+    $this->assertFileExists($cache_dir . '/git/cck_signup-' . md5('https://git.drupal.org/project/cck_signup.git'));
 
     // Test context_admin.info file.
     $this->assertFileExists(UNISH_SANDBOX . '/test-build/sites/all/modules/context_admin/context_admin.info');
@@ -329,7 +329,7 @@ class makeMakefileCase extends CommandUnishTestCase {
     $this->assertContains('project = "context_admin"', $contents);
 
     // Verify git reference cache exists.
-    $this->assertFileExists($cache_dir . '/git/context_admin-' . md5('http://git.drupal.org/project/context_admin.git'));
+    $this->assertFileExists($cache_dir . '/git/context_admin-' . md5('https://git.drupal.org/project/context_admin.git'));
 
     // Text caption_filter .info rewrite.
     $this->assertFileExists(UNISH_SANDBOX . '/test-build/sites/all/modules/contrib/caption_filter/caption_filter.info');

--- a/tests/makefiles/git.make
+++ b/tests/makefiles/git.make
@@ -27,5 +27,5 @@ projects[os_lightbox][download][revision] = "8d60090f2"
 ; Test a refspec fetch.
 projects[storypal][type] = module
 projects[storypal][download][type] = git
-projects[storypal][download][url] = http://git.drupal.org/project/storypal.git
+projects[storypal][download][url] = https://git.drupal.org/project/storypal.git
 projects[storypal][download][refspec] = refs/tags/7.x-1.0


### PR DESCRIPTION
We should no longer be using http whenever possible.