### PR TITLE
Add maintenance-mode flag support to `drush updatedb` command

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -442,11 +442,11 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         }
 
         if ($options['maintenance-mode']) {
-          $original_maint_mode = \Drupal::service('state')->get('system.maintenance_mode');
-          if (!$original_maint_mode) {
-              \Drupal::service('state')->set('system.maintenance_mode', true);
-              $operations[] = ['\Drush\Commands\core\UpdateDBCommands::restoreMaintMode', [false]];
-          }
+            $original_maint_mode = \Drupal::service('state')->get('system.maintenance_mode');
+            if (!$original_maint_mode) {
+                \Drupal::service('state')->set('system.maintenance_mode', true);
+                $operations[] = ['\Drush\Commands\core\UpdateDBCommands::restoreMaintMode', [false]];
+            }
         }
 
         $batch['operations'] = $operations;


### PR DESCRIPTION
### Problem

When running certain database updates, Drupal does not have to be switch into maintenance mode.

### Solution

Provide an optional flag to switch Drupal into maintenance mode during database updates.  The --maintenance-mode should default to TRUE, since it is recommended to place a site in maintenance mode... unless you know what you are doing.

Here is an example of the new flag.

`drush --maintenance-mode=0 updatedb`

#### Tasks

- Decide if this feature should be added to Drush.
- Determine if this feature can be added to Drush 9 or 10.
- Create PR implementing this feature
- Write test coverage this feature