### PR TITLE
[cron] Do not throw exception if cron is already running

### DIFF
--- a/src/Drupal/Commands/core/DrupalCommands.php
+++ b/src/Drupal/Commands/core/DrupalCommands.php
@@ -56,10 +56,7 @@ class DrupalCommands extends DrushCommands
      */
     public function cron()
     {
-        $result = $this->getCron()->run();
-        if (!$result) {
-            throw new \Exception(dt('Cron run failed.'));
-        }
+        $this->getCron()->run();
     }
 
     /**


### PR DESCRIPTION
Currently, when you run cron and it is already running, it throws an exception saying Cron run failed.

This PR removes the exception throw when the cron call returns false. Checking Drupal - it will only ever return false if the cron is already running, and a warning will have already been logged. This ensures that cron installations of `drush cron --uri=<uri> --quiet` do not randomly fail