### PR TITLE
Fixes #3845: Speculative Drush 10 compatibility

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -28,37 +28,43 @@ Drupal Compatibility
     <th rowspan="2"> PHP </th>
     <th colspan="4"> Drupal versions </th>
   </tr>
-    <th>6</th> <th>7</th> <th>-8.3</th> <th>8.4+</th>
+    <th>6</th> <th>7</th> <th>-8.3</th> <th>8.4-8.7</th> <th>8.8+</th>
+  </tr>
+  <tr>
+    <td> Drush 10 </td>
+    <td> <a href="https://travis-ci.org/drush-ops/drush">master</a> </td>
+    <td> 7.1+ </td>
+    <td></td> <td></td> <td></td> <td></td> <td><b>✅</b></td>
   </tr>
   <tr>
     <td> Drush 9 </td>
-    <td> <a href="https://travis-ci.org/drush-ops/drush">master</a> </td>
+    <td> <a href="https://travis-ci.org/drush-ops/drush">9.x</a> </td>
     <td> 5.6+ </td>
-    <td></td> <td></td> <td></td> <td>✅</td>
+    <td></td> <td></td> <td></td> <td>✅</td> <td><b>⚠️</b></td>
   </tr>
   <tr>
     <td> Drush 8 </td>
     <td> <a href="https://travis-ci.org/drush-ops/drush">8.x</a> </td>
     <td> 5.4.5+ </td>
-    <td>✅</td> <td>✅</td> <td>✅</td> <td><b>⚠️</b></td>
+    <td>✅</td> <td>✅</td> <td>✅</td> <td><b>⚠️</b></td> <td><b>⚠️</b></td>
   </tr>
   <tr>
     <td> Drush 7 </td>
     <td> <a href="https://travis-ci.org/drush-ops/drush">7.x</a> </td>
     <td> 5.3.0+ </td>
-    <td>✓</td> <td>✓</td> <td></td> <td></td>
+    <td>✓</td> <td>✓</td> <td></td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 6 </td>
     <td> <a href="https://travis-ci.org/drush-ops/drush">6.x</a> </td>
     <td> 5.3.0+ </td>
-    <td>✓</td> <td>✓</td> <td></td> <td></td>
+    <td>✓</td> <td>✓</td> <td></td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 5 </td>
     <td> <a href="https://travis-ci.org/drush-ops/drush">5.x</a> </td>
     <td> 5.2.0+ </td>
-    <td>✓</td> <td>✓</td> <td></td> <td></td>
+    <td>✓</td> <td>✓</td> <td></td> <td></td> <td></td>
   </tr>
 </table>
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -40,13 +40,13 @@ Drupal Compatibility
     <td> Drush 9 </td>
     <td> <a href="https://travis-ci.org/drush-ops/drush">9.x</a> </td>
     <td> 5.6+ </td>
-    <td></td> <td></td> <td></td> <td>✅</td> <td><b>⚠️</b></td>
+    <td></td> <td></td> <td></td> <td>✅</td> <td></td>
   </tr>
   <tr>
     <td> Drush 8 </td>
     <td> <a href="https://travis-ci.org/drush-ops/drush">8.x</a> </td>
     <td> 5.4.5+ </td>
-    <td>✅</td> <td>✅</td> <td>✅</td> <td><b>⚠️</b></td> <td><b>⚠️</b></td>
+    <td>✅</td> <td>✅</td> <td>✅</td> <td><b>⚠️</b></td> <td></td>
   </tr>
   <tr>
     <td> Drush 7 </td>

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,13 +28,13 @@ Drupal Compatibility
     <th rowspan="2"> PHP </th>
     <th colspan="4"> Drupal versions </th>
   </tr>
-    <th>6</th> <th>7</th> <th>-8.3</th> <th>8.4-8.7</th> <th>8.8+</th>
+    <th>6</th> <th>7</th> <th>-8.3</th> <th>8.4+</th> <th>9+</th>
   </tr>
   <tr>
     <td> Drush 10 </td>
     <td> <a href="https://travis-ci.org/drush-ops/drush">master</a> </td>
     <td> 7.1+ </td>
-    <td></td> <td></td> <td></td> <td></td> <td><b>✅</b></td>
+    <td></td> <td></td> <td></td> <td>✅</td> <td><b>✅</b></td>
   </tr>
   <tr>
     <td> Drush 9 </td>


### PR DESCRIPTION
We still need to make some decisions about compatibility for Drush 10. Here is a visual representation of what that might look like. Subject to change.

For example, consolidation/site-process still needs some minor changes to work with symfony/process 4+. We will probably want to have different major versions of consolidation/site-process for symfony/process -3 vs 4+. It is still speculative whether this will pose any issues for Drush.