### PR TITLE
Issue #4135 Fix Request to have correct base URL

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -137,19 +137,21 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
 
         // Normalize URI.
         $uri = rtrim($this->uri, '/') . '/';
+
         $parsed_url = parse_url($uri);
 
         // Account for users who omit the http:// prefix.
         if (empty($parsed_url['scheme'])) {
             $this->uri = 'http://' . $this->uri;
-            $parsed_url = parse_url('http://' . $uri);
+            $uri = 'http://' . $uri;
+            $parsed_url = parse_url($uri);
         }
 
         $server = [
             'SCRIPT_FILENAME' => getcwd() . '/index.php',
             'SCRIPT_NAME' => isset($parsed_url['path']) ? $parsed_url['path'] . 'index.php' : '/index.php',
         ];
-        $request = Request::create($this->uri, 'GET', [], [], [], $server);
+        $request = Request::create($uri, 'GET', [], [], [], $server);
         $this->setRequest($request);
         return true;
     }


### PR DESCRIPTION
- The Symfony request object had an incorrect base URL when using the --uri option
   with a subdirectory.
- Added tests for the url check.

Closes #4135