### PR TITLE
Make pm:security test more flexible

### DIFF
--- a/tests/integration/SecurityUpdatesTest.php
+++ b/tests/integration/SecurityUpdatesTest.php
@@ -17,7 +17,7 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
     {
         $this->drush('pm:security', [], ['format' => 'json'], self::EXIT_ERROR);
         $this->assertContains('One or more of your dependencies has an outstanding security update.', $this->getErrorOutput());
-        $this->assertContains('Try running: composer require drupal/alinks --update-with-dependencies', $this->getErrorOutput());
+        $this->assertContains('Try running: composer require drupal/alinks', $this->getErrorOutput());
         $security_advisories = $this->getOutputFromJSON();
         $this->assertObjectHasAttribute('drupal/alinks', $security_advisories);
         $this->assertEquals('drupal/alinks', $security_advisories->{"drupal/alinks"}->name);


### PR DESCRIPTION
The current pm:security test fails if there is also a pending security release for some other module, or Drupal core. Make the check a little more flexible to avoid this problem.