### PR TITLE
Closes #4071 by setting -y to sql-sync command

### DIFF
--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -221,8 +221,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
                 $runner = $targetRecord;
             }
             $this->logger()->notice(dt('Copying dump file from source to target.'));
-            $options = ['yes' => true];
-            $process = $this->processManager()->drush($runner, 'core-rsync', [$sourceRecord->name() . ":$source_dump_path", $targetRecord->name() . ":$target_dump_path"], $options, $double_dash_options);
+            $process = $this->processManager()->drush($runner, 'core-rsync', [$sourceRecord->name() . ":$source_dump_path", $targetRecord->name() . ":$target_dump_path"], ['yes' => true], $double_dash_options);
             $process->mustRun($process->showRealtime());
         }
         return $target_dump_path;

--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -221,7 +221,8 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
                 $runner = $targetRecord;
             }
             $this->logger()->notice(dt('Copying dump file from source to target.'));
-            $process = $this->processManager()->drush($runner, 'core-rsync', [$sourceRecord->name() . ":$source_dump_path", $targetRecord->name() . ":$target_dump_path"], [], $double_dash_options);
+            $options = ['yes' => true];
+            $process = $this->processManager()->drush($runner, 'core-rsync', [$sourceRecord->name() . ":$source_dump_path", $targetRecord->name() . ":$target_dump_path"], $options, $double_dash_options);
             $process->mustRun($process->showRealtime());
         }
         return $target_dump_path;


### PR DESCRIPTION
Tested with

- `drush sql-sync @remote-site-alias @self`
- `drush -y sql-sync @remote-site-alias @self`

This fixes the problem described in #4071 run inside the Alpine container.

Please advice if this needs to be somewhere else.