### PR TITLE
Notify success checking php security updates

### DIFF
--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -182,6 +182,6 @@ class SecurityUpdateCommands extends DrushCommands
             $this->logger()->notice("Run <comment>$suggested_command</comment> to learn what module requires the package.");
             return CommandResult::dataWithExitCode(new UnstructuredData($packages), self::EXIT_FAILURE);
         }
-        $this->logger()->success("<info>There are no outstanding security updates for your dependencies.</info>");
+        $this->logger()->success("There are no outstanding security updates for your dependencies.");
     }
 }

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -182,5 +182,6 @@ class SecurityUpdateCommands extends DrushCommands
             $this->logger()->notice("Run <comment>$suggested_command</comment> to learn what module requires the package.");
             return CommandResult::dataWithExitCode(new UnstructuredData($packages), self::EXIT_FAILURE);
         }
+        $this->logger()->success("<info>There are no outstanding security updates for your dependencies.</info>");
     }
 }


### PR DESCRIPTION
Provides a simple message on success instead of silently ending.

Wording and logging level copied form the Drupal version of the method.