### PR TITLE
Fix #4098. Stop using sql.db-su.

### DIFF
--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -97,7 +97,7 @@ EOT;
         }
         $sql[] = sprintf('DROP DATABASE IF EXISTS %s;', $dbname);
         $sql[] = sprintf('CREATE DATABASE %s /*!40100 DEFAULT CHARACTER SET utf8 */;', $dbname);
-        $db_superuser = $this->getConfig()->get('sql.db-su');
+        $db_superuser = $this->getOption('db-su');
         if (isset($db_superuser)) {
             // - For a localhost database, create a localhost user.  This is important for security.
             //   localhost is special and only allows local Unix socket file connections.


### PR DESCRIPTION
Now consistent with https://github.com/drush-ops/drush/commit/9b11884c12449c2413fd154b0bffe7d06d0c3797 and https://github.com/drush-ops/drush/pull/3998. 

This may cause some backward compat issues but its a bug fix. No backport for that reason.