### PR TITLE
Fixes drush.yml not discovered in sites/default

### DIFF
--- a/src/Config/ConfigLocator.php
+++ b/src/Config/ConfigLocator.php
@@ -280,7 +280,7 @@ class ConfigLocator
         // Remember that we've seen this location.
         $this->siteRoots[] = $siteRoot;
 
-        $this->addConfigPaths(self::DRUPAL_CONTEXT, [ dirname($siteRoot) . '/drush', "$siteRoot/drush", "$siteRoot/sites/all/drush" ]);
+        $this->addConfigPaths(self::DRUPAL_CONTEXT, [ dirname($siteRoot) . '/drush', "$siteRoot/drush", "$siteRoot/sites/all/drush", "$siteRoot/sites/default" ]);
         return $this;
     }
 
@@ -486,7 +486,7 @@ class ConfigLocator
      */
     protected function getSiteCommandFilePaths($root)
     {
-        $directories = ["$root/drush", dirname($root) . '/drush', "$root/sites/all/drush"];
+        $directories = ["$root/drush", dirname($root) . '/drush', "$root/sites/all/drush", "$root/sites/default"];
 
         return array_filter($directories, 'is_dir');
     }

--- a/src/Config/ConfigLocator.php
+++ b/src/Config/ConfigLocator.php
@@ -486,7 +486,7 @@ class ConfigLocator
      */
     protected function getSiteCommandFilePaths($root)
     {
-        $directories = ["$root/drush", dirname($root) . '/drush', "$root/sites/all/drush", "$root/sites/default"];
+        $directories = ["$root/drush", dirname($root) . '/drush', "$root/sites/all/drush"];
 
         return array_filter($directories, 'is_dir');
     }

--- a/tests/fixtures/sites/default/drush.yml
+++ b/tests/fixtures/sites/default/drush.yml
@@ -1,0 +1,2 @@
+test:
+  default: 'A default setting'

--- a/tests/unit/ConfigLocatorTest.php
+++ b/tests/unit/ConfigLocatorTest.php
@@ -35,6 +35,7 @@ class ConfigLocatorTest extends TestCase
         $this->assertEquals($this->fixturesDir() . '/etc/drush/drushVARIANT.yml', Path::canonicalize($sources['test']['variant']));
         $this->assertEquals($this->fixturesDir() . '/home/.drush/drush.yml', Path::canonicalize($sources['test']['home']));
         $this->assertEquals($this->fixturesDir() . '/sites/d8/drush/drush.yml', Path::canonicalize($sources['test']['site']));
+        $this->assertEquals($this->fixturesDir() . '/sites/default/drush.yml', Path::canonicalize($sources['test']['default']));
         $this->assertEquals($this->environment()->drushBasePath() . '/drush.yml', Path::canonicalize($sources['drush']['php']['minimum-version']));
 
         $config = $configLocator->config();
@@ -43,6 +44,7 @@ class ConfigLocatorTest extends TestCase
         $this->assertEquals('A system-wide setting', $config->get('test.system'));
         $this->assertEquals('A user-specific setting', $config->get('test.home'));
         $this->assertEquals('A site-specific setting', $config->get('test.site'));
+        $this->assertEquals('A default setting', $config->get('test.default'));
         $this->assertTrue($config->has('drush.php.minimum-version'));
     }
 


### PR DESCRIPTION
Fixes that drush.yml isn't discovered in for example web/sites/default/drush.yml, see #4324 .