### PR TITLE
Support wildcard aliases for Drush 8

### DIFF
--- a/examples/example.aliases.drushrc.php
+++ b/examples/example.aliases.drushrc.php
@@ -179,6 +179,36 @@
  *
  *   $ drush @none status
  *
+ * Wildcard Aliases for Service Providers
+ *
+ * Some service providers that manage Drupal sites allow customers to create
+ * multiple "environments" for a site. It is common for these providers to
+ * also have a feature to automatically create Drush aliases for all of a
+ * user's sites. Rather than write one record for every environment in that
+ * site, it is also possible to write a single "wildcard" alias that represents
+ * all possible environments. This is possible if the contents of each
+ * environment alias are identical save for the name of the environment in
+ * one or more values. The variable `${env-name}` will be substituted with the
+ * environment name wherever it appears.
+ *
+ * Example wildcard record:
+ *
+ * @code
+ *   $aliases['remote-example.*'] = array(
+ *     'remote-host' => '${env-name}.server.domain.com',
+ *     'remote-user' => 'www-admin',
+ *     'root' => '/path/to/${env-name}',
+ *     'uri' => '${env-name}.example.com',
+ *   );
+ * @endcode
+ *
+ * With a wildcard record, any environment name may be used, and will always
+ * match. This is not desirable in instances where the specified environment
+ * does not exist (e.g. if the user made a typo). An alias alter hook in a
+ * policy file may be used to catch these mistakes and report an error.
+ * @see policy.drush.inc for an example on how to do this.
+
+ *
  * See `drush help site-alias` for more options for displaying site
  * aliases.  See `drush topic docs-bastion` for instructions on configuring
  * remote access to a Drupal site behind a firewall via a bastion server.

--- a/examples/policy.drush.inc
+++ b/examples/policy.drush.inc
@@ -66,6 +66,22 @@ function policy_drush_sitealias_alter(&$alias_record) {
     }
     unset($alias_record['parent']);
   }
+
+  // If the alias is a remote wildcard alias, then test to see if the
+  // environment exists, and raise an "environment not found" error if
+  // it does not.
+  if (isset($alias_record['remote-host'])) {
+    $host = $alias_record['remote-host'];
+    if (preg_match('#\.myserver.com$#', $host)) {
+      $ip = gethostbyname($host);
+      // If the return value of gethostbyname equals its input parameter,
+      // that indicates failure.
+      if ($host == $ip) {
+        $aliasName = $alias_record['#name'];
+        return drush_set_error('NO_SUCH_ALIAS', "The alias $aliasName refers to a multidev environment that does not exist.");
+      }
+    }
+  }
 }
 
 /**

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -722,6 +722,9 @@ function _drush_sitealias_find_and_load_alias_from_file($aliasname, $alias_files
           $aliases[$group_name] = array('site-list' => implode(',', $alias_names), '#group' => $group_name, '#name' => $group_name);
         }
       }
+      // Wildcard check if necessary. This will insert a resolved alias
+      // record into the aliases list, allowing the existing code to match it.
+      _drush_sitealias_wildcard_check($aliasname, $aliases);
       // Store only the named alias into the alias cache
       if ((isset($aliases)) && !empty($aliasname) && array_key_exists($aliasname, $aliases)) {
         drush_set_config_special_contexts($options); // maybe unnecessary
@@ -749,6 +752,48 @@ function _drush_sitealias_find_and_load_alias_from_file($aliasname, $alias_files
     $result = array('site-list' => $result_names);
   }
 
+  return $result;
+}
+
+/**
+ * Convert a matching wildcard record into the requested record if needed.
+ */
+function _drush_sitealias_wildcard_check($aliasname, &$aliases) {
+  // Don't overwrite a specific alias record with a resolved wildcard record.
+  if (array_key_exists($aliasname, $aliases) || empty($aliasname)) {
+    return;
+  }
+  // If the alias is 'site.dev', then $alias_env is 'dev'
+  $alias_env = preg_replace('#^.*\.#', '', $aliasname);
+  // Check to see if there is a wildcard record.
+  // e.g. if alias is 'site.dev', then look for a record 'site.*'.
+  $wildcard_alias_name = preg_replace('#\.[^.]*$#', '.*', $aliasname);
+  if (($wildcard_alias_name == $aliasname) || empty($alias_env) || !array_key_exists($wildcard_alias_name, $aliases)) {
+    return;
+  }
+
+  $aliases[$aliasname] = _drush_sitealias_replace_wildcard_values($aliases[$wildcard_alias_name], $alias_env);
+}
+
+/**
+ * Make substitutions in a wildcard alias record.
+ */
+function _drush_sitealias_replace_wildcard_values($alias_record, $alias_env) {
+  $result = array();
+
+  foreach ($alias_record as $key => $value) {
+    if (is_array($value)) {
+      $result[$key] = _drush_sitealias_replace_wildcard_values($value, $alias_env);
+    }
+    elseif (is_string($value)) {
+      // This substitution looks just like a consolidation/config variable,
+      // although this is the only one we support.
+      $result[$key] = str_replace('${env-name}', $alias_env, $value);
+    }
+    else {
+      $result[$key] = $value;
+    }
+  }
   return $result;
 }
 

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -773,6 +773,7 @@ function _drush_sitealias_wildcard_check($aliasname, &$aliases) {
   }
 
   $aliases[$aliasname] = _drush_sitealias_replace_wildcard_values($aliases[$wildcard_alias_name], $alias_env);
+  $aliases[$aliasname]['#name'] = $aliasname;
 }
 
 /**

--- a/tests/siteAliasTest.php
+++ b/tests/siteAliasTest.php
@@ -172,6 +172,38 @@ EOD;
   }
 
   /**
+   * Test wildcard aliases
+   */
+  public function testWildcardAliases() {
+    $aliasPath = UNISH_SANDBOX . '/site-alias-directory';
+    file_exists($aliasPath) ?: mkdir($aliasPath);
+    $aliasFile = $aliasPath . '/wild.aliases.drushrc.php';
+    $aliasContents = <<<EOD
+  <?php
+  // Written by Unish. This file is safe to delete.
+  \$aliases['foo.*'] = array(
+    'remote-host' => '\${env-name}.remote-host.com',
+    'remote-user' => 'www-admin',
+    'root' => '/path/to/\${env-name}',
+    'uri' => 'https://\${env-name}.foo.example.com',
+  );
+EOD;
+    file_put_contents($aliasFile, $aliasContents);
+    $options = array(
+      'alias-path' => $aliasPath,
+      'yes' => NULL,
+    );
+    $this->drush('sa', array('@foo.bar'), $options, NULL, NULL, self::EXIT_SUCCESS);
+    $output = $this->getOutput();
+    $this->assertEquals("\$aliases[\"wild.foo.*\"] = array (
+  'remote-host' => 'bar.remote-host.com',
+  'remote-user' => 'www-admin',
+  'root' => '/path/to/bar',
+  'uri' => 'https://bar.foo.example.com',
+);", $output);
+  }
+
+  /**
    * Ensure that a --uri on CLI overrides on provided by site alias during a backend invoke.
    */
   public function testBackendHonorsAliasOverride() {

--- a/tests/siteAliasTest.php
+++ b/tests/siteAliasTest.php
@@ -195,7 +195,7 @@ EOD;
     );
     $this->drush('sa', array('@foo.bar'), $options, NULL, NULL, self::EXIT_SUCCESS);
     $output = $this->getOutput();
-    $this->assertEquals("\$aliases[\"wild.foo.*\"] = array (
+    $this->assertEquals("\$aliases[\"foo.bar\"] = array (
   'remote-host' => 'bar.remote-host.com',
   'remote-user' => 'www-admin',
   'root' => '/path/to/bar',


### PR DESCRIPTION
On Pantheon, some organizations have many many sites - so many that the operation to generate the Drush aliases for the org can time out and fail.

For Drush 9, site alias wildcard environments can be used to greatly reduce the number of records that need to be generated, as a single record can represent any number of environments for a single site. For example:

**examplesite.site.yml**
```
'*':
  host: appserver.${env-name}.8a5311d2-....pantheon.io
  uri: ${env-name}-a-far-off-site-with-no-org.pantheonsite.io
  user: ${env-name}.8a5311d2-....
  ssh:
    options: '-p 2222 -o "AddressFamily inet"'
    tty: false
```
If this alias is accessed via `drush @examplesite.foobar status`, then all occurrences of `${env-name}` will be replaced with `foobar`. If there is, in fact, an environment named `foobar`, then the alias that is generated on-the-fly will work to access the environment. This technique can be used in any instance where the contents of each sites' environments' alias records are identical save for the environment name.

This technique may be enhanced with an alias-alter hook to give a user-friendly error message if an environment that does not exist is accessed.

This PR adds wildcard alias handling to Drush 8, which will allow this technique to be used in a more uniform way, e.g. on customer's Drupal 7 sites.

A Drush 8 wildcard alias looks like this:

**pantheon.aliases.drushrc.php**
```
  $aliases['examplesite.*'] = array(
    'uri' => '${env-name}-a-far-off-site-with-no-org.pantheonsite.io',
    'remote-host' => 'appserver.${env-name}.8a5311d2-....pantheon.io',
    'remote-user' => '${env-name}.8a5311d2-....',
    'ssh-options' => '-p 2222 -o "AddressFamily inet"',
  );
```

Wildcard aliases also have the advantage of not needing to be regenerated when the user creates a new environment.