### PR TITLE
Fixed usage docs for user-add-role.

### DIFF
--- a/src/Drupal/Commands/core/UserCommands.php
+++ b/src/Drupal/Commands/core/UserCommands.php
@@ -159,7 +159,7 @@ class UserCommands extends DrushCommands
      * @param string $role The name of the role to add.
      * @param string $names A comma delimited list of user names.
      * @aliases urol,user-add-role
-     * @usage drush user:add-role "power user" user3
+     * @usage drush user-add-role "power user" user3
      *   Add the "power user" role to user3
      */
     public function addRole($role, $names)


### PR DESCRIPTION
The suggested usage is invalid. If we want to use the `:` notation, it should be `user:role:add`