### PR TITLE
Escape command name in RedispatchToSiteLocal.

### DIFF
--- a/src/Preflight/RedispatchToSiteLocal.php
+++ b/src/Preflight/RedispatchToSiteLocal.php
@@ -46,7 +46,7 @@ class RedispatchToSiteLocal
         }
 
         // Redispatch!
-        $command = $siteLocalDrush;
+        $command = escapeshellarg($siteLocalDrush);
         $preflightLog->log(dt('Redispatch to site-local Drush: !cmd.', ['!cmd' => $command]));
         array_shift($argv);
         $args = array_map(


### PR DESCRIPTION
Escape the command name in RedispatchToSiteLocal, making it possible to use a globally installed drush from a Drupal directory with a name containing spaces.

Fuller description of the issue in https://github.com/drush-ops/drush/issues/4306.