### PR TITLE
Allow the backup dir parent to be set in config.

### DIFF
--- a/src/Utils/FsUtils.php
+++ b/src/Utils/FsUtils.php
@@ -73,7 +73,7 @@ class FsUtils
         ];
 
         // Return the first usable candidate
-        foreach ($cadidates as $dir) {
+        foreach ($candidates as $dir) {
             if (self::isUsableDirectory($dir)) {
                 return $dir;
             }

--- a/src/Utils/FsUtils.php
+++ b/src/Utils/FsUtils.php
@@ -36,10 +36,28 @@ class FsUtils
         // Save the date to be used in the backup directory's path name.
         $date = gmdate('YmdHis', $_SERVER['REQUEST_TIME']);
         return Path::join(
-            Drush::config()->home(),
-            'drush-backups',
+            self::getBackupDirParent(),
             $subdir,
             $date
+        );
+    }
+
+    /**
+     * Get the base dir where our backup directories will be stored
+     *
+     * @return
+     *   A path to the backup directory parent
+     */
+    protected static function getBackupDirParent()
+    {
+        $dir = Drush::config()->get('backup-dir');
+        if ($dir) {
+            return $dir;
+        }
+
+        return Path::join(
+            Drush::config()->home(),
+            'drush-backups'
         );
     }
 

--- a/src/Utils/FsUtils.php
+++ b/src/Utils/FsUtils.php
@@ -24,20 +24,25 @@ class FsUtils
      */
     public static function getBackupDir($subdir = null)
     {
+        $parent = self::getBackupDirParent();
+
         // Try to use db name as subdir if none was provided.
         if (empty($subdir)) {
-            $subdir = 'unknown';
             if ($sql = SqlBase::create()) {
                 $db_spec = $sql->getDbSpec();
                 $subdir = $db_spec['database'];
             }
         }
 
+        // Add in the subdirectory if it was provided or inferred.
+        if (!empty($subdir)) {
+            $parent = Path::join($parent, $subdir);
+        }
+
         // Save the date to be used in the backup directory's path name.
         $date = gmdate('YmdHis', $_SERVER['REQUEST_TIME']);
         return Path::join(
-            self::getBackupDirParent(),
-            $subdir,
+            $parent,
             $date
         );
     }
@@ -47,18 +52,64 @@ class FsUtils
      *
      * @return
      *   A path to the backup directory parent
+     * @throws \Exception
      */
     protected static function getBackupDirParent()
     {
-        $dir = Drush::config()->get('backup-dir');
-        if ($dir) {
+        // Try in order:
+        //  1. The user-specified backup directory from drush.yml config file
+        //  2. The 'drush-backups' directory in $HOME
+        //  3. The 'drush-backups' directory in tmp
+        $candidates = [
+            Drush::config()->get('backup-dir'),
+            Path::join(
+                Drush::config()->home(),
+                'drush-backups'
+            ),
+            Path::join(
+                Drush::config()->tmp(),
+                'drush-backups'
+            ),
+        ];
+
+        // Return the first usable candidate
+        foreach ($cadidates as $dir) {
+            if (self::isUsableDirectory($dir)) {
+                return $dir;
+            }
+        }
+
+        throw new \Exception('No viable backup directory found.');
+    }
+
+    /**
+     * Description
+     * @param string $dir
+     *   Path to directory that we are considering using
+     * @return bool
+     *   True if the specified location is writable, or if a writable
+     *   directory could be created at that path.
+     */
+    public static function isUsableDirectory($dir)
+    {
+        // This directory is not usable if it is empty or if it is the root.
+        if (empty($dir) || (dirname($dir) == $dir)) {
+            return false;
+        }
+
+        // If the directory already exists and is writable, then it is usable.
+        if (is_writable($dir)) {
             return $dir;
         }
 
-        return Path::join(
-            Drush::config()->home(),
-            'drush-backups'
-        );
+        // If the directory exists (and is not writable), then it is not usable.
+        if (file_exists($dir)) {
+            return false;
+        }
+
+        // Otherwise, this directory is usable (could be created) if its
+        // parent directory is usable.
+        return self::isUsableDirectory(dirname($dir));
     }
 
     /**


### PR DESCRIPTION
Pantheon is rolling out new "Container-Optimized Environments" (COE). Most existing bindings and all new sites are one COE. This new environment puts $HOME at `/`, and of course `/` is unwritable. This causes problems with Drush sql:sync, which by default wants to put the dump file in the backup directory. The Drush backup directory is at $HOME/drush-backups, which is not writable under COE.

This PR makes the backup dir configurable, just as it was in Drush 8.