### PR TITLE
Fix #2762, #3117. Remove respawn after 50% memory exhaustion during batch processing.

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -52,13 +52,12 @@ class DrushBatchContext extends ArrayObject {
  * Process a Drupal batch by spawning multiple Drush processes.
  *
  * This function will include the correct batch engine for the current
- * major version of Drupal, and will make use of the drush_backend_invoke
- * system to spawn multiple worker threads to handle the processing of
- * the current batch, while keeping track of available memory.
+ * major version of Drupal, and will make use of the site-process
+ * library to spawn multiple worker threads to handle the processing of
+ * the current batch.
  *
  * The batch system will process as many batch sets as possible until
- * the entire batch has been completed or half of the available memory
- * has been used.
+ * the entire batch has been completed.
  *
  * This function is a drop in replacement for the existing batch_process()
  * function of Drupal.
@@ -279,14 +278,6 @@ function _drush_batch_worker() {
     // At this point, either $current_set contains operations that need to be
     // processed or all sets have been completed.
     $queue = _batch_queue($current_set);
-
-    // If we are in progressive mode, break processing after 1 second.
-    if (drush_memory_limit() > 0 && (memory_get_usage() * 2) >= drush_memory_limit()) {
-      Drush::logger()->notice(dt("Batch process has consumed in excess of 50% of available memory. Starting new thread"));
-      // Record elapsed wall clock time.
-      $current_set['elapsed'] = round((microtime(TRUE) - $current_set['start']) * 1000, 2);
-      break;
-    }
   }
 
   // Reporting 100% progress will cause the whole batch to be considered


### PR DESCRIPTION
This code is broken. Since [migrate already handles low memory](https://github.com/drupal/drupal/blob/8.6.x/core/modules/migrate/src/MigrateExecutable.php#L256), this code no longer serves its original purpose.