### PR TITLE
Don't call bootstrapValidate commands repeatedly, and add --uri tests

### DIFF
--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -346,9 +346,9 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
         $phases = $this->bootstrapPhases(true);
         static $result_cache = [];
 
-        if (!array_key_exists($phase, $result_cache)) {
-            $validated_phase = -1;
-            foreach ($phases as $phase_index => $current_phase) {
+        $validated_phase = -1;
+        foreach ($phases as $phase_index => $current_phase) {
+            if (!array_key_exists($phase_index, $result_cache)) {
                 if ($phase_index > $phase) {
                     break;
                 }

--- a/sut/sites/example.sites.php
+++ b/sut/sites/example.sites.php
@@ -53,3 +53,6 @@
  * @see \Drupal\Core\DrupalKernel::getSitePath()
  * @see https://www.drupal.org/documentation/install/multi-site
  */
+// The following are used by functional tests, at least testOptionsUri():
+$sites["test.uri"] = "dev";
+$sites["test.uri.subpath"] = "stage";

--- a/tests/functional/CoreTest.php
+++ b/tests/functional/CoreTest.php
@@ -47,13 +47,6 @@ class CoreCase extends CommandUnishTestCase
         'format' => 'json',
         'uri' => 'OMIT', // A special value which causes --uri to not be specified.
         ];
-        // Modify settings.php to check whether site paths correctly resolve.
-        $root = $this->webroot();
-        $fp = fopen($root . '/sites/sites.php', 'a+');
-        fwrite($fp, '
-$sites["test.uri"] = "dev";
-$sites["test.uri.subpath"] = "stage";
-');
         foreach ([
                    'test.uri' => ['http://test.uri', 'sites/dev'],
                    'test.uri/' => ['http://test.uri/', 'sites/dev'],

--- a/tests/functional/CoreTest.php
+++ b/tests/functional/CoreTest.php
@@ -40,23 +40,47 @@ class CoreCase extends CommandUnishTestCase
 
     public function testOptionsUri()
     {
-        // Put a yml file in the drush folder.
+        // Test whether a URI in a config file resolves correctly, and test
+        // various URI values for their expected Site URI and path.
         $drush_config_file = Path::join($this->webrootSlashDrush(), 'drush.yml');
-        $test_uri = 'http://test.uri';
-        $options_with_uri = [
-        'options' => [
-        'uri' => $test_uri,
-        ],
-        ];
-        $options = [
+        $command_options = [
         'format' => 'json',
         'uri' => 'OMIT', // A special value which causes --uri to not be specified.
         ];
-        file_put_contents($drush_config_file, Yaml::dump($options_with_uri, PHP_INT_MAX, 2));
-        $this->drush('core-status', [], $options);
-        unlink($drush_config_file);
-        $output = $this->getOutputFromJSON();
-        $this->assertEquals($test_uri, $output->uri);
+        // Modify settings.php to check whether site paths correctly resolve.
+        $root = $this->webroot();
+        $fp = fopen($root . '/sites/sites.php', 'a+');
+        fwrite($fp, '
+$sites["test.uri"] = "dev";
+$sites["test.uri.subpath"] = "stage";
+');
+        foreach ([
+                   'test.uri' => ['http://test.uri', 'sites/dev'],
+                   'test.uri/' => ['http://test.uri/', 'sites/dev'],
+                   'test.uri/subpath' => ['http://test.uri/subpath', 'sites/stage'],
+                   'test.uri/subpath/' => ['http://test.uri/subpath/', 'sites/stage'],
+                   'http://test.uri' => ['http://test.uri', 'sites/dev'],
+                   'http://test.uri/' => ['http://test.uri/', 'sites/dev'],
+                   'http://test.uri/subpath' => ['http://test.uri/subpath', 'sites/stage'],
+                   'http://test.uri/subpath/' => ['http://test.uri/subpath/', 'sites/stage'],
+                   'https://test.uri' => ['https://test.uri', 'sites/dev'],
+                   'https://test.uri/' => ['https://test.uri/', 'sites/dev'],
+                   'https://test.uri/subpath' => ['https://test.uri/subpath', 'sites/stage'],
+                   'https://test.uri/subpath/' => ['https://test.uri/subpath/', 'sites/stage'],
+                 ] as $test_uri => $expected) {
+            // Put a yml file in the drush folder.
+            $config_options = [
+              'options' => [
+                'uri' => $test_uri,
+              ],
+            ];
+            file_put_contents($drush_config_file, Yaml::dump($config_options, PHP_INT_MAX, 2));
+            $this->drush('core-status', [], $command_options);
+            unlink($drush_config_file);
+            $output = $this->getOutputFromJSON();
+            // Include the test URI, for some context in errors.
+            $this->assertEquals([$test_uri => $expected], [$test_uri => [$output->uri, $output->site]]);
+        }
     }
 
     public function testRecursiveConfigLoading()


### PR DESCRIPTION
These are two followups to #3847 which are not super related, but I hope putting them in one PR turns out to be less work.

1) I found out why bootstrapDrupalSiteValidate() is called a lot more lately (since #3820):
* BootstrapManager::bootstrapMax() has a loop for each phase, in which it calls bootstrapValidate()
* bootstrapValidate() only checks its $result_cache for _the current target phase_ is filled, and if it is not, validates _all phases from 0 up to this target phase_ again.

I'm going to just assume that was not intentional and that it can be fixed this way.

--

2) It was suggested to add a test, to add against regressions with the --uri flag.

So here it is. I'm guessing a fairly simple addition to CoreTest::testOptionsUri() will do the trick, even though that means it's now used to test two slightly different things.

Note - I just assumed that the 'expected' URLs are the ones that are returned by 'drush status' at this moment. I'm not 100% sure if that's true; you're in a better position to judge:
* test.uri/ leads to outputting "http://test.uri/"  for the Site URI. That wasn't the case before #3820 - i.e. in 9.6.0-beta3 (and all the way down to drush6), "test.uri/" was output instead. 
* I could imagine that http://test.uri and http://test.uri/ should actually both output the same result (i.e. without trailing slash) - but this was never the case before, so...

--

If this PR (containing _both_ commits) is applied to the commit from before #3847, the test for "--uri=test.uri/subpath" fails as expected.