### PR TITLE
Fix user:cancel

### DIFF
--- a/lib/Drush/User/UserSingleBase.php
+++ b/lib/Drush/User/UserSingleBase.php
@@ -88,7 +88,7 @@ abstract class UserSingleBase {
       // I got the following technique here: http://drupal.org/node/638712
       $batch =& batch_get();
       $batch['progressive'] = FALSE;
-      batch_process();
+      drush_backend_batch_process();
   }
 
   /**


### PR DESCRIPTION
Use drush_backend_batch_process() instead of batch_process() in user:cancel.

This should have broken 100% of the time, but instead it decided to break 0% of the time for years, until it started breaking only most of the time, but only when used with a site set up via Behat. Go figure.
