### PR TITLE
Add option to exclude entities by ID to entity:delete command.

### DIFF
--- a/src/Drupal/Commands/core/EntityCommands.php
+++ b/src/Drupal/Commands/core/EntityCommands.php
@@ -53,8 +53,8 @@ class EntityCommands extends DrushCommands
         } elseif ($options['bundle'] || $options['exclude']) {
             $query = $storage->getQuery();
             if ($exclude = StringUtils::csvToArray($options['exclude'])) {
-                $bundleId = $this->entityTypeManager->getDefinition($entity_type)->getKey('id');
-                $query = $query->condition($bundleId, $exclude, 'NOT IN');
+                $idKey = $this->entityTypeManager->getDefinition($entity_type)->getKey('id');
+                $query = $query->condition($idKey, $exclude, 'NOT IN');
             }
             if ($bundle = $options['bundle']) {
                 $bundleKey = $this->entityTypeManager->getDefinition($entity_type)->getKey('bundle');

--- a/src/Drupal/Commands/core/EntityCommands.php
+++ b/src/Drupal/Commands/core/EntityCommands.php
@@ -35,6 +35,8 @@ class EntityCommands extends DrushCommands
      *   Delete all shortcut entities.
      * @usage drush entity:delete node 22,24
      *   Delete nodes 22 and 24.
+     * @usage drush entity:delete node --exclude=9,14,81
+     *   Delete all nodes except node 9, 14 and 81.
      * @usage drush entity:delete user
      *   Delete all users except uid=1.
      *
@@ -42,7 +44,7 @@ class EntityCommands extends DrushCommands
      * @aliases edel,entity-delete
      * @throws \Exception
      */
-    public function delete($entity_type, $ids = null, $options = ['bundle' => self::REQ])
+    public function delete($entity_type, $ids = null, $options = ['bundle' => self::REQ, 'exclude' => self::REQ])
     {
         $storage = $this->entityTypeManager->getStorage($entity_type);
         if ($ids = StringUtils::csvToArray($ids)) {
@@ -58,6 +60,13 @@ class EntityCommands extends DrushCommands
         if ($entity_type == 'user') {
             unset($entities[1]);
             unset($entities[0]);
+        }
+
+        // Don't delete excluded entities.
+        if ($exclude = StringUtils::csvToArray($options['exclude'])) {
+            foreach ($exclude as $id) {
+                unset($entities[$id]);
+            }
         }
 
         if (empty($entities)) {


### PR DESCRIPTION
Following up on https://drupal.stackexchange.com/q/285037 and since I found myself already in a situation to need to delete every node *except* some very certain ones, I added an `--exclude` option to the `entity:delete` command.

Is it OK how it's written? Is it right to have the `$options` parameter array extended to also take `'exclude' => self::REQ` with `self::REQ`? I just followed the `'bundle' => self::REQ` pattern.

Finally everything else I added are the following few lines after the `$entities` are already loaded.

```php
// Don't delete excluded entities.
if ($exclude = StringUtils::csvToArray($options['exclude'])) {
    foreach ($exclude as $id) {
        unset($entities[$id]);
    }
}
```

Is there anything else I need to consider when adding this option? Do I need to extend existing tests for it? I wasn't able to find any specific tests for this command by searching the codebase.