### PR TITLE
Fixes #4034: Ensure that status code is nonzero on invalid shutdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ jobs:
         environment:
           - MYSQL_HOST=127.0.0.1
           - UNISH_DB_URL=mysql://root:@127.0.0.1
+          - COMPOSER_MEMORY_LIMIT=-1
       - image: circleci/mysql:5.7.24
     steps:
       - checkout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     container_name: ${PROJECT_NAME-unish}_drupal
     environment:
       PHP_SENDMAIL_PATH: /dev/null
-      COMPOSER_MEMORY_LIMIT: -1
       UNISH_DB_URL: ${UNISH_DB_URL-mysql://root:password@mariadb}
       UNISH_NO_TIMEOUTS: y
       COLUMNS: ${COLUMNS-80} # Set 80 columns for docker exec -it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     container_name: ${PROJECT_NAME-unish}_drupal
     environment:
       PHP_SENDMAIL_PATH: /dev/null
+      COMPOSER_MEMORY_LIMIT: -1
       UNISH_DB_URL: ${UNISH_DB_URL-mysql://root:password@mariadb}
       UNISH_NO_TIMEOUTS: y
       COLUMNS: ${COLUMNS-80} # Set 80 columns for docker exec -it.

--- a/src/Runtime/ShutdownHandler.php
+++ b/src/Runtime/ShutdownHandler.php
@@ -8,6 +8,7 @@ namespace Drush\Runtime;
 
 use Drush\Drush;
 use Drush\Log\LogLevel;
+use Drush\Commands\DrushCommands;
 use Webmozart\PathUtil\Path;
 
 use Psr\Log\LoggerAwareInterface;
@@ -45,7 +46,7 @@ class ShutdownHandler implements LoggerAwareInterface, HandlerInterface
             // Make sure that we will return an error code when we exit,
             // even if the code that got us here did not.
             if (!Runtime::exitCode()) {
-                Runtime::setExitCode(1);
+                Runtime::setExitCode(DrushCommands::EXIT_FAILURE);
             }
         }
 

--- a/src/Runtime/ShutdownHandler.php
+++ b/src/Runtime/ShutdownHandler.php
@@ -42,6 +42,11 @@ class ShutdownHandler implements LoggerAwareInterface, HandlerInterface
 
         if (!Drush::config()->get(Runtime::DRUSH_RUNTIME_COMPLETED_NAMESPACE)) {
             Drush::logger()->warning('Drush command terminated abnormally. Check for an exit() in your Drupal site.');
+            // Make sure that we will return an error code when we exit,
+            // even if the code that got us here did not.
+            if (!Runtime::exitCode()) {
+                Runtime::setExitCode(1);
+            }
         }
 
         if (Drush::backend()) {

--- a/tests/functional/ShutdownAndErrorHandlerTest.php
+++ b/tests/functional/ShutdownAndErrorHandlerTest.php
@@ -43,7 +43,7 @@ class ShutdownAndErrorHandlerTest extends CommandUnishTestCase
     public function testShutdownFunctionPHPError()
     {
         // Run some garbage php with a syntax error.
-        $this->drush('ev', ['\Drush\Drush::setContainer("string is the wrong type to pass here");'], [], null, null, DrushCommands::EXIT_FAILURE);
+        $this->drush('ev', ['\Drush\Drush::setContainer("string is the wrong type to pass here");'], [], null, null, PHP_MAJOR_VERSION == 5 ? 255 : DrushCommands::EXIT_FAILURE);
 
         $this->assertContains("Drush command terminated abnormally.", $this->getErrorOutput(), 'Error handler did not log a message.');
     }

--- a/tests/functional/ShutdownAndErrorHandlerTest.php
+++ b/tests/functional/ShutdownAndErrorHandlerTest.php
@@ -2,6 +2,8 @@
 
 namespace Unish;
 
+use Drush\Commands\DrushCommands;
+
 /**
  * Tests the Drush error handler.
  *
@@ -10,12 +12,38 @@ namespace Unish;
 class ShutdownAndErrorHandlerTest extends CommandUnishTestCase
 {
     /**
-     * Check to see if the shutdown function is working.
+     * Check to see if the shutdown function is working
+     * if request exits abruptly (e.g. page redirect)
      */
-    public function testShutdownFunction()
+    public function testShutdownFunctionAbruptExit()
     {
         // Run some garbage php with a syntax error.
-        $this->drush('ev', ['exit(0);']);
+        $this->drush('ev', ['exit(0);'], [], null, null, DrushCommands::EXIT_FAILURE);
+
+        $this->assertContains("Drush command terminated abnormally.", $this->getErrorOutput(), 'Error handler did not log a message.');
+    }
+
+    /**
+     * Check to see if the shutdown function is working
+     * and the exit code is passed through when script exist
+     * with a specific exit code.
+     */
+    public function testShutdownFunctionExitCodePassedThrough()
+    {
+        // Run some garbage php with a syntax error.
+        $this->drush('ev', ['exit(123);'], [], null, null, 123);
+
+        $this->assertContains("Drush command terminated abnormally.", $this->getErrorOutput(), 'Error handler did not log a message.');
+    }
+
+    /**
+     * Check to see if the shutdown function is working
+     * if request exits due to a PHP problem such as a syntax error
+     */
+    public function testShutdownFunctionPHPError()
+    {
+        // Run some garbage php with a syntax error.
+        $this->drush('ev', ['\Drush\Drush::setContainer("string is the wrong type to pass here");'], [], null, null, DrushCommands::EXIT_FAILURE);
 
         $this->assertContains("Drush command terminated abnormally.", $this->getErrorOutput(), 'Error handler did not log a message.');
     }


### PR DESCRIPTION
If we get to the shutdown handler in an error state, but the status code is still zero, force it to 1.