### PR TITLE
Fix the backup-dir configuration setting

### DIFF
--- a/examples/example.drush.yml
+++ b/examples/example.drush.yml
@@ -79,6 +79,11 @@ drush:
 
     # Specify a folder where Drush should store its file based caches. If unspecified, defaults to $HOME/.drush.
     #cache-directory: /tmp/.drush
+    
+    # Specify a folder where Drush should store backup files, including
+    # temporary sql dump files created during sql:sync. If unspecified,
+    # defaults to $HOME/drush-backups
+    # backup-dir: /tmp/drush-backups
 
 # This section is for setting global options.
 options:

--- a/src/Utils/FsUtils.php
+++ b/src/Utils/FsUtils.php
@@ -58,10 +58,14 @@ class FsUtils
     {
         // Try in order:
         //  1. The user-specified backup directory from drush.yml config file
+        //     n.b. drush.path.backup-dir is the correct location; backup-dir
+        //          was checked by accident, and is still included for
+        //          backwards compatibility.
         //  2. The 'drush-backups' directory in $HOME
         //  3. The 'drush-backups' directory in tmp
         $candidates = [
-            Drush::config()->get('backup-dir'),
+            Drush::config()->get('drush.paths.backup-dir'),
+            Drush::config()->get('backup-dir'), // deprecated
             Path::join(
                 Drush::config()->home(),
                 'drush-backups'

--- a/src/Utils/FsUtils.php
+++ b/src/Utils/FsUtils.php
@@ -58,14 +58,10 @@ class FsUtils
     {
         // Try in order:
         //  1. The user-specified backup directory from drush.yml config file
-        //     n.b. drush.path.backup-dir is the correct location; backup-dir
-        //          was checked by accident, and is still included for
-        //          backwards compatibility.
         //  2. The 'drush-backups' directory in $HOME
         //  3. The 'drush-backups' directory in tmp
         $candidates = [
             Drush::config()->get('drush.paths.backup-dir'),
-            Drush::config()->get('backup-dir'), // deprecated
             Path::join(
                 Drush::config()->home(),
                 'drush-backups'


### PR DESCRIPTION
The drush backup-dir configuration setting should have been drush.paths.backup-dir, for consistency.

Also added some documentation.