### PR TITLE
Restore the EmptyBoot bootstrap object.

### DIFF
--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -188,7 +188,7 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
                 return $candidate;
             }
         }
-        return null;
+        return new EmptyBoot();
     }
 
     /**

--- a/src/Boot/EmptyBoot.php
+++ b/src/Boot/EmptyBoot.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drush\Boot;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * This is a do-nothing 'Boot' class that is used when there
+ * is no site at --root, or when no root is specified.
+ *
+ * The 'empty' boot must be careful to never change state,
+ * in case bootstrap code might later come along and set
+ * a site (e.g. in command completion).
+ */
+class EmptyBoot extends BaseBoot
+{
+
+    public function validRoot($path)
+    {
+        return false;
+    }
+
+    public function bootstrapPhases()
+    {
+        return [
+        DRUSH_BOOTSTRAP_DRUSH => '_drush_bootstrap_drush',
+        ];
+    }
+
+    public function bootstrapInitPhases()
+    {
+        return [DRUSH_BOOTSTRAP_DRUSH];
+    }
+}


### PR DESCRIPTION
The bootstrap manager was not designed to work without some bootstrap object.