### PR TITLE
Allow uri overrides on remote servers in 9.5.x.

### DIFF
--- a/src/Preflight/PreflightArgs.php
+++ b/src/Preflight/PreflightArgs.php
@@ -121,6 +121,7 @@ class PreflightArgs extends Config implements PreflightArgsInterface
             self::SIMULATE =>       \Robo\Config\Config::SIMULATE,
             self::BACKEND =>        self::BACKEND,
             self::LOCAL =>          self::DRUSH_RUNTIME_CONTEXT_NAMESPACE . '.' . self::LOCAL,
+            self::URI =>          self::DRUSH_RUNTIME_CONTEXT_NAMESPACE . '.' . self::URI,
         ];
     }
 


### PR DESCRIPTION
We are locked into 9.5.x with Acquia currently. We are also having an issue where any remote Drush commands we issue with the --uri flag do not pass the uri to the server. Since we are using ACSF with a large number of sites we need to be able to specify the uri in our commands.