### PR TITLE
Bump minimum version of consolidation/annotated-command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "php": ">=5.4.5",
     "psr/log": "~1.0",
     "psy/psysh": "~0.6",
-    "consolidation/annotated-command": "^2.9.1",
+    "consolidation/annotated-command": "^2.12.0",
     "consolidation/output-formatters": "~3",
     "symfony/yaml": "~2.3|^3",
     "symfony/var-dumper": "~2.7|^3",


### PR DESCRIPTION
The current requirement of `consolidation/annotated-command:^2.9.1` does not include code needed for latest drush 8.2.0. I discovered it needs at least 2.11.0, but this PR bumps to the latest since I didn't exhaustively test every version.

Fixes #3985 