### PR TITLE
Let site:install work with just PDO and no shell commands.

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -323,10 +323,9 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
             $msg[] = dt('create a @sitesfile file', ['@sitesfile' => $sitesfile]);
         }
 
-
         $program_exists = $this->programExists($sql->command());
         if (!$program_exists) {
-            $msg[] = dt('Program @program not found. Please create or empty the database prior to running site:install', ['@program' => $sql->command()]);
+            $msg[] = dt('Program @program not found. Proceed if you have already created or emptied the Drupal database.', ['@program' => $sql->command()]);
         }
         elseif ($sql->dbExists()) {
             $msg[] = dt("DROP all tables in your '@db' database.", ['@db' => $db_spec['database']]);

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -326,8 +326,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
         $program_exists = $this->programExists($sql->command());
         if (!$program_exists) {
             $msg[] = dt('Program @program not found. Proceed if you have already created or emptied the Drupal database.', ['@program' => $sql->command()]);
-        }
-        elseif ($sql->dbExists()) {
+        } elseif ($sql->dbExists()) {
             $msg[] = dt("DROP all tables in your '@db' database.", ['@db' => $db_spec['database']]);
         } else {
             $msg[] = dt("CREATE the '@db' database.", ['@db' => $db_spec['database']]);

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -11,6 +11,7 @@ use Drush\Exceptions\UserAbortException;
 use Drupal\Core\Config\FileStorage;
 use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
+use Drush\Exec\ExecTrait;
 use Drush\Sql\SqlBase;
 use Drush\Utils\StringUtils;
 use Webmozart\PathUtil\Path;
@@ -18,6 +19,7 @@ use Webmozart\PathUtil\Path;
 class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {
     use SiteAliasManagerAwareTrait;
+    use ExecTrait;
 
     /**
      * Install Drupal along with modules/themes/configuration/profile.
@@ -320,7 +322,13 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
         if ($sitesfile_write) {
             $msg[] = dt('create a @sitesfile file', ['@sitesfile' => $sitesfile]);
         }
-        if ($sql->dbExists()) {
+
+
+        $program_exists = $this->programExists($sql->command());
+        if (!$program_exists) {
+            $msg[] = dt('Program @program not found. Please create or empty the database prior to running site:install', ['@program' => $sql->command()]);
+        }
+        elseif ($sql->dbExists()) {
             $msg[] = dt("DROP all tables in your '@db' database.", ['@db' => $db_spec['database']]);
         } else {
             $msg[] = dt("CREATE the '@db' database.", ['@db' => $db_spec['database']]);
@@ -357,7 +365,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
         $bootstrapManager = Drush::bootstrapManager();
         $bootstrapManager->doBootstrap(DRUSH_BOOTSTRAP_DRUPAL_SITE);
 
-        if (!$sql->dropOrCreate()) {
+        if ($program_exists && !$sql->dropOrCreate()) {
             throw new \Exception(dt('Failed to drop or create the database: @error', ['@error' => $sql->getProcess()->getOutput()]));
         }
     }


### PR DESCRIPTION
Bootstrap already works without `mysql`, but I had not yet dealt with `si` and `sql:*`. This PR takes care of `si`. 