### PR TITLE
Prevent patch context being ignored (#4193)

### DIFF
--- a/commands/make/make.project.inc
+++ b/commands/make/make.project.inc
@@ -289,7 +289,7 @@ class DrushMakeProject {
           foreach ($patch_levels as $patch_level) {
             // --no-backup-if-mismatch here is a hack that fixes some
             // differences between how patch works on windows and unix.
-            if ($patched = drush_shell_exec("patch %s --no-backup-if-mismatch -d %s < %s", $patch_level, $project_directory, $filename)) {
+            if ($patched = drush_shell_exec("patch %s -F 0 --no-backup-if-mismatch -d %s < %s", $patch_level, $project_directory, $filename)) {
               break;
             }
           }


### PR DESCRIPTION
The initial 'git apply' command does not employ the -C option to allow
fuzzy context matching, so neither should the fallback 'patch' command
be allowed to use its default fuzz factor.  Both commands should treat
context in a consistent manner.

By default 'patch' will allow a hunk to apply with only a single line
of the provided context matching either side, and by default drush make
will not show any of the output which indicates that such fuzzy matching
has taken place.

This makes it far too easy for inapplicable patches to be 'successfully'
(but incorrectly) applied, with no warning to the user.