### PR TITLE
Entity type provided by a module installed via update hook not available

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -23,6 +23,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
     protected $maintenanceModeOriginalState;
 
     /**
+     * The list of extensions that are installed before updates are applied.
      * @var array
      */
     protected $originalExtensionList;

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -386,6 +386,8 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
      */
     public function updateBatch($options)
     {
+        // Track the currently installed extensions so that we can detect if any
+        // new extensions are added in the update.
         $this->originalExtensionList = \Drupal::config('core.extension')->getRawData();
 
         $start = $this->getUpdateList();

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -373,7 +373,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         \Drupal::configFactory()->reset('core.extension');
         $final_extension_list = \Drupal::config('core.extension')->getRawData();
         if ($final_extension_list !== $this->originalExtensionList) {
-            // If the installed extension list has been changed, clear caches and invalidate the container.
+            // Invalidate the container if the installed extension list has been changed.
             \Drupal::service('kernel')->invalidateContainer();
         }
     }

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -362,15 +362,16 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
      * @param array $results
      * @param array $operations
      */
-    public static function updateFinished($success, $results, $operations)
+    public function updateFinished($success, $results, $operations)
     {
-        // Flush all caches at the end of the batch operation. When Drupal core
-        // performs database updates it also clears the cache at the end. This
-        // ensures that we are compatible with updates that rely on this
-        // behavior.
-        drupal_flush_all_caches();
+        if ($this->cache_clear) {
+            // Flush all caches at the end of the batch operation. When Drupal
+            // core performs database updates it also clears the cache at the
+            // end. This ensures that we are compatible with updates that rely
+            // on this behavior.
+            drupal_flush_all_caches();
+        }
     }
-
 
     /**
      * Start the database update batch process.
@@ -445,7 +446,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
             'title' => 'Updating',
             'init_message' => 'Starting updates',
             'error_message' => 'An unrecoverable error has occurred. You can find the error message below. It is advised to copy it to the clipboard for reference.',
-            'finished' => '\Drush\Commands\core\UpdateDBCommands::updateFinished',
+            'finished' => [$this, 'updateFinished'],
             'file' => 'core/includes/update.inc',
         ];
         batch_set($batch);

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -364,8 +364,10 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
      */
     public static function updateFinished($success, $results, $operations)
     {
-        // Some (post)updates might install/uninstall extensions that require
-        // clearing the static and persistent caches and container invalidation.
+        // Flush all caches at the end of the batch operation. When Drupal core
+        // performs database updates it also clears the cache at the end. This
+        // ensures that we are compatible with updates that rely on this
+        // behavior.
         drupal_flush_all_caches();
     }
 

--- a/tests/functional/UpdateDBTest.php
+++ b/tests/functional/UpdateDBTest.php
@@ -323,20 +323,15 @@ POST_UPDATE;
         // Force re-run of woot_update_8106().
         $this->drush('php:eval', ['drupal_set_installed_schema_version("woot", 8105)'], $options);
 
-        // Allow installation of testing modules.
-        $settings_php = $this->webroot() . '/sites/dev/settings.php';
-        @chmod($settings_php, 0777);
-        file_put_contents($settings_php, "\n\$settings['extension_discovery_scan_tests'] = TRUE;\n", FILE_APPEND);
-
         // Run updates.
         $this->drush('updatedb', [], $options);
 
         // Check that the post-update function returns the new entity type ID.
-        $this->assertContains('[notice] entity_test', $this->getErrorOutputRaw());
+        $this->assertContains('[notice] taxonomy_term', $this->getErrorOutputRaw());
 
         // Check that the new entity type is installed.
-        $this->drush('php:eval', ['print \Drupal::entityTypeManager()->getDefinition("entity_test")->id();']);
-        $this->assertContains('entity_test', $this->getOutputRaw());
+        $this->drush('php:eval', ['print \Drupal::entityTypeManager()->getDefinition("taxonomy_term")->id();']);
+        $this->assertContains('taxonomy_term', $this->getOutputRaw());
     }
 
     /**
@@ -351,23 +346,18 @@ POST_UPDATE;
         $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
         $this->drush('pm:enable', ['woot'], $options);
 
-        // Force re-run of woot_post_update_install_entity_test().
-        $this->forcePostUpdate('woot_post_update_install_entity_test', $options);
-
-        // Allow installation of testing modules.
-        $settings_php = $this->webroot() . '/sites/dev/settings.php';
-        @chmod($settings_php, 0777);
-        file_put_contents($settings_php, "\n\$settings['extension_discovery_scan_tests'] = TRUE;\n", FILE_APPEND);
+        // Force re-run of woot_post_update_install_taxonomy().
+        $this->forcePostUpdate('woot_post_update_install_taxonomy', $options);
 
         // Run updates.
         $this->drush('updatedb', [], $options);
 
         // Check that the post-update function returns the new entity type ID.
-        $this->assertContains('[notice] entity_test', $this->getErrorOutputRaw());
+        $this->assertContains('[notice] taxonomy_term', $this->getErrorOutputRaw());
 
         // Check that the new entity type is installed.
-        $this->drush('php:eval', ['print \Drupal::entityTypeManager()->getDefinition("entity_test")->id();']);
-        $this->assertContains('entity_test', $this->getOutputRaw());
+        $this->drush('php:eval', ['print \Drupal::entityTypeManager()->getDefinition("taxonomy_term")->id();']);
+        $this->assertContains('taxonomy_term', $this->getOutputRaw());
     }
 
     public function tearDown()

--- a/tests/functional/UpdateDBTest.php
+++ b/tests/functional/UpdateDBTest.php
@@ -330,7 +330,7 @@ POST_UPDATE;
         $this->assertContains('[notice] taxonomy_term', $this->getErrorOutputRaw());
 
         // Check that the new entity type is installed.
-        $this->drush('php:eval', ['print \Drupal::entityTypeManager()->getDefinition("taxonomy_term")->id();']);
+        $this->drush('php:eval', ['woot_get_taxonomy_term_entity_type_id();']);
         $this->assertContains('taxonomy_term', $this->getOutputRaw());
     }
 
@@ -356,7 +356,7 @@ POST_UPDATE;
         $this->assertContains('[notice] taxonomy_term', $this->getErrorOutputRaw());
 
         // Check that the new entity type is installed.
-        $this->drush('php:eval', ['print \Drupal::entityTypeManager()->getDefinition("taxonomy_term")->id();']);
+        $this->drush('php:eval', ['woot_get_taxonomy_term_entity_type_id();']);
         $this->assertContains('taxonomy_term', $this->getOutputRaw());
     }
 

--- a/tests/functional/UpdateDBTest.php
+++ b/tests/functional/UpdateDBTest.php
@@ -308,6 +308,68 @@ POST_UPDATE;
         $this->assertContains($expected_post_update_output, $actual_output);
     }
 
+    /**
+     * Tests installing modules with entity type definitions via update hooks.
+     */
+    public function testEnableModuleViaUpdate()
+    {
+        $options = [
+            'yes' => null,
+        ];
+        $this->setUpDrupal(1, true);
+        $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
+        $this->drush('pm:enable', ['woot'], $options);
+
+        // Force re-run of woot_update_8106().
+        $this->drush('php:eval', ['drupal_set_installed_schema_version("woot", 8105)'], $options);
+
+        // Allow installation of testing modules.
+        $settings_php = $this->webroot() . '/sites/dev/settings.php';
+        @chmod($settings_php, 0777);
+        file_put_contents($settings_php, "\n\$settings['extension_discovery_scan_tests'] = TRUE;\n", FILE_APPEND);
+
+        // Run updates.
+        $this->drush('updatedb', [], $options);
+
+        // Check that the post-update function returns the new entity type ID.
+        $this->assertContains('[notice] entity_test', $this->getErrorOutputRaw());
+
+        // Check that the new entity type is installed.
+        $this->drush('php:eval', ['print \Drupal::entityTypeManager()->getDefinition("entity_test")->id();']);
+        $this->assertContains('entity_test', $this->getOutputRaw());
+    }
+
+    /**
+     * Tests installing modules with entity type definitions via post-update hooks.
+     */
+    public function testEnableModuleViaPostUpdate()
+    {
+        $options = [
+            'yes' => null,
+        ];
+        $this->setUpDrupal(1, true);
+        $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
+        $this->drush('pm:enable', ['woot'], $options);
+
+        // Force re-run of woot_post_update_install_entity_test().
+        $this->forcePostUpdate('woot_post_update_install_entity_test', $options);
+
+        // Allow installation of testing modules.
+        $settings_php = $this->webroot() . '/sites/dev/settings.php';
+        @chmod($settings_php, 0777);
+        file_put_contents($settings_php, "\n\$settings['extension_discovery_scan_tests'] = TRUE;\n", FILE_APPEND);
+
+        // Run updates.
+        $this->drush('updatedb', [], $options);
+
+        // Check that the post-update function returns the new entity type ID.
+        $this->assertContains('[notice] entity_test', $this->getErrorOutputRaw());
+
+        // Check that the new entity type is installed.
+        $this->drush('php:eval', ['print \Drupal::entityTypeManager()->getDefinition("entity_test")->id();']);
+        $this->assertContains('entity_test', $this->getOutputRaw());
+    }
+
     public function tearDown()
     {
         $this->recursiveDelete($this->pathPostUpdate, true);

--- a/tests/functional/resources/modules/d8/woot/woot.install
+++ b/tests/functional/resources/modules/d8/woot/woot.install
@@ -49,3 +49,12 @@ function woot_update_8105(array &$sandbox) {
   }
   return "Iteration {$sandbox['current']}.";
 }
+
+/**
+ * Install entity_test.module
+ */
+function woot_update_8106()
+{
+    \Drupal::service('module_installer')->install(['entity_test']);
+    return \Drupal::entityTypeManager()->getDefinition('entity_test')->id();
+}

--- a/tests/functional/resources/modules/d8/woot/woot.install
+++ b/tests/functional/resources/modules/d8/woot/woot.install
@@ -51,10 +51,10 @@ function woot_update_8105(array &$sandbox) {
 }
 
 /**
- * Install entity_test.module
+ * Install taxonomy.module
  */
 function woot_update_8106()
 {
-    \Drupal::service('module_installer')->install(['entity_test']);
-    return \Drupal::entityTypeManager()->getDefinition('entity_test')->id();
+    \Drupal::service('module_installer')->install(['taxonomy']);
+    return \Drupal::entityTypeManager()->getDefinition('taxonomy_term')->id();
 }

--- a/tests/functional/resources/modules/d8/woot/woot.module
+++ b/tests/functional/resources/modules/d8/woot/woot.module
@@ -33,7 +33,7 @@ function woot_theme() {
 }
 
 /**
- * Provides a helper for tests.
+ * Prints the entity type ID of the taxonomy term entity type.
  *
  * @see \Unish\UpdateDBTest::testEnableModuleViaUpdate()
  * @see \Unish\UpdateDBTest::testEnableModuleViaPostUpdate()

--- a/tests/functional/resources/modules/d8/woot/woot.module
+++ b/tests/functional/resources/modules/d8/woot/woot.module
@@ -31,3 +31,14 @@ function woot_theme() {
 
   return $theme;
 }
+
+/**
+ * Provides a helper for tests.
+ *
+ * @see \Unish\UpdateDBTest::testEnableModuleViaUpdate()
+ * @see \Unish\UpdateDBTest::testEnableModuleViaPostUpdate()
+ */
+function woot_get_taxonomy_term_entity_type_id()
+{
+    print \Drupal::entityTypeManager()->getDefinition("taxonomy_term")->id();
+}

--- a/tests/functional/resources/modules/d8/woot/woot.post_update.php
+++ b/tests/functional/resources/modules/d8/woot/woot.post_update.php
@@ -48,3 +48,12 @@ function woot_post_update_batch(array &$sandbox)
 {
     return woot_update_8105($sandbox);
 }
+
+/**
+ * Install entity_test.module
+ */
+function woot_post_update_install_entity_test()
+{
+    \Drupal::service('module_installer')->install(['entity_test']);
+    return \Drupal::entityTypeManager()->getDefinition('entity_test')->id();
+}

--- a/tests/functional/resources/modules/d8/woot/woot.post_update.php
+++ b/tests/functional/resources/modules/d8/woot/woot.post_update.php
@@ -50,10 +50,10 @@ function woot_post_update_batch(array &$sandbox)
 }
 
 /**
- * Install entity_test.module
+ * Install taxonomy.module
  */
-function woot_post_update_install_entity_test()
+function woot_post_update_install_taxonomy()
 {
-    \Drupal::service('module_installer')->install(['entity_test']);
-    return \Drupal::entityTypeManager()->getDefinition('entity_test')->id();
+    \Drupal::service('module_installer')->install(['taxonomy']);
+    return \Drupal::entityTypeManager()->getDefinition('taxonomy_term')->id();
 }


### PR DESCRIPTION
If an entity type is provided by a module being installed via a (post)update hook. The next Drush command will fail to recognize the new installed definition, unless a cache rebuild is run just after `updatedb`. For example, with this hook:

```php
function woot_post_update_install_taxonomy()
{
    \Drupal::service('module_installer')->install(['taxonomy']);
    return \Drupal::entityTypeManager()->getDefinition('taxonomy_term')->id();
}
```
When running:
```bash
$ drush updb --yes
```
This will end successfully and will return `taxonomy_term`, but if I run immediately:
```bash
$ drush eval 'print \Drupal::entityTypeManager()->getDefinition("taxonomy_term")->id();'
```
...will output:
```
In EntityTypeManager.php line 150:

  The "taxonomy_term" entity type does not exist.
```

The bug is reproduced in the provided regression test. Rebuilding the cache in between is a workaround. This was not a bug before. We see this happening after moving to Drupal 8.7.x (is it probably related to https://www.drupal.org/node/3034742?)

It's interesting that the post-update recognizes the new installed entity type, as it returns its ID. This is not a Drupal issue. I tested the same scenario by running the UI update and works without error. I also run the next sequence with no errors:

```bash
$ drush en taxonomy
$ drush eval 'print \Drupal::entityTypeManager()->getDefinition("taxonomy_term")->id();'
```

The issue pops-up only when enabling the module via a (post)update.
