### PR TITLE
alinks has no D9 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
       - run: cp .docker/zz-php.ini /usr/local/etc/php/conf.d/
       - run: composer require --dev drupal/core-recommended:9.0.x-dev --no-update
       # Replace alinks once we have a project that version that is both D9 compatible is insecure.
-      - run: composer remove drupal/alinks --no-update
+      - run: composer remove --dev drupal/alinks --no-update
       - run: composer config platform.php 7.3.0
       - run: composer update --no-scripts
       - run: composer install -n

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,8 @@ jobs:
       - checkout
       - run: cp .docker/zz-php.ini /usr/local/etc/php/conf.d/
       - run: composer require --dev drupal/core-recommended:9.0.x-dev --no-update
+      # Replace alinks once we have a project that version that is both D9 compatible is insecure.
+      - run: composer remove drupal/alinks --no-update
       - run: composer config platform.php 7.3.0
       - run: composer update --no-scripts
       - run: composer install -n

--- a/tests/integration/SecurityUpdatesTest.php
+++ b/tests/integration/SecurityUpdatesTest.php
@@ -17,7 +17,7 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
     {
         // Remove this once we have a project that version that is both D9 compatible is insecure. alinks is not that yet.
         if ($this->isDrupalGreaterThanOrEqualTo('9.0.0')) {
-          $this->markTestSkipped('No modules have had a security release since they became D9 compatible.');
+            $this->markTestSkipped('No modules have had a security release since they became D9 compatible.');
         }
 
         $this->drush('pm:security', [], ['format' => 'json'], self::EXIT_ERROR);

--- a/tests/integration/SecurityUpdatesTest.php
+++ b/tests/integration/SecurityUpdatesTest.php
@@ -15,7 +15,11 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
    */
     public function testInsecureDrupalPackage()
     {
-        // @todo This passes on Drupal because drupal/alinks has a security release for 8 and we don't actually install that module on our d9 tests.
+        // Remove this once we have a project that version that is both D9 compatible is insecure. alinks is not that yet.
+        if ($this->isDrupalGreaterThanOrEqualTo('9.0.0')) {
+          $this->markTestSkipped('No modules have had a security release since they became D9 compatible.');
+        }
+
         $this->drush('pm:security', [], ['format' => 'json'], self::EXIT_ERROR);
         $this->assertContains('One or more of your dependencies has an outstanding security update.', $this->getErrorOutput());
         $this->assertContains('Try running: composer require drupal/alinks', $this->getErrorOutput());


### PR DESCRIPTION
Replace alinks once there is a contrib module release that is both D9 compatible and insecure.