### PR TITLE
Fix config import with `--partial`

### DIFF
--- a/src/Commands/config/ConfigImportCommands.php
+++ b/src/Commands/config/ConfigImportCommands.php
@@ -35,7 +35,7 @@ class ConfigImportCommands extends DrushCommands
      * @option diff Show preview as a diff.
      * @option preview Deprecated. Format for displaying proposed changes. Recognized values: list, diff.
      * @option source An arbitrary directory that holds the configuration files. An alternative to label argument
-     * @option partial Allows for partial config imports from the source directory. Only updates and new configs will be processed with this flag (missing configs will not be deleted).
+     * @option partial Allows for partial config imports from the source directory. Only updates and new configs will be processed with this flag (missing configs will not be deleted). No config transformation happens.
      * @aliases cim,config-import
      * @kernel update
      * @bootstrap full

--- a/src/Drupal/Commands/config/ConfigImportCommands.php
+++ b/src/Drupal/Commands/config/ConfigImportCommands.php
@@ -231,10 +231,11 @@ class ConfigImportCommands extends DrushCommands
                 $replacement_storage->replaceData($name, $data);
             }
             $source_storage = $replacement_storage;
-        }
-
-        // Use the import transformer if it is available.
-        if ($this->hasImportTransformer()) {
+        } elseif ($this->hasImportTransformer()) {
+            // Use the import transformer if it is available. (Drupal ^8.8)
+            // Drupal core does not apply transformations for single imports.
+            // And in addition the StorageReplaceDataWrapper is not compatible
+            // with StorageCopyTrait::replaceStorageContents.
             $source_storage = $this->getImportTransformer()->transform($source_storage);
         }
 


### PR DESCRIPTION
The `--partial` is equivalent to a single import in the UI. Config transformations are not applied in that case. So we should also skip them in the drush import.

This bug exists because of a core bug with `StorageReplaceDataWrapper` which "forgets" the replaced data when the collection is switched.