### PR TITLE
Fixes #3988: Move code to get version directly to the static access methods.

### DIFF
--- a/includes/environment.inc
+++ b/includes/environment.inc
@@ -10,6 +10,7 @@
  * @see includes/bootstrap.inc
  */
 
+use Drush\Drush;
 use Drush\Log\LogLevel;
 use Webmozart\PathUtil\Path;
 
@@ -612,9 +613,7 @@ function _drush_test_os($os, $os_list_to_check) {
  * Read the drush info file.
  */
 function drush_read_drush_info() {
-  $drush_info_file = dirname(__FILE__) . '/../drush.info';
-
-  return parse_ini_file($drush_info_file);
+  return Drush::ReadDrushInfo();
 }
 
 /**

--- a/includes/preflight.inc
+++ b/includes/preflight.inc
@@ -5,6 +5,7 @@
  * Preflight, postflight and shutdown code.
  */
 
+use Drush\Drush;
 use Drush\Log\LogLevel;
 
 /**
@@ -169,11 +170,10 @@ function drush_preflight_prepare() {
     return; // An error was logged.
   }
 
-  $drush_info = drush_read_drush_info();
-  define('DRUSH_VERSION', $drush_info['drush_version']);
-  $version_parts = explode('.', DRUSH_VERSION);
-  define('DRUSH_MAJOR_VERSION', $version_parts[0]);
-  define('DRUSH_MINOR_VERSION', $version_parts[1]);
+  // For backwards compatibility. Prefer the static accessors.
+  define('DRUSH_VERSION', Drush::getVersion());
+  define('DRUSH_MAJOR_VERSION', Drush::getMajorVersion());
+  define('DRUSH_MINOR_VERSION', Drush::getMinorVersion());
 
   define('DRUSH_REQUEST_TIME', microtime(TRUE));
 

--- a/lib/Drush/Drush.php
+++ b/lib/Drush/Drush.php
@@ -39,6 +39,9 @@ class Drush
     protected static $processManager = null;
     protected static $input = null;
     protected static $output = null;
+    protected static $drushVersion = null;
+    protected static $drushMajorVersion = null;
+    protected static $drushMinorVersion = null;
 
     /**
      * Number of seconds before timeout for subprocesses. Can be customized via setTimeout() method.
@@ -60,17 +63,49 @@ class Drush
      */
     public static function getVersion()
     {
-        return DRUSH_VERSION;
+        if (!isset(self::$drushVersion)) {
+            $drush_info = self::ReadDrushInfo();
+            self::$drushVersion = $drush_info['drush_version'];
+        }
+
+        return self::$drushVersion;
     }
 
+    /**
+     * Return the Drush major version, e.g. 8, 9 or 10
+     */
     public static function getMajorVersion()
     {
-        return DRUSH_MAJOR_VERSION;
+        if (!isset(self::$drushMajorVersion)) {
+            $version_parts = explode('.', self::getVersion());
+            self::$drushMajorVersion = $version_parts[0];
+        }
+
+        return self::$drushMajorVersion;
     }
 
+    /**
+     * Return the Drush minor version, e.g. the minor version of
+     * Drush 9.5.2 is "5".
+     */
     public static function getMinorVersion()
     {
-        return DRUSH_MINOR_VERSION;
+        if (!isset(self::$drushMinorVersion)) {
+            $version_parts = explode('.', self::getVersion());
+            self::$drushMinorVersion = $version_parts[1];
+        }
+
+        return self::$drushMinorVersion;
+    }
+
+    /**
+     * Read the drush info file.
+     */
+    public static function ReadDrushInfo()
+    {
+        $drush_info_file = dirname(dirname(__DIR__)) . '/drush.info';
+
+        return parse_ini_file($drush_info_file);
     }
 
     // public static function setContainer(ContainerInterface $container)


### PR DESCRIPTION
This allows them to be called directly, e.g. from a module.
