### PR TITLE
Add missing base theme key and remove system_rebuild_module_data().

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,9 @@ jobs:
   #   Determines whether a newer version of a dependency has broken Drush.
   test_72_drupal89:
     <<: *defaults
+    # override for just this image.
+    environment:
+      SYMFONY_DEPRECATIONS_HELPER: enabled
     docker:
       - image: wodby/php:7.2
         environment:

--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -5,6 +5,7 @@ use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Extension\MissingDependencyException;
+use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Extension\ThemeHandlerInterface;
 use Drush\Commands\DrushCommands;
@@ -21,12 +22,15 @@ class PmCommands extends DrushCommands
 
     protected $themeHandler;
 
-    public function __construct(ConfigFactoryInterface $configFactory, ModuleInstallerInterface $moduleInstaller, ThemeHandlerInterface $themeHandler)
+    protected $extensionListModule;
+
+    public function __construct(ConfigFactoryInterface $configFactory, ModuleInstallerInterface $moduleInstaller, ThemeHandlerInterface $themeHandler, ModuleExtensionList $extensionListModule)
     {
         parent::__construct();
         $this->configFactory = $configFactory;
         $this->moduleInstaller = $moduleInstaller;
         $this->themeHandler = $themeHandler;
+        $this->extensionListModule = $extensionListModule;
     }
 
     /**
@@ -51,6 +55,14 @@ class PmCommands extends DrushCommands
     public function getThemeHandler()
     {
         return $this->themeHandler;
+    }
+
+    /**
+     * @return \Drupal\Core\Extension\ModuleExtensionList
+     */
+    public function getExtensionListModule()
+    {
+        return $this->extensionListModule;
     }
 
     /**
@@ -156,8 +168,8 @@ class PmCommands extends DrushCommands
     public function pmList($options = ['format' => 'table', 'type' => 'module,theme', 'status' => 'enabled,disabled', 'package' => self::REQ, 'core' => false, 'no-core' => false])
     {
         $rows = [];
-        // @todo Update this and other usages once Drupal 8.5 is unsupported by Drush https://www.drupal.org/node/2709919.
-        $modules = \system_rebuild_module_data();
+
+        $modules = $this->getExtensionListModule()->getList();
         $themes = $this->getThemeHandler()->rebuildThemeData();
         $both = array_merge($modules, $themes);
 
@@ -240,7 +252,7 @@ class PmCommands extends DrushCommands
 
     public function addInstallDependencies($modules)
     {
-        $module_data = system_rebuild_module_data();
+        $module_data = $this->getExtensionListModule()->reset()->getList();
         $module_list  = array_combine($modules, $modules);
         if ($missing_modules = array_diff_key($module_list, $module_data)) {
             // One or more of the given modules doesn't exist.
@@ -274,7 +286,7 @@ class PmCommands extends DrushCommands
     public function addUninstallDependencies($modules)
     {
         // Get all module data so we can find dependencies and sort.
-        $module_data = system_rebuild_module_data();
+        $module_data = $this->getExtensionListModule()->reset()->getList();
         $module_list = array_combine($modules, $modules);
         if ($diff = array_diff_key($module_list, $module_data)) {
             throw new \Exception(dt('A specified extension does not exist: !diff', ['!diff' => implode(',', $diff)]));

--- a/src/Drupal/Commands/pm/drush.services.yml
+++ b/src/Drupal/Commands/pm/drush.services.yml
@@ -1,7 +1,7 @@
 services:
   pm.commands:
     class: \Drush\Drupal\Commands\pm\PmCommands
-    arguments: ['@config.factory', '@module_installer', '@theme_handler']
+    arguments: ['@config.factory', '@module_installer', '@theme_handler', '@extension.list.module']
     tags:
       -  { name: drush.command }
   theme.commands:

--- a/sut/themes/unish/drush_empty_theme/drush_empty_theme.info.yml
+++ b/sut/themes/unish/drush_empty_theme/drush_empty_theme.info.yml
@@ -2,3 +2,4 @@ name: Drush empty theme
 description: 'Drush empty theme'
 core: 8.x
 type: theme
+base theme: stable

--- a/tests/unish/UnishTestCase.php
+++ b/tests/unish/UnishTestCase.php
@@ -691,7 +691,8 @@ EOT;
             'db-url' => $this->dbUrl($uri),
             'sites-subdir' => $uri,
             'yes' => true,
-            'quiet' => true,
+            // quiet suppresses error reporting as well.
+            // 'quiet' => true,
         ];
         if ($level = $this->logLevel()) {
             $options[$level] = true;


### PR DESCRIPTION
Fixes Drupal 9 install error.