### PR TITLE
Remove deprecated each().

### DIFF
--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -357,7 +357,8 @@ function _drush_backend_proc_open($cmds, $process_limit, $context = NULL) {
     if (count($cmds) && (count($open_processes) < $process_limit)) {
       // Pop the site and command (key / value) from the cmds array
       end($cmds);
-      list($site, $cmd) = each($cmds);
+      $cmd = current($cmds);
+      $site = key($cmds);
       unset($cmds[$site]);
 
       if (is_array($cmd)) {


### PR DESCRIPTION
This is a backport fix for the 8.x branch. See #3472 and #3469.