### PR TITLE
Better error handling for update functions in wrong files 

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -303,7 +303,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         }
 
         list($module, $name) = explode('_post_update_', $function, 2);
-        $filename = $module . '.post_update';    
+        $filename = $module . '.post_update';
         \Drupal::moduleHandler()->loadInclude($module, 'php', $filename);
         if (function_exists($function)) {
             if (empty($context['results'][$module][$name]['type'])) {
@@ -331,8 +331,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
                     'query' => t('%type: @message in %function (line %line of %file).', $variables),
                 ];
             }
-        }
-        else {
+        } else {
             $ret['#abort'] = ['success' => false];
             Drush::logger()->warning(dt('Post update function @function not found in file @filename', [
                 '@function' => $function,

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -238,7 +238,10 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
             }
         } else {
             $ret['#abort'] = ['success' => false];
-            Drush::logger()->warning(dt('Update function @function not found', ['@function' => $function]));
+            Drush::logger()->warning(dt('Update function @function not found in file @filename', [
+                '@function' => $function,
+                '@filename' => "$module.install.php",
+            ]));
         }
 
         if (isset($context['sandbox']['#finished'])) {
@@ -300,7 +303,8 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         }
 
         list($module, $name) = explode('_post_update_', $function, 2);
-        module_load_include('php', $module, $module . '.post_update');
+        $filename = $module . '.post_update';    
+        \Drupal::moduleHandler()->loadInclude($module, 'php', $filename);
         if (function_exists($function)) {
             if (empty($context['results'][$module][$name]['type'])) {
                 Drush::logger()->notice("Update started: $function");
@@ -328,7 +332,14 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
                 ];
             }
         }
-
+        else {
+            $ret['#abort'] = ['success' => false];
+            Drush::logger()->warning(dt('Post update function @function not found in file @filename', [
+                '@function' => $function,
+                '@filename' => "$filename.php",
+            ]));
+        }
+        
         if (isset($context['sandbox']['#finished'])) {
             $context['finished'] = $context['sandbox']['#finished'];
             unset($context['sandbox']['#finished']);

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -240,7 +240,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
             $ret['#abort'] = ['success' => false];
             Drush::logger()->warning(dt('Update function @function not found in file @filename', [
                 '@function' => $function,
-                '@filename' => "$module.install.php",
+                '@filename' => "$module.install",
             ]));
         }
 


### PR DESCRIPTION
This PR fixes 3 problems:
1. Currently post update hooks appear successful if placed in my_module.install, but are not actually invoked
2. If you put your update or post update function in the wrong file, it would be helpful to tell you what the right file is
3. Post-update processing should use Drupal::moduleHandler()->loadInclude not module_load_include(), as update processing already does. 