### PR TITLE
Revert "Remove respawn after 50% memory exhaustion during batch proce…

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -52,12 +52,13 @@ class DrushBatchContext extends ArrayObject {
  * Process a Drupal batch by spawning multiple Drush processes.
  *
  * This function will include the correct batch engine for the current
- * major version of Drupal, and will make use of the site-process
- * library to spawn multiple worker threads to handle the processing of
- * the current batch.
+ * major version of Drupal, and will make use of the drush_backend_invoke
+ * system to spawn multiple worker threads to handle the processing of
+ * the current batch, while keeping track of available memory.
  *
  * The batch system will process as many batch sets as possible until
- * the entire batch has been completed.
+ * the entire batch has been completed or half of the available memory
+ * has been used.
  *
  * This function is a drop in replacement for the existing batch_process()
  * function of Drupal.
@@ -278,6 +279,14 @@ function _drush_batch_worker() {
     // At this point, either $current_set contains operations that need to be
     // processed or all sets have been completed.
     $queue = _batch_queue($current_set);
+
+    // If we are in progressive mode, break processing after 1 second.
+    if (drush_memory_limit() > 0 && (memory_get_usage() * 2) >= drush_memory_limit()) {
+      Drush::logger()->notice(dt("Batch process has consumed in excess of 50% of available memory. Starting new thread"));
+      // Record elapsed wall clock time.
+      $current_set['elapsed'] = round((microtime(TRUE) - $current_set['start']) * 1000, 2);
+      break;
+    }
   }
 
   // Reporting 100% progress will cause the whole batch to be considered

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -196,6 +196,9 @@ function _drush_batch_command($id) {
   if (_drush_batch_worker()) {
     return _drush_batch_finished();
   }
+  else {
+    return ['drush_batch_process_finished' => FALSE];
+  }
 }
 
 
@@ -203,7 +206,7 @@ function _drush_batch_command($id) {
  * Process batch operations
  *
  * Using the current $batch process each of the operations until the batch
- * has been completed or half of the available memory for the process has been
+ * has been completed or 60% of the available memory for the process has been
  * reached.
  */
 function _drush_batch_worker() {
@@ -280,8 +283,9 @@ function _drush_batch_worker() {
     // processed or all sets have been completed.
     $queue = _batch_queue($current_set);
 
-    // If we are in progressive mode, break processing after 1 second.
-    if (drush_memory_limit() > 0 && (memory_get_usage() * 2) >= drush_memory_limit()) {
+    // If we are in progressive mode, break processing after 60% of memory usage
+    // is reached.
+    if (drush_memory_limit() > 0 && (memory_get_usage() * 1.6) >= drush_memory_limit()) {
       Drush::logger()->notice(dt("Batch process has consumed in excess of 50% of available memory. Starting new thread"));
       // Record elapsed wall clock time.
       $current_set['elapsed'] = round((microtime(TRUE) - $current_set['start']) * 1000, 2);


### PR DESCRIPTION
…ssing. (#3909)"

This reverts https://github.com/drush-ops/drush/pull/3909

Like @markcarver commented in the pull request 
> Removing this is not a BC "solution" for code that actually **relies** on this functionality (which is hard to get around in Drush due to the way batches are handled).

We currently have two scenarios where we depend on this.

1. search api reindex/index - Search API loads all entity in a batch process to index them, resulting in reaching the memory limit because of Drupal static caches. (https://www.drupal.org/project/search_api/issues/3036504)
2. batches in update processes - Its very common (happens also in core, e.g. taxonomy in 8.5) that a update is creating a batch because a lot of entities are updated. Same issue as above loading a lot of entities will fill Drupals static caches and resulting in reaching the memory limit.

I'm not sure if something like this should be removed, even if better ways for handling above cases are implemented (see https://www.drupal.org/project/drupal/issues/2577417). As the basic idea of using batches was to circumvent issues with memory limit (in cli) and max execution times (in browser). Removing this means I can't use batches anymore if I know I do something very memory consuming, meaning I need to reinvent something new for this case.

> This code is broken. Since [migrate already handles low memory](https://github.com/drupal/drupal/blob/8.6.x/core/modules/migrate/src/MigrateExecutable.php#L256), this code no longer serves its original purpose.

Maybe we could set the limit to 60% to not interfere with migrate batch?