### PR TITLE
Add second parameter in createdb function in SqlOracle.php .

### DIFF
--- a/src/Sql/SqlOracle.php
+++ b/src/Sql/SqlOracle.php
@@ -28,7 +28,7 @@ class SqlOracle extends SqlBase
         return ' ' . $this->dbSpec['username'] . '/' . $this->dbSpec['password'] . ($this->dbSpec['host'] == 'USETNS' ? '@' . $this->dbSpec['database'] : '@//' . $this->dbSpec['host'] . ':' . ($db_spec['port'] ? $db_spec['port'] : '1521') . '/' . $this->dbSpec['database']);
     }
 
-    public function createdbSql($dbname)
+    public function createdbSql($dbname, $quoted = false)
     {
         Drush::logger()->error("Unable to generate CREATE DATABASE sql for $dbname");
         return false;


### PR DESCRIPTION
Add fix in SqlOracle.php to address warning - [warning] Declaration of Drush\Sql\SqlOracle::createdbSql($dbname) should be compatible with Drush\Sql\SqlBase::createdbSql($dbname, $quoted = false) SqlOracle.php:98
Read more https://github.com/drush-ops/drush/issues/3896