### PR TITLE
Consider deprecation error messages as warnings instead of errors

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -1454,6 +1454,9 @@ function _drush_log_drupal_messages() {
           // This is a special case. PHP logs sql errors as 'User Warnings', not errors.
           drush_set_error('DRUSH_DRUPAL_ERROR_MESSAGE', preg_replace('/^user warning: /i', '', $error));
         }
+        elseif (preg_match('/^deprecated function:/i', $error)) {
+          drush_log(preg_replace('/^deprecated function: /i', '', $error), LogLevel::WARNING);
+        }
         else {
           drush_set_error('DRUSH_DRUPAL_ERROR_MESSAGE', $error);
         }


### PR DESCRIPTION
## Problem

Drush (`site-install` to be more precise) was failing when used with an old Drupal 7 site. 

Some of the modules used in that site still use curly braces to access array elements and this is deprecated since PHP 7.4. The deprecation error messages got captured by drupal and, since there was no specific rule for such error messages, drush was logging them as errors, resulting in an exit code of 1.

## Solution

While very useful, messages about deprecated features should be treated more like warnings instead of errors, as the application will work fine even though it uses a feature that won't be available in the future.

To avoid that, we now check for any messages starting with "deprecated function:" and log them as warnings instead of errors.