### PR TITLE
Bring back printing of an argument default in Help. Also change <info> to italic on Commands site

### DIFF
--- a/src/Commands/OptionsCommands.php
+++ b/src/Commands/OptionsCommands.php
@@ -13,7 +13,7 @@ class OptionsCommands
 
     /**
      * @hook option @optionset_proc_build
-     * @option ssh-options A string of extra options that will be passed to the ssh command (e.g. "-p 100")
+     * @option ssh-options A string of extra options that will be passed to the ssh command (e.g. <info>-p 100</info>)
      * @option tty Create a tty (e.g. to run an interactive program).
      */
     public function optionsetProcBuild($options = ['ssh-options' => self::REQ, 'tty' => false])
@@ -22,7 +22,7 @@ class OptionsCommands
 
     /**
      * @hook option @optionset_get_editor
-     * @option editor A string of bash which launches user's preferred text editor. Defaults to ${VISUAL-${EDITOR-vi}}.
+     * @option editor A string of bash which launches user's preferred text editor. Defaults to <info>${VISUAL-${EDITOR-vi}}</info>.
      */
     public function optionsetGetEditor($options = ['editor' => '', 'bg' => false])
     {
@@ -40,7 +40,7 @@ class OptionsCommands
      * @hook option @optionset_sql
      * @option database The DB connection key if using multiple connections in settings.php.
      * @option db-url A Drupal 6 style database URL.
-     * @option target The name of a target within the specified database connection. Defaults to default
+     * @option target The name of a target within the specified database connection.
      * @option show-passwords Show password on the CLI. Useful for debugging.
      */
     public function optionsetSql($options = ['database' => 'default', 'target' => 'default', 'db-url' => self::REQ, 'show-passwords' => false])

--- a/src/Commands/config/ConfigPullCommands.php
+++ b/src/Commands/config/ConfigPullCommands.php
@@ -23,12 +23,12 @@ class ConfigPullCommands extends DrushCommands implements SiteAliasManagerAwareI
      * @param array $options
      * @throws \Exception
      * @option safe Validate that there are no git uncommitted changes before proceeding
-     * @option label A config directory label (i.e. a key in \$config_directories array in settings.php). Defaults to 'sync'
-     * @option runner Where to run the rsync command; defaults to the local site. Can also be 'source' or 'destination'
+     * @option label A config directory label (i.e. a key in $config_directories array in settings.php).
+     * @option runner Where to run the rsync command; defaults to the local site. Can also be <info>source</info> or <info>destination</info>.
      * @usage drush config:pull @prod @stage
      *   Export config from @prod and transfer to @stage.
      * @usage drush config:pull @prod @self --label=vcs
-     *   Export config from @prod and transfer to the 'vcs' config directory of current site.
+     *   Export config from @prod and transfer to the <info>vcs</info> config directory of current site.
      * @usage drush config:pull @prod @self:../config/sync
      *   Export config to a custom directory. Relative paths are calculated from Drupal root.
      * @aliases cpull,config-pull

--- a/src/Commands/core/BrowseCommands.php
+++ b/src/Commands/core/BrowseCommands.php
@@ -20,7 +20,7 @@ class BrowseCommands extends DrushCommands implements SiteAliasManagerAwareInter
      *
      * @param string|null $path Path to open. If omitted, the site front page will be opened.
      * @param array $options An associative array of options whose values come from cli, aliases, config, etc.
-     * @option string $browser Specify a particular browser (defaults to operating system default). Use --no-browser to suppress opening a browser.
+     * @option string $browser Specify a particular browser (defaults to OS default). Use --no-browser to suppress opening a browser.
      * @option integer $redirect-port The port that the web server is redirected to (e.g. when running within a Vagrant environment).
      * @usage drush browse
      *   Open default web browser (if configured or detected) to the site front page.

--- a/src/Commands/core/CacheCommands.php
+++ b/src/Commands/core/CacheCommands.php
@@ -128,7 +128,7 @@ class CacheCommands extends DrushCommands implements CustomEventAwareInterface, 
      * @param $bin The cache bin to store the object in.
      * @param $expire 'CACHE_PERMANENT', or a Unix timestamp.
      * @param $tags A comma delimited list of cache tags.
-     * @option input-format The format of value. Use 'json' for complex values.
+     * @option input-format The format of value. Use <info>json</info> for complex values.
      * @option cache-get If the object is the result a previous fetch from the cache, only store the value in the 'data' property of the object in the cache.
      * @aliases cs,cache-set
      * @bootstrap full

--- a/src/Commands/core/DrupalDirectoryCommands.php
+++ b/src/Commands/core/DrupalDirectoryCommands.php
@@ -25,8 +25,7 @@ class DrupalDirectoryCommands extends DrushCommands implements SiteAliasManagerA
      * Return the filesystem path for modules/themes and other key folders.
      *
      * @command drupal:directory
-     * @param string $target A module/theme name, or special names like root, files, private, or an alias : path alias string such as @alias:%files. Defaults to root.
-     * @option component The portion of the evaluated path to return.  Defaults to 'path'; 'name' returns the site alias of the target.
+     * @param string $target A module/theme name, or special names like root, files, private, or an <info>alias:path</info> string such as @alias:%files.
      * @option local-only Reject any target that specifies a remote site.
      * @usage cd $(drush dd devel)
      *   Navigate into the devel module directory
@@ -37,7 +36,7 @@ class DrupalDirectoryCommands extends DrushCommands implements SiteAliasManagerA
      * @usage drush dd @alias:%files
      *   Print the path to the files directory on the site @alias.
      * @usage edit $(drush dd devel)/devel.module
-     *   Open devel module in your editor (customize 'edit' for your editor)
+     *   Open devel module in your editor
      * @aliases dd,drupal-directory
      */
     public function drupalDirectory($target = 'root', $options = ['local-only' => false])

--- a/src/Commands/core/MkCommands.php
+++ b/src/Commands/core/MkCommands.php
@@ -50,7 +50,7 @@ class MkCommands extends DrushCommands implements SiteAliasManagerAwareInterface
                 $pages[] = $filename;
                 $body = "# $name\n\n";
                 if ($command->getDescription()) {
-                    $body .= $command->getDescription() ."\n\n";
+                    $body .= self::cliTextToMarkdown($command->getDescription()) ."\n\n";
                     if ($command->getHelp()) {
                         $body .= $command->getHelp(). "\n\n";
                     }
@@ -58,7 +58,7 @@ class MkCommands extends DrushCommands implements SiteAliasManagerAwareInterface
                 if ($examples = $command->getExampleUsages()) {
                     $body .= "#### Examples\n\n";
                     foreach ($examples as $key => $value) {
-                        $body .= '- <code>' . $key . '</code>. ' . $value . "\n";
+                        $body .= '- <code>' . $key . '</code>. ' . self::cliTextToMarkdown($value) . "\n";
                     }
                     $body .= "\n";
                 }
@@ -66,7 +66,7 @@ class MkCommands extends DrushCommands implements SiteAliasManagerAwareInterface
                     $body .= "#### Arguments\n\n";
                     foreach ($args as $arg) {
                         $arg_array = self::argToArray($arg);
-                        $body .= '- **' . HelpCLIFormatter::formatArgumentName($arg_array) . '**. ' . $arg->getDescription() . "\n";
+                        $body .= '- **' . HelpCLIFormatter::formatArgumentName($arg_array) . '**. ' . self::cliTextToMarkdown($arg->getDescription()) . "\n";
                     }
                     $body .= "\n";
                 }
@@ -75,7 +75,7 @@ class MkCommands extends DrushCommands implements SiteAliasManagerAwareInterface
                     foreach ($opts as $opt) {
                         if (!HelpCLIFormatter::isGlobalOption($opt->getName())) {
                             $opt_array = self::optionToArray($opt);
-                            $body .= '- **' . HelpCLIFormatter::formatOptionKeys($opt_array) . '**. ' . HelpCLIFormatter::formatOptionDescription($opt_array) . "\n";
+                            $body .= '- **' . HelpCLIFormatter::formatOptionKeys($opt_array) . '**. ' . self::cliTextToMarkdown(HelpCLIFormatter::formatOptionDescription($opt_array)) . "\n";
                         }
                     }
                     $body .= "\n";
@@ -94,7 +94,7 @@ class MkCommands extends DrushCommands implements SiteAliasManagerAwareInterface
                                     $rel_from_docs = str_replace('.md', '', Path::makeRelative($abs, $docs_path));
                                     $value = "- [$topic_description](https://docs.drush.org/en/master/$rel_from_docs) ($name)";
                                 } else {
-                                    $rel_from_root = str_replace('.md', '', Path::makeRelative($abs, DRUSH_BASE_PATH));
+                                    $rel_from_root = Path::makeRelative($abs, DRUSH_BASE_PATH);
                                     $value = "- [$topic_description](https://raw.githubusercontent.com/drush-ops/drush/master/$rel_from_root) ($name)";
                                 }
                             }
@@ -216,5 +216,16 @@ EOT;
             $return['defaults'] = (array)$opt->getDefault();
         }
         return $return;
+    }
+
+    /**
+     * Convert text like <info>foo</info> to *foo*.
+     *
+     * @param $text
+     *
+     * @return string
+     */
+    public static function cliTextToMarkdown($text) {
+        return str_replace(['<info>', '</info>'], '*', $text);
     }
 }

--- a/src/Commands/core/MkCommands.php
+++ b/src/Commands/core/MkCommands.php
@@ -225,7 +225,8 @@ EOT;
      *
      * @return string
      */
-    public static function cliTextToMarkdown($text) {
+    public static function cliTextToMarkdown($text)
+    {
         return str_replace(['<info>', '</info>'], '*', $text);
     }
 }

--- a/src/Commands/core/RunserverCommands.php
+++ b/src/Commands/core/RunserverCommands.php
@@ -39,8 +39,6 @@ class RunserverCommands extends DrushCommands
      *   Start runserver on localhost (using rDNS to determine binding IP), port 8888, and open /user in browser.
      * @usage drush rs /
      *  Start runserver on default IP/port (127.0.0.1, port 8888), and open / in browser.
-     * @usage drush rs --default-server=127.0.0.1:8080/ -
-     *   Use a default (would be specified in your drushrc) that starts runserver on port 8080, and opens a browser to the front page. Set path to a single hyphen path in argument to prevent opening browser for this session.
      * @usage drush rs :9000/admin
      *   Start runserver on 127.0.0.1, port 9000, and open /admin in browser. Note that you need a colon when you specify port and path, but no IP.
      * @usage drush --quiet rs

--- a/src/Commands/help/HelpCLIFormatter.php
+++ b/src/Commands/help/HelpCLIFormatter.php
@@ -43,10 +43,9 @@ class HelpCLIFormatter implements FormatterInterface
             foreach ($data['arguments'] as $argument) {
                 $formatted = $this->formatArgumentName($argument);
                 $description = $argument['description'];
-                // @todo No argument default in Helpdocument
-                //        if ($argument['default']) {
-        //          $description .= ' [default: ' . $argument->getDefault() . ']';
-        //        }
+                if (isset($argument['defaults'])) {
+                    $description .= ' [default: <info>' . implode(',', $argument['defaults']) . '</info>]';
+                }
                 $rows[] = [' ' . $formatted, $description];
             }
             $formatterManager->write($output, 'table', new RowsOfFields($rows), $options);
@@ -111,7 +110,7 @@ class HelpCLIFormatter implements FormatterInterface
 
     public static function formatOptionDescription($option)
     {
-        $defaults = array_key_exists('defaults', $option) ? ' [default: "' . implode(' ', $option['defaults']) . '"]' : '';
+        $defaults = array_key_exists('defaults', $option) ? ' [default: <info>' . implode(' ', $option['defaults']) . '</info>]' : '';
         return $option['description'] . $defaults;
     }
 

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -86,8 +86,8 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
      * @command config:get
      * @validate-config-name
      * @interact-config-name
-     * @param $config_name The config object name, for example "system.site".
-     * @param $key The config key, for example "page.front". Optional.
+     * @param $config_name The config object name, for example <info>system.site</info>.
+     * @param $key The config key, for example <info>page.front</info>. Optional.
      * @option source The config storage source to read. Additional labels may be defined in settings.php.
      * @option include-overridden Apply module and settings.php overrides to values.
      * @usage drush config:get system.site
@@ -112,14 +112,14 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
      * @command config:set
      * @validate-config-name
      * @todo @interact-config-name deferred until we have interaction for key.
-     * @param $config_name The config object name, for example "system.site".
-     * @param $key The config key, for example "page.front".
-     * @param $value The value to assign to the config key. Use '-' to read from STDIN.
-     * @option input-format Format to parse the object. Use "string" for string (default), and "yaml" for YAML.
+     * @param $config_name The config object name, for example <info>system.site</info>.
+     * @param $key The config key, for example <info>page.front</info>.
+     * @param $value The value to assign to the config key. Use <info>-</info> to read from STDIN.
+     * @option input-format Format to parse the object. Recognized values: <info>string</info>, <info>yaml</info>
      * @option value The value to assign to the config key (if any).
      * @hidden-options value
      * @usage drush config:set system.site page.front '/path/to/page'
-     *   Sets the given URL path as value for the config item with key "page.front" of "system.site" config object.
+     *   Sets the given URL path as value for the config item with key <info>page.front</info> of <info>system.site</info> config object.
      * @aliases cset,config-set
      */
     public function set($config_name, $key, $value = null, $options = ['input-format' => 'string', 'value' => self::REQ])
@@ -173,7 +173,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
      * @command config:edit
      * @validate-config-name
      * @interact-config-name
-     * @param $config_name The config object name, for example "system.site".
+     * @param $config_name The config object name, for example <info>system.site</info>.
      * @optionset_get_editor
      * @allow_additional_options config-import
      * @hidden-options source,partial
@@ -246,8 +246,8 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
      *
      * @command config:status
      * @option state  A comma-separated list of states to filter results.
-     * @option prefix Prefix The config prefix. For example, "system". No prefix will return all names in the system.
-     * @option string $label A config directory label (i.e. a key in \$config_directories array in settings.php).
+     * @option prefix Prefix The config prefix. For example, <info>system</info>. No prefix will return all names in the system.
+     * @option string $label A config directory label (i.e. a key in $config_directories array in settings.php).
      * @usage drush config:status
      *   Display configuration items that need to be synchronized.
      * @usage drush config:status --state=Identical

--- a/src/Drupal/Commands/config/ConfigExportCommands.php
+++ b/src/Drupal/Commands/config/ConfigExportCommands.php
@@ -102,6 +102,8 @@ class ConfigExportCommands extends DrushCommands
      * @option message Commit comment for the exported configuration.  Optional; may only be used with --commit.
      * @option destination An arbitrary directory that should receive the exported files. A backup directory is used when no value is provided.
      * @option diff Show preview as a diff, instead of a change list.
+     * @usage drush config:export
+     *   Export configuration files to the site's config directory.
      * @usage drush config:export --destination
      *   Export configuration; Save files in a backup directory named config-export.
      * @aliases cex,config-export


### PR DESCRIPTION
Apparently its been gone for 3 years.

Also better help formatting on several commands.