### PR TITLE
drush runserver with Drush >= 8.1.* and Drupal 7: doesn't decode URL paths the same as Apache or nginx would

### DIFF
--- a/commands/runserver/d7-rs-router.php
+++ b/commands/runserver/d7-rs-router.php
@@ -52,7 +52,7 @@ if (file_exists('.' . urldecode($url['path']))) {
 }
 
 // Populate the "q" query key with the path, skip the leading slash.
-$_GET['q'] = $_REQUEST['q'] = substr($url['path'], 1);
+$_GET['q'] = $_REQUEST['q'] = urldecode(substr($url['path'], 1));
 
 // We set the base_url so that Drupal generates correct URLs for runserver
 // (e.g. http://127.0.0.1:8888/...), but can still select and serve a specific

--- a/tests/makefiles/lockfiles/git.lock.yml
+++ b/tests/makefiles/lockfiles/git.lock.yml
@@ -9,4 +9,4 @@ projects:
       url: 'https://git.drupalcode.org/project/atom.git'
       type: git
       branch: 8.x-1.x
-      revision: eef5044d467380991080cc6e6060de3b99832c27
+      revision: c6b3f3fe1edd24641c56d080bb94ad71824d9b42


### PR DESCRIPTION
In Panopoly's automated tests, we've been pinned to Drush 8.0.* for years, because using Drush 8.1.* or newer had some mysterious issues with Panels, that I've finally gotten around to figuring out. :-)

This is important for us now, because we need to update to Drush 8.4.* in order to run our tests on PHP 7.4.

Anyway, the bug is that `drush runserver` won't decode the URL paths the same way that Apache and nginx does. This affects some Panels AJAX URLs, for example, with this URL from my local test site:

http://127.0.0.1:55432/panels/ajax/ipe/save_form/panel_context%3Apage-panopoly_demo_panel%3A%3Apage_panopoly_demo_panel_panel_context%3A%3A%3A%3A?destination=demo

When the AJAX request for the URL goes through Apache or nginx, then `panels_ajax_router()` (a page callback) will get its 3rd decoded as `'panel_context:page-panopoly_demo_panel::page_panopoly_demo_panel_panel_context::::'`.

However, when running via `drush runserver` that argument will still be encoded as `'panel_context%3Apage-panopoly_demo_panel%3A%3Apage_panopoly_demo_panel_panel_context%3A%3A%3A%3A'` and Panels won't work as expected.

This broke in Drush 8.1.* when d7-rs-router.php was added; in Drush 8.0.*, both Drush 6 & 7 used runserver-prepend.php. Looking at runserver-prepend.php, it has:

```
$_GET['q'] = substr(urldecode($request_path), $base_path_len + 1);
```

... whereas, d7-rs-router.php has:

```
$_GET['q'] = $_REQUEST['q'] = substr($url['path'], 1);
```

So, it was just that `urldecode()` that got lost, and this PR is adding that back. :-)