### PR TITLE
Closes #4203 - In CREATE DATABASE statements, quote database name by default

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -372,7 +372,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
         $bootstrapManager = Drush::bootstrapManager();
         $bootstrapManager->doBootstrap(DRUSH_BOOTSTRAP_DRUPAL_SITE);
 
-        if ($program_exists && !$sql->dropOrCreate()) {
+        if ($program_exists && !$sql->dropOrCreate($sql->getOption('quoted'))) {
             throw new \Exception(dt('Failed to drop or create the database: @error', ['@error' => $sql->getProcess()->getOutput()]));
         }
     }

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -86,7 +86,7 @@ class SqlCommands extends DrushCommands implements StdinAwareInterface
      *   Create the database as specified in the db-url option.
      * @bootstrap max configuration
      */
-    public function create($options = ['db-su' => self::REQ, 'db-su-pw' => self::REQ])
+    public function create($options = ['db-su' => self::REQ, 'db-su-pw' => self::REQ, 'quoted' => true])
     {
         $sql = SqlBase::create($options);
         $db_spec = $sql->getDbSpec();
@@ -100,7 +100,7 @@ class SqlCommands extends DrushCommands implements StdinAwareInterface
             throw new UserAbortException();
         }
 
-        if (!$sql->createdb(true)) {
+        if (!$sql->createdb($sql->getOption('quoted'))) {
             throw new \Exception('Unable to create database. Rerun with --debug to see any error message.');
         }
     }

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -77,6 +77,7 @@ class SqlCommands extends DrushCommands implements StdinAwareInterface
      * @aliases sql-create
      * @option db-su Account to use when creating a new database.
      * @option db-su-pw Password for the db-su account.
+     * @option quoted Whether to quote the database name.
      * @optionset_sql
      * @usage drush sql:create
      *   Create the database for the current site.
@@ -84,6 +85,8 @@ class SqlCommands extends DrushCommands implements StdinAwareInterface
      *   Create the database as specified for @site.test.
      * @usage drush sql:create --db-su=root --db-su-pw=rootpassword --db-url="mysql://drupal_db_user:drupal_db_password@127.0.0.1/drupal_db"
      *   Create the database as specified in the db-url option.
+     * @usage drush sql:create --quoted=0
+     *   Create the database in a Windows environment that has problems with backticks.
      * @bootstrap max configuration
      */
     public function create($options = ['db-su' => self::REQ, 'db-su-pw' => self::REQ, 'quoted' => true])

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -86,6 +86,7 @@ class SqlBase implements ConfigAwareInterface
             'db-url' => null,
             'databases' => null,
             'db-prefix' => null,
+            'quoted' => true,
         ];
         $database = $options['database'];
         $target = $options['target'];
@@ -424,10 +425,10 @@ class SqlBase implements ConfigAwareInterface
      *   The database name.
      * @param boolean $quoted
      *   Quote the database name. Mysql uses backticks to quote which can cause problems
-     *   in a Windows shell. Set TRUE if the CREATE is not running on the bash command line.
+     *   in a Windows shell. Set FALSE if the CREATE is running on the bash command line.
      * @return string
      */
-    public function createdbSql($dbname, $quoted = false)
+    public function createdbSql($dbname, $quoted = true)
     {
     }
 
@@ -436,11 +437,11 @@ class SqlBase implements ConfigAwareInterface
      *
      * @param boolean $quoted
      *   Quote the database name. Mysql uses backticks to quote which can cause problems
-     *   in a Windows shell. Set TRUE if the CREATE is not running on the bash command line.
+     *   in a Windows shell. Set FALSE if the CREATE is running on the bash command line.
      * @return boolean
      *   True if successful, FALSE otherwise.
      */
-    public function createdb($quoted = false)
+    public function createdb($quoted = true)
     {
         $dbname = $this->getDbSpec()['database'];
         $sql = $this->createdbSql($dbname, $quoted);
@@ -455,12 +456,12 @@ class SqlBase implements ConfigAwareInterface
      * return boolean
      *   TRUE or FALSE depending on success.
      */
-    public function dropOrCreate()
+    public function dropOrCreate($quoted = true)
     {
         if ($this->dbExists()) {
             return $this->drop($this->listTables());
         } else {
-            return $this->createdb();
+            return $this->createdb($quoted);
         }
     }
 

--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -89,7 +89,7 @@ EOT;
         return '--silent';
     }
 
-    public function createdbSql($dbname, $quoted = false)
+    public function createdbSql($dbname, $quoted = true)
     {
         $dbSpec = $this->getDbSpec();
         if ($quoted) {

--- a/src/Sql/SqlPgsql.php
+++ b/src/Sql/SqlPgsql.php
@@ -78,7 +78,7 @@ class SqlPgsql extends SqlBase
         return $this->paramsToOptions($parameters);
     }
 
-    public function createdbSql($dbname, $quoted = false)
+    public function createdbSql($dbname, $quoted = true)
     {
         if ($quoted) {
             $dbname = '"' . $dbname . '"';

--- a/src/Sql/SqlSqlite.php
+++ b/src/Sql/SqlSqlite.php
@@ -31,9 +31,9 @@ class SqlSqlite extends SqlBase
      *
      * @param boolean $quoted
      *   Quote the database name. Mysql uses backticks to quote which can cause problems
-     *   in a Windows shell. Set TRUE if the CREATE is not running on the bash command line.
+     *   in a Windows shell. Set FALSE if the CREATE is running on the bash command line.
      */
-    public function createdb($quoted = false)
+    public function createdb($quoted = true)
     {
         $file = $this->getDbSpec()['database'];
         if (file_exists($file)) {


### PR DESCRIPTION
The default behavior should be to quote database names and to provide an option to not do so if on a platform that has problems with it.

Closes #4203