### PR TITLE
Avoid exception when clearing Drush’s own cache files

### DIFF
--- a/src/Commands/core/CacheCommands.php
+++ b/src/Commands/core/CacheCommands.php
@@ -288,11 +288,11 @@ class CacheCommands extends DrushCommands implements CustomEventAwareInterface, 
     public static function clearDrush()
     {
         try {
-            drush_cache_clear_all(null, 'default');// commandfiles, etc.
-            drush_cache_clear_all(null, 'factory'); // command info from annotated-command library
+            drush_cache_clear_all(null, 'default');// No longer used by Drush core, but still cleared for backward compat.
+            drush_cache_clear_all(null, 'factory'); // command info from annotated-command library (i.e. parsed annotations)
         } catch (IOException $e) {
             // Sometimes another process writes files into a bin dir and \Drush\Cache\FileCache::clear fails.
-            // That is not considered an error.
+            // That is not considered an error. https://github.com/drush-ops/drush/pull/4535.
             Drush::logger()->info($e->getMessage());
         }
     }

--- a/src/Commands/core/CacheCommands.php
+++ b/src/Commands/core/CacheCommands.php
@@ -15,6 +15,7 @@ use Drush\Drush;
 use Drush\Utils\StringUtils;
 use Consolidation\AnnotatedCommand\Input\StdinAwareInterface;
 use Consolidation\AnnotatedCommand\Input\StdinAwareTrait;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 /*
  * Interact with Drupal's Cache API.
@@ -286,8 +287,14 @@ class CacheCommands extends DrushCommands implements CustomEventAwareInterface, 
      */
     public static function clearDrush()
     {
-        drush_cache_clear_all(null, 'default'); // commandfiles, etc.
-        drush_cache_clear_all(null, 'factory'); // command info from annotated-command library
+        try {
+            drush_cache_clear_all(null, 'default');// commandfiles, etc.
+            drush_cache_clear_all(null, 'factory'); // command info from annotated-command library
+        } catch (IOException $e) {
+            // Sometimes another process writes files into a bin dir and \Drush\Cache\FileCache::clear fails.
+            // That is not considered an error.
+            Drush::logger()->info($e->getMessage());
+        }
     }
 
     /**

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -58,8 +58,6 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
         // It is possible that no updates were pending and thus no caches cleared yet.
         $this->logger()->success("Cache rebuild start.");
         $process = $manager->drush($self, 'cache:rebuild', [], $redispatchOptions);
-        // To avoid occasional rmdir errors, disable Drush cache for this request.
-        $process->setEnv(['DRUSH_PATHS_CACHE_DIRECTORY' => drush_tempdir()]);
         $process->mustRun($process->showRealtime());
     }
 }


### PR DESCRIPTION
Yet another attempt to deal with #3592. This accepts the race condition and simply converts the Exception into a notice. Its pragmatic, having dealt with this for years.