### PR TITLE
Replace twig_render_template() with \Drupal::service('twig')->loadTemplate()

### DIFF
--- a/src/Drupal/Commands/core/TwigCommands.php
+++ b/src/Drupal/Commands/core/TwigCommands.php
@@ -126,7 +126,7 @@ class TwigCommands extends DrushCommands
         foreach ($files as $file) {
             $relative = Path::makeRelative($file->getRealPath(), Drush::bootstrapManager()->getRoot());
             // Loading the template ensures the compiled template is cached.
-            \Drupal::service('twig')->loadTemplate($relative);
+            $this->getTwig()->loadTemplate($relative);
             $this->logger()->success(dt('Compiled twig template !path', ['!path' => $relative]));
         }
     }

--- a/src/Drupal/Commands/core/TwigCommands.php
+++ b/src/Drupal/Commands/core/TwigCommands.php
@@ -125,8 +125,8 @@ class TwigCommands extends DrushCommands
         ->in($searchpaths);
         foreach ($files as $file) {
             $relative = Path::makeRelative($file->getRealPath(), Drush::bootstrapManager()->getRoot());
-            // @todo Dynamically disable twig debugging since there is no good info there anyway.
-            twig_render_template($relative, ['theme_hook_original' => '']);
+            // Loading the template ensures the compiled template is cached.
+            \Drupal::service('twig')->loadTemplate($relative);
             $this->logger()->success(dt('Compiled twig template !path', ['!path' => $relative]));
         }
     }


### PR DESCRIPTION
Loading the template ensures the compiled template is cached. It is not necessary to also render it.

drush-ops/drush#1969
