### PR TITLE
Allow implementing `SiteAliasManagerAwareInterface`. 

### DIFF
--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -49,17 +49,25 @@ For example:
 namespace Drupal\my_module\Commands;
 
 use Drush\Commands\DrushCommands;
+use Consolidation\OutputFormatters\StructuredData\ListDataFromKeys;
 use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
-use Consolidation\SiteAlias\SiteSliasManagerAwareTrait;
+use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 
-class MyModuleiCommands extends DrushCommands implements SiteAliasManagerAwareInterface
+class MyModuleCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {
   use SiteAliasManagerAwareTrait;
-public function commandName($) 
-{
-  $selfAlias = $this->aliasManager()->getSelf();
-$this->logger()->success(‘The current alias is {name}’, [‘name’ => $selfAlias]);
-}
+  /**
+   * Prints the currenbt alias name and info.
+   *
+   * @command mymodule:myAlias
+   * @return \Consolidation\OutputFormatters\StructuredData\ListDataFromKeys
+   */
+  public function myAlias() 
+  {
+    $selfAlias = $this->siteAliasManager()->getSelf();
+    $this->logger()->success(‘The current alias is {name}’, [‘name’ => $selfAlias]);
+    return new ListDataFromKeys($aliasRecord->export());
+  }
 }
 ```
 All Drush command files extend DrushCommands. DrushCommands implements ConfigAwareInterface, IOAwareInterface, LoggerAwareInterface, which gives access to `$this->getConfig()`, `$this->logger()` and other ways to do input and output. See the [IO documentation](io.md) for more information.

--- a/src/Boot/BaseBoot.php
+++ b/src/Boot/BaseBoot.php
@@ -143,7 +143,7 @@ abstract class BaseBoot implements Boot, LoggerAwareInterface, ContainerAwareInt
             $object->setOutputAdapter($container->get('outputAdapter'));
         }
         if ($object instanceof \Consolidation\SiteAlias\SiteAliasManagerAwareInterface) {
-            $object->setOutputAdapter($container->get('site.alias.manager'));
+            $object->siteAliasManager($container->get('site.alias.manager'));
         }
     }
 

--- a/src/Boot/BaseBoot.php
+++ b/src/Boot/BaseBoot.php
@@ -143,7 +143,7 @@ abstract class BaseBoot implements Boot, LoggerAwareInterface, ContainerAwareInt
             $object->setOutputAdapter($container->get('outputAdapter'));
         }
         if ($object instanceof \Consolidation\SiteAlias\SiteAliasManagerAwareInterface) {
-            $object->siteAliasManager($container->get('site.alias.manager'));
+            $object->setSiteAliasManager($container->get('site.alias.manager'));
         }
     }
 


### PR DESCRIPTION
Currently it's impossible to implement such interface because in `\Drush\Boot\BaseBoot::inflect():146` the wrong method is called.

When an object implements `SiteAliasManagerAwareInterface` it should be injected via `siteAliasManager` instead of `setOutputAdapter` which is part of `VerbosityThresholdInterface`