### PR TITLE
Don't use the UpdateKernel for config:import.

### DIFF
--- a/src/Commands/config/ConfigImportCommands.php
+++ b/src/Commands/config/ConfigImportCommands.php
@@ -37,7 +37,6 @@ class ConfigImportCommands extends DrushCommands
      * @option source An arbitrary directory that holds the configuration files. An alternative to label argument
      * @option partial Allows for partial config imports from the source directory. Only updates and new configs will be processed with this flag (missing configs will not be deleted). No config transformation happens.
      * @aliases cim,config-import
-     * @kernel update
      * @bootstrap full
      */
     public function import($label = null, $options = ['preview' => 'list', 'source' => self::REQ, 'partial' => false, 'diff' => false])

--- a/tests/functional/ConfigTest.php
+++ b/tests/functional/ConfigTest.php
@@ -137,7 +137,17 @@ YAML_FRAGMENT;
         $extension['module'] = module_config_sort($extension['module']);
         file_put_contents($extensionFile, Yaml::encode($extension));
 
+        // When importing config, the 'woot' module should warn about a validation error.
+        $this->drush('config:import', [], [], null, null, CommandUnishTestCase::EXIT_ERROR);
+        $this->assertContains("woot config error", $this->getErrorOutput(), 'Woot returned an expected config validation error.');
+
+        // Now we disable the error, and retry the config import.
+        $this->drush('state:set', ['woot.shoud_not_fail_on_cim', 'true']);
         $this->drush('config:import');
+
+        // We make sure that the service inside the newly enabled module exists now.
+        $this->drush('php:eval', ['var_dump(\Drupal::hasService("drush_empty_module.service"));']);
+        $this->assertOutputEquals('bool(true)');
     }
 
     protected function getConfigSyncDir()

--- a/tests/functional/ConfigTest.php
+++ b/tests/functional/ConfigTest.php
@@ -145,9 +145,9 @@ YAML_FRAGMENT;
         $this->drush('state:set', ['woot.shoud_not_fail_on_cim', 'true']);
         $this->drush('config:import');
 
-        // We make sure that the service inside the newly enabled module exists now.
-        $this->drush('php:eval', ['var_dump(\Drupal::hasService("drush_empty_module.service"));']);
-        $this->assertOutputEquals('bool(true)');
+        // We make sure that the service inside the newly enabled module exists now. A fatal
+        // error will be thrown by Drupal if the service does not exist.
+        $this->drush('php:eval', ['Drupal::service("drush_empty_module.service");']);
     }
 
     protected function getConfigSyncDir()

--- a/tests/functional/resources/modules/d8/woot/src/EventSubscriber/ConfigSubscriber.php
+++ b/tests/functional/resources/modules/d8/woot/src/EventSubscriber/ConfigSubscriber.php
@@ -35,8 +35,10 @@ class ConfigSubscriber extends ConfigImportValidateEventSubscriberBase
    */
     public function onConfigImporterValidate(ConfigImporterEvent $event)
     {
-        // Always log an error.
-        $importer = $event->getConfigImporter();
-        $importer->logError($this->t('woot config error'));
+        // Always log an error, except when there has been a state key set that explicitly disables this functionality.
+        if (!\Drupal::state()->get('woot.shoud_not_fail_on_cim')) {
+            $importer = $event->getConfigImporter();
+            $importer->logError($this->t('woot config error'));
+        }
     }
 }


### PR DESCRIPTION
This removes the usage of UpdateKernel from the `config:import` command and thereby fixes #4350.

I expected to see an error in 'testConfigImport', but all tests pass (after fixing another minor test issue).

It also looks like the config validation event was not invoked anymore - that is now also fixed and being checked on in the test.

To showcase that this test would be failing without this change, please see #4369 .