### PR TITLE
Fix $this being used in a static context in Drush.php.

### DIFF
--- a/lib/Drush/Drush.php
+++ b/lib/Drush/Drush.php
@@ -280,7 +280,7 @@ class Drush
      */
     public static function drush(SiteAliasInterface $siteAlias, $command, $args = [], $options = [], $options_double_dash = [])
     {
-        return $this->processManager()->drush($siteAlias, $command, $args, $options, $options_double_dash);
+        return static::processManager()->drush($siteAlias, $command, $args, $options, $options_double_dash);
     }
 
     /**
@@ -297,7 +297,7 @@ class Drush
      */
     public static function siteProcess(SiteAliasInterface $siteAlias, $args = [], $options = [], $options_double_dash = [])
     {
-        return $this->processManager()->siteProcess($siteAlias, $args, $options, $options_double_dash);
+        return static::processManager()->siteProcess($siteAlias, $args, $options, $options_double_dash);
     }
 
     /**
@@ -320,7 +320,7 @@ class Drush
      */
     public static function process($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60)
     {
-        return $this->processManager()->process($commandline, $cwd, $env, $input, $timeout);
+        return static::processManager()->process($commandline, $cwd, $env, $input, $timeout);
     }
 
     /**
@@ -337,7 +337,7 @@ class Drush
      */
     public static function shell($command, $cwd = null, array $env = null, $input = null, $timeout = 60)
     {
-        return $this->processManager()->shell($command, $cwd, $env, $input, $timeout);
+        return static::processManager()->shell($command, $cwd, $env, $input, $timeout);
     }
 
     /**


### PR DESCRIPTION
Discovered via the _PHPCompatibility.Variables.ForbiddenThisUseContexts.OutsideObjectContext_ PHPCompatibility PHPCS rule:

> "$this" can no longer be used in a plain function or method since PHP 7.1.