### PR TITLE
Feat: add executable as option for sql-dump.

### DIFF
--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -218,6 +218,7 @@ class SqlCommands extends DrushCommands implements StdinAwareInterface
      * @option gzip Compress the dump using the gzip program which must be in your $PATH.
      * @option extra Add custom arguments/options when connecting to database (used internally to list tables).
      * @option extra-dump Add custom arguments/options to the dumping of the database (e.g. mysqldump command).
+     * @option executable The database executable to use.
      * @usage drush sql:dump --result-file=../18.sql
      *   Save SQL dump to the directory above Drupal root.
      * @usage drush sql:dump --skip-tables-key=common
@@ -234,7 +235,7 @@ class SqlCommands extends DrushCommands implements StdinAwareInterface
      * @notes
      *   createdb is used by sql-sync, since including the DROP TABLE statements interfere with the import when the database is created.
      */
-    public function dump($options = ['result-file' => self::REQ, 'create-db' => false, 'data-only' => false, 'ordered-dump' => false, 'gzip' => false, 'extra' => self::REQ, 'extra-dump' => self::REQ, 'format' => 'null'])
+    public function dump($options = ['result-file' => self::REQ, 'create-db' => false, 'data-only' => false, 'ordered-dump' => false, 'gzip' => false, 'extra' => self::REQ, 'extra-dump' => self::REQ, 'format' => 'null', 'executable' => self::REQ])
     {
         $sql = SqlBase::create($options);
         $return = $sql->dump();

--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -147,7 +147,10 @@ EOT;
         // The ordered-dump option is only supported by MySQL for now.
         $ordered_dump = $this->getOption('ordered-dump');
 
-        $exec = 'mysqldump ';
+        $executable = $this->getOption('executable') ?? 'mysqldump';
+
+        $exec = "{$executable} ";
+
         // mysqldump wants 'databasename' instead of 'database=databasename' for no good reason.
         $only_db_name = str_replace('--database=', ' ', $this->creds());
         $exec .= $only_db_name;
@@ -178,7 +181,7 @@ EOT;
 
             // Run mysqldump again and append output if we need some structure only tables.
             if (!empty($structure_tables)) {
-                $exec .= " && mysqldump " . $only_db_name . " --no-data $extra " . implode(' ', $structure_tables);
+                $exec .= " && {$executable} " . $only_db_name . " --no-data $extra " . implode(' ', $structure_tables);
                 $parens = true;
             }
         }


### PR DESCRIPTION
I'd like to use a GDPR dump library (https://github.com/machbarmacher/gdpr-dump) for creating anonymized dumps. That library provides its own mysqldump executable for anonymizing the data. So for this to properly work with drush, we would need an option to choose their mysqldump executable instead of the default one. This PR adds that option.