### PR TITLE
Drush 8 - PHP 7.4: Fix deprecation notices

### DIFF
--- a/commands/core/rsync.core.inc
+++ b/commands/core/rsync.core.inc
@@ -75,7 +75,7 @@ function drush_core_rsync($source, $destination, $additional_options = array()) 
   // Get all of the args and options that appear after the command name.
   $original_args = drush_get_original_cli_args_and_options();
   foreach ($original_args as $original_option) {
-    if ($original_option{0} == '-') {
+    if ($original_option[0] == '-') {
       $options .= ' ' . $original_option;
     }
   }

--- a/commands/make/generate.make.inc
+++ b/commands/make/generate.make.inc
@@ -207,7 +207,7 @@ function _drush_generate_custom_project($name, $extension, $version_options) {
             drush_shell_cd_and_exec($repo_root, 'git branch');
             $output = drush_shell_exec_output();
             foreach ($output as $line) {
-              if ($line{0} == '*') {
+              if ($line[0] == '*') {
                 $branch = substr($line, 2);
                 if ($branch != "master") {
                   $project['download][branch'] = $branch;

--- a/commands/pm/info.pm.inc
+++ b/commands/pm/info.pm.inc
@@ -132,7 +132,7 @@ function _drush_pm_info_theme($info) {
   $data['core'] = $info->info['core'];
   $data['php'] = $info->info['php'];
   $data['engine'] = $info->info['engine'];
-  $data['base_theme'] = isset($info->base_themes) ? implode($info->base_themes, ', ') : '';
+  $data['base_theme'] = isset($info->base_themes) ? implode(', ', $info->base_themes) : '';
   $regions = $info->info['regions'];
   $data['regions'] = $regions;
   $features = $info->info['features'];

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -857,9 +857,9 @@ function drush_parse_args() {
       $command_args[] = $opt;
     }
     // Is the arg an option (starting with '-')?
-    if (!empty($opt) && $opt{0} == "-" && strlen($opt) != 1) {
+    if (!empty($opt) && $opt[0] == "-" && strlen($opt) != 1) {
       // Do we have multiple options behind one '-'?
-      if (strlen($opt) > 2 && $opt{1} != "-") {
+      if (strlen($opt) > 2 && $opt[1] != "-") {
         // Each char becomes a key of its own.
         for ($j = 1; $j < strlen($opt); $j++) {
           $opt_char = substr($opt, $j, 1);
@@ -870,7 +870,7 @@ function drush_parse_args() {
         }
       }
       // Do we have a longopt (starting with '--')?
-      elseif ($opt{1} == "-") {
+      elseif ($opt[1] == "-") {
         if ($pos = strpos($opt, '=')) {
           $options[substr($opt, 2, $pos - 2)] = substr($opt, $pos + 1);
         }

--- a/includes/sitealias.inc
+++ b/includes/sitealias.inc
@@ -172,8 +172,8 @@ function drush_sitealias_resolve_sitespecs($site_specifications, $alias_path_con
 function drush_sitealias_valid_alias_format($alias) {
   return ( (strpos($alias, ',') !== false) ||
     ((strpos($alias, '@') === FALSE ? 0 : 1) + (strpos($alias, '/') === FALSE ? 0 : 1) + (strpos($alias, '#') === FALSE ? 0 : 1) >= 2) ||
-    ($alias{0} == '#') ||
-    ($alias{0} == '@')
+    ($alias[0] == '#') ||
+    ($alias[0] == '@')
   );
 }
 


### PR DESCRIPTION
- Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4
- Passing the $glue and $pieces parameters in reverse order to implode has been deprecated since PHP 7.4; $glue should be the first parameter and $pieces the second