### PR TITLE
Fix misleading usage examples for config:set and config:delete commands

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -89,8 +89,8 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface
      * @option input-format Format to parse the object. Use "string" for string (default), and "yaml" for YAML.
      * @option value The value to assign to the config key (if any).
      * @hidden-options value
-     * @usage drush config:set system.site page.front node
-     *   Sets system.site:page.front to "node".
+     * @usage drush config:set system.site page.front '/path/to/page'
+     *   Sets the given URL path as value for the config item with key "page.front" of "system.site" config object.
      * @aliases cset,config-set
      */
     public function set($config_name, $key, $value = null, $options = ['input-format' => 'string', 'value' => self::REQ])

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -194,7 +194,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface
      * @param $key A config key to clear, for example "page.front".
      * @usage drush config:delete system.site
      *   Delete the the system.site config object.
-     * @usage drush config:delete system.site page.front node
+     * @usage drush config:delete system.site page.front
      *   Delete the 'page.front' key from the system.site object.
      * @aliases cdel,config-delete
      */


### PR DESCRIPTION
I fell into that mistake that naively believed the syntax the usage hint suggested and ran this command like this:
`$ drush config:set system.site page.403 filter/tips`
When tested the results in browser, I got the regular exception from Drupal core:

> The website encountered an unexpected error. Please try again later.
> InvalidArgumentException: The user-entered string 'filter/tips' must begin with a '/', '?', or '#'. in Drupal\Core\Url::fromUserInput() (line 204 of core/lib/Drupal/Core/Url.php).

Although Drupal's GUI still lacks of consistency on how to properly request users to type in internal URL paths (with or without leading slashes), at least on the CLI side Drush could do better. Let's help future fellows not to fall again into this pitfall I learned today. Once they took the time to check `--help` before running the actual command, that examples should really help them, not misleading.