### PR TITLE
use defaults-extra-file instead of defaults-file

### DIFF
--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -31,7 +31,7 @@ password="{$dbSpec['password']}"
 EOT;
 
             $file = drush_save_data_to_temp_file($contents);
-            $parameters['defaults-file'] = $file;
+            $parameters['defaults-extra-file'] = $file;
         } else {
             // User is required. Drupal calls it 'username'. MySQL calls it 'user'.
             $parameters['user'] = $dbSpec['username'];


### PR DESCRIPTION
use defaults-extra-file for creds instead of defaults-file so mysqldump still reads the global defaults for setting stuff like "set-gtid-purged=OFF"