### PR TITLE
Fixes #3940: Do not get confused by the SUT

### DIFF
--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -343,8 +343,17 @@ class Preflight
     {
         if ($selectedRoot || $fallbackPath) {
             $foundRoot = $this->drupalFinder->locateRoot($selectedRoot);
+            // If we did not find a site at the selected root, check the
+            // PARENT directory of the fallback path. This will find a site
+            // that Drush is installed in while avoiding the SUT.
             if (!$foundRoot && $fallbackPath) {
-                $this->drupalFinder->locateRoot($fallbackPath);
+                $foundRoot = $this->drupalFinder->locateRoot(dirname(dirname($fallbackPath)));
+            }
+            // If we can't find a site that Drush is installed in, and
+            // Drush has been installed with a sut (git or composer dev install),
+            // then look for the sut.
+            if (!$foundRoot && $fallbackPath && is_dir($fallbackPath . '/sut') && is_dir($fallbackPath . '/vendor')) {
+                $foundRoot = $this->drupalFinder->locateRoot($fallbackPath);
             }
             return $this->drupalFinder()->getDrupalRoot();
         }


### PR DESCRIPTION
If Drush is installed as a dependency of a Drupal site (as we stipulate it always should be) and the cwd / alias does not find a site, then search for the site that Drush is installed in, and fall back to the sut only as a last resort.

Note that this PR does not fix the case where your cwd is inside the Drush project root for a Drush site installed inside a Drupal site. That is an edge case that not too many folks should encounter.