### PR TITLE
Added additional content type for gzip found on 7.4

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -975,6 +975,7 @@ function drush_file_is_tarball($path) {
   $supported = array(
     'application/x-bzip2',
     'application/x-gzip',
+    'application/gzip',
     'application/x-tar',
     'application/x-zip',
     'application/zip',


### PR DESCRIPTION
Using Drush 8.x on PHP 7.4.0RC5 produces issues when trying to run `drush dl [project]` as drush is not seeing this as a proper mime type.

To reproduce this I ran the following command:

```
drush dl --default-major=7 registry_rebuild --destination=$HOME/.drush
``` 

and it produces the following error:

```
Unable to extract /tmp/drush_tmp_1572887476_5dc05bb4f30ee/registry_rebuild-7.x-2.5.tar.gz. Unknown archive format. [error]
```

I was able to confirm this using the following method:

```
cd /tmp
wget https://ftp.drupal.org/files/projects/registry_rebuild-7.x-2.5.tar.gz
```

and then running the following PHP test which mimics the following: https://github.com/drush-ops/drush/blob/8.x/includes/drush.inc#L893-L894

```
php > $finfo = new finfo(FILEINFO_MIME_TYPE);
php > $content_type = $finfo->file('/tmp/registry_rebuild-7.x-2.5.tar.gz');
php > echo $content_type;
application/gzip
```