### PR TITLE
Preserve environment variables in $_SERVER when creating request.

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -145,10 +145,9 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
             $parsed_url = parse_url('http://' . $uri);
         }
 
-        $server = [
-            'SCRIPT_FILENAME' => getcwd() . '/index.php',
-            'SCRIPT_NAME' => isset($parsed_url['path']) ? $parsed_url['path'] . 'index.php' : '/index.php',
-        ];
+        $server = $_SERVER;
+        $server['SCRIPT_FILENAME'] = getcwd() . '/index.php';
+        $server['SCRIPT_NAME'] = isset($parsed_url['path']) ? $parsed_url['path'] . 'index.php' : '/index.php';
         $request = Request::create($this->uri, 'GET', [], [], [], $server);
         $this->setRequest($request);
         return true;


### PR DESCRIPTION
Drush creates a request when bootstrapping, but does not preserve the `$_SERVER` environment variables.

With this PR, environment variables found in `$_SERVER` can also be found in `\Drupal::requestStack()->getCurrentRequest()->server` as would be expected.

(There might be some reason this isn't already the case, and a clean environment is created, but I'm not sure what that would be... :)