### PR TITLE
Replace blacklist/whitelist with blocklist/allowlist

### DIFF
--- a/src/Drupal/Commands/core/CliCommands.php
+++ b/src/Drupal/Commands/core/CliCommands.php
@@ -205,7 +205,7 @@ class CliCommands extends DrushCommands
     /**
      * Returns a list of PHP keywords.
      *
-     * This will act as a blacklist for command and alias names.
+     * This will act as a blocklist for command and alias names.
      *
      * @return array
      */

--- a/src/Drupal/Commands/sql/SanitizeCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeCommands.php
@@ -25,7 +25,7 @@ class SanitizeCommands extends DrushCommands implements CustomEventAwareInterfac
      * @aliases sqlsan,sql-sanitize
      * @usage drush sql:sanitize --sanitize-password=no
      *   Sanitize database without modifying any passwords.
-     * @usage drush sql:sanitize --whitelist-fields=field_biography,field_phone_number
+     * @usage drush sql:sanitize --allowlist-fields=field_biography,field_phone_number
      *   Sanitizes database but exempts two user fields from modification.
      */
     public function sanitize()

--- a/src/Drupal/Commands/sql/SanitizeUserFieldsCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserFieldsCommands.php
@@ -52,7 +52,11 @@ class SanitizeUserFieldsCommands extends DrushCommands implements SanitizePlugin
         $conn = $this->getDatabase();
         $field_definitions = $this->getEntityFieldManager()->getFieldDefinitions('user', 'user');
         $field_storage = $this->getEntityFieldManager()->getFieldStorageDefinitions('user');
+        /** @deprecated Use $options['allowlist-fields'] instead. */
         foreach (explode(',', $options['whitelist-fields']) as $key) {
+            unset($field_definitions[$key], $field_storage[$key]);
+        }
+        foreach (explode(',', $options['allowlist-fields']) as $key) {
             unset($field_definitions[$key], $field_storage[$key]);
         }
 
@@ -131,9 +135,10 @@ class SanitizeUserFieldsCommands extends DrushCommands implements SanitizePlugin
 
     /**
      * @hook option sql-sanitize
-     * @option whitelist-fields A comma delimited list of fields exempt from sanitization.
+     * @option whitelist-fields Deprecated. Use allowlist-fields instead.
+     * @option allowlist-fields A comma delimited list of fields exempt from sanitization.
      */
-    public function options($options = ['whitelist-fields' => ''])
+    public function options($options = ['whitelist-fields' => '', 'allowlist-fields' => ''])
     {
     }
 }


### PR DESCRIPTION
Following up on https://www.drupal.org/project/ideas/issues/3159647#comment-13755051 let's fix this now.

This PR replaces blacklist which only had one occurrence in a comment. And it deprecates whitelist which only appeared in an option to the `sql:sanitize` command. 