### PR TITLE
Add vagrant transport to Drush.

### DIFF
--- a/src/Runtime/DependencyInjection.php
+++ b/src/Runtime/DependencyInjection.php
@@ -15,6 +15,7 @@ use Consolidation\SiteAlias\SiteAliasManager;
 use Drush\Command\DrushCommandInfoAlterer;
 use Consolidation\Config\Util\ConfigOverlay;
 use Drush\Config\DrushConfig;
+use Drush\SiteAlias\ProcessManager;
 
 /**
  * Prepare our Dependency Injection Container
@@ -111,11 +112,13 @@ class DependencyInjection
         $container->share('tildeExpansion.hook', 'Drush\Runtime\TildeExpansionHook');
         $container->share('ssh.transport', \Consolidation\SiteProcess\Factory\SshTransportFactory::class);
         $container->share('docker-compose.transport', \Consolidation\SiteProcess\Factory\DockerComposeTransportFactory::class);
-        $container->share('process.manager', 'Drush\SiteAlias\ProcessManager')
+        $container->share('vagrant.transport', \Consolidation\SiteProcess\Factory\VagrantTransportFactory::class);
+        $container->share('process.manager', ProcessManager::class)
             ->withMethodCall('setConfig', ['config'])
             ->withMethodCall('setConfigRuntime', ['config.runtime'])
             ->withMethodCall('add', ['ssh.transport'])
-            ->withMethodCall('add', ['docker-compose.transport']);
+            ->withMethodCall('add', ['docker-compose.transport'])
+            ->withMethodCall('add', ['vagrant.transport']);
         $container->share('redispatch.hook', 'Drush\Runtime\RedispatchHook')
             ->withArgument('process.manager');
 

--- a/src/Runtime/DependencyInjection.php
+++ b/src/Runtime/DependencyInjection.php
@@ -110,15 +110,9 @@ class DependencyInjection
         $container->share('bootstrap.hook', 'Drush\Boot\BootstrapHook')
           ->withArgument('bootstrap.manager');
         $container->share('tildeExpansion.hook', 'Drush\Runtime\TildeExpansionHook');
-        $container->share('ssh.transport', \Consolidation\SiteProcess\Factory\SshTransportFactory::class);
-        $container->share('docker-compose.transport', \Consolidation\SiteProcess\Factory\DockerComposeTransportFactory::class);
-        $container->share('vagrant.transport', \Consolidation\SiteProcess\Factory\VagrantTransportFactory::class);
         $container->share('process.manager', ProcessManager::class)
             ->withMethodCall('setConfig', ['config'])
-            ->withMethodCall('setConfigRuntime', ['config.runtime'])
-            ->withMethodCall('add', ['ssh.transport'])
-            ->withMethodCall('add', ['docker-compose.transport'])
-            ->withMethodCall('add', ['vagrant.transport']);
+            ->withMethodCall('setConfigRuntime', ['config.runtime']);
         $container->share('redispatch.hook', 'Drush\Runtime\RedispatchHook')
             ->withArgument('process.manager');
 
@@ -165,6 +159,8 @@ class DependencyInjection
 
         $commandProcessor = $container->get('commandProcessor');
         $commandProcessor->setPassExceptions(true);
+
+        ProcessManager::addTransports($container->get('process.manager'));
     }
 
     protected function injectApplicationServices(ContainerInterface $container, Application $application)


### PR DESCRIPTION
This allows executing drush calls via vagrant ssh -c by just using vagrant: in the site alias file. Support for this was added in site-process here: https://github.com/consolidation/site-process/pull/40