### PR TITLE
Fix --security-only for make-update; improve non-bootstrapped version detection

### DIFF
--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -1642,12 +1642,14 @@ function pm_parse_version($version, $is_core = FALSE) {
       else {
         $version_parts = array(
           'version' => '',
+          // This could be incorrect (e.g., returns 2.1 and not a valid Drupal
+          // version), but keeping for BC. All other lines were historically ''.
           'drupal_version'  => $core_parts['major'] . '.x',
-          'project_version' => '',
-          'version_major'   => '',
+          'project_version' => $core_parts['major'] . '.' . $core_parts['patch'],
+          'version_major'   => $core_parts['major'],
           'version_minor'   => '',
-          'version_patch'   => '',
-          'version_extra'   => '',
+          'version_patch'   => $core_parts['patch'],
+          'version_extra'   => ($core_parts['patch'] == 'x') ? 'dev' : $core_parts['extra'],
           'version_offset'  => '',
         );
       }

--- a/lib/Drush/UpdateService/StatusInfoDrush.php
+++ b/lib/Drush/UpdateService/StatusInfoDrush.php
@@ -131,6 +131,8 @@ class StatusInfoDrush implements StatusInfoInterface {
         'install_type'     => $install_type,
         'existing_version' => $project['version'],
         'existing_major'   => $version['version_major'],
+        'existing_minor'   => $version['version_minor'],
+        'existing_patch'   => $version['version_patch'],
         'status'           => $project_status,
         'datestamp'        => empty($project['datestamp']) ? NULL : $project['datestamp'],
       );
@@ -358,8 +360,12 @@ class StatusInfoDrush implements StatusInfoInterface {
     //
 
     if (!empty($project_data['security updates'])) {
-      // If we found security updates, that always trumps any other status.
-      $project_data['status'] = DRUSH_UPDATESTATUS_NOT_SECURE;
+      foreach ($project_data['security updates'] as $securityCandidate) {
+        if ($securityCandidate['version_major'] > $existing_major || $securityCandidate['version_patch'] > $project_data['existing_patch']) {
+          // If we found security updates, that always trumps any other status.
+          $project_data['status'] = DRUSH_UPDATESTATUS_NOT_SECURE;
+        }
+      }
     }
 
     if (isset($project_data['status'])) {


### PR DESCRIPTION
Note: I'm not sure if this is appropriate to target against `8.x` directly, but since `master` is basically 9.x, and this is an 8.x only change, I'm not sure what other option I have?

Return more useful version information when not bootstrapped; ensure security update is actually logical to suggest.

Refs/fixes (?) https://github.com/drush-ops/drush/issues/3914 - though it was closed for lack of active maintenance on 8.x.