### PR TITLE
Make check for test modules stricter in PM:LIST

### DIFF
--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -170,7 +170,7 @@ class PmCommands extends DrushCommands
             $extension->info += ['package' => ''];
 
             // Filter out test modules/themes.
-            if (strpos($extension->getPath(), 'tests')) {
+            if (strpos($extension->getPath(), DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR)) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes #4182 

My proposal that explained problem would be to make check stricter.

Instead of checking for `tests`, we should check for `/tests/` in module/theme path.