### PR TITLE
Add pm:security-php command for checking PHP dependencies for vulnerabilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
   "require-dev": {
     "composer/installers": "^1.7",
     "cweagans/composer-patches": "~1.0",
+    "david-garcia/phpwhois": "4.3.0",
     "drupal/core-recommended": "^8.8",
     "drupal/alinks": "1.0.0",
     "g1a/composer-test-scenarios": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "687c56451fd255ea7d7c95ea939b8e37",
+    "content-hash": "fe97971dd34c30bd115742ab1fbb34c7",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",
@@ -2512,6 +2512,71 @@
             "time": "2019-08-29T20:11:49+00:00"
         },
         {
+            "name": "david-garcia/phpwhois",
+            "version": "4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DavidGarciaCat/phpWhois.git",
+                "reference": "652e8b3c4e22bab934baebb53740c9d2d8c05cd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DavidGarciaCat/phpWhois/zipball/652e8b3c4e22bab934baebb53740c9d2d8c05cd6",
+                "reference": "652e8b3c4e22bab934baebb53740c9d2d8c05cd6",
+                "shasum": ""
+            },
+            "require": {
+                "mso/idna-convert": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.4.1"
+            },
+            "suggest": {
+                "lib-openssl": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpWhois\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Jeftovic",
+                    "email": "markjr@easydns.com"
+                },
+                {
+                    "name": "David Saez Padros",
+                    "email": "david@ols.es"
+                },
+                {
+                    "name": "Ross Golder",
+                    "email": "ross@golder.org"
+                },
+                {
+                    "name": "Dmitry Lukashin",
+                    "email": "dmitry@lukashin.ru"
+                },
+                {
+                    "name": "David Garcia",
+                    "email": "me@davidgarcia.cat"
+                }
+            ],
+            "description": "phpWhois - library for querying whois services and parsing results. Based on phpwhois.org",
+            "homepage": "http://phpwhois.pw",
+            "keywords": [
+                "php",
+                "phpwhois",
+                "whois"
+            ],
+            "time": "2017-08-30T22:37:26+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "v1.4.0",
             "source": {
@@ -3718,6 +3783,224 @@
             "time": "2019-07-01T23:21:34+00:00"
         },
         {
+            "name": "laminas/laminas-escaper",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-escaper.git",
+                "reference": "25f2a053eadfa92ddacb609dcbbc39362610da70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/25f2a053eadfa92ddacb609dcbbc39362610da70",
+                "reference": "25f2a053eadfa92ddacb609dcbbc39362610da70",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-escaper": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "escaper",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:43:30+00:00"
+        },
+        {
+            "name": "laminas/laminas-feed",
+            "version": "2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-feed.git",
+                "reference": "64d25e18a6ea3db90c27fe2d6b95630daa1bf602"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-feed/zipball/64d25e18a6ea3db90c27fe2d6b95630daa1bf602",
+                "reference": "64d25e18a6ea3db90c27fe2d6b95630daa1bf602",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "laminas/laminas-escaper": "^2.5.2",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-feed": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-cache": "^2.7.2",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-db": "^2.8.2",
+                "laminas/laminas-http": "^2.7",
+                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
+                "laminas/laminas-validator": "^2.10.1",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "psr/http-message": "^1.0.1"
+            },
+            "suggest": {
+                "laminas/laminas-cache": "Laminas\\Cache component, for optionally caching feeds between requests",
+                "laminas/laminas-db": "Laminas\\Db component, for use with PubSubHubbub",
+                "laminas/laminas-http": "Laminas\\Http for PubSubHubbub, and optionally for use with Laminas\\Feed\\Reader",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component, for easily extending ExtensionManager implementations",
+                "laminas/laminas-validator": "Laminas\\Validator component, for validating email addresses used in Atom feeds and entries when using the Writer subcomponent",
+                "psr/http-message": "PSR-7 ^1.0.1, if you wish to use Laminas\\Feed\\Reader\\Http\\Psr7ResponseDecorator"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.12.x-dev",
+                    "dev-develop": "2.13.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Feed\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides functionality for consuming RSS and Atom feeds",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "feed",
+                "laminas"
+            ],
+            "time": "2019-12-31T16:46:54+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "2b18347625a2f06a1a485acfbc870f699dbe51c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/2b18347625a2f06a1a485acfbc870f699dbe51c6",
+                "reference": "2b18347625a2f06a1a485acfbc870f699dbe51c6",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-stdlib": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "stdlib"
+            ],
+            "time": "2019-12-31T17:51:15+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/0fb9675b84a1666ab45182b6c5b29956921e818d",
+                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev",
+                    "dev-develop": "1.1.x-dev"
+                },
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "time": "2020-01-07T22:58:31+00:00"
+        },
+        {
             "name": "lox/xhprof",
             "version": "dev-master",
             "source": {
@@ -3820,6 +4103,55 @@
                 "xml"
             ],
             "time": "2017-09-04T12:26:28+00:00"
+        },
+        {
+            "name": "mso/idna-convert",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/algo26-matthias/idna-convert.git",
+                "reference": "2717d05713454991936bc581d068c6cea0d84e3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/2717d05713454991936bc581d068c6cea0d84e3b",
+                "reference": "2717d05713454991936bc581d068c6cea0d84e3b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "php": ">=5.6.0"
+            },
+            "suggest": {
+                "ext-iconv": "Install ext/iconv for using input / output other than UTF-8 or ISO-8859-1",
+                "ext-mbstring": "Install ext/mbstring for using input / output other than UTF-8 or ISO-8859-1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Algo26\\IdnaConvert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1+"
+            ],
+            "authors": [
+                {
+                    "name": "Matthias Sommerfeld",
+                    "email": "matthias.sommerfeld@algo26.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A library for encoding and decoding internationalized domain names",
+            "homepage": "http://idnaconv.net/",
+            "keywords": [
+                "idn",
+                "idna",
+                "php"
+            ],
+            "abandoned": "algo26-matthias/idna-convert",
+            "time": "2019-03-04T17:07:46+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -6761,163 +7093,6 @@
             ],
             "abandoned": "laminas/laminas-diactoros",
             "time": "2019-08-06T17:53:53+00:00"
-        },
-        {
-            "name": "zendframework/zend-escaper",
-            "version": "2.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-escaper.git",
-                "reference": "3801caa21b0ca6aca57fa1c42b08d35c395ebd5f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/3801caa21b0ca6aca57fa1c42b08d35c395ebd5f",
-                "reference": "3801caa21b0ca6aca57fa1c42b08d35c395ebd5f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6.x-dev",
-                    "dev-develop": "2.7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Escaper\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
-            "keywords": [
-                "ZendFramework",
-                "escaper",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-escaper",
-            "time": "2019-09-05T20:03:20+00:00"
-        },
-        {
-            "name": "zendframework/zend-feed",
-            "version": "2.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-feed.git",
-                "reference": "d926c5af34b93a0121d5e2641af34ddb1533d733"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-feed/zipball/d926c5af34b93a0121d5e2641af34ddb1533d733",
-                "reference": "d926c5af34b93a0121d5e2641af34ddb1533d733",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "php": "^5.6 || ^7.0",
-                "zendframework/zend-escaper": "^2.5.2",
-                "zendframework/zend-stdlib": "^3.2.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
-                "psr/http-message": "^1.0.1",
-                "zendframework/zend-cache": "^2.7.2",
-                "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-db": "^2.8.2",
-                "zendframework/zend-http": "^2.7",
-                "zendframework/zend-servicemanager": "^2.7.8 || ^3.3",
-                "zendframework/zend-validator": "^2.10.1"
-            },
-            "suggest": {
-                "psr/http-message": "PSR-7 ^1.0.1, if you wish to use Zend\\Feed\\Reader\\Http\\Psr7ResponseDecorator",
-                "zendframework/zend-cache": "Zend\\Cache component, for optionally caching feeds between requests",
-                "zendframework/zend-db": "Zend\\Db component, for use with PubSubHubbub",
-                "zendframework/zend-http": "Zend\\Http for PubSubHubbub, and optionally for use with Zend\\Feed\\Reader",
-                "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for easily extending ExtensionManager implementations",
-                "zendframework/zend-validator": "Zend\\Validator component, for validating email addresses used in Atom feeds and entries when using the Writer subcomponent"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.12.x-dev",
-                    "dev-develop": "2.13.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Feed\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "provides functionality for consuming RSS and Atom feeds",
-            "keywords": [
-                "ZendFramework",
-                "feed",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-feed",
-            "time": "2019-03-05T20:08:49+00:00"
-        },
-        {
-            "name": "zendframework/zend-stdlib",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-stdlib.git",
-                "reference": "66536006722aff9e62d1b331025089b7ec71c065"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/66536006722aff9e62d1b331025089b7ec71c065",
-                "reference": "66536006722aff9e62d1b331025089b7ec71c065",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpbench/phpbench": "^0.13",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev",
-                    "dev-develop": "3.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Stdlib\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "SPL extensions, array utilities, error handlers, and more",
-            "keywords": [
-                "ZendFramework",
-                "stdlib",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-stdlib",
-            "time": "2018-08-28T21:34:05+00:00"
         }
     ],
     "aliases": [],

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -80,7 +80,7 @@ class SecurityUpdateCommands extends DrushCommands
         }
         $suggested_command .= '--update-with-dependencies';
         $this->logger()->warning('One or more of your dependencies has an outstanding security update.');
-        $this->logger()->notice("Try running: <comment>$suggested_command</comment>");
+        $this->logger()->notice("Try running <comment>$suggested_command</comment>");
         $this->logger()->notice("If that fails due to a conflict then you must update one or more root dependencies.");
     }
 
@@ -179,7 +179,7 @@ class SecurityUpdateCommands extends DrushCommands
         if ($packages = json_decode($out, true)) {
             $suggested_command = "composer why " . key($packages);
             $this->logger()->warning('One or more of your dependencies has an outstanding security update.');
-            $this->logger()->notice("Try running: <comment>$suggested_command</comment> to learn what  module requires the package.");
+            $this->logger()->notice("Run <comment>$suggested_command</comment> to learn what  module requires the package.");
             return CommandResult::dataWithExitCode(new UnstructuredData($packages), self::EXIT_FAILURE);
         }
     }

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -4,6 +4,7 @@ namespace Drush\Commands\pm;
 use Composer\Semver\Semver;
 use Consolidation\AnnotatedCommand\CommandResult;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Consolidation\OutputFormatters\StructuredData\UnstructuredData;
 use Drush\Commands\DrushCommands;
 use Drush\Drush;
 use Exception;
@@ -14,6 +15,27 @@ use Webmozart\PathUtil\Path;
  */
 class SecurityUpdateCommands extends DrushCommands
 {
+
+    /**
+     * Return path to composer.lock
+     *
+     * @return string
+     * @throws \Exception
+     */
+    public static function composerLockPath(): string
+    {
+        $composer_root = Drush::bootstrapManager()->getComposerRoot();
+        $composer_lock_file_name = getenv('COMPOSER') ? str_replace('.json', '',
+            getenv('COMPOSER')) : 'composer';
+        $composer_lock_file_name .= '.lock';
+        $composer_lock_file_path = Path::join($composer_root,
+            $composer_lock_file_name);
+        if (!file_exists($composer_lock_file_path)) {
+            throw new Exception("Cannot find $composer_lock_file_path!");
+        }
+        return $composer_lock_file_path;
+    }
+
     /**
      * Check Drupal Composer packages for pending security updates.
      *
@@ -40,12 +62,15 @@ class SecurityUpdateCommands extends DrushCommands
     {
         $security_advisories_composer_json = $this->fetchAdvisoryComposerJson();
         $composer_lock_data = $this->loadSiteComposerLock();
-        $updates = $this->calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json);
+        $updates = $this->calculateSecurityUpdates($composer_lock_data,
+            $security_advisories_composer_json);
         if ($updates) {
             $this->suggestComposerCommand($updates);
-            return CommandResult::dataWithExitCode(new RowsOfFields($updates), self::EXIT_FAILURE);
+            return CommandResult::dataWithExitCode(new RowsOfFields($updates),
+                self::EXIT_FAILURE);
         } else {
-            $this->logger()->success("<info>There are no outstanding security updates for Drupal projects.</info>");
+            $this->logger()
+                ->success("<info>There are no outstanding security updates for Drupal projects.</info>");
         }
     }
 
@@ -59,9 +84,12 @@ class SecurityUpdateCommands extends DrushCommands
             $suggested_command .= $package['name'] . ' ';
         }
         $suggested_command .= '--update-with-dependencies';
-        $this->logger()->warning('One or more of your dependencies has an outstanding security update.');
-        $this->logger()->notice("Try running: <comment>$suggested_command</comment>");
-        $this->logger()->notice("If that fails due to a conflict then you must update one or more root dependencies.");
+        $this->logger()
+            ->warning('One or more of your dependencies has an outstanding security update.');
+        $this->logger()
+            ->notice("Try running: <comment>$suggested_command</comment>");
+        $this->logger()
+            ->notice("If that fails due to a conflict then you must update one or more root dependencies.");
     }
 
     /**
@@ -95,20 +123,7 @@ class SecurityUpdateCommands extends DrushCommands
      */
     protected function loadSiteComposerLock()
     {
-        $composer_root = Drush::bootstrapManager()->getComposerRoot();
-        $composer_lock_file_name = getenv('COMPOSER') ? str_replace(
-            '.json',
-            '',
-            getenv('COMPOSER')
-        ) : 'composer';
-        $composer_lock_file_name .= '.lock';
-        $composer_lock_file_path = Path::join(
-            $composer_root,
-            $composer_lock_file_name
-        );
-        if (!file_exists($composer_lock_file_path)) {
-            throw new Exception("Cannot find $composer_lock_file_path!");
-        }
+        $composer_lock_file_path = self::composerLockPath();
         $composer_lock_contents = file_get_contents($composer_lock_file_path);
         $composer_lock_data = json_decode($composer_lock_contents, true);
         if (!array_key_exists('packages', $composer_lock_data)) {
@@ -127,14 +142,18 @@ class SecurityUpdateCommands extends DrushCommands
      *
      * @return array
      */
-    protected function calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json)
-    {
+    protected function calculateSecurityUpdates(
+        $composer_lock_data,
+        $security_advisories_composer_json
+    ) {
         $updates = [];
-        $both = array_merge($composer_lock_data['packages-dev'], $composer_lock_data['packages']);
+        $both = array_merge($composer_lock_data['packages-dev'],
+            $composer_lock_data['packages']);
         $conflict = $security_advisories_composer_json['conflict'];
         foreach ($both as $package) {
             $name = $package['name'];
-            if (!empty($conflict[$name]) && Semver::satisfies($package['version'], $security_advisories_composer_json['conflict'][$name])) {
+            if (!empty($conflict[$name]) && Semver::satisfies($package['version'],
+                    $security_advisories_composer_json['conflict'][$name])) {
                 $updates[$name] = [
                     'name' => $name,
                     'version' => $package['version'],
@@ -142,5 +161,40 @@ class SecurityUpdateCommands extends DrushCommands
             }
         }
         return $updates;
+    }
+
+    /**
+     * Check non-Drupal PHP packages for pending security updates.
+     *
+     * Thanks to https://github.com/FriendsOfPHP/security-advisories and Symfony
+     * for providing this service.
+     *
+     * @param array $options
+     *
+     * @return UnstructuredData
+     * @throws \Exception
+     * @command pm:security-php
+     * @aliases sec-php,pm:security-php
+     * @bootstrap none
+     *
+     * @usage drush pm:security-php --format=json
+     *   Get security data in JSON format.
+     */
+    public function securityPhp($options = ['format' => 'yaml'])
+    {
+        $path = self::composerLockPath();
+        // Note: wget does not support multipart/form-data so its not supported by this command.
+        $command = ['curl', '-H', 'Accept: application/json', 'https://security.symfony.com/check_lock', '-F', "lock=@{$path}"];
+        $process = $this->processManager()->process($command);
+        $process->mustRun();
+        $out = $process->getOutput();
+        if ($packages = json_decode($out, true)) {
+            $suggested_command = "composer why " . key($packages);
+            $this->logger()
+                ->warning('One or more of your dependencies has an outstanding security update.');
+            $this->logger()
+                ->notice("Try running: <comment>$suggested_command</comment> to learn what  module requires the package.");
+            return CommandResult::dataWithExitCode(new UnstructuredData($packages), self::EXIT_FAILURE);
+        }
     }
 }

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -80,7 +80,7 @@ class SecurityUpdateCommands extends DrushCommands
         }
         $suggested_command .= '--update-with-dependencies';
         $this->logger()->warning('One or more of your dependencies has an outstanding security update.');
-        $this->logger()->notice("Try running <comment>$suggested_command</comment>");
+        $this->logger()->notice("Try running: <comment>$suggested_command</comment>");
         $this->logger()->notice("If that fails due to a conflict then you must update one or more root dependencies.");
     }
 

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -25,8 +25,7 @@ class SecurityUpdateCommands extends DrushCommands
     public static function composerLockPath(): string
     {
         $composer_root = Drush::bootstrapManager()->getComposerRoot();
-        $composer_lock_file_name = getenv('COMPOSER') ? str_replace('.json', '',
-            getenv('COMPOSER')) : 'composer';
+        $composer_lock_file_name = getenv('COMPOSER') ? str_replace('.json', '', getenv('COMPOSER')) : 'composer';
         $composer_lock_file_name .= '.lock';
         $composer_lock_file_path = Path::join($composer_root,
             $composer_lock_file_name);
@@ -62,15 +61,12 @@ class SecurityUpdateCommands extends DrushCommands
     {
         $security_advisories_composer_json = $this->fetchAdvisoryComposerJson();
         $composer_lock_data = $this->loadSiteComposerLock();
-        $updates = $this->calculateSecurityUpdates($composer_lock_data,
-            $security_advisories_composer_json);
+        $updates = $this->calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json);
         if ($updates) {
             $this->suggestComposerCommand($updates);
-            return CommandResult::dataWithExitCode(new RowsOfFields($updates),
-                self::EXIT_FAILURE);
+            return CommandResult::dataWithExitCode(new RowsOfFields($updates), self::EXIT_FAILURE);
         } else {
-            $this->logger()
-                ->success("<info>There are no outstanding security updates for Drupal projects.</info>");
+            $this->logger()->success("<info>There are no outstanding security updates for Drupal projects.</info>");
         }
     }
 
@@ -84,12 +80,9 @@ class SecurityUpdateCommands extends DrushCommands
             $suggested_command .= $package['name'] . ' ';
         }
         $suggested_command .= '--update-with-dependencies';
-        $this->logger()
-            ->warning('One or more of your dependencies has an outstanding security update.');
-        $this->logger()
-            ->notice("Try running: <comment>$suggested_command</comment>");
-        $this->logger()
-            ->notice("If that fails due to a conflict then you must update one or more root dependencies.");
+        $this->logger()->warning('One or more of your dependencies has an outstanding security update.');
+        $this->logger()->notice("Try running: <comment>$suggested_command</comment>");
+        $this->logger()->notice("If that fails due to a conflict then you must update one or more root dependencies.");
     }
 
     /**
@@ -147,13 +140,11 @@ class SecurityUpdateCommands extends DrushCommands
         $security_advisories_composer_json
     ) {
         $updates = [];
-        $both = array_merge($composer_lock_data['packages-dev'],
-            $composer_lock_data['packages']);
+        $both = array_merge($composer_lock_data['packages-dev'], $composer_lock_data['packages']);
         $conflict = $security_advisories_composer_json['conflict'];
         foreach ($both as $package) {
             $name = $package['name'];
-            if (!empty($conflict[$name]) && Semver::satisfies($package['version'],
-                    $security_advisories_composer_json['conflict'][$name])) {
+            if (!empty($conflict[$name]) && Semver::satisfies($package['version'], $security_advisories_composer_json['conflict'][$name])) {
                 $updates[$name] = [
                     'name' => $name,
                     'version' => $package['version'],
@@ -190,10 +181,8 @@ class SecurityUpdateCommands extends DrushCommands
         $out = $process->getOutput();
         if ($packages = json_decode($out, true)) {
             $suggested_command = "composer why " . key($packages);
-            $this->logger()
-                ->warning('One or more of your dependencies has an outstanding security update.');
-            $this->logger()
-                ->notice("Try running: <comment>$suggested_command</comment> to learn what  module requires the package.");
+            $this->logger()->warning('One or more of your dependencies has an outstanding security update.');
+            $this->logger()->notice("Try running: <comment>$suggested_command</comment> to learn what  module requires the package.");
             return CommandResult::dataWithExitCode(new UnstructuredData($packages), self::EXIT_FAILURE);
         }
     }

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -27,8 +27,7 @@ class SecurityUpdateCommands extends DrushCommands
         $composer_root = Drush::bootstrapManager()->getComposerRoot();
         $composer_lock_file_name = getenv('COMPOSER') ? str_replace('.json', '', getenv('COMPOSER')) : 'composer';
         $composer_lock_file_name .= '.lock';
-        $composer_lock_file_path = Path::join($composer_root,
-            $composer_lock_file_name);
+        $composer_lock_file_path = Path::join($composer_root, $composer_lock_file_name);
         if (!file_exists($composer_lock_file_path)) {
             throw new Exception("Cannot find $composer_lock_file_path!");
         }
@@ -135,10 +134,8 @@ class SecurityUpdateCommands extends DrushCommands
      *
      * @return array
      */
-    protected function calculateSecurityUpdates(
-        $composer_lock_data,
-        $security_advisories_composer_json
-    ) {
+    protected function calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json)
+    {
         $updates = [];
         $both = array_merge($composer_lock_data['packages-dev'], $composer_lock_data['packages']);
         $conflict = $security_advisories_composer_json['conflict'];

--- a/sut/themes/unish/drush_empty_theme/drush_empty_theme.info.yml
+++ b/sut/themes/unish/drush_empty_theme/drush_empty_theme.info.yml
@@ -1,5 +1,6 @@
 name: Drush empty theme
 description: 'Drush empty theme'
 core: 8.x
+core_version_requirement: ^8 || ^9
 type: theme
 base theme: stable

--- a/tests/integration/SecurityUpdatesTest.php
+++ b/tests/integration/SecurityUpdatesTest.php
@@ -32,7 +32,7 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
     {
         $this->drush('pm:security-php', [], ['format' => 'json'], self::EXIT_ERROR);
         $this->assertContains('One or more of your dependencies has an outstanding security update.', $this->getErrorOutput());
-        $this->assertContains('Try running: composer why david-garcia/phpwhois', $this->getErrorOutput());
+        $this->assertContains('Run composer why david-garcia/phpwhois to learn what  module requires the package.', $this->getErrorOutput());
         $security_advisories = $this->getOutputFromJSON();
         $this->arrayHasKey('david-garcia/phpwhois', $security_advisories);
     }

--- a/tests/integration/SecurityUpdatesTest.php
+++ b/tests/integration/SecurityUpdatesTest.php
@@ -11,9 +11,9 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
 {
 
   /**
-   * Test that insecure packages are correctly identified.
+   * Test that insecure Drupal packages are correctly identified.
    */
-    public function testInsecurePackage()
+    public function testInsecureDrupalPackage()
     {
         // @todo This passes on Drupal because drupal/alinks has a security release for 8 and we don't actually install that module on our d9 tests.
         $this->drush('pm:security', [], ['format' => 'json'], self::EXIT_ERROR);
@@ -23,5 +23,17 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
         $this->arrayHasKey('drupal/alinks', $security_advisories);
         $this->assertEquals('drupal/alinks', $security_advisories["drupal/alinks"]['name']);
         $this->assertEquals('1.0.0', $security_advisories["drupal/alinks"]['version']);
+    }
+
+    /**
+     * Test that insecure PHP packages are correctly identified.
+     */
+    public function testInsecurePhpPackage()
+    {
+        $this->drush('pm:security-php', [], ['format' => 'json'], self::EXIT_ERROR);
+        $this->assertContains('One or more of your dependencies has an outstanding security update.', $this->getErrorOutput());
+        $this->assertContains('Try running: composer why david-garcia/phpwhois', $this->getErrorOutput());
+        $security_advisories = $this->getOutputFromJSON();
+        $this->arrayHasKey('david-garcia/phpwhois', $security_advisories);
     }
 }


### PR DESCRIPTION
```
./drush pm:security-php                                                                                    
 [warning] One or more of your dependencies has an outstanding security update.
 [notice] Try running: composer why david-garcia/phpwhois to learn what  module requires the package.
david-garcia/phpwhois:
  version: 4.3.0
  advisories:
    -
      title: 'PHP Code Injection'
      link: 'https://github.com/sbaresearch/advisories/tree/public/2018/SBA-ADV-20180425-01_phpWhois_Code_Execution'
      cve: CVE-2015-5243
```

Uploads a site's composer.lock to https://security.symfony.com/ and returns any found vulnerabilities in YAML format (by default). An exit code of 1 is returned in this case.

Requires `curl` to be available and on your PATH.

Our long standing pm:security command which checks Drupal packages remains available, and should be used in addition to this new command. 

The underlying SA data is maintained at https://github.com/FriendsOfPHP/security-advisories. Thanks to Symfony for this data and for the web service.