### PR TITLE
Fixes #4468: Rename "master" branch to "10.x".

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run: composer cs
 
   # Mergeable test:
-  #   FAIL if merging test branch with master produces conflicts
+  #   FAIL if merging test branch with 10.x produces conflicts
   #   PASS if the test branch is out of date, but mergeable without conflicts
   check_mergable:
     <<: *defaults

--- a/.circleci/mergable.sh
+++ b/.circleci/mergable.sh
@@ -1,7 +1,7 @@
 set -e
 
 # No need to check for mergability on commits that are already merged.
-if [ "$CIRCLE_BRANCH" == "master" ] || [ "$CIRCLE_BRANCH" == "9.x" ] ; then
+if [ "$CIRCLE_BRANCH" == "10.x" ] || [ "$CIRCLE_BRANCH" == "9.x" ] ; then
 	exit 0
 fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,19 @@
 name: Build static sites
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# events but only for the 10.x branch
 on:
   push:
-    branches: [master]
+    branches: [10.x]
 #  pull_request:
-#    branches: [master]
+#    branches: [10.x]
 
 jobs:
   build:
     name: Build and Push
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout master
+      - name: Checkout 10.x
         uses: actions/checkout@v2
 
       - name: Checkout gh-pages branch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/CONTRIBUTING.md
+edit_url: https://github.com/drush-ops/drush/blob/10.x/CONTRIBUTING.md
 ---
 Drush is built by people like you! Please [join us](https://github.com/drush-ops/drush).
 
 ## Git and Pull requests
 * Contributions are submitted, reviewed, and accepted using GitHub pull requests.
-* The latest changes are in the `master` branch. PR's should initially target this branch.
+* The latest changes are in the `10.x` branch. PR's should initially target this branch.
 * Try to make clean commits that are easily readable (including descriptive commit messages!)
-* See the test-specific [README.md](https://github.com/drush-ops/drush/blob/master/tests/README.md) for instructions on running the test suite. Test before you push. Get familiar with Unish, our test suite. Optionally run tests in the provided Docker containers.
+* See the test-specific [README.md](https://github.com/drush-ops/drush/blob/10.x/tests/README.md) for instructions on running the test suite. Test before you push. Get familiar with Unish, our test suite. Optionally run tests in the provided Docker containers.
 * We maintain branches named 10.x, 9.x, etc. These are release branches. From these branches, we make new tags for patch and minor versions.
 
 ## Development Environment

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/README.md
+edit_url: https://github.com/drush-ops/drush/blob/10.x/README.md
 ---
 Drush is a command line shell and Unix scripting interface for Drupal. Drush core ships with lots of [useful commands](commands/10.x/all.md) for interacting with code like modules/themes/profiles. Similarly, it runs update.php, executes SQL queries and DB migrations, and misc utilities like run cron or clear cache. Developers love the [generate command](commands/10.x/generate.md), which jump starts your coding project by writing ready-to-customize PHP and YML files. Drush can be extended by [3rd party commandfiles](https://www.drupal.org/project/project_module?f[2]=im_vid_3%3A4654).
 
@@ -10,10 +10,10 @@ Resources
 * [Installing and Upgrading](install.md) ([Drush 8](https://docs.drush.org/en/8.x/install/))
 * [General Documentation](usage.md) ([Drush 8](https://docs.drush.org/en/8.x/install/))
 * [Drush Commands](commands/10.x/all.md)
-* [API Documentation](/api/master/index.html)
+* [API Documentation](/api/10.x/index.html)
 * [Drush packages available via Composer](https://packagist.org/search/?type=drupal-drush)
 * [A list of modules that include Drush integration](https://www.drupal.org/project/project_module?f[2]=im_vid_3%3A4654&solrsort=ds_project_latest_release+desc)
-* Drush comes with a [full test suite](https://github.com/drush-ops/drush/blob/master/tests/README.md) powered by [PHPUnit](https://github.com/sebastianbergmann/phpunit). Each commit gets tested by our CI bots.
+* Drush comes with a [full test suite](https://github.com/drush-ops/drush/blob/10.x/tests/README.md) powered by [PHPUnit](https://github.com/sebastianbergmann/phpunit). Each commit gets tested by our CI bots.
 
 Support
 -----------
@@ -37,7 +37,7 @@ go to them, but they are in the minority. Most pronounce Drush so that it
 rhymes with hush, rush, flush, etc. This is the preferred pronunciation.
 
 #### Does Drush have unit tests?
-Drush has an excellent suite of unit tests. See [tests/README.md](https://github.com/drush-ops/drush/blob/master/tests/README.md) for more information.
+Drush has an excellent suite of unit tests. See [tests/README.md](https://github.com/drush-ops/drush/blob/10.x/tests/README.md) for more information.
 
 
 Credits

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ platform: 'x86'
 clone_folder: C:\projects\work
 branches:
   only:
-    - master
+    - 10.x
 
   ## Cache composer bits
 cache:

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -29,7 +29,7 @@ Set up and test for a valid Drupal root, either through the --root options, or e
 
 @bootstrap site
 ------------------------------
-Set up a Drupal site directory and the correct environment variables to allow Drupal to find the configuration file. If no site is specified with the --uri options, Drush will assume the site is 'default', which mimics Drupal's behaviour.  Note that it is necessary to specify a full URI, e.g. --uri=http://example.com, in order for certain Drush commands and Drupal modules to behave correctly. See the [example Config file](https://github.com/drush-ops/drush/blob/master/examples/example.drush.yml) for more information. Any code that needs to modify or interact with a specific Drupal site's settings.php file should bootstrap to this phase.
+Set up a Drupal site directory and the correct environment variables to allow Drupal to find the configuration file. If no site is specified with the --uri options, Drush will assume the site is 'default', which mimics Drupal's behaviour.  Note that it is necessary to specify a full URI, e.g. --uri=http://example.com, in order for certain Drush commands and Drupal modules to behave correctly. See the [example Config file](https://github.com/drush-ops/drush/blob/10.x/examples/example.drush.yml) for more information. Any code that needs to modify or interact with a specific Drupal site's settings.php file should bootstrap to this phase.
 
 @bootstrap configuration
 ---------------------------------------

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,9 +7,9 @@ Creating a new Drush command or porting a legacy command is easy. Follow the ste
     1. (optional) Drush will also prompt for the path to a legacy command file to port. See [tips on porting command to Drush 9](https://weitzman.github.io/blog/port-to-drush9)
     1. The module selected must already exist and be enabled. Use `drush generate module-standard` to create a new module.
 1. Drush will then report that it created a commandfile, a drush.services.yml file and a composer.json file. Edit those files as needed.
-1. Use the classes for the core Drush commands at [/src/Drupal/Commands](https://github.com/drush-ops/drush/tree/master/src/Drupal/Commands) as inspiration and documentation.
+1. Use the classes for the core Drush commands at [/src/Drupal/Commands](https://github.com/drush-ops/drush/tree/10.x/src/Drupal/Commands) as inspiration and documentation.
 1. See the [dependency injection docs](dependency-injection.md) for interfaces you can implement to gain access to Drush config, Drupal site aliases, etc.
-1. Write PHPUnit tests based on [Drush Test Traits](https://github.com/drush-ops/drush/tree/master/tests#drush-test-traits).
+1. Write PHPUnit tests based on [Drush Test Traits](https://github.com/drush-ops/drush/tree/10.x/tests#drush-test-traits).
 1. Once your two files are ready, run `drush cr` to get your command recognized by the Drupal container.
 
 ## Specifying the Services File
@@ -54,7 +54,7 @@ In order to alter an existing command info, follow the steps below:
 For an example, see the alterer class provided by the testing 'woot' module: `tests/functional/resources/modules/d8/woot/src/WootCommandInfoAlterer.php`.
 
 ## Site-Wide Drush Commands
-Commandfiles that are installed in a Drupal site and are not bundled inside a Drupal module are called 'site-wide' commandfiles. Site-wide commands may either be added directly to the Drupal site's repository (e.g. for site-specific policy files), or via `composer require`. See the [examples/Commands](https://github.com/drush-ops/drush/tree/master/examples/Commands) folder for examples. In general, it's better to use modules to carry your Drush commands, as module-based commands may [participate in Drupal's dependency injection via the drush.services.yml](#specifying-the-services-file).
+Commandfiles that are installed in a Drupal site and are not bundled inside a Drupal module are called 'site-wide' commandfiles. Site-wide commands may either be added directly to the Drupal site's repository (e.g. for site-specific policy files), or via `composer require`. See the [examples/Commands](https://github.com/drush-ops/drush/tree/10.x/examples/Commands) folder for examples. In general, it's better to use modules to carry your Drush commands, as module-based commands may [participate in Drupal's dependency injection via the drush.services.yml](#specifying-the-services-file).
 
 If you still prefer using site-wide commandfiles, here are some examples of valid commandfile names and namespaces:
 
@@ -106,4 +106,4 @@ With this configuration in place, global commands may be placed as described in 
 It is recommended that you avoid global Drush commands, and favor site-wide commandfiles instead. If you really need a command or commands that are not part of any Drupal site, consider making a stand-alone script or custom .phar instead. See [ahoy](https://github.com/ahoy-cli/ahoy), [Robo](https://github.com/consolidation/robo) and [g1a/starter](https://github.com/g1a/starter) as potential starting points.
 
 !!! warning "Symlinked packages"
-    While it is good practice to make your custom commands into a Composer package, please beware that symlinked packages (by using the composer repository type [Path](https://getcomposer.org/doc/05-repositories.md#path)) will **not** be discovered by Drush. When in development, it is recommended to [specify your package's](https://github.com/drush-ops/drush/blob/master/examples/example.drush.yml#L52-L67) path in your `drush.yml` to have quick access to your commands.
+    While it is good practice to make your custom commands into a Composer package, please beware that symlinked packages (by using the composer repository type [Path](https://getcomposer.org/doc/05-repositories.md#path)) will **not** be discovered by Drush. When in development, it is recommended to [specify your package's](https://github.com/drush-ops/drush/blob/10.x/examples/example.drush.yml#L52-L67) path in your `drush.yml` to have quick access to your commands.

--- a/docs/deploycommand.md
+++ b/docs/deploycommand.md
@@ -19,7 +19,7 @@ Below are the 3 types of update functions run by this command, in order. Choose 
 | --- | --- | --- |
 | [HOOK_update_n()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_update_N) | Not allowed | Low level changes. |
 | [HOOK_post_update_NAME()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_post_update_NAME) | Allowed | Runs *before* config is imported. |
-| [HOOK_deploy_NAME()](https://github.com/drush-ops/drush/blob/master/tests/functional/resources/modules/d8/woot/woot.deploy.php) | Allowed | Runs *after* config is imported. | 
+| [HOOK_deploy_NAME()](https://github.com/drush-ops/drush/blob/10.x/tests/functional/resources/modules/d8/woot/woot.deploy.php) | Allowed | Runs *after* config is imported. | 
 
 ## Configuration
 

--- a/docs/examples/ArtCommands.php.md
+++ b/docs/examples/ArtCommands.php.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/examples/Commands/ArtCommands.php
+edit_url: https://github.com/drush-ops/drush/blob/10.x/examples/Commands/ArtCommands.php
 ---
 
 ```php

--- a/docs/examples/PolicyCommands.php.md
+++ b/docs/examples/PolicyCommands.php.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/examples/Commands/PolicyCommands.php
+edit_url: https://github.com/drush-ops/drush/blob/10.x/examples/Commands/PolicyCommands.php
 ---
 ```php
 --8<-- "examples/Commands/PolicyCommands.php"

--- a/docs/examples/SiteAliasAlterCommands.php.md
+++ b/docs/examples/SiteAliasAlterCommands.php.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/examples/Commands/SiteAliasAlterCommands.php
+edit_url: https://github.com/drush-ops/drush/blob/10.x/examples/Commands/SiteAliasAlterCommands.php
 ---
 ```php
 --8<-- "examples/Commands/SiteAliasAlterCommands.php"

--- a/docs/examples/SyncViaHttpCommands.php.md
+++ b/docs/examples/SyncViaHttpCommands.php.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/examples/Commands/SyncViaHttpCommands.php
+edit_url: https://github.com/drush-ops/drush/blob/10.x/examples/Commands/SyncViaHttpCommands.php
 ---
 ```php
 --8<-- "examples/Commands/SyncViaHttpCommands.php"

--- a/docs/examples/XkcdCommands.php.md
+++ b/docs/examples/XkcdCommands.php.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/examples/Commands/XkcdCommands.php
+edit_url: https://github.com/drush-ops/drush/blob/10.x/examples/Commands/XkcdCommands.php
 ---
 ```php
 --8<-- "examples/Commands/XkcdCommands.php"

--- a/docs/examples/example.bashrc.md
+++ b/docs/examples/example.bashrc.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/examples/example.bashrc
+edit_url: https://github.com/drush-ops/drush/blob/10.x/examples/example.bashrc
 ---
 ```shell
 --8<-- "examples/example.bashrc"

--- a/docs/examples/example.prompt.sh.md
+++ b/docs/examples/example.prompt.sh.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/examples/example.prompt.sh
+edit_url: https://github.com/drush-ops/drush/blob/10.x/examples/example.prompt.sh
 ---
 ```shell
 --8<-- "examples/example.prompt.sh"

--- a/docs/examples/example.site.yml.md
+++ b/docs/examples/example.site.yml.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/examples/example.site.yml
+edit_url: https://github.com/drush-ops/drush/blob/10.x/examples/example.site.yml
 ---
 ```yaml
 --8<-- "examples/example.site.yml"

--- a/docs/examples/git-bisect.example.sh.md
+++ b/docs/examples/git-bisect.example.sh.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/examples/git-bisect.example.sh
+edit_url: https://github.com/drush-ops/drush/blob/10.x/examples/git-bisect.example.sh
 ---
 ```shell
 --8<-- "examples/git-bisect.example.sh"

--- a/docs/examples/helloworld.script.md
+++ b/docs/examples/helloworld.script.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/examples/helloworld.script
+edit_url: https://github.com/drush-ops/drush/blob/10.x/examples/helloworld.script
 ---
 ```php
 --8<-- "examples/helloworld.script"

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -1,16 +1,16 @@
 # Overview
 Generators jump start your coding by building all the boring boilerplate code for you. After running the [generate command](commands/10.x/generate.md), you have a guide for where to insert your custom logic.
 
-Drush's generators reuse classes provided by the excellent [Drupal Code Generator](https://github.com/Chi-teck/drupal-code-generator) project. See its [Commands directory](https://github.com/Chi-teck/drupal-code-generator/tree/master/src/Command) for inspiration.
+Drush's generators reuse classes provided by the excellent [Drupal Code Generator](https://github.com/Chi-teck/drupal-code-generator) project. See its [Commands directory](https://github.com/Chi-teck/drupal-code-generator/tree/10.x/src/Command) for inspiration.
 
 ## Writing Custom Generators
 Drupal modules may supply their own Generators, just like they can supply Commands.
 
-See [Woot module](https://github.com/drush-ops/drush/blob/master/tests/functional/resources/modules/d8/woot), which Drush uses for testing. Specifically,
+See [Woot module](https://github.com/drush-ops/drush/blob/10.x/tests/functional/resources/modules/d8/woot), which Drush uses for testing. Specifically,
 
-  1. Write a class similar to [ExampleGenerator](https://github.com/drush-ops/drush/tree/master/tests/functional/resources/modules/d8/woot/src/Generators/). Implement your custom logic in the interact() method. Typically this class is placed in the src/Generators directory.
+  1. Write a class similar to [ExampleGenerator](https://github.com/drush-ops/drush/tree/10.x/tests/functional/resources/modules/d8/woot/src/Generators/). Implement your custom logic in the interact() method. Typically this class is placed in the src/Generators directory.
   1. Add a .twig file to the same directory. This template specifies what gets output from the generator.
-  1. Add your class to your module's drush.services.yml file ([example](https://github.com/drush-ops/drush/blob/master/tests/functional/resources/modules/d8/woot/drush.services.yml)). Use the tag `drush.generator` instead of `drush.command`.
+  1. Add your class to your module's drush.services.yml file ([example](https://github.com/drush-ops/drush/blob/10.x/tests/functional/resources/modules/d8/woot/drush.services.yml)). Use the tag `drush.generator` instead of `drush.command`.
   1. Perform a `drush cache-rebuild` to compile your drush.services.yml changes into the Drupal container.
 
 ## Global Generators

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -6,7 +6,7 @@ All commandfiles may implement methods that are called by Drush at various times
 
 ## Custom Hooks
 
-Drush commands can define custom events that other command files can hook. You can find examples in [CacheCommands](https://github.com/drush-ops/drush/blob/master/src/Commands/core/CacheCommands.php) and [SanitizeCommands](https://github.com/drush-ops/drush/blob/master/src/Drupal/Commands/sql/SanitizeCommands.php)
+Drush commands can define custom events that other command files can hook. You can find examples in [CacheCommands](https://github.com/drush-ops/drush/blob/10.x/src/Commands/core/CacheCommands.php) and [SanitizeCommands](https://github.com/drush-ops/drush/blob/10.x/src/Drupal/Commands/sql/SanitizeCommands.php)
 
 First, the command must implement CustomEventAwareInterface and use CustomEventAwareTrait, as described in the [dependency injection](dependency-injection.md) documentation.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,7 +30,7 @@ Drupal Compatibility
   </tr>
   <tr>
     <td> Drush 10 </td>
-    <td> master </td>
+    <td> 10.x </td>
     <td> 7.1+ </td>
     <!-- Released Oct 2019 -->
     <td> <i>TBD</i> </td>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -13,7 +13,7 @@
     <meta property="og:title" content="{{ title }}" />
     <meta property="og:description" content="{{ config.site_description }}" />
     <meta property="og:url" content="{{ page.canonical_url }}" />
-    <meta property="og:image" content="https://raw.githubusercontent.com/drush-ops/drush/master/drush_logo-black.png" />
+    <meta property="og:image" content="https://raw.githubusercontent.com/drush-ops/drush/10.x/drush_logo-black.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="218" />
     <meta property="og:image:height" content="215" />
@@ -29,6 +29,6 @@
     <meta name="twitter:creator" content="@weitzman" />
     <meta name="twitter:title" content="{{ title }}" />
     <meta name="twitter:description" content="{{ config.site_description }}" />
-    <meta name="twitter:image" content="https://raw.githubusercontent.com/drush-ops/drush/master/drush_logo-black.png" />
+    <meta name="twitter:image" content="https://raw.githubusercontent.com/drush-ops/drush/10.x/drush_logo-black.png" />
 {% endblock %}
 

--- a/docs/overrides/partials/tabs.html
+++ b/docs/overrides/partials/tabs.html
@@ -13,7 +13,7 @@
       {% endfor %}
 
       <li class="md-tabs__item">
-        <a href="/api/master" class="md-tabs__link">API</a>
+        <a href="/api/10.x" class="md-tabs__link">API</a>
       </li>
 
     </ul>

--- a/docs/site-alias-manager.md
+++ b/docs/site-alias-manager.md
@@ -1,12 +1,12 @@
 Site Alias Manager
 ==================
 
-The [Site Alias Manager (SAM)](https://github.com/consolidation/site-alias/blob/master/src/SiteAliasManager.php) service is used to retrieve information about one or all of the site aliases for the current installation.
+The [Site Alias Manager (SAM)](https://github.com/consolidation/site-alias/blob/10.x/src/SiteAliasManager.php) service is used to retrieve information about one or all of the site aliases for the current installation.
 
-- An informative example is the [browse command](https://github.com/drush-ops/drush/blob/master/src/Commands/core/BrowseCommands.php)
+- An informative example is the [browse command](https://github.com/drush-ops/drush/blob/10.x/src/Commands/core/BrowseCommands.php)
 - A commandfile gets access to the SAM by implementing the SiteAliasManagerAwareInterface and *use*ing the SiteAliasManagerAwareTrait trait. Then you gain access via `$this->siteAliasManager()`.
 - If an alias was used for the current request, it is available via $this->siteAliasManager()->getself().
 - The SAM generally deals in [SiteAlias](https://github.com/consolidation/site-alias/blob/main/src/SiteAlias.php) objects. That is how any given site alias is represented. See its methods for determining things like whether the alias points to a local host or remote host.
-- [An example site alias file](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.site.yml).
-- [Dynamically alter site aliases](https://raw.githubusercontent.com/drush-ops/drush/master/examples/Commands/SiteAliasAlterCommands.php).
+- [An example site alias file](https://raw.githubusercontent.com/drush-ops/drush/10.x/examples/example.site.yml).
+- [Dynamically alter site aliases](https://raw.githubusercontent.com/drush-ops/drush/10.x/examples/Commands/SiteAliasAlterCommands.php).
 - The SAM is also available for as [a standalone Composer project](https://github.com/consolidation/site-alias). More information available in the README there.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,5 +36,5 @@ $ drush rsync @staging:%files/ @live:%files
 $ drush sql:sync --structure-tables-key=custom @live @self
 ```
 
-See [example.site.yml](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.site.yml) for more information.
+See [example.site.yml](https://raw.githubusercontent.com/drush-ops/drush/10.x/examples/example.site.yml) for more information.
 

--- a/docs/using-drush-configuration.md
+++ b/docs/using-drush-configuration.md
@@ -3,7 +3,7 @@ Drush Configuration
 
 Drush users may provide configuration via: 
 
-1. yml files that are placed in specific directories. [See our example file](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.drush.yml) for more information. You may also add configuration to a site alias - [see example site alias](https://raw.githubusercontent.com/drush-ops/drush/master/examples/example.site.yml).
+1. yml files that are placed in specific directories. [See our example file](https://raw.githubusercontent.com/drush-ops/drush/10.x/examples/example.drush.yml) for more information. You may also add configuration to a site alias - [see example site alias](https://raw.githubusercontent.com/drush-ops/drush/10.x/examples/example.site.yml).
 1. Properly named environment variables are automatically used as configuration. To populate the options.uri config item, create an environment variable like so `DRUSH_OPTIONS_URI=http://example.com`. As you can see, variable names should be uppercased, prefixed with `DRUSH_`, and periods replaced with dashes. 
 
 If you are authoring a commandfile and wish to access the user's configuration, see [Command Authoring](commands.md).

--- a/examples/Commands/ArtCommands.php
+++ b/examples/Commands/ArtCommands.php
@@ -23,7 +23,7 @@ use Drush\Utils\StringUtils;
  * This file is a good example of the first of those bullets (a commandfile) but
  * since it isn't part of a module, it does not implement drush.services.yml.
  *
- * See [Drush Test Traits](https://github.com/drush-ops/drush/blob/master/tests/README.md#about-the-test-suites) for info on testing Drush commands.
+ * See [Drush Test Traits](https://github.com/drush-ops/drush/blob/10.x/tests/README.md#about-the-test-suites) for info on testing Drush commands.
  */
 
 class ArtCommands extends DrushCommands implements CustomEventAwareInterface

--- a/examples/Commands/PolicyCommands.php
+++ b/examples/Commands/PolicyCommands.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Input\InputOption;
 /**
  * Load this commandfile using the --include option - e.g. `drush --include=/path/to/drush/examples`
  *
- * See [Drush Test Traits](https://github.com/drush-ops/drush/blob/master/tests/README.md#about-the-test-suites) for info on testing Drush commands.
+ * See [Drush Test Traits](https://github.com/drush-ops/drush/blob/10.x/tests/README.md#about-the-test-suites) for info on testing Drush commands.
  */
 
 class PolicyCommands extends DrushCommands

--- a/examples/example.prompt.sh
+++ b/examples/example.prompt.sh
@@ -16,7 +16,7 @@
 # Note that your Bash session must already have the __git_ps1 function available.
 # Typically this is provided by git-prompt.sh, see instructions for downloading
 # and including this file here:
-# https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh
+# https://github.com/git/git/blob/10.x/contrib/completion/git-prompt.sh
 #
 # Features:
 #
@@ -48,7 +48,7 @@ if [ -n "$(type -t __git_ps1)" ] && [ "$(type -t __git_ps1)" = function ] && [ "
   DRUSH_PS1_SHOWCOLORHINTS=true
 
   # Git offers various prompt customization options as well as seen in
-  # https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh.
+  # https://github.com/git/git/blob/10.x/contrib/completion/git-prompt.sh.
   # Adjust the following lines to enable the corresponding features:
   #
   GIT_PS1_SHOWDIRTYSTATE=true

--- a/mkdocs_base.yml
+++ b/mkdocs_base.yml
@@ -16,7 +16,7 @@ theme:
 site_url: http://www.drush.org
 repo_url: https://github.com/drush-ops/drush
 #Overridden on many pages via edit_uri plugin. See front matter.
-edit_uri: blob/master/docs
+edit_uri: blob/10.x/docs
 extra_css:
   - css/extra.readthedocs.css
 plugins:

--- a/sami-config.php
+++ b/sami-config.php
@@ -9,25 +9,25 @@ use Sami\RemoteRepository\GitHubRemoteRepository;
 use Sami\Version\GitVersionCollection;
 use Symfony\Component\Finder\Finder;
 
+$dir = __DIR__.'/src';
+
 $iterator = Finder::create()
   ->files()
   ->name('*.php')
   //->exclude('Resources')
   //->exclude('Tests')
-  ->in($dir = __DIR__.'/src')
+  ->in($dir)
 ;
 
-// generate documentation for all v2.0.* tags, the 2.0 branch, and the master one
-// $versions = GitVersionCollection::create($dir)
-//   ->addFromTags('8.*')
-//   ->add('8.x', '8.x branch')
-// Sami actively checks out each ref listed here.
-//   ->add('no-travis', 'Master branch')
-//;
+// Generate documentation for the main branch only
+$versions = GitVersionCollection::create($dir)
+//   ->addFromTags('10.*') // Also generate documentation for 10.x semver releases
+   ->add('10.x', 'Main branch')
+   ;
 
 return new Sami($iterator, array(
   // 'theme'                => 'symfony',
-  //'versions'             => $versions,
+  'versions'             => $versions,
   'title'                => 'Drush API',
   'build_dir'            => __DIR__.'/gh-pages/api/%version%',
   'cache_dir'            => __DIR__.'/.sami-cache/%version%',

--- a/src/Commands/core/MkCommands.php
+++ b/src/Commands/core/MkCommands.php
@@ -22,7 +22,7 @@ class MkCommands extends DrushCommands implements SiteAliasManagerAwareInterface
     /**
      * Build a Markdown document for each Drush command thats available on a site.
      *
-     * This command is an early step when building the www.drush.org static site. Adapt it to build a similar site listing the commands that are available on your site. Also see Drush's [Github Actions workflow](https://github.com/drush-ops/drush/blob/master/.github/workflows/main.yml).
+     * This command is an early step when building the www.drush.org static site. Adapt it to build a similar site listing the commands that are available on your site. Also see Drush's [Github Actions workflow](https://github.com/drush-ops/drush/blob/10.x/.github/workflows/main.yml).
      *
      * @option destination The path, relative to 'docs' dir, where command docs should be written.
      *
@@ -115,7 +115,7 @@ EOT;
                             $value = "- [$topic_description]($target_relative) ($name)";
                         } else {
                             $rel_from_root = Path::makeRelative($abs, DRUSH_BASE_PATH);
-                            $value = "- [$topic_description](https://raw.githubusercontent.com/drush-ops/drush/master/$rel_from_root) ($name)";
+                            $value = "- [$topic_description](https://raw.githubusercontent.com/drush-ops/drush/10.x/$rel_from_root) ($name)";
                         }
                     }
                 }
@@ -174,7 +174,7 @@ EOT;
         $path = Path::makeRelative($command->getAnnotationData()->get('_path'), $root);
         $body = <<<EOT
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/$path
+edit_url: https://github.com/drush-ops/drush/blob/10.x/$path
 ---
 
 EOT;

--- a/src/Drupal/DrupalKernelTrait.php
+++ b/src/Drupal/DrupalKernelTrait.php
@@ -145,7 +145,7 @@ trait DrupalKernelTrait
         if (!file_exists($result)) {
             return;
         }
-        Drush::logger()->info(dt("!module should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/master/commands/#specifying-the-services-file.", ['!module' => $module]));
+        Drush::logger()->info(dt("!module should have an extra.drush.services section in its composer.json. See http://docs.drush.org/en/10.x/commands/#specifying-the-services-file.", ['!module' => $module]));
         return $result;
     }
 

--- a/src/TestTraits/DrushTestTrait.php
+++ b/src/TestTraits/DrushTestTrait.php
@@ -5,7 +5,7 @@ namespace Drush\TestTraits;
  * DrushTestTrait provides a `drush()` method that may be
  * used to write functional tests for Drush extensions.
  *
- * More information is available at https://github.com/drush-ops/drush/tree/master/tests#drush-test-traits.
+ * More information is available at https://github.com/drush-ops/drush/tree/10.x/tests#drush-test-traits.
  */
 trait DrushTestTrait
 {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,5 @@
 ---
-edit_url: https://github.com/drush-ops/drush/blob/master/tests/README.md
+edit_url: https://github.com/drush-ops/drush/blob/10.x/tests/README.md
 ---
 Drush's test suite (aka Unish) is based on [PHPUnit](http://www.phpunit.de). In order to maintain
 high quality, our tests are run on every push. See [CircleCi](https://circleci.com/gh/drush-ops/drush).
@@ -8,7 +8,7 @@ high quality, our tests are run on every push. See [CircleCi](https://circleci.c
 1. git clone https://github.com/drush-ops/drush.git
 1. cd drush
 1. composer install
-1. Review the configuration settings in [tests/phpunit.xml.dist](https://github.com/drush-ops/drush/blob/master/tests/phpunit.xml.dist). 
+1. Review the configuration settings in [tests/phpunit.xml.dist](https://github.com/drush-ops/drush/blob/10.x/tests/phpunit.xml.dist). 
 1. If customization is needed, copy phpunit.xml.dist to phpunit.xml and edit away.
 1. Run all test suites: `composer test`
 


### PR DESCRIPTION
n.b. This branch should not be merged; instead, once it is ready, change the GitHub default branch to 10.x and close this PR.

This PR changes references to the Drush 'master' branch to '10.x', but leaves references to 'master' to external entities unchanged.