### PR TITLE
Allow command discovery to follow symlinks.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -372,6 +372,7 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
         $discovery
             ->setIncludeFilesAtBase(true)
             ->setSearchDepth(3)
+            ->followLinks()
             ->ignoreNamespacePart('contrib', 'Commands')
             ->ignoreNamespacePart('custom', 'Commands')
             ->ignoreNamespacePart('src')


### PR DESCRIPTION
Fixes #4094

I attempted to manually list a symlinked directory using my drush.yml file, but even then it doesn't work:
```
drush:
  paths:
    include:
      - '${env.PWD}/Commands/custom/symlinked-directory'
```