### PR TITLE
add unix socket configuration to mysql credentials

### DIFF
--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -18,10 +18,14 @@ class SqlMysql extends SqlBase
     {
         $dbSpec = $this->getDbSpec();
         if ($hide_password) {
+            // Default to unix socket if configured.
+            $unixSocket=(!empty($dbSpec['unix_socket'])) ? $unixSocket="socket=\"".$dbSpec['unix_socket']."\"" : "";
+
             // EMPTY password is not the same as NO password, and is valid.
             $contents = <<<EOT
 #This file was written by Drush's Sqlmysql.php.
 [client]
+{$unixSocket}
 user="{$dbSpec['username']}"
 password="{$dbSpec['password']}"
 EOT;


### PR DESCRIPTION
Hello, i've asked for this feature some time ago in #4158 and finally had the time to add it. 

It would leave an empty line if no socket is set but that shouldn't be a big issue as the file is temporary anyways. Would be nice to have this feature in Drush in order to be able to run MySQL commands on setups with socket connections.

If you merge it, thanks in advance.