### PR TITLE
Remove test dependency on devel/empty_theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,18 +55,16 @@
     "webmozart/path-util": "^2.1.0"
   },
   "require-dev": {
-    "lox/xhprof": "dev-master",
-    "g1a/composer-test-scenarios": "^3",
-    "phpunit/phpunit": "^4.8.36 || ^6.1",
-    "squizlabs/php_codesniffer": "^2.7 || ^3",
     "composer/installers": "^1.2",
     "cweagans/composer-patches": "~1.0",
-    "webflo/drupal-core-strict": "8.7.x-dev",
-    "webflo/drupal-core-require-dev": "8.7.x-dev",
-    "drupal/empty_theme": "1.0",
-    "drupal/devel": "^2",
     "drupal/alinks": "1.0.0",
-    "vlucas/phpdotenv": "^2.4"
+    "g1a/composer-test-scenarios": "^3",
+    "lox/xhprof": "dev-master",
+    "phpunit/phpunit": "^4.8.36 || ^6.1",
+    "squizlabs/php_codesniffer": "^2.7 || ^3",
+    "vlucas/phpdotenv": "^2.4",
+    "webflo/drupal-core-require-dev": "8.7.x-dev",
+    "webflo/drupal-core-strict": "8.7.x-dev"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6308734d90e4bf0b407575fc96ffc95a",
+    "content-hash": "a6f2352c7eefd57c9cb65d317da29ccd",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",
@@ -2132,19 +2132,19 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "role": "Lead Developer",
                     "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org"
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Armin Ronacher",
-                    "role": "Project Founder",
-                    "email": "armin.ronacher@active-4.com"
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
                 },
                 {
                     "name": "Twig Team",
-                    "role": "Contributors",
-                    "homepage": "https://twig.symfony.com/contributors"
+                    "homepage": "https://twig.symfony.com/contributors",
+                    "role": "Contributors"
                 }
             ],
             "description": "Twig, the flexible, fast, and secure template language for PHP",
@@ -3588,142 +3588,6 @@
             "time": "2019-08-02T14:45:21+00:00"
         },
         {
-            "name": "drupal/devel",
-            "version": "2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/devel.git",
-                "reference": "8.x-2.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/devel-8.x-2.1.zip",
-                "reference": "8.x-2.1",
-                "shasum": "8f735892922aa5f228e681e645e5f02b1c008f14"
-            },
-            "require": {
-                "drupal/core": "~8.0",
-                "symfony/var-dumper": "~2.7|^3|^4"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-2.1",
-                    "datestamp": "1556799496",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                },
-                "drush": {
-                    "services": {
-                        "drush.services.yml": "^9"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Moshe Weitzman",
-                    "homepage": "https://github.com/weitzman",
-                    "email": "weitzman@tejasa.com",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Hans Salvisberg",
-                    "homepage": "https://www.drupal.org/u/salvis",
-                    "email": "drupal@salvisberg.com",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Luca Lusso",
-                    "homepage": "https://www.drupal.org/u/lussoluca",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Marco (willzyx)",
-                    "homepage": "https://www.drupal.org/u/willzyx",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "See contributors",
-                    "homepage": "https://www.drupal.org/node/3236/committers"
-                },
-                {
-                    "name": "salvis",
-                    "homepage": "https://www.drupal.org/user/82964"
-                },
-                {
-                    "name": "willzyx",
-                    "homepage": "https://www.drupal.org/user/1043862"
-                }
-            ],
-            "description": "Various blocks, pages, and functions for developers.",
-            "homepage": "http://drupal.org/project/devel",
-            "support": {
-                "source": "http://cgit.drupalcode.org/devel",
-                "issues": "http://drupal.org/project/devel",
-                "irc": "irc://irc.freenode.org/drupal-contribute"
-            }
-        },
-        {
-            "name": "drupal/empty_theme",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/empty_theme.git",
-                "reference": "8.x-1.0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/empty_theme-8.x-1.0.zip",
-                "reference": "8.x-1.0",
-                "shasum": "04e6d2493d2ed9f84cde3d01c3442a34dcbeea18"
-            },
-            "require": {
-                "drupal/core": "~8.0"
-            },
-            "type": "drupal-theme",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-1.0",
-                    "datestamp": "1488718983",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Dave Reid",
-                    "homepage": "https://www.drupal.org/user/53892"
-                },
-                {
-                    "name": "moshe weitzman",
-                    "homepage": "https://www.drupal.org/user/23"
-                }
-            ],
-            "description": "An empty theme to use for testing.",
-            "homepage": "https://www.drupal.org/project/empty_theme",
-            "support": {
-                "source": "https://git.drupalcode.org/project/empty_theme"
-            }
-        },
-        {
             "name": "easyrdf/easyrdf",
             "version": "0.9.1",
             "source": {
@@ -3763,14 +3627,14 @@
             "authors": [
                 {
                     "name": "Nicholas Humfrey",
-                    "role": "Developer",
                     "email": "njh@aelius.com",
-                    "homepage": "http://www.aelius.com/njh/"
+                    "homepage": "http://www.aelius.com/njh/",
+                    "role": "Developer"
                 },
                 {
                     "name": "Alexey Zakhlestin",
-                    "role": "Developer",
-                    "email": "indeyets@gmail.com"
+                    "email": "indeyets@gmail.com",
+                    "role": "Developer"
                 }
             ],
             "description": "EasyRdf is a PHP library designed to make it easy to consume and produce RDF.",
@@ -4713,18 +4577,18 @@
             "authors": [
                 {
                     "name": "Greg Beaver",
-                    "role": "Helper",
-                    "email": "cellog@php.net"
+                    "email": "cellog@php.net",
+                    "role": "Helper"
                 },
                 {
                     "name": "Andrei Zmievski",
-                    "role": "Lead",
-                    "email": "andrei@php.net"
+                    "email": "andrei@php.net",
+                    "role": "Lead"
                 },
                 {
                     "name": "Stig Bakken",
-                    "role": "Developer",
-                    "email": "stig@php.net"
+                    "email": "stig@php.net",
+                    "role": "Developer"
                 }
             ],
             "description": "More info available on: http://pear.php.net/package/Console_Getopt",
@@ -7486,6 +7350,17 @@
         {
             "name": "webflo/drupal-core-require-dev",
             "version": "8.7.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webflo/drupal-core-require-dev.git",
+                "reference": "8ac5e56a494eb5d54bbd0db6aee264663583926c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webflo/drupal-core-require-dev/zipball/8ac5e56a494eb5d54bbd0db6aee264663583926c",
+                "reference": "8ac5e56a494eb5d54bbd0db6aee264663583926c",
+                "shasum": ""
+            },
             "require": {
                 "behat/mink": "1.7.x-dev",
                 "behat/mink-goutte-driver": "^1.2",
@@ -7508,11 +7383,22 @@
                 "GPL-2.0-or-later"
             ],
             "description": "require-dev dependencies from drupal/core",
-            "time": "2019-09-04T10:31:38+00:00"
+            "time": "2019-10-02T19:31:42+00:00"
         },
         {
             "name": "webflo/drupal-core-strict",
             "version": "8.7.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webflo/drupal-core-strict.git",
+                "reference": "21784560e6c9af85219d61f7f8941586d1b91fff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webflo/drupal-core-strict/zipball/21784560e6c9af85219d61f7f8941586d1b91fff",
+                "reference": "21784560e6c9af85219d61f7f8941586d1b91fff",
+                "shasum": ""
+            },
             "require": {
                 "asm89/stack-cors": "1.2.0",
                 "brumann/polyfill-unserialize": "v1.0.3",
@@ -7608,7 +7494,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Locked core dependencies",
-            "time": "2019-09-04T10:30:46+00:00"
+            "time": "2019-10-02T19:30:48+00:00"
         },
         {
             "name": "wikimedia/composer-merge-plugin",
@@ -7867,8 +7753,8 @@
     "stability-flags": {
         "consolidation/site-alias": 0,
         "lox/xhprof": 20,
-        "webflo/drupal-core-strict": 20,
-        "webflo/drupal-core-require-dev": 20
+        "webflo/drupal-core-require-dev": 20,
+        "webflo/drupal-core-strict": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/sut/modules/unish/drush_empty_module/drush_empty_module.info.yml
+++ b/sut/modules/unish/drush_empty_module/drush_empty_module.info.yml
@@ -1,6 +1,5 @@
 name: Drush empty module
 description: 'Drush empty module'
-core_version_requirement: ^8.8 || ^9.0
 core: 8.x
 type: module
 # Require for the sake of tests - simulate what packaging would do.

--- a/sut/modules/unish/drush_empty_module/drush_empty_module.info.yml
+++ b/sut/modules/unish/drush_empty_module/drush_empty_module.info.yml
@@ -1,0 +1,7 @@
+name: Drush empty module
+description: 'Drush empty module'
+core_version_requirement: ^8.8 || ^9.0
+core: 8.x
+type: module
+# Require for the sake of tests - simulate what packaging would do.
+project: drush_empty_module

--- a/sut/modules/unish/drush_empty_module/drush_empty_module.install
+++ b/sut/modules/unish/drush_empty_module/drush_empty_module.install
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Provides install and update functions for drush_empty_module.
+ */
+
+/**
+ * Fake update hook.
+ */
+function drush_empty_module_update_8001() {
+  return 'The update ran';
+}

--- a/sut/modules/unish/drush_empty_module/drush_empty_module.routing.yml
+++ b/sut/modules/unish/drush_empty_module/drush_empty_module.routing.yml
@@ -1,0 +1,7 @@
+drush_empty_module.admin_settings:
+  path: '/admin/config/development/drush_empty_module'
+  defaults:
+    _controller: '\Drupal\drush_empty_module\MuchControllerManyWow::sparkles'
+    _title: 'Sparkles'
+  requirements:
+    _permission: 'administer site configuration'

--- a/sut/modules/unish/drush_empty_module/drush_empty_module.services.yml
+++ b/sut/modules/unish/drush_empty_module/drush_empty_module.services.yml
@@ -1,0 +1,3 @@
+services:
+  drush_empty_module.service:
+    class: Drupal\drush_empty_module\MuchServiceManyWow

--- a/sut/modules/unish/drush_empty_module/src/MuchControllerManyWow.php
+++ b/sut/modules/unish/drush_empty_module/src/MuchControllerManyWow.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\drush_empty_module;
+
+/**
+ * Defines a class for a controller.
+ */
+class MuchControllerManyWow {
+
+  /**
+   * Controller callback.
+   *
+   * @return array
+   *   Render array.
+   */
+  public function sparkles() {
+    return [
+      '#markup' => 'And there was much sparkling',
+    ];
+  }
+
+}

--- a/sut/modules/unish/drush_empty_module/src/MuchServiceManyWow.php
+++ b/sut/modules/unish/drush_empty_module/src/MuchServiceManyWow.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\drush_empty_module;
+
+/**
+ * Defines a class for a service.
+ */
+class MuchServiceManyWow {
+
+}

--- a/sut/themes/unish/drush_empty_theme/drush_empty_theme.info.yml
+++ b/sut/themes/unish/drush_empty_theme/drush_empty_theme.info.yml
@@ -1,0 +1,5 @@
+name: Drush empty theme
+description: 'Drush empty theme'
+core_version_requirement: ^8.8 || ^9.0
+core: 8.x
+type: theme

--- a/sut/themes/unish/drush_empty_theme/drush_empty_theme.info.yml
+++ b/sut/themes/unish/drush_empty_theme/drush_empty_theme.info.yml
@@ -1,5 +1,4 @@
 name: Drush empty theme
 description: 'Drush empty theme'
-core_version_requirement: ^8.8 || ^9.0
 core: 8.x
 type: theme

--- a/tests/functional/ConfigTest.php
+++ b/tests/functional/ConfigTest.php
@@ -103,22 +103,22 @@ class ConfigCase extends CommandUnishTestCase
         $serviceDefinition = <<<YAML_FRAGMENT
   woot.depending_service:
     class: Drupal\woot\DependingService
-    arguments: ['@devel.dumper']
+    arguments: ['@drush_empty_module.service']
 YAML_FRAGMENT;
         file_put_contents($filename, $serviceDefinition, FILE_APPEND);
 
         $filename = Path::join($root, 'modules/unish/woot/woot.info.yml');
         $moduleDependency = <<<YAML_FRAGMENT
 dependencies:
-  - devel
+  - drush_empty_module
 YAML_FRAGMENT;
         file_put_contents($filename, $moduleDependency, FILE_APPEND);
 
-        // Add the 'devel' module in core.extension.yml.
+        // Add the 'drush_empty_module' module in core.extension.yml.
         $extensionFile = $this->getConfigSyncDir() . '/core.extension.yml';
         $this->assertFileExists($extensionFile);
         $extension = Yaml::decode(file_get_contents($extensionFile));
-        $extension['module']['devel'] = 0;
+        $extension['module']['drush_empty_module'] = 0;
         require_once $root . "/core/includes/module.inc";
         $extension['module'] = module_config_sort($extension['module']);
         file_put_contents($extensionFile, Yaml::encode($extension));

--- a/tests/functional/ConfigTest.php
+++ b/tests/functional/ConfigTest.php
@@ -63,18 +63,18 @@ class ConfigCase extends CommandUnishTestCase
         $this->drush('core:status', [], ['field' => 'drupal-version']);
         $drupal_version = $this->getOutputRaw();
         if (Comparator::greaterThanOrEqualTo($drupal_version, '8.6')) {
-          $contents = file_get_contents($system_site_yml);
-          $contents = preg_replace('/front: .*/', 'front: unish existing', $contents);
-          file_put_contents($system_site_yml, $contents);
-          $this->installDrupal('dev', true, ['existing-config' => true], false);
-          $this->drush('config-get', ['system.site', 'page'], ['format' => 'json']);
-          $page = $this->getOutputFromJSON('system.site:page');
-          $this->assertContains('unish existing', $page['front'], 'Existing config was successfully imported during site:install.');
+            $contents = file_get_contents($system_site_yml);
+            $contents = preg_replace('/front: .*/', 'front: unish existing', $contents);
+            file_put_contents($system_site_yml, $contents);
+            $this->installDrupal('dev', true, ['existing-config' => true], false);
+            $this->drush('config-get', ['system.site', 'page'], ['format' => 'json']);
+            $page = $this->getOutputFromJSON('system.site:page');
+            $this->assertContains('unish existing', $page['front'], 'Existing config was successfully imported during site:install.');
         }
 
         // Similar, but this time via --partial option.
         if (version_compare('8.8.0', \Drupal::VERSION, '>=')) {
-          $this->markTestSkipped('Partial config import not yet working on 8.8.0');
+            $this->markTestSkipped('Partial config import not yet working on 8.8.0');
         }
         $contents = file_get_contents($system_site_yml);
         $contents = preg_replace('/front: .*/', 'front: unish partial', $contents);

--- a/tests/functional/LanguageAddTest.php
+++ b/tests/functional/LanguageAddTest.php
@@ -35,7 +35,7 @@ class LanguageAddCase extends CommandUnishTestCase
 
     public function testLanguageAddWithTranslations()
     {
-        $info_yml = Path::join($this->webroot(), 'modules/unish/devel/devel.info.yml');
+        $info_yml = Path::join($this->webroot(), 'modules/unish/drush_empty_module/drush_empty_module.info.yml');
         if (strpos(file_get_contents($info_yml), 'project:') === false || $this->isWindows()) {
             $this->markTestSkipped('Devel dev snapshot detected. Incompatible with translation import.');
         }
@@ -49,19 +49,19 @@ class LanguageAddCase extends CommandUnishTestCase
         $this->drush('config-set', ['locale.settings', 'translation.use_source', 'locale']);
         $this->drush('config-set', ['locale.settings', 'translation.default_filename', '%project.%language.po']);
         $this->drush('config-set', ['locale.settings', 'translation.path', '../translations']);
-        $source = Path::join(__DIR__, 'resources/devel.nl.po');
+        $source = Path::join(__DIR__, 'resources/drush_empty_module.nl.po');
         $translationDir = Path::join($this->webroot(), '../translations');
         $this->mkdir($translationDir);
-        copy($source, Path::join($translationDir, 'devel.nl.po'));
+        copy($source, Path::join($translationDir, 'drush_empty_module.nl.po'));
 
-        $this->drush('pm-enable', ['devel']);
+        $this->drush('pm-enable', ['drush_empty_module']);
         $this->drush('language-add', ['nl']);
 
         $this->drush('watchdog-show', []);
         $this->assertContains('Translations imported:', $this->getSimplifiedOutput());
 
         // Clean up the mess this test creates.
-        unlink(Path::join($translationDir, 'devel.nl.po'));
+        unlink(Path::join($translationDir, 'drush_empty_module.nl.po'));
         rmdir($translationDir);
     }
 }

--- a/tests/functional/LocaleTest.php
+++ b/tests/functional/LocaleTest.php
@@ -17,40 +17,40 @@ class LocaleTest extends CommandUnishTestCase
         $this->drush('pm:enable', ['language', 'locale']);
         $this->drush('language:add', ['nl'], ['skip-translations' => null]);
 
-        $source = Path::join(__DIR__, '/resources/devel.nl.po');
+        $source = Path::join(__DIR__, '/resources/drush_empty_module.nl.po');
 
         $this->drush('locale:import', ['nl', $source]);
-        $this->assertTranslation('Devel', 'NL Devel', 'nl', 0);
+        $this->assertTranslation('Drush Empty Module', 'NL Drush Empty Module', 'nl', 0);
 
         // Import without override.
-        $this->drush('sql:query', ["UPDATE locales_target SET translation = 'NO Devel'"]);
-        $this->assertTranslation('Devel', 'NO Devel', 'nl', 0);
+        $this->drush('sql:query', ["UPDATE locales_target SET translation = 'NO Drush Empty Module'"]);
+        $this->assertTranslation('Drush Empty Module', 'NO Drush Empty Module', 'nl', 0);
         $this->drush('locale:import', ['nl', $source], ['override' => 'none']);
-        $this->assertTranslation('Devel', 'NO Devel', 'nl', 0);
+        $this->assertTranslation('Drush Empty Module', 'NO Drush Empty Module', 'nl', 0);
 
         // Import with override.
-        $this->drush('sql:query', ["UPDATE locales_target SET translation = 'NO Devel'"]);
-        $this->assertTranslation('Devel', 'NO Devel', 'nl', 0);
+        $this->drush('sql:query', ["UPDATE locales_target SET translation = 'NO Drush Empty Module'"]);
+        $this->assertTranslation('Drush Empty Module', 'NO Drush Empty Module', 'nl', 0);
         $this->drush('locale:import', ['nl', $source], ['override' => 'not-customized']);
-        $this->assertTranslation('Devel', 'NL Devel', 'nl', 0);
+        $this->assertTranslation('Drush Empty Module', 'NL Drush Empty Module', 'nl', 0);
 
         // Import without override of custom translation
-        $this->drush('sql:query', ["UPDATE locales_target SET translation = 'NO Devel', customized = 1"]);
-        $this->assertTranslation('Devel', 'NO Devel', 'nl', 1);
+        $this->drush('sql:query', ["UPDATE locales_target SET translation = 'NO Drush Empty Module', customized = 1"]);
+        $this->assertTranslation('Drush Empty Module', 'NO Drush Empty Module', 'nl', 1);
         $this->drush('locale:import', ['nl', $source], ['override' => 'not-customized']);
-        $this->assertTranslation('Devel', 'NO Devel', 'nl', 1);
+        $this->assertTranslation('Drush Empty Module', 'NO Drush Empty Module', 'nl', 1);
 
         // Import with override of custom translation.
-        $this->drush('sql:query', ["UPDATE locales_target SET translation = 'NO Devel', customized = 1"]);
-        $this->assertTranslation('Devel', 'NO Devel', 'nl', 1);
+        $this->drush('sql:query', ["UPDATE locales_target SET translation = 'NO Drush Empty Module', customized = 1"]);
+        $this->assertTranslation('Drush Empty Module', 'NO Drush Empty Module', 'nl', 1);
         $this->drush('locale:import', ['nl', $source], ['override' => 'customized']);
-        $this->assertTranslation('Devel', 'NL Devel', 'nl', 0);
+        $this->assertTranslation('Drush Empty Module', 'NL Drush Empty Module', 'nl', 0);
 
         // Import with override of custom translation as customized.
-        $this->drush('sql:query', ["UPDATE locales_target SET translation = 'NO Devel', customized = 1"]);
-        $this->assertTranslation('Devel', 'NO Devel', 'nl', 1);
+        $this->drush('sql:query', ["UPDATE locales_target SET translation = 'NO Drush Empty Module', customized = 1"]);
+        $this->assertTranslation('Drush Empty Module', 'NO Drush Empty Module', 'nl', 1);
         $this->drush('locale:import', ['nl', $source], ['type' => 'customized', 'override' => 'customized']);
-        $this->assertTranslation('Devel', 'NL Devel', 'nl', 1);
+        $this->assertTranslation('Drush Empty Module', 'NL Drush Empty Module', 'nl', 1);
     }
 
     /**

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -23,13 +23,13 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
         // Test that pm-list lists uninstalled modules.
         $this->drush('pm-list', [], ['no-core' => null, 'status' => 'disabled']);
         $out = $this->getOutput();
-        $this->assertContains('devel', $out);
+        $this->assertContains('drush_empty_module', $out);
 
         // Test pm-enable enables a module, and pm-list verifies that.
-        $this->drush('pm-enable', ['devel']);
+        $this->drush('pm-enable', ['drush_empty_module']);
         $this->drush('pm-list', [], ['status' => 'enabled']);
         $out = $this->getOutput();
-        $this->assertContains('devel', $out);
+        $this->assertContains('drush_empty_module', $out);
 
         $this->drush('core:status', [], ['field' => 'drupal-version']);
         $drupal_version = $this->getOutputRaw();
@@ -46,7 +46,7 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
 
         // Test cache was cleared after enabling a module.
         $table = 'router';
-        $path = '/admin/config/development/devel';
+        $path = '/admin/config/development/drush_empty_module';
         $this->drush('sql-query', ["SELECT path FROM $table WHERE path = '$path';"]);
         $list = $this->getOutputAsList();
         $this->assertTrue(in_array($path, $list), 'Cache was cleared after modules were enabled');
@@ -54,12 +54,12 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
         // Test pm-list filtering.
         $this->drush('pm-list', [], ['package' => 'Core']);
         $out = $this->getOutput();
-        $this->assertNotContains('devel', $out, 'Devel is not part of core package');
+        $this->assertNotContains('drush_empty_module', $out, 'Drush Empty Module is not part of core package');
 
         // Test module uninstall.
-        $this->drush('pm-uninstall', ['devel']);
+        $this->drush('pm-uninstall', ['drush_empty_module']);
         $this->drush('pm-list', [], ['status' => 'disabled', 'type' => 'module']);
         $out = $this->getOutput();
-        $this->assertContains('devel', $out);
+        $this->assertContains('drush_empty_module', $out);
     }
 }

--- a/tests/functional/PmEnLocaleImportTest.php
+++ b/tests/functional/PmEnLocaleImportTest.php
@@ -16,7 +16,7 @@ class PmEnLocaleImportCase extends CommandUnishTestCase
 
     public function testBatchImportTranslations()
     {
-        $info_yml = Path::join($this->webroot(), 'modules/unish/devel/devel.info.yml');
+        $info_yml = Path::join($this->webroot(), 'modules/unish/drush_empty_module/drush_empty_module.info.yml');
         if (strpos(file_get_contents($info_yml), 'project:') === false || $this->isWindows()) {
             $this->markTestSkipped('Devel dev snapshot detected. Incompatible with translation import.');
         }
@@ -33,19 +33,19 @@ class PmEnLocaleImportCase extends CommandUnishTestCase
         $this->drush('config-set', ['locale.settings', 'translation.use_source', 'locale']);
         $this->drush('config-set', ['locale.settings', 'translation.default_filename', '%project.%language.po']);
         $this->drush('config-set', ['locale.settings', 'translation.path', '../translations']);
-        $source = Path::join(__DIR__, 'resources/devel.nl.po');
+        $source = Path::join(__DIR__, 'resources/drush_empty_module.nl.po');
         $translationDir = Path::join($root, '../translations');
         $this->mkdir($translationDir);
-        copy($source, Path::join($translationDir, 'devel.nl.po'));
+        copy($source, Path::join($translationDir, 'drush_empty_module.nl.po'));
 
         $this->drush('language-add', ['nl']);
 
-        $this->drush('pm-enable', ['devel']);
+        $this->drush('pm-enable', ['drush_empty_module']);
         $this->drush('watchdog-show');
         $this->assertContains('Translations imported:', $this->getSimplifiedOutput());
 
         // Clean up the mess this test creates.
-        unlink(Path::join($translationDir, 'devel.nl.po'));
+        unlink(Path::join($translationDir, 'drush_empty_module.nl.po'));
         rmdir($translationDir);
     }
 }

--- a/tests/functional/UpdateDBTest.php
+++ b/tests/functional/UpdateDBTest.php
@@ -17,7 +17,7 @@ class UpdateDBTest extends CommandUnishTestCase
     public function testUpdateDBStatus()
     {
         $this->setUpDrupal(1, true);
-        $this->drush('pm:enable', ['devel']);
+        $this->drush('pm:enable', ['drush_empty_module']);
         $this->drush('updatedb:status');
         $err = $this->getErrorOutput();
         $this->assertContains('[success] No database updates required.', $err);
@@ -27,8 +27,8 @@ class UpdateDBTest extends CommandUnishTestCase
 
         // Assert that pending hook_update_n appears
         $this->drush('updatedb:status', [], ['format' => 'json']);
-        $out = $this->getOutputFromJSON('devel_update_8002');
-        $this->assertContains('Add enforced dependencies to system.menu.devel', trim($out['description']));
+        $out = $this->getOutputFromJSON('drush_empty_module_update_8001');
+        $this->assertContains('Fake update hook', trim($out['description']));
 
         // Run hook_update_n
         $this->drush('updatedb', []);
@@ -39,10 +39,10 @@ class UpdateDBTest extends CommandUnishTestCase
         $this->assertContains('[success] No database updates required.', $err);
 
         // Assure that a pending post-update is reported.
-        $this->pathPostUpdate = Path::join($this->webroot(), 'modules/unish/devel/devel.post_update.php');
-        copy(__DIR__ . '/resources/devel.post_update.php', $this->pathPostUpdate);
+        $this->pathPostUpdate = Path::join($this->webroot(), 'modules/unish/drush_empty_module/drush_empty_module.post_update.php');
+        copy(__DIR__ . '/resources/drush_empty_module.post_update.php', $this->pathPostUpdate);
         $this->drush('updatedb:status', [], ['format' => 'json']);
-        $out = $this->getOutputFromJSON('devel-post-null_op');
+        $out = $this->getOutputFromJSON('drush_empty_module-post-null_op');
         $this->assertContains('This is a test of the emergency broadcast system.', trim($out['description']));
     }
 
@@ -200,8 +200,8 @@ class UpdateDBTest extends CommandUnishTestCase
         $this->setupModulesForTests(['woot'], Path::join(__DIR__, 'resources/modules/d8'));
         $this->drush('pm-enable', ['woot'], $options);
 
-        // Force re-run of the post-update woot_post_update_install_devel().
-        $this->forcePostUpdate('woot_post_update_install_devel', $options);
+        // Force re-run of the post-update woot_post_update_install_drush_empty_module().
+        $this->forcePostUpdate('woot_post_update_install_drush_empty_module', $options);
 
         // Force a flush of the dependency injection container, so that we can
         // test that the container can be correctly rebuilt even if new services
@@ -214,14 +214,14 @@ class UpdateDBTest extends CommandUnishTestCase
         $serviceDefinition = <<<YAML_FRAGMENT
   woot.depending_service:
     class: Drupal\woot\DependingService
-    arguments: ['@devel.dumper']
+    arguments: ['@drush_empty_module.service']
 YAML_FRAGMENT;
         file_put_contents($filename, $serviceDefinition, FILE_APPEND);
 
         $filename = Path::join($root, 'modules/unish/woot/woot.info.yml');
         $moduleDependency = <<<YAML_FRAGMENT
 dependencies:
-  - devel
+  - drush_empty_module
 YAML_FRAGMENT;
         file_put_contents($filename, $moduleDependency, FILE_APPEND);
 

--- a/tests/functional/resources/drush_empty_module.nl.po
+++ b/tests/functional/resources/drush_empty_module.nl.po
@@ -1,8 +1,8 @@
-# Mock Dutch translation of Devel
+# Mock Dutch translation of Drush Empty Module
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Devel\n"
+"Project-Id-Version: Drush Empty Module\n"
 "POT-Creation-Date: 2016-12-18 21:58+0000\n"
 "PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Language-Team: Dutch\n"
@@ -11,5 +11,5 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-msgid "Devel"
-msgstr "NL Devel"
+msgid "Drush Empty Module"
+msgstr "NL Drush Empty Module"

--- a/tests/functional/resources/drush_empty_module.post_update.php
+++ b/tests/functional/resources/drush_empty_module.post_update.php
@@ -3,7 +3,7 @@
 /**
  * This is a test of the emergency broadcast system.
  */
-function devel_post_update_null_op(&$sandbox = null)
+function drush_empty_module_post_update_null_op(&$sandbox = null)
 {
     $sandbox['#finished'] = 1;
     return t('Done doing nothing.');

--- a/tests/functional/resources/modules/d8/woot/src/DependingService.php
+++ b/tests/functional/resources/modules/d8/woot/src/DependingService.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\woot;
 
-use Drupal\devel\DevelDumperManagerInterface;
+use Drupal\drush_empty_module\MuchServiceManyWow;
 
 /**
  * Test service that depends on another service.
@@ -23,12 +23,12 @@ class DependingService
 {
 
     /**
-     * @var \Drupal\devel\DevelDumperManagerInterface
+     * @var \Drupal\drush_empty_module\MuchServiceManyWow
      */
-    protected $develDumperManager;
+    protected $muchServiceManyWow;
 
-    public function __construct(DevelDumperManagerInterface $develDumperManager)
+    public function __construct(MuchServiceManyWow $muchServiceManyWow)
     {
-        $this->develDumperManager = $develDumperManager;
+        $this->muchServiceManyWow = $muchServiceManyWow;
     }
 }

--- a/tests/functional/resources/modules/d8/woot/woot.post_update.php
+++ b/tests/functional/resources/modules/d8/woot/woot.post_update.php
@@ -21,9 +21,9 @@ function woot_post_update_failing()
 /**
  * Install the Devel module.
  */
-function woot_post_update_install_devel()
+function woot_post_update_install_drush_empty_module()
 {
-    \Drupal::service('module_installer')->install(['devel']);
+    \Drupal::service('module_installer')->install(['drush_empty_module']);
 }
 
 /**

--- a/tests/functional/resources/updatedb_script.php
+++ b/tests/functional/resources/updatedb_script.php
@@ -1,5 +1,6 @@
 <?php
 
-// Set the schema version of devel to a lower version, so we have a pending update.
-$current = drupal_get_installed_schema_version('devel');
-drupal_set_installed_schema_version('devel', $current - 1);
+// Set the schema version of drush_empty_module to a lower version, so we have a
+// pending update.
+$current = drupal_get_installed_schema_version('drush_empty_module');
+drupal_set_installed_schema_version('drush_empty_module', $current - 1);

--- a/tests/integration/CoreTest.php
+++ b/tests/integration/CoreTest.php
@@ -60,15 +60,15 @@ class CoreTest extends UnishIntegrationTestCase
         $output = $this->getOutput();
         $this->assertEquals(Path::join($root, $sitewide . '/modules'), $output);
 
-        $this->drush('pm-enable', ['devel']);
-        $this->drush('theme-enable', ['empty_theme']);
+        $this->drush('pm-enable', ['drush_empty_module']);
+        $this->drush('theme-enable', ['drush_empty_theme']);
 
-        $this->drush('drupal-directory', ['devel']);
+        $this->drush('drupal-directory', ['drush_empty_module']);
         $output = $this->getOutput();
-        $this->assertEquals(Path::join($root, '/modules/unish/devel'), $output);
+        $this->assertEquals(Path::join($root, '/modules/unish/drush_empty_module'), $output);
 
-        $this->drush('drupal-directory', ['empty_theme']);
+        $this->drush('drupal-directory', ['drush_empty_theme']);
         $output = $this->getOutput();
-        $this->assertEquals(Path::join($root, '/themes/unish/empty_theme'), $output);
+        $this->assertEquals(Path::join($root, '/themes/unish/drush_empty_theme'), $output);
     }
 }


### PR DESCRIPTION
Removes test dependency on devel and empty_theme by adding mock module and themes for the same purposes

I tried to remove the dependency on `drupal/alink` too, but unfortunately SecurityUpdatesTest expects to find an insecure module in composer.lock.

I don't know if that can be gotten around.