### PR TITLE
Display "composer why" suggestion for every package

### DIFF
--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -177,7 +177,7 @@ class SecurityUpdateCommands extends DrushCommands
         $process->mustRun();
         $out = $process->getOutput();
         if ($packages = json_decode($out, true)) {
-            $suggested_command = "composer why " . implode('; composer why ', array_keys($packages));
+            $suggested_command = "composer why " . implode('&& composer why ', array_keys($packages));
             $this->logger()->warning('One or more of your dependencies has an outstanding security update.');
             $this->logger()->notice("Run <comment>$suggested_command</comment> to learn what module requires the package.");
             return CommandResult::dataWithExitCode(new UnstructuredData($packages), self::EXIT_FAILURE);

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -177,7 +177,7 @@ class SecurityUpdateCommands extends DrushCommands
         $process->mustRun();
         $out = $process->getOutput();
         if ($packages = json_decode($out, true)) {
-            $suggested_command = "composer why " . implode('&& composer why ', array_keys($packages));
+            $suggested_command = "composer why " . implode(' && composer why ', array_keys($packages));
             $this->logger()->warning('One or more of your dependencies has an outstanding security update.');
             $this->logger()->notice("Run <comment>$suggested_command</comment> to learn what module requires the package.");
             return CommandResult::dataWithExitCode(new UnstructuredData($packages), self::EXIT_FAILURE);

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -177,7 +177,7 @@ class SecurityUpdateCommands extends DrushCommands
         $process->mustRun();
         $out = $process->getOutput();
         if ($packages = json_decode($out, true)) {
-            $suggested_command = "composer why " . key($packages);
+            $suggested_command = "composer why " . implode('; composer why ', array_keys($packages));
             $this->logger()->warning('One or more of your dependencies has an outstanding security update.');
             $this->logger()->notice("Run <comment>$suggested_command</comment> to learn what module requires the package.");
             return CommandResult::dataWithExitCode(new UnstructuredData($packages), self::EXIT_FAILURE);

--- a/tests/integration/SecurityUpdatesTest.php
+++ b/tests/integration/SecurityUpdatesTest.php
@@ -32,7 +32,7 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
     {
         $this->drush('pm:security-php', [], ['format' => 'json'], self::EXIT_ERROR);
         $this->assertContains('One or more of your dependencies has an outstanding security update.', $this->getErrorOutput());
-        $this->assertContains('Run composer why david-garcia/phpwhois to learn what module requires the package.', $this->getErrorOutput());
+        $this->assertContains('Run composer why david-garcia/phpwhois && composer why drupal/core to learn what module requires the package.', $this->getErrorOutput());
         $security_advisories = $this->getOutputFromJSON();
         $this->arrayHasKey('david-garcia/phpwhois', $security_advisories);
     }

--- a/tests/integration/SecurityUpdatesTest.php
+++ b/tests/integration/SecurityUpdatesTest.php
@@ -32,7 +32,7 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
     {
         $this->drush('pm:security-php', [], ['format' => 'json'], self::EXIT_ERROR);
         $this->assertContains('One or more of your dependencies has an outstanding security update.', $this->getErrorOutput());
-        $this->assertContains('Run composer why david-garcia/phpwhois && composer why drupal/core to learn what module requires the package.', $this->getErrorOutput());
+        $this->assertContains('Run composer why david-garcia/phpwhois', $this->getErrorOutput());
         $security_advisories = $this->getOutputFromJSON();
         $this->arrayHasKey('david-garcia/phpwhois', $security_advisories);
     }


### PR DESCRIPTION
Fixes https://github.com/drush-ops/drush/issues/4366.

Unfortunately, it does not seem possible to use a single `composer why` call for multiple packages.