### PR TITLE
Transform the storage to import instead of the active one for export

### DIFF
--- a/src/Drupal/Commands/config/drush.services.yml
+++ b/src/Drupal/Commands/config/drush.services.yml
@@ -5,6 +5,7 @@ services:
     arguments: ['@config.factory', '@config.storage']
     calls:
       - [setExportStorage, ['@?config.storage.export']]
+      - [setImportTransformer, ['@?config.import_transformer']]
     tags:
       -  { name: drush.command }
   config.export.commands:


### PR DESCRIPTION
in #4194 we added a export transformation to compare with a given storage.
We should have instead transformed that storage for import to do the comparison.