### PR TITLE
Make Log message status transparent

### DIFF
--- a/lib/Drush/Log/Logger.php
+++ b/lib/Drush/Log/Logger.php
@@ -55,9 +55,9 @@ class Logger extends AbstractLogger {
         $green = "[%s]";
       }
       else {
-        $red = "\033[31;40m\033[1m[%s]\033[0m";
-        $yellow = "\033[1;33;40m\033[1m[%s]\033[0m";
-        $green = "\033[1;32;40m\033[1m[%s]\033[0m";
+        $red = "\033[31m\033[1m[%s]\033[0m";
+        $yellow = "\033[1;33m\033[1m[%s]\033[0m";
+        $green = "\033[1;32m\033[1m[%s]\033[0m";
       }
 
       $verbose = drush_get_context('DRUSH_VERBOSE');


### PR DESCRIPTION
I've noticed that colored log statuses have a black background, which looks ugly on some semi-transparent terminals. Is there a reason to force the bg color?

I'm using `gnome-terminal` in `i3wm`, with `compton` for compositing. Here's a screenshot with my fix:
![transparency demo](https://i.ibb.co/sPdBvvL/drush-log-message-transparency.png)