### PR TITLE
Fix #4134: Detects proxy settings before fetching drupal-security-adv…

### DIFF
--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -45,7 +45,7 @@ class SecurityUpdateCommands extends DrushCommands
      *
      * @command pm:security
      * @aliases sec,pm-security
-     * @bootstrap configuration
+     * @bootstrap max
      * @table-style default
      * @field-labels
      *   name: Name


### PR DESCRIPTION
Hi,
here's a PR to fix  https://github.com/drush-ops/drush/issues/4134 
It use bootstrap configuration to detect proxy settings and use them to get drupal-security-advisories.

It could be improve by detecting proxy env variable.