### PR TITLE
Fixes #4004: Do not set tty mode if stdout is redirected.

### DIFF
--- a/.scenarios.lock/php5/composer.json
+++ b/.scenarios.lock/php5/composer.json
@@ -64,7 +64,7 @@
         "consolidation/output-formatters": "^3.3.1",
         "consolidation/robo": "^1.4.6",
         "consolidation/site-alias": "^3.0.0@stable",
-        "consolidation/site-process": "^2.0.0@stable",
+        "consolidation/site-process": "^2.0.1",
         "grasmash/yaml-expander": "^1.1.1",
         "league/container": "~2",
         "psr/log": "~1.0",

--- a/.scenarios.lock/php5/composer.lock
+++ b/.scenarios.lock/php5/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93b4861626e79b19b2ff43b4c995a649",
+    "content-hash": "13ec7785d53b970393f8d1416cccaad0",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",
@@ -780,16 +780,16 @@
         },
         {
             "name": "consolidation/site-process",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/site-process.git",
-                "reference": "29d6860e65eb22c1ffaff9777a6f1ce6e7adf188"
+                "reference": "d923bbf8843f4b273733db5912198b7dba0f236d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/site-process/zipball/29d6860e65eb22c1ffaff9777a6f1ce6e7adf188",
-                "reference": "29d6860e65eb22c1ffaff9777a6f1ce6e7adf188",
+                "url": "https://api.github.com/repos/consolidation/site-process/zipball/d923bbf8843f4b273733db5912198b7dba0f236d",
+                "reference": "d923bbf8843f4b273733db5912198b7dba0f236d",
                 "shasum": ""
             },
             "require": {
@@ -848,7 +848,7 @@
                 }
             ],
             "description": "A thin wrapper around the Symfony Process Component that allows applications to use the Site Alias library to specify the target for a remote call.",
-            "time": "2019-03-12T17:36:24+00:00"
+            "time": "2019-04-02T18:47:44+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -1632,7 +1632,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -1682,7 +1682,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -1897,7 +1897,7 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
@@ -2898,7 +2898,7 @@
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://git.drupal.org/project/alinks",
+                "url": "https://git.drupalcode.org/project/alinks.git",
                 "reference": "8.x-1.0"
             },
             "dist": {
@@ -2918,7 +2918,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1501766275",
+                    "datestamp": "1533185792",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3213,7 +3213,7 @@
             "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://git.drupal.org/project/devel",
+                "url": "https://git.drupalcode.org/project/devel.git",
                 "reference": "8.x-2.0"
             },
             "dist": {
@@ -3298,7 +3298,7 @@
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://git.drupal.org/project/empty_theme",
+                "url": "https://git.drupalcode.org/project/empty_theme.git",
                 "reference": "8.x-1.0"
             },
             "dist": {
@@ -6292,7 +6292,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "consolidation/site-alias": 0,
-        "consolidation/site-process": 0,
         "lox/xhprof": 20,
         "webflo/drupal-core-strict": 20
     },

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "consolidation/output-formatters": "^3.3.1",
     "consolidation/robo": "^1.4.6",
     "consolidation/site-alias": "^3.0.0@stable",
-    "consolidation/site-process": "^2.0.0@stable",
+    "consolidation/site-process": "^2.0.1",
     "grasmash/yaml-expander": "^1.1.1",
     "league/container": "~2",
     "psr/log": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9211771eab31cbdc509bf754a65fe2b",
+    "content-hash": "356206bc561c48d2a351be671273db2d",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",
@@ -780,16 +780,16 @@
         },
         {
             "name": "consolidation/site-process",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/site-process.git",
-                "reference": "29d6860e65eb22c1ffaff9777a6f1ce6e7adf188"
+                "reference": "d923bbf8843f4b273733db5912198b7dba0f236d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/site-process/zipball/29d6860e65eb22c1ffaff9777a6f1ce6e7adf188",
-                "reference": "29d6860e65eb22c1ffaff9777a6f1ce6e7adf188",
+                "url": "https://api.github.com/repos/consolidation/site-process/zipball/d923bbf8843f4b273733db5912198b7dba0f236d",
+                "reference": "d923bbf8843f4b273733db5912198b7dba0f236d",
                 "shasum": ""
             },
             "require": {
@@ -848,7 +848,7 @@
                 }
             ],
             "description": "A thin wrapper around the Symfony Process Component that allows applications to use the Site Alias library to specify the target for a remote call.",
-            "time": "2019-03-12T17:36:24+00:00"
+            "time": "2019-04-02T18:47:44+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -1632,7 +1632,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -1682,7 +1682,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -1897,7 +1897,7 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
@@ -2898,7 +2898,7 @@
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://git.drupal.org/project/alinks",
+                "url": "https://git.drupalcode.org/project/alinks.git",
                 "reference": "8.x-1.0"
             },
             "dist": {
@@ -2918,7 +2918,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1501766275",
+                    "datestamp": "1533185792",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3213,7 +3213,7 @@
             "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://git.drupal.org/project/devel",
+                "url": "https://git.drupalcode.org/project/devel.git",
                 "reference": "8.x-2.0"
             },
             "dist": {
@@ -3298,7 +3298,7 @@
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://git.drupal.org/project/empty_theme",
+                "url": "https://git.drupalcode.org/project/empty_theme.git",
                 "reference": "8.x-1.0"
             },
             "dist": {
@@ -6688,7 +6688,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "consolidation/site-alias": 0,
-        "consolidation/site-process": 0,
         "lox/xhprof": 20,
         "webflo/drupal-core-strict": 20
     },

--- a/src/Runtime/RedispatchHook.php
+++ b/src/Runtime/RedispatchHook.php
@@ -100,7 +100,7 @@ class RedispatchHook implements InitializeHookInterface, ConfigAwareInterface, S
         if (!TerminalUtils::isTty()) {
             $process->setInput(STDIN);
         } else {
-            $process->setTty($this->getConfig()->get('ssh.tty', $input->isInteractive()));
+            $process->setTty($this->getConfig()->get('ssh.tty', TerminalUtils::useTty() && $input->isInteractive()));
         }
         $process->mustRun($process->showRealtime());
 

--- a/src/Utils/TerminalUtils.php
+++ b/src/Utils/TerminalUtils.php
@@ -5,8 +5,9 @@ namespace Drush\Utils;
 class TerminalUtils
 {
     /**
-     * isTty determines if the STDIN stream is a TTY. If we cannot tell,
-     * then we return a default value.
+     * isTty determines if the STDIN stream is a TTY. We use this function
+     * to determine whether or not we should redirect input of a process
+     * using our STDIN stream. If we cannot tell, then we return a default value.
      *
      * @param bool $default Result to assume when the posix functions
      *   are not available.
@@ -19,5 +20,23 @@ class TerminalUtils
         }
 
         return posix_isatty(STDIN);
+    }
+
+    /**
+     * useTty determines if both the STDIN and STDOUT streams connect to a TTY.
+     * We use this to determine whether we should use tty mode with our process
+     * component. If we cannot tell, then we return a default value.
+     *
+     * @param bool $default Result to assume when the posix functions
+     *   are not available.
+     * @return bool
+     */
+    public static function useTty($default = true)
+    {
+        if (!function_exists('posix_isatty')) {
+            return $default;
+        }
+
+        return posix_isatty(STDOUT) && posix_isatty(STDIN);
     }
 }


### PR DESCRIPTION
When tty mode is used, the output stream provided to the Symfony Process Component / proc_open is ignored, and output goes directly to the connected terminal instead. It is therefore important for Drush to detect that output has been redirected, and avoid using tty mode in that instance.

This PR also sets the minimum acceptable version for consolidation/site-process to ^2.0.1 to pick up a related bugfix.