### PR TITLE
Updated subscription options in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Resources
 * [General Documentation](http://docs.drush.org)
 * [API Documentation](http://api.drush.org)
 * [Drush Commands](http://drushcommands.com)
-* Subscribe [this atom feed](https://github.com/drush-ops/drush/releases.atom) to receive notification on new releases. Also, [Version eye](https://www.versioneye.com/).
+* To receive notifications on new releases, use GitHub's 'Watch' button and select 'Releases only'. Also, [this atom feed](https://github.com/drush-ops/drush/releases.atom).
 * [Drush packages available via Composer](https://packagist.org/search/?type=drupal-drush)
 * [A list of modules that include Drush integration](https://www.drupal.org/project/project_module?f[2]=im_vid_3%3A4654&solrsort=ds_project_latest_release+desc)
 * Drush comes with a [full test suite](https://github.com/drush-ops/drush/blob/master/tests/README.md) powered by [PHPUnit](https://github.com/sebastianbergmann/phpunit). Each commit gets tested by the awesome [Travis.ci continuous integration service](https://travis-ci.org/drush-ops/drush).


### PR DESCRIPTION
Added info about GitHub's 'Releases only' watch option and removed old Version Eye link.