### PR TITLE
Fix sql-dump log message

### DIFF
--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -236,7 +236,10 @@ class SqlCommands extends DrushCommands
             throw new \Exception('Unable to dump database. Rerun with --debug to see any error message.');
         }
 
-        $this->logger()->success(dt('Database dump saved to !path', ['!path' => $return]));
+        // SqlBase::dump() returns null if 'result-file' option is empty.
+        if ($return) {
+          $this->logger()->success(dt('Database dump saved to !path', ['!path' => $return]));
+        }
         return new PropertyList(['path' => $return]);
     }
 


### PR DESCRIPTION
When dumping database to standard output Drush prints incomplete message because `result-file` option is not specified.
```
$ drush sql:dump > /dev/null
 [success] Database dump saved to 
```