### PR TITLE
Fix PHP 8 deprecation with required parameters

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -113,7 +113,7 @@ function drush_batch_command($id) {
  *   A return array. The callers only care about the finished marker and an #abort on an operation.
  *
  */
-function _drush_backend_batch_process($command = 'batch-process', $args, $options) {
+function _drush_backend_batch_process($command = 'batch-process', $args = [], $options = []) {
   $result = NULL;
 
   $batch =& batch_get();


### PR DESCRIPTION
**Describe the bug**
Running drush on PHP 8 throws a deprecation warning.

**To Reproduce**
Run `drush en -y pathauto` (or any module). I suppose it would happen with other commands as well.

**Expected behavior**
No warnings

**Actual behavior**
Couple of deprecation warnings.

```
Deprecated: Required parameter $args follows optional parameter $command in /var/www/html/vendor/drush/drush/includes/batch.inc on line 116

Deprecated: Required parameter $options follows optional parameter $command in /var/www/html/vendor/drush/drush/includes/batch.inc on line 116
```

**Workaround**
I suppose suppressing error messages would do the job (or change `error_reporting` in php.ini).

### System Configuration
| Q               | A
| --------------- | ---
| Drush version?  | 10.3.4
| Drupal version? | 9.1.x-dev
| PHP version     | 8.0.0-beta4
| OS?             | Linux (Buster)

**Additional information**

PHP 8 deprecates the behaviour which allowed the required parameters to follow optional parameters. This change avoids the deprecation warnings.