### PR TITLE
sql:sync shouldn't crash due to leftover files.

### DIFF
--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -308,7 +308,7 @@ class SqlBase implements ConfigAwareInterface
     {
         $input_file_original = $input_file;
         if ($input_file && drush_file_is_tarball($input_file)) {
-            $process = Drush::process(['gzip', '-d', $input_file]);
+            $process = Drush::process(['gzip', '-df', $input_file]);
             $process->setSimulated(false);
             $process->run();
             $this->setProcess($process);


### PR DESCRIPTION
There are currently situations where `sql:sync` can fail in somewhat unexpected ways. For instance, if you terminate a `sql:sync` operation during the db import it can leave behind files that break subsequent invocations.

To reproduce:
1. Simulate cruft leftover from a previous run of `sql:sync`: `touch /tmp/tmp.target.sql`
2. Try to run a sync: `drush sql-sync @foo @self --target-dump=/tmp/tmp.target.sql.gz`
3. Observe error: `Failed to import /tmp/tmp.target.sql.gz into target.`

This is easily fixed by just forcing gzip to unpack the db dump even if there's an existing copy.

This is the root cause for https://github.com/acquia/blt/issues/3279