### PR TITLE
Calculate memory_limit correctly when there is no suffix

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -216,7 +216,7 @@ function drush_call_user_func_array($function, $args = []) {
 function drush_memory_limit() {
   $value = trim(ini_get('memory_limit'));
   $last = strtolower($value[strlen($value)-1]);
-  $size = (int) substr($value, 0, -1);
+  $size = (int) rtrim($value, 'GgMmKk');
   switch ($last) {
     case 'g':
       $size *= DRUSH_KILOBYTE;


### PR DESCRIPTION
Fixes drush_memory_limit to give correct value if memory limit is strictly numeric