### PR TITLE
Unsupport Drush 9 as of May 2020

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -39,7 +39,7 @@ Drupal Compatibility
     <td> Drush 9 </td>
     <td> 9.x </td>
     <td> 5.6+ </td>
-    <td></td> <td></td> <td></td> <td>✅</td> <td></td>
+    <td></td> <td></td> <td></td> <td>✓</td> <td></td>
   </tr>
   <tr>
     <td> Drush 8 </td>


### PR DESCRIPTION
Drush 9 will be minimally maintained until May 1, 2020. Sites are encouraged to upgrade to Drush 10. The command APIs have not changed - just a few deprecated functions are removed. Most commandfiles will just work. Feel free to use [#drush on Drupal Slack](https://drupal.slack.com/archives/C62H9CWQM) for discussion.

Drush 8 is still supported for sites that are on older versions of Drupal or PHP. See bottom of [Install docs](http://docs.drush.org/en/master/install/).