### PR TITLE
Fix missing version info from Git Deploy

### DIFF
--- a/commands/core/drupal/update_7.inc
+++ b/commands/core/drupal/update_7.inc
@@ -167,8 +167,8 @@ function update_main_prepare() {
 
   // Load module basics.
   include_once $core . '/includes/module.inc';
-  $module_list['system']['filename'] = 'modules/system/system.module';
-  module_list(TRUE, FALSE, FALSE, $module_list);
+  $GLOBALS['module_list']['system']['filename'] = 'modules/system/system.module';
+  module_list(TRUE, FALSE, FALSE, $GLOBALS['module_list']);
   drupal_load('module', 'system');
 
   // Reset the module_implements() cache so that any new hook implementations


### PR DESCRIPTION
Git Deploy is unable to provide version info to the Drush 8 update-db command. Since this is the only version of Drush that supports Drupal 7, updates of Drupal 7 modules that have specific version dependencies will fail if any of those dependencies are installed with Git. Moshe Weitzman has refused to accept a fix. You can use a [fork](https://github.com/darrenoh/drush) of Drush 8 to run updates on Drupal 7.

### Details of the fix
In _update.php_, `$module_list` is a global array. [Git Deploy](https://www.drupal.org/project/git_deploy) can add itself to the array and add version info to modules cloned with Git. In the _updatedb_ command `$module_list` is a local variable. This causes every module that has a version dependency on a cloned module to generate errors. The fix is to make `$module_list` a global array as it is in _update.php_.