### PR TITLE
Narrow the drush-drupal compat table to avoid horizontal scrolling

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -21,60 +21,53 @@ Drupal Compatibility
 <table>
   <tr>
     <th rowspan="2"> Drush Version </th> 
-    <th rowspan="2"> Drush Branch </th>
-    <th rowspan="2"> PHP </th>
-    <th rowspan="2"> EOL </th>
+    <th rowspan="2"> PHP Version</th>
+    <th rowspan="2"> End Of Life </th>
     <th colspan="5"> Drupal versions </th>
   </tr>
-    <th>6</th> <th>7</th> <th>-8.3</th> <th>8.4+</th> <th>9</th>
+    <th>7</th> <th>-8.3</th> <th>8.4+</th> <th>9</th>
   </tr>
   <tr>
     <td> Drush 10 </td>
-    <td> 10.x </td>
     <td> 7.1+ </td>
     <!-- Released Oct 2019 -->
     <td> <i>TBD</i> </td>
-    <td></td> <td></td> <td></td> <td>✅</td> <td><b>✅</b></td>
+    <td></td> <td></td> <td>✅</td> <td><b>✅</b></td>
   </tr>
   <tr>
     <td> Drush 9 </td>
-    <td> 9.x </td>
     <td> 5.6+ </td>
     <!-- Released Jan 2018 -->
     <td> <i>May 2020</i> </td>
-    <td></td> <td></td> <td></td> <td>✅</td> <td></td>
+    <td></td> <td></td> <td>✅</td> <td></td>
   </tr>
   <tr>
     <td> Drush 8 </td>
-    <td> 8.x </td>
     <td> 5.4.5+ </td>
     <!-- Released Nov 2015 -->
     <td> ❶ </td>
-    <td>✅</td> <td>✅</td> <td>✅</td> <td><b>⚠️</b></td> <td></td>
+    <td>✅</td> <td>✅</td> <td><b>⚠️</b></td> <td></td>
   </tr>
   <tr>
     <td> Drush 7 </td>
-    <td> 7.x </td>
     <td> 5.3.0+ </td>
     <!-- Released May 2015 -->
     <td> Jul 2017 </td>
-    <td>✓</td> <td>✓</td> <td></td> <td></td> <td></td>
+    <td>✓</td> <td></td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 6 </td>
-    <td> 6.x </td>
     <td> 5.3.0+ </td>
     <!-- Released Aug 2013 -->
     <td> Dec 2015 </td>
-    <td>✓</td> <td>✓</td> <td></td> <td></td> <td></td>
+    <td>✓</td> <td></td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 5 </td>
-    <td> 5.x </td>
     <td> 5.2.0+ </td>
     <!-- Released March 2012 -->
     <td> May 2015 </td>
-    <td>✓</td> <td>✓</td> <td></td> <td></td> <td></td>
+    <td>✓</td> <td></td> <td></td> <td></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Removes 'Drush brach' column since thats obvious now with master being dropped in favor of 10.x. Also removed Drupal 6 column as its way past EOL and I'd rather show the table without horiz scrolling.