### PR TITLE
Do not load the local autoload file if the alias is remote.

### DIFF
--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -47,8 +47,12 @@ class Environment
      * @param string $root
      * @return ClassLoader
      */
-    public function loadSiteAutoloader($root)
+    public function loadSiteAutoloader($root, $selfAlias)
     {
+        if ($selfAlias->isRemote()) {
+            return $this->loader;
+        }
+
         $autloadFilePath = "$root/autoload.php";
         if (!file_exists($autloadFilePath)) {
             return $this->loader;

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -47,12 +47,8 @@ class Environment
      * @param string $root
      * @return ClassLoader
      */
-    public function loadSiteAutoloader($root, $selfAlias)
+    public function loadSiteAutoloader($root)
     {
-        if ($selfAlias->isRemote()) {
-            return $this->loader;
-        }
-
         $autloadFilePath = "$root/autoload.php";
         if (!file_exists($autloadFilePath)) {
             return $this->loader;

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -209,7 +209,7 @@ class Preflight
 
     public function loadSiteAutoloader()
     {
-        return $this->environment()->loadSiteAutoloader($this->drupalFinder()->getDrupalRoot());
+        return $this->environment()->loadSiteAutoloader($this->drupalFinder()->getDrupalRoot(), $this->aliasManager()->getSelf());
     }
 
     public function config()

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -276,14 +276,14 @@ class Preflight
 
             // Process the selected alias. This might change the selected site,
             // so we will add new site-wide config location for the new root.
-            $root = $this->setSelectedSite($selfSiteAlias->localRoot());
+            $root = $this->setSelectedSite($selfSiteAlias->localRoot(), false, $root);
         }
 
         // Now that we have our final Drupal root, check to see if there is
         // a site-local Drush. If there is, we will redispatch to it.
         // NOTE: termination handlers have not been set yet, so it is okay
         // to exit early without taking special action.
-        $status = RedispatchToSiteLocal::redispatchIfSiteLocalDrush($argv, $root, $this->environment->vendorPath(), $this->logger())    ;
+        $status = RedispatchToSiteLocal::redispatchIfSiteLocalDrush($argv, $root, $this->environment->vendorPath(), $this->logger());
         if ($status !== false) {
             return $status;
         }
@@ -342,7 +342,7 @@ class Preflight
      * @param string $selectedRoot The location to being searching for a site
      * @param string|bool $fallbackPath The secondary location to search (usualy the vendor director)
      */
-    protected function setSelectedSite($selectedRoot, $fallbackPath = false)
+    protected function setSelectedSite($selectedRoot, $fallbackPath = false, $originalSelection = null)
     {
         if ($selectedRoot || $fallbackPath) {
             $foundRoot = $this->drupalFinder->locateRoot($selectedRoot);
@@ -360,6 +360,7 @@ class Preflight
             }
             return $this->drupalFinder()->getDrupalRoot();
         }
+        return $originalSelection;
     }
 
     /**

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -209,7 +209,7 @@ class Preflight
 
     public function loadSiteAutoloader()
     {
-        return $this->environment()->loadSiteAutoloader($this->drupalFinder()->getDrupalRoot(), $this->aliasManager()->getSelf());
+        return $this->environment()->loadSiteAutoloader($this->drupalFinder()->getDrupalRoot());
     }
 
     public function config()


### PR DESCRIPTION
Similar to #3970, this is something I run in primarily when working on Drush.

- Run command using a global Drush (e.g. development Drush checked out from git)
- Use a site alias to a remote Pantheon site (n.b. there is no `root` element set)
- cwd points to a **different** local site with a similar site-local version of Drush

The flow of execution is something like this:

1. Because there is no root in the selected site alias, the reference to the site at the `$cwd` is lost, and the redispatch to site local does not happen.
2. Redispatching to remote sites happen after dependency injection
3. The local site's autoload file is loaded prior to dependency injection
4. The local site at the cwd is rediscovered and its autload file is loaded, just prior to the redispatch to the remote site. This causes dependency hell + crash

My first attempt at fixing this attacked the symptom at step 4, and prevented the loading of the site-local autoload file if the alias is remote (in which case we do not need the local site's vendor contents).

I realized that a better way to fix this was to repair the original defect, and prevent `$root` from being lost in step 1. This is what I did in my second commit, after reverting the first.