### PR TITLE
Fixes #3997: Pass --db-su through to sql methods

### DIFF
--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -88,18 +88,17 @@ class SqlCommands extends DrushCommands
         $sql = SqlBase::create($options);
         $db_spec = $sql->getDbSpec();
         // Prompt for confirmation.
-        if (!$this->getConfig()->simulate()) {
-            // @todo odd - maybe for sql-sync.
-            $txt_destination = (isset($db_spec['remote-host']) ? $db_spec['remote-host'] . '/' : '') . $db_spec['database'];
-            $this->output()->writeln(dt("Creating database !target. Any existing database will be dropped!", ['!target' => $txt_destination]));
 
-            if (!$this->io()->confirm(dt('Do you really want to continue?'))) {
-                throw new UserAbortException();
-            }
+        // @todo odd - maybe for sql-sync.
+        $txt_destination = (isset($db_spec['remote-host']) ? $db_spec['remote-host'] . '/' : '') . $db_spec['database'];
+        $this->output()->writeln(dt("Creating database !target. Any existing database will be dropped!", ['!target' => $txt_destination]));
 
-            if (!$sql->createdb(true)) {
-                throw new \Exception('Unable to create database. Rerun with --debug to see any error message.');
-            }
+        if (!$this->getConfig()->simulate() && !$this->io()->confirm(dt('Do you really want to continue?'))) {
+            throw new UserAbortException();
+        }
+
+        if (!$sql->createdb(true)) {
+            throw new \Exception('Unable to create database. Rerun with --debug to see any error message.');
         }
     }
 

--- a/src/Exec/ExecTrait.php
+++ b/src/Exec/ExecTrait.php
@@ -91,6 +91,7 @@ trait ExecTrait
     {
         $command = Escape::isWindows() ? "where $program" : "command -v $program";
         $process = Drush::shell($command);
+        $process->setSimulated(false);
         $process->run();
         if (!$process->isSuccessful()) {
             Drush::logger()->debug($process->getErrorOutput());

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -122,7 +122,6 @@ class Preflight
             '--halt-on-error' => '-Druntime.php.halt-on-error',
             '--output_charset' => '-Dio.output.charset',
             '--output-charset' => '-Dio.output.charset',
-            '--db-su' => '-Dsql.db-su',
             '--notify' => '-Dnotify.duration',
             '--xh-link' => '-Dxh.link',
         ];


### PR DESCRIPTION
Remapping `--db-su` to an sql config option was misguided; `--db-su` and `--db-su-pw` are ordinary command options, and should be treated as such.

The only change in this PR directly relevant to the bugfix is the deletion in src/Preflight/Preflight.php; the other changes merely make simulated mode work better with sql commands. Note that simulated mode does not help you see what is happening with `--db-su` and `--db-su-pw`, as we want to avoid echoing credentials to the terminal.