### PR TITLE
DB prefix ignored when installing site

### DIFF
--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -93,7 +93,7 @@ class SqlBase implements ConfigAwareInterface
         if ($url = $options['db-url']) {
             $url = is_array($url) ? $url[$database] : $url;
             $db_spec = self::dbSpecFromDbUrl($url);
-            $db_spec['db_prefix'] = $options['db-prefix'];
+            $db_spec['prefix'] = $options['db-prefix'];
             return self::getInstance($db_spec, $options);
         } elseif (($databases = $options['databases']) && (array_key_exists($database, $databases)) && (array_key_exists($target, $databases[$database]))) {
             // @todo 'databases' option is not declared anywhere?

--- a/tests/functional/SiteInstallTest.php
+++ b/tests/functional/SiteInstallTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Unish;
+
+/**
+ * @group base
+ * @group slow
+ */
+class SiteInstallCommandCase extends CommandUnishTestCase
+{
+
+    /**
+     * Test functionality of site set.
+     */
+    public function testSiteInstallPrefix()
+    {
+        if ($this->dbDriver() === 'sqlite') {
+            $this->markTestSkipped('SQLite do not prefix tables, it prefixes DB storage files');
+        } else {
+            // Install Drupal in "drupal_" prefix.
+            $this->installDrupal('dev', true, ['db-prefix' => 'drupal_']);
+
+            // Run 'core-status' and insure that we can bootstrap Drupal.
+            $this->drush('core-status', [], ['fields' => 'bootstrap']);
+            $output = $this->getOutput();
+            $this->assertContains('Successful', $output);
+
+            // Issue a query and check the result to verify the connection.
+            $this->drush('sql:query', ["SELECT uid FROM drupal_users where uid = 1;"]);
+            $output = $this->getOutput();
+            $this->assertContains('1', $output);
+        }
+    }
+}


### PR DESCRIPTION
Testing is only done for PostgreSQL and MySQL because SQLite doesn't actually prefix tables (see #3849 ) .