### PR TITLE
Use the version of the service dependencies patch for Drupal 8.7.x.

### DIFF
--- a/.circleci/patch.sh
+++ b/.circleci/patch.sh
@@ -8,11 +8,6 @@
 
 cd $HOME/drush/sut
 
-# There are two versions of the patch, for 8.7.x and for 8.6.x and below.
-PATCH=https://www.drupal.org/files/issues/2863986-62.patch
-
-if [ "$1" == "8.7.x" ]; then
-  PATCH=https://www.drupal.org/files/issues/2018-11-15/2863986-77-8.7.x.patch
-fi
+PATCH=https://www.drupal.org/files/issues/2018-11-15/2863986-77-8.7.x.patch
 
 curl -S $PATCH | patch -p1


### PR DESCRIPTION
We are applying a patch to fix a core bug that is causing our tests to fail. Now that we are on Drupal 8.7.x we no longer need to support the 8.6.x version of the patch.

We are seeing test failures because the patch can no longer be applied.