### PR TITLE
pm:enable option to skip translations

### DIFF
--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -70,9 +70,10 @@ class PmCommands extends DrushCommands
      *
      * @command pm:enable
      * @param $modules A comma delimited list of modules.
+     * @options skip-translations Do not import interface translations of enabled modules.
      * @aliases en,pm-enable
      */
-    public function enable(array $modules)
+    public function enable(array $modules, $options = ['skip-translations' => self::OPT])
     {
         $modules = StringUtils::csvToArray($modules);
         $todo = $this->addInstallDependencies($modules);
@@ -90,7 +91,7 @@ class PmCommands extends DrushCommands
         if (!$this->getModuleInstaller()->install($modules, true)) {
             throw new \Exception('Unable to install modules.');
         }
-        if (batch_get()) {
+        if (batch_get() && !$options['skip-translations']) {
             drush_backend_batch_process();
         }
         $this->logger()->success(dt('Successfully enabled: !list', $todo_str));

--- a/tests/functional/PmEnLocaleImportTest.php
+++ b/tests/functional/PmEnLocaleImportTest.php
@@ -40,6 +40,16 @@ class PmEnLocaleImportCase extends CommandUnishTestCase
 
         $this->drush('language-add', ['nl']);
 
+        // Enable without importing translations.
+        $this->drush('pm-enable', ['drush_empty_module'], ['skip-translations' => true]);
+        $this->drush('watchdog-show');
+        $this->assertNotContains('Translations imported:', $this->getSimplifiedOutput());
+
+        // Uninstall module and restore the translation file that gets removed during uninstall.
+        $this->drush('pm-uninstall', ['drush_empty_module']);
+        copy($source, $translationDir . '/drush_empty_module.nl.po');
+
+        // Enable with importing translations.
         $this->drush('pm-enable', ['drush_empty_module']);
         $this->drush('watchdog-show');
         $this->assertContains('Translations imported:', $this->getSimplifiedOutput());


### PR DESCRIPTION
There are situations when a developer does not want to download and import interface translation files while enabling a module. For example:

* When enabling large number of modules
* When enabling a module to try it out. (Translation import can not be reverted)
* When working on a limited bandwith connection, e.g. while traveling

Usage example:

```
drush en devel --skip-translations
```

This PR replaces PR #3531 that could not be continued because I lost the repo.