### PR TITLE
Consider parent directories of site roots when searching for alias paths

### DIFF
--- a/src/Config/ConfigLocator.php
+++ b/src/Config/ConfigLocator.php
@@ -399,12 +399,18 @@ class ConfigLocator
     {
         // In addition to the paths passed in to us (from --alias-paths
         // commandline options), add some site-local locations.
-        $base_dirs = array_filter(array_merge($this->siteRoots, [$this->composerRoot]));
+        $siteroot_parents = array_map(
+            function ($dir) {
+                return dirname($dir);
+            },
+            $this->siteRoots
+        );
+        $base_dirs = array_filter(array_merge($this->siteRoots, $siteroot_parents, [$this->composerRoot]));
         $site_local_paths = array_map(
             function ($item) {
                 return Path::join($item, '/drush/sites');
             },
-            $base_dirs
+            array_unique($base_dirs)
         );
         $paths = array_merge($paths, $site_local_paths);
 

--- a/tests/unit/ConfigLocatorTest.php
+++ b/tests/unit/ConfigLocatorTest.php
@@ -83,7 +83,7 @@ class ConfigLocatorTest extends TestCase
         );
         sort($aliasPaths);
 
-        $expected = ['/fixtures/sites/d8/drush/sites', '/home/user/aliases'];
+        $expected = ['/fixtures/sites/d8/drush/sites', '/fixtures/sites/drush/sites', '/home/user/aliases'];
         $this->assertEquals($expected, $aliasPaths);
     }
 


### PR DESCRIPTION
Imagine you have a project layout that looks like this:
```
composer.json
sut
  drush
    drush.yml
    sites
      self.site.yml
  web
    index.php
```

Prior to this PR, Drush *does* find `drush.yml`, but it does *not* find `self.site.yml`. This is because the search paths Drush considers for alias paths includes the composer root and the Drupal root, but the parent of the Drupal root is not considered. This PR adds the parent of the Drupal root as a search base for site alias files.

This limitation does not affect Drush because the Drush sut has its document root as its base directory (where its composer.json would be, if it had its own composer.json). In the example project I am building, I want the sut to follow the same directory pattern as drupal-composer/drupal-project, for familiarity. There are probably other use-cases for relocating the Drupal root deeper in the project tree. The search path for alias files should in any event be consistent with the search path for config files.