### PR TITLE
Allow Drush 8 uli to call Drush 10 and get the right reset link.

### DIFF
--- a/commands/user/user.drush.inc
+++ b/commands/user/user.drush.inc
@@ -376,13 +376,14 @@ function drush_user_login($inputs = '', $path = NULL) {
   // the *local* machine.
   $alias = drush_get_context('DRUSH_TARGET_SITE_ALIAS');
   if (drush_sitealias_is_remote_site($alias)) {
-    $return = drush_invoke_process($alias, 'user-login', $args, drush_redispatch_get_options(), array('integrate' => FALSE));
+    $return = drush_invoke_process($alias, 'user-login', $args, drush_redispatch_get_options(), array('integrate' => FALSE, 'convert-stdout-to-backend' => TRUE));
+
     if ($return['error_status']) {
       return drush_set_error('Unable to execute user login.');
     }
     else {
       // Prior versions of Drupal returned a string so cast to an array if needed.
-      $links = is_string($return['object']) ? array($return['object']) : $return['object'];
+      $links = !isset($return['object']) ? [ $return['output'] ] : (is_string($return['object']) ? array($return['object']) : $return['object']);
     }
   }
   else {

--- a/includes/backend.inc
+++ b/includes/backend.inc
@@ -1039,18 +1039,26 @@ function _drush_backend_invoke($cmds, $common_backend_options = array(), $contex
         $values = drush_backend_parse_output($proc['output'], $proc['backend-options'], $proc['outputted']);
         if (is_array($values)) {
           $values['site'] = $site;
-          if (empty($ret)) {
-            $ret = $values;
-          }
-          elseif (!array_key_exists('concurrent', $ret)) {
-            $ret = array('concurrent' => array($ret, $values));
-          }
-          else {
-            $ret['concurrent'][] = $values;
-          }
+        }
+        elseif (!empty($common_backend_options['convert-stdout-to-backend'])) {
+          $values = [
+            'site' => $site,
+            'output' => $proc['output'],
+            'error_status' => $proc['code'],
+            'log' => [],
+          ];
         }
         else {
-          $ret = drush_set_error('DRUSH_FRAMEWORK_ERROR', dt("The command could not be executed successfully (returned: !return, code: !code)", array("!return" => $proc['output'], "!code" =>  $proc['code'])));
+          return drush_set_error('DRUSH_FRAMEWORK_ERROR', dt("The command could not be executed successfully (returned: !return, code: !code)", array("!return" => $proc['output'], "!code" =>  $proc['code'])));
+        }
+        if (empty($ret)) {
+          $ret = $values;
+        }
+        elseif (!array_key_exists('concurrent', $ret)) {
+          $ret = array('concurrent' => array($ret, $values));
+        }
+        else {
+          $ret['concurrent'][] = $values;
         }
       }
     }


### PR DESCRIPTION
Drush 10 does not support backend invoke, which causes problems for Drush uli when a local Drush 8 is trying to get a login link from a remote site with Drush 10.

This PR adds a mode to backend invoke which will convert the output of a remote command from any app into a backend invoke record. The uli command then uses this flag to allow Drush 8 uli to work on Drush 10 targets.