### PR TITLE
Fix #4293. Stop using CONFIG_ACTIVE_DIRECTORY and especially CONFIG_SYNC_DIRECTORY.

### DIFF
--- a/includes/legacy.inc
+++ b/includes/legacy.inc
@@ -27,15 +27,14 @@ function drush_file_directory_temp()
  * settings.php.
  *
  * @param string $type
- *   The type of config directory to return. Drupal core provides the
- *   CONFIG_SYNC_DIRECTORY constant to access the sync directory.
+ *   The type of config directory to return.
  *
  * @return string
  *   The configuration directory path.
  *
  * @throws \Exception
  */
-function drush_config_get_config_directory($type) {
+function drush_config_get_config_directory($type = 'sync') {
     if (drush_drupal_major_version() >= 9) {
         return Settings::get('config_sync_directory');
     }

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -84,7 +84,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
 
         // Was giving error during validate() so its here for now.
         if ($options['existing-config']) {
-            $existing_config_dir = drush_config_get_config_directory(CONFIG_SYNC_DIRECTORY);
+            $existing_config_dir = drush_config_get_config_directory();
             if (!is_dir($existing_config_dir)) {
                 throw new \Exception(dt('Existing config directory @dir not found', ['@dir' => $existing_config_dir]));
             }
@@ -175,7 +175,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
         // @todo Arguably Drupal core [$boot->getKernel()->getInstallProfile()] could do this - https://github.com/drupal/drupal/blob/8.6.x/core/lib/Drupal/Core/DrupalKernel.php#L1606 reads from DB storage but not file storage.
         if (empty($profile) && $options['existing-config']) {
             FileCacheFactory::setConfiguration([FileCacheFactory::DISABLE_CACHE => true]);
-            $source_storage = new FileStorage(drush_config_get_config_directory(CONFIG_SYNC_DIRECTORY));
+            $source_storage = new FileStorage(drush_config_get_config_directory());
             if (!$source_storage->exists('core.extension')) {
                 throw new \Exception('Existing configuration directory not found or does not contain a core.extension.yml file.".');
             }

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -348,7 +348,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface
             }
         } else {
             // If a directory isn't specified, use the label argument or default sync directory.
-            $return = \drush_config_get_config_directory($label ?: CONFIG_SYNC_DIRECTORY);
+            $return = \drush_config_get_config_directory($label ?: 'sync');
         }
         return Path::canonicalize($return);
     }
@@ -377,7 +377,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface
      */
     public function getStorage($directory)
     {
-        if ($directory == Path::canonicalize(\drush_config_get_config_directory(CONFIG_SYNC_DIRECTORY))) {
+        if ($directory == Path::canonicalize(\drush_config_get_config_directory())) {
             return \Drupal::service('config.storage.sync');
         } else {
             return new FileStorage($directory);
@@ -454,7 +454,9 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface
         $option_name = $input->hasOption('destination') ? 'destination' : 'source';
         if (empty($input->getArgument('label') && empty($input->getOption($option_name)))) {
             $choices = drush_map_assoc(array_keys($config_directories));
-            unset($choices[CONFIG_ACTIVE_DIRECTORY]);
+            if (drush_drupal_major_version() == 8) {
+                unset($choices[CONFIG_ACTIVE_DIRECTORY]);
+            }
             if (count($choices) >= 2) {
                 $label = $this->io()->choice('Choose a '. $option_name, $choices);
                 $input->setArgument('label', $label);

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -449,14 +449,17 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface
      */
     public function interactConfigLabel(InputInterface $input, ConsoleOutputInterface $output)
     {
+        if (drush_drupal_major_version() >= 9) {
+            // Nothing to do.
+            return;
+        }
+
         global $config_directories;
 
         $option_name = $input->hasOption('destination') ? 'destination' : 'source';
         if (empty($input->getArgument('label') && empty($input->getOption($option_name)))) {
             $choices = drush_map_assoc(array_keys($config_directories));
-            if (drush_drupal_major_version() == 8) {
-                unset($choices[CONFIG_ACTIVE_DIRECTORY]);
-            }
+            unset($choices[CONFIG_ACTIVE_DIRECTORY]);
             if (count($choices) >= 2) {
                 $label = $this->io()->choice('Choose a '. $option_name, $choices);
                 $input->setArgument('label', $label);

--- a/src/Drupal/Commands/config/ConfigExportCommands.php
+++ b/src/Drupal/Commands/config/ConfigExportCommands.php
@@ -123,7 +123,7 @@ class ConfigExportCommands extends DrushCommands
     public function doExport($options, $destination_dir)
     {
         // Prepare the configuration storage for the export.
-        if ($destination_dir ==  Path::canonicalize(\drush_config_get_config_directory(CONFIG_SYNC_DIRECTORY))) {
+        if ($destination_dir ==  Path::canonicalize(\drush_config_get_config_directory())) {
             $target_storage = $this->getConfigStorageSync();
         } else {
             $target_storage = new FileStorage($destination_dir);

--- a/src/Drupal/Commands/config/ConfigImportCommands.php
+++ b/src/Drupal/Commands/config/ConfigImportCommands.php
@@ -216,7 +216,7 @@ class ConfigImportCommands extends DrushCommands
         $source_storage_dir = ConfigCommands::getDirectory($label, $options['source']);
 
         // Prepare the configuration storage for the import.
-        if ($source_storage_dir == Path::canonicalize(\drush_config_get_config_directory(CONFIG_SYNC_DIRECTORY))) {
+        if ($source_storage_dir == Path::canonicalize(\drush_config_get_config_directory())) {
             $source_storage = $this->getConfigStorageSync();
         } else {
             $source_storage = new FileStorage($source_storage_dir);


### PR DESCRIPTION
Avoids D9 warnings.