### PR TITLE
Document how to show current site alias in Zsh prompt

### DIFF
--- a/examples/example.prompt.sh
+++ b/examples/example.prompt.sh
@@ -2,8 +2,8 @@
 #
 # Example PS1 prompt.
 #
-# Note: This file does a lot, and is designed for Bash. If youo want to show the
-# currently set alias in your prompt, use the first 2 lines below as an example.
+# Note: This file does a lot, and is designed for Bash. If you want to show the
+# currently set alias in your prompt, use the first 2 values below as an example.
 # This example can be used directly for the POWERLEVEL9K theme for Oh My Zsh.
 #FILE="${TMPDIR:-/tmp/}/drush-env-${USER}/drush-drupal-site-$$"
 #POWERLEVEL9K_CUSTOM_DRUSH="[ -r $FILE ] && cat $FILE"

--- a/examples/example.prompt.sh
+++ b/examples/example.prompt.sh
@@ -2,6 +2,14 @@
 #
 # Example PS1 prompt.
 #
+# Note: This file does a lot, and is designed for Bash. If youo want to show the
+# currently set alias in your prompt, use the first 2 lines below as an example.
+# This example can be used directly for the POWERLEVEL9K theme for Oh My Zsh.
+#FILE="${TMPDIR:-/tmp/}/drush-env-${USER}/drush-drupal-site-$$"
+#POWERLEVEL9K_CUSTOM_DRUSH="[ -r $FILE ] && cat $FILE"
+#POWERLEVEL9K_CUSTOM_DRUSH_BACKGROUND="green"
+#POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(context dir vcs custom_drush)
+#
 # Use `drush init` to copy this to ~/.drush/drush.prompt.sh, and source it in
 # ~/.bashrc or ~/.bash_profile.
 #


### PR DESCRIPTION
I've been using ZSH for the past week. Digging it!

For Drush 10, I think I'd like to simplify example.prompt.sh so it only provides a function that people can then call in their prompts. 