### PR TITLE
Fix #3894. Assume pre-escaped for single arg calls to ssh command.

### DIFF
--- a/src/Commands/core/SshCommands.php
+++ b/src/Commands/core/SshCommands.php
@@ -22,7 +22,7 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
      * @usage drush @mysite ssh
      *   Open an interactive shell on @mysite's server.
      * @usage drush @prod ssh ls /tmp
-     *   Run "ls /tmp" on @prod site. If @prod is a site list, then ls will be executed on each site.
+     *   Run "ls /tmp" on @prod site.
      * @usage drush @prod ssh git pull
      *   Run "git pull" on the Drupal root directory on the @prod site.
      * @aliases ssh,site-ssh

--- a/src/Commands/core/SshCommands.php
+++ b/src/Commands/core/SshCommands.php
@@ -1,6 +1,7 @@
 <?php
 namespace Drush\Commands\core;
 
+use Consolidation\SiteProcess\Util\Shell;
 use Drush\Commands\DrushCommands;
 use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
@@ -27,7 +28,7 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
      * @aliases ssh,site-ssh
      * @topics docs:aliases
      */
-    public function ssh(array $args, $options = ['cd' => self::REQ, 'tty' => false, 'legacy' => true])
+    public function ssh(array $args, $options = ['cd' => self::REQ, 'tty' => false])
     {
         $alias = $this->siteAliasManager()->getSelf();
         if ($alias->isNone()) {
@@ -43,10 +44,8 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
             $options['tty'] = true;
         }
 
-        // Legacy support: if there is only one argument provided, then
-        // explode it. This may be disabled via the --no-legacy option.
-        if ((count($args) == 1) && $options['legacy']) {
-            $args = explode(' ', $args[0]);
+        if ((count($args) == 1)) {
+            $args = [Shell::preEscaped($args[0])];
         }
 
         $process = $this->processManager()->siteProcess($alias, $args);

--- a/tests/functional/SiteSshTest.php
+++ b/tests/functional/SiteSshTest.php
@@ -30,16 +30,16 @@ class SiteSshCase extends CommandUnishTestCase
     }
 
     /**
-     * Test drush ssh --simulate 'date'.
+     * Test drush ssh --simulate 'time && date'.
      */
     public function testNonInteractive()
     {
         $options = [
             'simulate' => true,
         ];
-        $this->drush('ssh', ['date'], $options, 'user@server/path/to/drupal#sitename');
+        $this->drush('ssh', ['time && date'], $options, 'user@server/path/to/drupal#sitename');
         $output = $this->getErrorOutput();
-        $expected = "ssh -o PasswordAuthentication=no user@server 'cd /path/to/drupal && date'";
+        $expected = "ssh -o PasswordAuthentication=no user@server 'cd /path/to/drupal && time && date'";
         $this->assertContains($expected, $output);
     }
 
@@ -58,9 +58,9 @@ class SiteSshCase extends CommandUnishTestCase
     }
 
     /**
-     * Test drush ssh with multiple arguments (legacy form). Also test --cd option.
+     * Test with single arg and --cd option.
      */
-    public function testSshMultipleArgsLegacy()
+    public function testSshSingleArgs()
     {
         $options = [
             'cd' => '/foo/bar',


### PR DESCRIPTION
Gets rid of --legacy which was not even declared as an option.