### PR TITLE
Fix broken link in commands documentation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -59,7 +59,7 @@ For an example, see the alterer class provided by the testing 'woot' module: `te
 Site-Wide Drush Commands
 ==============================
 
-Commandfiles that are installed in a Drupal site and are not bundled inside a Drupal module are called 'site-wide' commandfiles. Site-wide commands may either be added directly to the Drupal site's repository (e.g. for site-specific policy files), or via `composer require`. See the [examples/Commands](/examples/Commands) folder for examples. In general, it's better to use modules to carry your Drush commands, as module-based commands may [participate in Drupal's dependency injection via the drush.services.yml](#specifying-the-services-file). 
+Commandfiles that are installed in a Drupal site and are not bundled inside a Drupal module are called 'site-wide' commandfiles. Site-wide commands may either be added directly to the Drupal site's repository (e.g. for site-specific policy files), or via `composer require`. See the [examples/Commands](https://github.com/drush-ops/drush/tree/master/examples/Commands) folder for examples. In general, it's better to use modules to carry your Drush commands, as module-based commands may [participate in Drupal's dependency injection via the drush.services.yml](#specifying-the-services-file).
 
 If you still prefer using site-wide commandfiles, here are some examples of valid commandfile names and namespaces:
 


### PR DESCRIPTION
https://github.com/drush-ops/drush/blob/master/docs/commands.md#site-wide-drush-commands

Currently the `examples/Commands` link leads to non-existing documentation  page.
http://docs.drush.org/en/master/examples/Commands

I suppose it should open `examples/Commands` folder on GitHub.

Also note that 404 pages on docs.drush.org are broken.