### PR TITLE
Avoid logging during web requests.

### DIFF
--- a/src/Drush.php
+++ b/src/Drush.php
@@ -138,7 +138,6 @@ class Drush
     public static function getContainer()
     {
         if (!\Robo\Robo::hasContainer()) {
-            debug_print_backtrace();
             throw new \RuntimeException('Drush::$container is not initialized yet. \Drush::setContainer() must be called with a real container.');
         }
         return \Robo\Robo::getContainer();

--- a/src/Log/DrushLog.php
+++ b/src/Log/DrushLog.php
@@ -53,7 +53,6 @@ class DrushLog implements LoggerInterface, LoggerAwareInterface
     public function __construct(LogMessageParserInterface $parser)
     {
         $this->parser = $parser;
-        $this->logger = Drush::logger();
     }
 
     /**
@@ -61,6 +60,11 @@ class DrushLog implements LoggerInterface, LoggerAwareInterface
      */
     public function log($level, $message, array $context = [])
     {
+        // Only log during Drush requests, not web requests.
+        if (!\Robo\Robo::hasContainer()) {
+            return;
+        }
+
         // Translate the RFC logging levels into their Drush counterparts, more or
         // less.
         // @todo ALERT, CRITICAL and EMERGENCY are considered show-stopping errors,
@@ -107,6 +111,6 @@ class DrushLog implements LoggerInterface, LoggerAwareInterface
 
         $message = empty($message_placeholders) ? $message : strtr($message, $message_placeholders);
 
-        $this->logger->log($error_type, $message, $context);
+        Drush::logger()->log($error_type, $message, $context);
     }
 }


### PR DESCRIPTION
Follow-up to last PR merge.