### PR TITLE
Add new deploy command. Performs site deployment.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,9 +61,9 @@ install:
   # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 test_script:
-  - vendor/bin/phpunit --colors=always --configuration tests --testsuite --debug functional
-  - vendor/bin/phpunit --colors=always --configuration tests --testsuite --debug integration
-  - vendor/bin/phpunit --colors=always --configuration tests --testsuite --debug unit
+  - vendor/bin/phpunit --colors=always --configuration tests --testsuite functional --debug
+  - vendor/bin/phpunit --colors=always --configuration tests --testsuite integration --debug
+  - vendor/bin/phpunit --colors=always --configuration tests --testsuite unit --debug
 
 on_finish:
   # Uncomment this and above line to enable RDP into build machine https://www.appveyor.com/docs/how-to/rdp-to-build-worker/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
   - SET PATH=C:\Program Files\MySql\MySQL Server 5.7\bin\;%PATH%
   - choco search php --exact --all-versions -r
   #Install PHP per https://blog.wyrihaximus.net/2016/11/running-php-unit-tests-on-windows-using-appveyor-and-chocolatey/
-  - ps: appveyor-retry cinst --ignore-checksums -y php --version 7.3.7
+  - ps: appveyor-retry cinst --limit-output --ignore-checksums -y php --version 7.3.7
   - cd c:\tools\php73
   - copy php.ini-production php.ini
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,9 +61,9 @@ install:
   # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 test_script:
-  - vendor/bin/phpunit --colors=always --configuration tests --testsuite functional --debug
-  - vendor/bin/phpunit --colors=always --configuration tests --testsuite integration --debug
-  - vendor/bin/phpunit --colors=always --configuration tests --testsuite unit --debug
+  - vendor/bin/phpunit --colors=always --configuration tests --testsuite --debug functional
+  - vendor/bin/phpunit --colors=always --configuration tests --testsuite --debug integration
+  - vendor/bin/phpunit --colors=always --configuration tests --testsuite --debug unit
 
 on_finish:
   # Uncomment this and above line to enable RDP into build machine https://www.appveyor.com/docs/how-to/rdp-to-build-worker/

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -7,8 +7,7 @@ performs the following:
 ```
 drush updatedb
 drush config:import
-drush deploy:hook
-drush cache:rebuild
+drush cache:rebuilddrush deploy:hook
 ```
 
 # Authoring update functions

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -11,6 +11,15 @@ drush deploy:hook
 drush cache:rebuild
 ```
 
+# Authoring update functions
+Below are the 3 types of update functions run by this command. Choose the most appropriate for your need. 
+
+| Function | Purpose |
+| --- | --- |
+| [hook_update_n()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_update_N) | Low level changes. Drupal API not allowed. |
+| [hook_post_update_NAME()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_post_update_NAME) | Drupal API allowed. |
+| hook_deploy() | Runs after config is imported. Drupal API allowed. | 
+
 ## Configuration
 
 If you need to customize this command, you should use Drush configuration for the 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,17 @@
+# Introduction
+
+The deploy command standardizes how Drupal deployments work. The intent is your 
+deployment script updates the codebase for the target site and then this command 
+performs the following:
+
+```
+drush updatedb
+drush config:import
+drush deploy:hook
+drush cache:rebuild
+```
+
+## Configuration
+
+If you need to customize this command, you should use Drush configuration for the 
+subcommands listed above (e.g. updatedb, config:import, etc.).

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -7,7 +7,8 @@ performs the following:
 ```
 drush updatedb
 drush config:import
-drush cache:rebuilddrush deploy:hook
+drush cache:rebuild
+drush deploy:hook
 ```
 
 # Authoring update functions
@@ -15,9 +16,9 @@ Below are the 3 types of update functions run by this command. Choose the most a
 
 | Function | Purpose |
 | --- | --- |
-| [hook_update_n()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_update_N) | Low level changes. Drupal API not allowed. |
-| [hook_post_update_NAME()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_post_update_NAME) | Drupal API allowed. |
-| hook_deploy() | Runs after config is imported. Drupal API allowed. | 
+| [HOOK_update_n()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_update_N) | Low level changes. Drupal API not allowed. |
+| [HOOK_post_update_NAME()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_post_update_NAME) | Drupal API allowed. |
+| [HOOK_deploy_NAME()](https://github.com/drush-ops/drush/blob/master/tests/functional/resources/modules/d8/woot/woot.deploy.php) | Runs after config is imported. Drupal API allowed. | 
 
 ## Configuration
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ pages:
   - Drupal configuration: config-exporting.md
   - Output Formats, Fields & Filters: output-formats-filters.md
   - REPL (a custom shell for Drupal): repl.md
+  - Deploy: deploy.md
 - Writing commands/generators:
   - Command Authoring: commands.md
   - Hooks: hooks.md

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -1,0 +1,54 @@
+<?php
+namespace Drush\Commands\core;
+
+use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
+use Drush\Commands\DrushCommands;
+use Drush\Drush;
+use Drush\SiteAlias\SiteAliasManagerAwareInterface;
+
+class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInterface
+{
+    use SiteAliasManagerAwareTrait;
+
+    /**
+     * Run several update related commands after performing a code deployment.
+     *
+     * @command deploy
+     *
+     * @usage drush deploy -v -y
+     *   Run updates with verbose logging and accept all prompts.
+     *
+     * @todo Add a topic. Add a test.
+     *
+     * @throws \Exception
+     */
+    public function deploy()
+    {
+        $self = $this->siteAliasManager()->getSelf();
+        $redispatchOptions = Drush::redispatchOptions();
+
+        $this->logger()->notice("Database updates start.");
+        $options = ['no-cache-clear' => TRUE];
+        $process = $this->processManager()->drush($self, 'updatedb', [], $options + $redispatchOptions);
+        $process->mustRun($process->showRealtime());
+        $this->logger()->success("Database updates complete.");
+
+        $this->logger()->success("Config import start.");
+        $process = $this->processManager()->drush($self, 'config:import', [], $redispatchOptions);
+        $process->mustRun($process->showRealtime());
+        $this->logger()->success("Config import complete.");
+
+        $this->logger()->success("Deploy hook start.");
+        $process = $this->processManager()->drush($self, 'deploy:hook', [], $redispatchOptions);
+        // $process->mustRun($process->showRealtime());
+        $this->logger()->success("Deploy hook complete.");
+
+        // It is possible that no updates were pending and thus no caches cleared yet.
+        $this->logger()->success("Cache rebuild start.");
+        $process = $this->processManager()->drush($self, 'cache:rebuild', [], $redispatchOptions);
+        // To avoid occasional rmdir errors, disable Drush cache for this request.
+        $process->setEnv(['DRUSH_PATHS_CACHE_DIRECTORY ' => file_exists('/dev/null') ? '/dev/null' : 'nul']);
+        $process->mustRun($process->showRealtime());
+        $this->logger()->success("Cache rebuild complete.");
+    }
+}

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -11,14 +11,14 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
     use SiteAliasManagerAwareTrait;
 
     /**
-     * Run several update related commands after performing a code deployment.
+     * Run several commands after performing a code deployment.
      *
      * @command deploy
      *
      * @usage drush deploy -v -y
      *   Run updates with verbose logging and accept all prompts.
      *
-     * @todo Add a topic. Add a test.
+     * @topics docs:deploy
      *
      * @throws \Exception
      */

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -41,7 +41,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
         $this->logger()->success("Cache rebuild start.");
         $process = $manager->drush($self, 'cache:rebuild', [], $redispatchOptions);
         // To avoid occasional rmdir errors, disable Drush cache for this request.
-        $process->setEnv(['DRUSH_PATHS_CACHE_DIRECTORY ' => file_exists('/dev/null') ? '/dev/null' : 'nul']);
+        $process->setEnv(['DRUSH_PATHS_CACHE_DIRECTORY' => file_exists('/dev/null') ? '/dev/null' : 'nul']);
         $process->mustRun($process->showRealtime());
 
         $this->logger()->success("Deploy hook start.");

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -28,7 +28,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
         $redispatchOptions = Drush::redispatchOptions();
 
         $this->logger()->notice("Database updates start.");
-        $options = ['no-cache-clear' => TRUE];
+        $options = ['no-cache-clear' => true];
         $process = $this->processManager()->drush($self, 'updatedb', [], $options + $redispatchOptions);
         $process->mustRun($process->showRealtime());
         $this->logger()->success("Database updates complete.");

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -41,7 +41,9 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
         $this->logger()->success("Cache rebuild start.");
         $process = $manager->drush($self, 'cache:rebuild', [], $redispatchOptions);
         // To avoid occasional rmdir errors, disable Drush cache for this request.
-        $process->setEnv(['DRUSH_PATHS_CACHE_DIRECTORY' => file_exists('/dev/null') ? '/dev/null' : 'nul']);
+        if (file_exists('/dev/null')) {
+            $process->setEnv(['DRUSH_PATHS_CACHE_DIRECTORY' => '/dev/null']);
+        }
         $process->mustRun($process->showRealtime());
 
         $this->logger()->success("Deploy hook start.");

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -37,15 +37,15 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
         $process = $manager->drush($self, 'config:import', [], $redispatchOptions);
         $process->mustRun($process->showRealtime());
 
-        $this->logger()->success("Deploy hook start.");
-        $process = $manager->drush($self, 'deploy:hook', [], $redispatchOptions);
-        // $process->mustRun($process->showRealtime());
-
         // It is possible that no updates were pending and thus no caches cleared yet.
         $this->logger()->success("Cache rebuild start.");
         $process = $manager->drush($self, 'cache:rebuild', [], $redispatchOptions);
         // To avoid occasional rmdir errors, disable Drush cache for this request.
         $process->setEnv(['DRUSH_PATHS_CACHE_DIRECTORY ' => file_exists('/dev/null') ? '/dev/null' : 'nul']);
         $process->mustRun($process->showRealtime());
+
+        $this->logger()->success("Deploy hook start.");
+        $process = $manager->drush($self, 'deploy:hook', [], $redispatchOptions);
+        // $process->mustRun($process->showRealtime());
     }
 }

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -26,29 +26,26 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
     {
         $self = $this->siteAliasManager()->getSelf();
         $redispatchOptions = Drush::redispatchOptions();
+        $manager = $this->processManager();
 
         $this->logger()->notice("Database updates start.");
         $options = ['no-cache-clear' => true];
-        $process = $this->processManager()->drush($self, 'updatedb', [], $options + $redispatchOptions);
+        $process = $manager->drush($self, 'updatedb', [], $options + $redispatchOptions);
         $process->mustRun($process->showRealtime());
-        $this->logger()->success("Database updates complete.");
 
         $this->logger()->success("Config import start.");
-        $process = $this->processManager()->drush($self, 'config:import', [], $redispatchOptions);
+        $process = $manager->drush($self, 'config:import', [], $redispatchOptions);
         $process->mustRun($process->showRealtime());
-        $this->logger()->success("Config import complete.");
 
         $this->logger()->success("Deploy hook start.");
-        $process = $this->processManager()->drush($self, 'deploy:hook', [], $redispatchOptions);
+        $process = $manager->drush($self, 'deploy:hook', [], $redispatchOptions);
         // $process->mustRun($process->showRealtime());
-        $this->logger()->success("Deploy hook complete.");
 
         // It is possible that no updates were pending and thus no caches cleared yet.
         $this->logger()->success("Cache rebuild start.");
-        $process = $this->processManager()->drush($self, 'cache:rebuild', [], $redispatchOptions);
+        $process = $manager->drush($self, 'cache:rebuild', [], $redispatchOptions);
         // To avoid occasional rmdir errors, disable Drush cache for this request.
         $process->setEnv(['DRUSH_PATHS_CACHE_DIRECTORY ' => file_exists('/dev/null') ? '/dev/null' : 'nul']);
         $process->mustRun($process->showRealtime());
-        $this->logger()->success("Cache rebuild complete.");
     }
 }

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -48,6 +48,6 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
         $this->logger()->success("Deploy hook start.");
         $process = $manager->drush($self, 'deploy:hook', [], $redispatchOptions);
-        // $process->mustRun($process->showRealtime());
+        $process->mustRun($process->showRealtime());
     }
 }

--- a/src/Commands/core/DocsCommands.php
+++ b/src/Commands/core/DocsCommands.php
@@ -194,4 +194,17 @@ class DocsCommands extends DrushCommands
     {
         self::printFile(DRUSH_BASE_PATH. '/examples/Commands/PolicyCommands.php');
     }
+
+    /**
+     * Deploy command for Drupal.
+     *
+     * @command docs:deploy
+     * @aliases docs-deploy
+     * @hidden
+     * @topic
+     */
+    public function deploy()
+    {
+        self::printFile(DRUSH_BASE_PATH. '/docs/deploy.md');
+    }
 }

--- a/src/Drupal/Commands/core/DeployHookCommands.php
+++ b/src/Drupal/Commands/core/DeployHookCommands.php
@@ -71,6 +71,7 @@ class DeployHookCommands extends DrushCommands implements SiteAliasManagerAwareI
      * @default-fields module,hook,description
      *
      * @command deploy:hook-status
+     * @topics docs:deploy
      *
      * @filter-default-field hook
      * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
@@ -101,6 +102,7 @@ class DeployHookCommands extends DrushCommands implements SiteAliasManagerAwareI
      *   Run pending deploy hooks.
      *
      * @command deploy:hook
+     * @topics docs:deploy
      */
     public function run()
     {

--- a/tests/functional/resources/modules/d8/woot/woot.deploy.php
+++ b/tests/functional/resources/modules/d8/woot/woot.deploy.php
@@ -1,8 +1,14 @@
 <?php
 
 /**
+ * This is a NAME.deploy.php file. It contains "deploy" functions. These are
+ * one-time functions that run *after* config is imported during a deployment.
+ * These are a higher level alternative to hook_update_n and hook_post_update_NAME
+ * functions. Also, the `drush deploy` command runs those before config:import.
+ */
+
+/**
  * Successful deploy hook.
- * Implements HOOK_deploy_NAME().
  */
 function woot_deploy_a()
 {
@@ -13,7 +19,6 @@ function woot_deploy_a()
 
 /**
  * Successful batched deploy hook.
- * Implements HOOK_deploy_NAME().
  */
 function woot_deploy_batch(array &$sandbox)
 {
@@ -27,7 +32,6 @@ function woot_deploy_batch(array &$sandbox)
 
 /**
  * Failing deploy hook.
- * Implements HOOK_deploy_NAME().
  */
 function woot_deploy_failing()
 {

--- a/tests/integration/DeployTest.php
+++ b/tests/integration/DeployTest.php
@@ -14,9 +14,9 @@ class DeployTest extends UnishIntegrationTestCase
     public function testDeploy()
     {
         // Prep a config directory that will be imported later.
-        $this->drush('config:export', []);
+        $this->drush('config:export');
         
-        $this->drush('deploy', []);
+        $this->drush('deploy');
         $expecteds = ["Database updates start.", 'Config import start.', 'Deploy hook start.', 'Cache rebuild start.'];
         foreach ($expecteds as $expected) {
             $this->assertContains($expected, $this->getErrorOutput());

--- a/tests/integration/DeployTest.php
+++ b/tests/integration/DeployTest.php
@@ -16,7 +16,7 @@ class DeployTest extends UnishIntegrationTestCase
         // Prep a config directory that will be imported later.
         $this->drush('config:export');
         
-        $this->drush('deploy');
+        $this->drush('deploy', [], ['debug' => true]);
         $expecteds = ["Database updates start.", 'Config import start.', 'Deploy hook start.', 'Cache rebuild start.'];
         foreach ($expecteds as $expected) {
             $this->assertContains($expected, $this->getErrorOutput());

--- a/tests/integration/DeployTest.php
+++ b/tests/integration/DeployTest.php
@@ -21,6 +21,5 @@ class DeployTest extends UnishIntegrationTestCase
         foreach ($expecteds as $expected) {
             $this->assertContains($expected, $this->getErrorOutput());
         }
-        $this->assertContains('ss', 'ww');
     }
 }

--- a/tests/integration/DeployTest.php
+++ b/tests/integration/DeployTest.php
@@ -16,7 +16,7 @@ class DeployTest extends UnishIntegrationTestCase
         // Prep a config directory that will be imported later.
         $this->drush('config:export');
         
-        $this->drush('deploy', [], ['debug' => true]);
+        $this->drush('deploy');
         $expecteds = ["Database updates start.", 'Config import start.', 'Deploy hook start.', 'Cache rebuild start.'];
         foreach ($expecteds as $expected) {
             $this->assertContains($expected, $this->getErrorOutput());

--- a/tests/integration/DeployTest.php
+++ b/tests/integration/DeployTest.php
@@ -21,5 +21,6 @@ class DeployTest extends UnishIntegrationTestCase
         foreach ($expecteds as $expected) {
             $this->assertContains($expected, $this->getErrorOutput());
         }
+        $this->assertContains('ss', 'ww');
     }
 }

--- a/tests/integration/DeployTest.php
+++ b/tests/integration/DeployTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Unish;
+
+/**
+ * @group commands
+ */
+class DeployTest extends UnishIntegrationTestCase
+{
+
+    /**
+     * A simple test since all the sub-commands are tested elsewhere.
+     */
+    public function testDeploy()
+    {
+        // Prep a config directory that will be imported later.
+        $this->drush('config:export', []);
+        
+        $this->drush('deploy', []);
+        $expecteds = ["Database updates start.", 'Config import start.', 'Deploy hook start.', 'Cache rebuild start.'];
+        foreach ($expecteds as $expected) {
+            $this->assertContains($expected, $this->getErrorOutput());
+        }
+    }
+
+
+}

--- a/tests/integration/DeployTest.php
+++ b/tests/integration/DeployTest.php
@@ -22,6 +22,4 @@ class DeployTest extends UnishIntegrationTestCase
             $this->assertContains($expected, $this->getErrorOutput());
         }
     }
-
-
 }

--- a/tests/unish/UnishIntegrationTestCase.php
+++ b/tests/unish/UnishIntegrationTestCase.php
@@ -93,10 +93,9 @@ abstract class UnishIntegrationTestCase extends UnishTestCase
         chdir($this->webroot());
         $this->log("Executing: " . implode(' ', $cmd), 'verbose');
         $return = $application->run($input, $output);
-        $this->assertEquals($expected_return, $return, "Command failed: \n\n" . $this->getErrorOutput());
-
         $this->stdout = $output->fetch();
         $this->stderr = $output->getErrorOutput()->fetch();
+        $this->assertEquals($expected_return, $return, "Command failed: \n\n" . $this->getErrorOutput());
 
         return $return;
     }


### PR DESCRIPTION
This command is intended to standardize how Drupal deployments work. The intent is that your deployment script updates the codebase for the target site and then this command performs the following:

```
drush updatedb --no-cache-clear # Runs updates and post-updates
drush cache:rebuild
drush config:import
drush cache:rebuild
drush deploy:hook
```

- The last step above runs pending [HOOK_deploy_NAME()](https://github.com/drush-ops/drush/blob/master/tests/functional/resources/modules/d8/woot/woot.deploy.php) implementations. This is a new hook introduced by Drush for deployments. Code which used to be in post_update hook should usually move to this hook now. This hook could alternatively be run via a web UI, should anyone care to write that.
- See the [Help topic](https://github.com/drush-ops/drush/blob/master/docs/deploy.md) about this feature.

Todo
--------
- [x] Tests
- [x] Add a topic
- [x] Update/Write Drupal docs about deployment.
- [x] The deploy:hook command still needs to be written.