### PR TITLE
@topic annotation can be a relative path to a file

### DIFF
--- a/src/Commands/DrushCommands.php
+++ b/src/Commands/DrushCommands.php
@@ -1,6 +1,7 @@
 <?php
 namespace Drush\Commands;
 
+use Consolidation\AnnotatedCommand\CommandData;
 use Drush\Drush;
 use Drush\Style\DrushStyle;
 use Psr\Log\LoggerAwareInterface;
@@ -13,6 +14,7 @@ use Robo\Common\IO;
 use Symfony\Component\Console\Input\InputOption;
 use Consolidation\SiteProcess\ProcessManagerAwareTrait;
 use Consolidation\SiteProcess\ProcessManagerAwareInterface;
+use Webmozart\PathUtil\Path;
 
 abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, ConfigAwareInterface, ProcessManagerAwareInterface
 {
@@ -86,5 +88,17 @@ abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, 
                 }
             }
         }
+    }
+
+    /**
+     * Print the contents of a file. The path comes the @topic annotation.
+     *
+     * @param CommandData $commandData
+     *   Full path to a file.
+     */
+    protected function printFileTopic(CommandData $commandData)
+    {
+        $file = $commandData->annotationData()->get('topic');
+        $this->printFile(Path::makeAbsolute($file, dirname($commandData->annotationData()->get('_path'))));
     }
 }

--- a/src/Commands/core/DocsCommands.php
+++ b/src/Commands/core/DocsCommands.php
@@ -1,6 +1,7 @@
 <?php
 namespace Drush\Commands\core;
 
+use Consolidation\AnnotatedCommand\CommandData;
 use Drush\Commands\DrushCommands;
 use Webmozart\PathUtil\Path;
 
@@ -14,6 +15,11 @@ use Webmozart\PathUtil\Path;
 class DocsCommands extends DrushCommands
 {
     /**
+     * @var CommandData
+     */
+    protected $commandData;
+
+    /**
      * README.md
      *
      * @command docs:readme
@@ -23,7 +29,7 @@ class DocsCommands extends DrushCommands
      */
     public function readme()
     {
-        self::printFile(Path::makeAbsolute('../../../README.md', __DIR__));
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -32,11 +38,11 @@ class DocsCommands extends DrushCommands
      * @command docs:bisect
      * @aliases docs-bisect
      * @hidden
-     * @topic
+     * @topic ../../../examples/git-bisect.example.sh
      */
     public function bisect()
     {
-        self::printFile(DRUSH_BASE_PATH. '/examples/git-bisect.example.sh');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -45,11 +51,11 @@ class DocsCommands extends DrushCommands
      * @command docs:bashrc
      * @aliases docs-bashrc
      * @hidden
-     * @topic
+     * @topic ../../../examples/example.bashrc
      */
     public function bashrc()
     {
-        self::printFile(DRUSH_BASE_PATH. '/examples/example.bashrc');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -58,11 +64,11 @@ class DocsCommands extends DrushCommands
      * @command docs:configuration
      * @aliases docs-configuration
      * @hidden
-     * @topic
+     * @topic ../../../examples/example.drush.yml
      */
     public function config()
     {
-        self::printFile(DRUSH_BASE_PATH. '/examples/example.drush.yml');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -71,11 +77,11 @@ class DocsCommands extends DrushCommands
      * @command docs:config:exporting
      * @aliases docs-config-exporting
      * @hidden
-     * @topic
+     * @topic ../../../docs/config-exporting.md
      */
     public function configExport()
     {
-        self::printFile(DRUSH_BASE_PATH. '/docs/config-exporting.md');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -85,11 +91,11 @@ class DocsCommands extends DrushCommands
      * @aliases docs:output
      * @aliases docs-output
      * @hidden
-     * @topic
+     * @topic  ../../../docs/output-formats-filters.md
      */
     public function outputFormatsFilters()
     {
-        self::printFile(DRUSH_BASE_PATH. '/docs/output-formats-filters.md');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -98,11 +104,11 @@ class DocsCommands extends DrushCommands
      * @command docs:aliases
      * @aliases docs-aliases
      * @hidden
-     * @topic
+     * @topic ../../../examples/example.site.yml
      */
     public function siteAliases()
     {
-        self::printFile(DRUSH_BASE_PATH. '/examples/example.site.yml');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -111,11 +117,11 @@ class DocsCommands extends DrushCommands
      * @command docs:bootstrap
      * @aliases docs-bootstrap
      * @hidden
-     * @topic
+     * @topic ../../..//docs/bootstrap.md
      */
     public function bootstrap()
     {
-        self::printFile(DRUSH_BASE_PATH. '/docs/bootstrap.md');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -124,11 +130,11 @@ class DocsCommands extends DrushCommands
      * @command docs:cron
      * @aliases docs-cron
      * @hidden
-     * @topic
+     * @topic ../../../docs/cron.md
      */
     public function cron()
     {
-        self::printFile(DRUSH_BASE_PATH. '/docs/cron.md');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -137,11 +143,11 @@ class DocsCommands extends DrushCommands
      * @command docs:commands
      * @aliases docs-commands
      * @hidden
-     * @topic
+     * @topic ../../../docs/commands.md
      */
     public function commands()
     {
-        self::printFile(DRUSH_BASE_PATH. '/docs/commands.md');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -150,11 +156,11 @@ class DocsCommands extends DrushCommands
      * @command docs:generators
      * @aliases docs-generators
      * @hidden
-     * @topic
+     * @topic ../../../docs/generators.md
      */
     public function generators()
     {
-        self::printFile(DRUSH_BASE_PATH. '/docs/generators.md');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -163,11 +169,11 @@ class DocsCommands extends DrushCommands
      * @command docs:examplecommand
      * @aliases docs-examplecommand
      * @hidden
-     * @topic
+     * @topic ../../../examples/Commands/ArtCommands.php
      */
     public function exampleCommand()
     {
-        self::printFile(DRUSH_BASE_PATH. '/examples/Commands/ArtCommands.php');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -176,11 +182,11 @@ class DocsCommands extends DrushCommands
      * @command docs:example-sync-via-http
      * @aliases docs-example-sync-via-http
      * @hidden
-     * @topic
+     * @topic ../../../examples/Commands/SyncViaHttpCommands.php
      */
     public function syncHttp()
     {
-        self::printFile(DRUSH_BASE_PATH. '/examples/Commands/SyncViaHttpCommands.php');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -189,11 +195,11 @@ class DocsCommands extends DrushCommands
      * @command docs:policy
      * @aliases docs-policy
      * @hidden
-     * @topic
+     * @topic ../../../examples/Commands/PolicyCommands.php
      */
     public function policy()
     {
-        self::printFile(DRUSH_BASE_PATH. '/examples/Commands/PolicyCommands.php');
+        self::printFileTopic($this->commandData);
     }
 
     /**
@@ -202,10 +208,20 @@ class DocsCommands extends DrushCommands
      * @command docs:deploy
      * @aliases docs-deploy
      * @hidden
-     * @topic
+     * @topic  ../../../docs/deploy.md
      */
     public function deploy()
     {
-        self::printFile(DRUSH_BASE_PATH. '/docs/deploy.md');
+        self::printFileTopic($this->commandData);
+    }
+
+    /**
+     * @hook pre-command *
+     *
+     * @param \Consolidation\AnnotatedCommand\CommandData $commandData
+     */
+    public function pre(CommandData $commandData)
+    {
+        $this->commandData = $commandData;
     }
 }

--- a/src/Commands/core/DocsCommands.php
+++ b/src/Commands/core/DocsCommands.php
@@ -2,6 +2,7 @@
 namespace Drush\Commands\core;
 
 use Drush\Commands\DrushCommands;
+use Webmozart\PathUtil\Path;
 
 /**
  * Topic commands.
@@ -18,11 +19,11 @@ class DocsCommands extends DrushCommands
      * @command docs:readme
      * @aliases docs-readme
      * @hidden
-     * @topic
+     * @topic ../../../README.md
      */
     public function readme()
     {
-        self::printFile(DRUSH_BASE_PATH. '/README.md');
+        self::printFile(Path::makeAbsolute('../../../README.md', __DIR__));
     }
 
     /**

--- a/src/Commands/core/MkCommands.php
+++ b/src/Commands/core/MkCommands.php
@@ -83,8 +83,15 @@ class MkCommands extends DrushCommands implements SiteAliasManagerAwareInterface
                 }
                 if ($topics = $command->getTopics()) {
                     $body .= "#### Topics\n\n";
-                    foreach ($topics as $value) {
-                        $body .= "- `drush $value`\n";
+                    foreach ($topics as $name) {
+                        $value = "- `drush $name`";
+                        $annotationData = Drush::getApplication()->find($name)->getAnnotationData();
+                        if ($file = $annotationData->get('topic')) {
+                            $value = 'TBD';
+                        }
+                        else {
+                            $body .= "$value\n";
+                        }
                     }
                     $body .= "\n";
                 }


### PR DESCRIPTION
I would like to hyperlink the topics on the new Commands web pages. For example, see 3 topics at bottom of https://www.drush.org/commands/10.x/config_pull/.

This PR adds a value to one `@topic` with a relative link to the file. The mk:docs command can programmatically use that value to build the hyperlink.

This PR duplicates the path `../../../README.md` in the body of the command method. Ideally it would use the value from its own annotation. However I do not see a way in a command method to learn what the current command name is. If I could do that, I would get load a $command object and fetch the annotationData. Hooks get the command info as a param but the command method does not.

This PR will change more methods once the above question is settled.