### PR TITLE
Replace classy with stark in EnDisUnListInfoCase::testEnDisUnList

### DIFF
--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -31,8 +31,8 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
         $out = $this->getOutput();
         $this->assertContains('devel', $out);
 
-        $this->drush('core:status', [], ['field' => 'drupal-version']);
-        $drupal_version = $this->getOutputRaw();
+        $drupal_root = Drush::bootstrapManager()->getRoot();
+        $drupal_version = Drush::bootstrap()->getVersion($drupal_root);
 
         // Test the testing install profile theme is installed.
         // Since Drupal 8.8, stark is the default testing theme.

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -8,7 +8,6 @@
 namespace Unish;
 
 use Composer\Semver\Comparator;
-use Drush\Drush;
 
 /**
  *  @group slow

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -29,7 +29,7 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
         $out = $this->getOutput();
         $this->assertContains('devel', $out);
 
-	// Test the testing install profile theme is installed.
+        // Test the testing install profile theme is installed.
         // Since Drupal 8.8, stark is the default testing theme.
         // https://www.drupal.org/node/3083055.
         // TODO: Replace once Drupal 8.7 is no longer supported.

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -31,6 +31,9 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
         $out = $this->getOutput();
         $this->assertContains('devel', $out);
 
+        $this->drush('core:status', [], ['field' => 'drupal-version']);
+        $drupal_version = $this->getOutputRaw();
+
         // Test the testing install profile theme is installed.
         // Since Drupal 8.8, stark is the default testing theme.
         // https://www.drupal.org/node/3083055.

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -28,8 +28,16 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
         $this->drush('pm-list', [], ['status' => 'enabled']);
         $out = $this->getOutput();
         $this->assertContains('devel', $out);
-        // Test the testing install profile theme is installed.;
-        $this->assertContains('stark', $out, 'Themes are in the pm-list');
+
+	// Test the testing install profile theme is installed.
+        // Since Drupal 8.8, stark is the default testing theme.
+        // https://www.drupal.org/node/3083055.
+        // TODO: Replace once Drupal 8.7 is no longer supported.
+        $active_theme = 'stark';
+        if (Comparator::lessThan($drupal_version, '8.8')) {
+          $active_theme = 'classy';
+        }
+        $this->assertContains($active_theme, $out, 'Themes are in the pm-list');
 
         // Test cache was cleared after enabling a module.
         $table = 'router';

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -7,6 +7,8 @@
 
 namespace Unish;
 
+use Composer\Semver\Comparator;
+
 /**
  *  @group slow
  *  @group pm

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -8,6 +8,7 @@
 namespace Unish;
 
 use Composer\Semver\Comparator;
+use Drush\Drush;
 
 /**
  *  @group slow

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -35,7 +35,7 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
         // TODO: Replace once Drupal 8.7 is no longer supported.
         $active_theme = 'stark';
         if (Comparator::lessThan($drupal_version, '8.8')) {
-          $active_theme = 'classy';
+            $active_theme = 'classy';
         }
         $this->assertContains($active_theme, $out, 'Themes are in the pm-list');
 

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -32,8 +32,8 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
         $out = $this->getOutput();
         $this->assertContains('devel', $out);
 
-        $drupal_root = Drush::bootstrapManager()->getRoot();
-        $drupal_version = Drush::bootstrap()->getVersion($drupal_root);
+        $this->drush('core:status', [], ['field' => 'drupal-version']);
+        $drupal_version = $this->getOutputRaw();
 
         // Test the testing install profile theme is installed.
         // Since Drupal 8.8, stark is the default testing theme.

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -29,7 +29,7 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
         $out = $this->getOutput();
         $this->assertContains('devel', $out);
         // Test the testing install profile theme is installed.;
-        $this->assertContains('classy', $out, 'Themes are in the pm-list');
+        $this->assertContains('stark', $out, 'Themes are in the pm-list');
 
         // Test cache was cleared after enabling a module.
         $table = 'router';


### PR DESCRIPTION
Since classy is no longer the default testing theme, the Unish\EnDisUnListInfoCase::testEnDisUnList is currently failing.

This test is checking if classy is installed. Since classy is no longer the default testing theme, the test will nog longer find classy in the installed modules/themes list.

Issue: https://www.drupal.org/project/drupal/issues/2352949#comment-13252667
CR: https://www.drupal.org/node/3083055