### PR TITLE
Fixed corrupt module_hook_info() cache

### DIFF
--- a/commands/core/drupal/update_7.inc
+++ b/commands/core/drupal/update_7.inc
@@ -174,6 +174,7 @@ function update_main_prepare() {
   // Reset the module_implements() cache so that any new hook implementations
   // in updated code are picked up.
   module_implements('', FALSE, TRUE);
+  module_list(TRUE, FALSE, TRUE);
 
   // Set up $language, since the installer components require it.
   drupal_language_initialize();


### PR DESCRIPTION
This was tricky to track down but it's straightforward to reproduce with drush 8.3.2:

1. Enable a module calling `drush_bootstrap_max()` in a  `drush_hook_pre_updatedb` hook, e.g.:
  ```
  function drush_drush_update_modules_pre_updatedb() {
    drush_bootstrap_max();
    // ...
  }
  ```
2. Run `drush updb -y`
3. Run `drush ev "return module_hook_info()"`

Expected result: lots of stuff :)
Actual result:
```
array(
  'token_info' => array(
    'group' => 'tokens',
  ),
  'token_info_alter' => array(
    'group' => 'tokens',
  ),
  'tokens' => array(
    'group' => 'tokens',
  ),
  'tokens_alter' => array(
    'group' => 'tokens',
  ),
)
```

This does not normally happens because [drupal_maintenance_theme()](https://github.com/drush-ops/drush/blob/75c3362fc874c3045fe6bef28f31bc24a5fbe6f7/commands/core/drupal/update_7.inc#L182) runs before the global `$theme` variable has been initialized. When full-bootstrapping before executing the command, you get the following stack trace instead:
```
module.inc:883, module_hook_info()
module.inc:780, module_implements()
module.inc:1091, drupal_alter()
system.module:2443, _system_rebuild_module_data()
system.module:2471, system_rebuild_module_data()
system.install:447, system_requirements()
update_7.inc:130, update_check_requirements()
update_7.inc:186, update_main_prepare()
update_7.inc:231, update_main()
core.drush.inc:466, drush_core_updatedb()
command.inc:422, _drush_invoke_hooks()
command.inc:231, drush_command()
command.inc:199, drush_dispatch()
BaseBoot.php:67, Drush\Boot\DrupalBoot7->bootstrap_and_dispatch()
preflight.inc:67, drush_main()
drush.php:12, {main}()
```
In this case the `module_hook_info()` cache is corrupt because only the `system` module is returned by [module_list()](https://github.com/drush-ops/drush/blob/75c3362fc874c3045fe6bef28f31bc24a5fbe6f7/commands/core/drupal/update_7.inc#L170).