### PR TITLE
Fix #4402 by removing deprecated use of Process::inheritEnvironmentVariables

### DIFF
--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -153,7 +153,9 @@ class ProcessManager extends ConsolidationProcessManager
         // Handle BC method of making env variables inherited. The default in
         // later versions is always inherit and this method disappears.
         if (method_exists($process, 'inheritEnvironmentVariables')) {
+            set_error_handler();
             $process->inheritEnvironmentVariables();
+            restore_error_handler();
         }
         $process->setLogger(Drush::logger());
         $process->setRealtimeOutput(new DrushStyle(Drush::input(), Drush::output()));

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -153,7 +153,7 @@ class ProcessManager extends ConsolidationProcessManager
         // Handle BC method of making env variables inherited. The default in
         // later versions is always inherit and this method disappears.
         if (method_exists($process, 'inheritEnvironmentVariables')) {
-            set_error_handler();
+            set_error_handler(null);
             $process->inheritEnvironmentVariables();
             restore_error_handler();
         }

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -150,6 +150,11 @@ class ProcessManager extends ConsolidationProcessManager
     {
         $process->setSimulated(Drush::simulate());
         $process->setVerbose(Drush::verbose());
+        // Handle BC method of making env variables inherited. The default in
+        // later versions is always inherit and this method disappears.
+        if (method_exists($process, 'inheritEnvironmentVariables')) {
+            $process->inheritEnvironmentVariables();
+        }
         $process->setLogger(Drush::logger());
         $process->setRealtimeOutput(new DrushStyle(Drush::input(), Drush::output()));
         $process->setTimeout(Drush::getTimeout());

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -150,7 +150,6 @@ class ProcessManager extends ConsolidationProcessManager
     {
         $process->setSimulated(Drush::simulate());
         $process->setVerbose(Drush::verbose());
-        $process->inheritEnvironmentVariables();
         $process->setLogger(Drush::logger());
         $process->setRealtimeOutput(new DrushStyle(Drush::input(), Drush::output()));
         $process->setTimeout(Drush::getTimeout());

--- a/src/TestTraits/CliTestTrait.php
+++ b/src/TestTraits/CliTestTrait.php
@@ -94,7 +94,6 @@ trait CliTestTrait
         try {
             // Process uses a default timeout of 60 seconds, set it to 0 (none).
             $this->process = new Process($command, $cd, $env, $input, 0);
-            $this->process->inheritEnvironmentVariables(true);
             if ($this->timeout) {
                 $this->process->setTimeout($this->timeout)
                 ->setIdleTimeout($this->idleTimeout);

--- a/src/TestTraits/CliTestTrait.php
+++ b/src/TestTraits/CliTestTrait.php
@@ -94,6 +94,11 @@ trait CliTestTrait
         try {
             // Process uses a default timeout of 60 seconds, set it to 0 (none).
             $this->process = new Process($command, $cd, $env, $input, 0);
+            // Handle BC method of making env variables inherited. The default
+            // in later versions is always inherit and this method disappears.
+            if (method_exists($this->process, 'inheritEnvironmentVariables')) {
+                $this->process->inheritEnvironmentVariables();
+            }
             if ($this->timeout) {
                 $this->process->setTimeout($this->timeout)
                 ->setIdleTimeout($this->idleTimeout);

--- a/src/TestTraits/CliTestTrait.php
+++ b/src/TestTraits/CliTestTrait.php
@@ -97,7 +97,9 @@ trait CliTestTrait
             // Handle BC method of making env variables inherited. The default
             // in later versions is always inherit and this method disappears.
             if (method_exists($this->process, 'inheritEnvironmentVariables')) {
+                set_error_handler(null);
                 $this->process->inheritEnvironmentVariables();
+                restore_error_handler();
             }
             if ($this->timeout) {
                 $this->process->setTimeout($this->timeout)


### PR DESCRIPTION
Here's the message from Symfony's code

```php
        if (!$inheritEnv) {
            @trigger_error('Not inheriting environment variables is deprecated since Symfony 3.3 and will always happen in 4.0. Set "Process::inheritEnvironmentVariables()" to true instead.', E_USER_DEPRECATED);
        }
```