### PR TITLE
Change how we NULL the cache dir during deploy command.

### DIFF
--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -59,9 +59,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
         $this->logger()->success("Cache rebuild start.");
         $process = $manager->drush($self, 'cache:rebuild', [], $redispatchOptions);
         // To avoid occasional rmdir errors, disable Drush cache for this request.
-        if (file_exists('/dev/null')) {
-            $process->setEnv(['DRUSH_PATHS_CACHE_DIRECTORY' => '/dev/null']);
-        }
+        $process->setEnv(['DRUSH_PATHS_CACHE_DIRECTORY' => drush_tempdir()]);
         $process->mustRun($process->showRealtime());
     }
 }


### PR DESCRIPTION
We can't use /dev/null as a value because it fails the candidate check `$fs->mkdir($candidate)` in \Drush\Config\DrushConfig::cache. A temp dir works just as well.