### PR TITLE
Allow passing config-dir for clean install

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -83,7 +83,7 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
 
         // Was giving error during validate() so its here for now.
         if ($options['existing-config']) {
-            $existing_config_dir = drush_config_get_config_directory();
+            $existing_config_dir = $options['config-dir'] ?? drush_config_get_config_directory();
             if (!is_dir($existing_config_dir)) {
                 throw new \Exception(dt('Existing config directory @dir not found', ['@dir' => $existing_config_dir]));
             }


### PR DESCRIPTION
A drush site:install with `--existing-config` option fails if there is no settings.php yet since in that case `drush_config_get_config_directory()` throws an exception with the rather unhelpful message "The configuration directory type 'sync' does not exist"

This solution takes the passed in `config-dir` option instead, allowing a completely fresh install of drupal from existing config.

Fixes #4326