### PR TITLE
4485: Allowed packages in security update checks

### DIFF
--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -170,6 +170,7 @@ class SecurityUpdateCommands extends DrushCommands
      * Validate pm:security.
      *
      * @param \Consolidation\AnnotatedCommand\CommandData $data
+     *   The command data object.
      *
      * @hook validate pm:security
      */

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -2,6 +2,7 @@
 namespace Drush\Commands\pm;
 
 use Composer\Semver\Semver;
+use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\CommandResult;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drush\Commands\DrushCommands;
@@ -156,13 +157,28 @@ class SecurityUpdateCommands extends DrushCommands
      */
     protected function filterAllowedPackages(&$flagged_packages, $allowed_packages = NULL) {
         if (!empty($allowed_packages)) {
-            $allowed_packages = explode(',', $allowed_packages);
             foreach ($allowed_packages as $package) {
                 list($package_name, $package_version) = explode(':', $package);
                 if (!empty($flagged_packages[$package_name]) && $flagged_packages[$package_name]['version'] == $package_version) {
                     unset($flagged_packages[$package_name]);
                 }
             }
+        }
+    }
+
+    /**
+     * Validate pm:security.
+     *
+     * @param \Consolidation\AnnotatedCommand\CommandData $data
+     *
+     * @hook validate pm:security
+     */
+    public function validateDrupalSecurityCommand(CommandData $data) {
+        $options = $data->options();
+        if (!empty($options['allowed']) && is_string($options['allowed'])) {
+            // Convert to array so its consistent with the expected structure
+            // if you were to set the option in drush.yml.
+            $data->input()->setOption('allowed', explode(',', $options['allowed']));
         }
     }
 }


### PR DESCRIPTION
# Changes

- Adds an `allowed` option that can be passed to `pm:security` which is a comma separated list of package/version pairs:

```
drush pm:security --allowed='drupal/group:1.0.0-rc5'
```

Or optionally in drush.yml:

```
command:
  pm:
    security:
      options:
        allowed:
          - drupal/group:1.0.0-rc5
```

Ultimately, the `allowed` option internally is converted into an array for processing.