### PR TITLE
Fix sqlsync between Drush 9 websites using Drush 8

### DIFF
--- a/commands/sql/sqlsync.drush.inc
+++ b/commands/sql/sqlsync.drush.inc
@@ -214,6 +214,9 @@ function drush_sqlsync_sql_sync($source, $destination) {
     }
     else {
       $source_dump_path = $return['object'];
+      if (is_array($source_dump_path) && isset($source_dump_path['path'])) {
+        $source_dump_path = $source_dump_path['path'];
+      }
       if (!is_string($source_dump_path)) {
         return drush_set_error('DRUSH_SQL_DUMP_FILE_NOT_REPORTED', dt('The Drush sql-dump command did not report the path to the dump file produced.  Try upgrading the version of Drush you are using on the source machine.'));
       }


### PR DESCRIPTION
Since #3758 syncing a database between two remote Drush 9 servers using Drush 8 seems broken. 
Since #3758 the object resulted by Drush for sql dump is an array containing the path, instead of a string of the path.

Server specs:
Local: Drush 8
Server @a: Drush 9.7.1
Server @b: Drush 9.7.1

Command executed at server Local: drush sql-sync @a @b

Result before this PR:
```
The Drush sql-dump command did not report the path to the dump file produced.  Try upgrading the version of Drush you are using on the source machine.
```

Result with this fix:
```
Starting to import dump file onto Destination database.   [ok]
```