### PR TITLE
Fix #4544. Use exit code 3 when insecure packages are found in security commands

### DIFF
--- a/src/Commands/DrushCommands.php
+++ b/src/Commands/DrushCommands.php
@@ -30,6 +30,8 @@ abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, 
     // Common exit codes.
     const EXIT_SUCCESS = 0;
     const EXIT_FAILURE = 1;
+    // Used to signal that the command completed successfully, but we still want to indicate a failure to the caller.
+    const EXIT_FAILURE_WITH_CLARITY = 3;
 
     use LoggerAwareTrait;
     use ConfigAwareTrait;

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -65,7 +65,7 @@ class SecurityUpdateCommands extends DrushCommands
         $updates = $this->calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json);
         if ($updates) {
             $this->suggestComposerCommand($updates);
-            return CommandResult::dataWithExitCode(new RowsOfFields($updates), self::EXIT_FAILURE);
+            return CommandResult::dataWithExitCode(new RowsOfFields($updates), self::EXIT_FAILURE_WITH_CLARITY);
         } else {
             $this->logger()->success("<info>There are no outstanding security updates for Drupal projects.</info>");
         }
@@ -183,7 +183,7 @@ class SecurityUpdateCommands extends DrushCommands
             $suggested_command = "composer why " . implode(' && composer why ', array_keys($packages));
             $this->logger()->warning('One or more of your dependencies has an outstanding security update.');
             $this->logger()->notice("Run <comment>$suggested_command</comment> to learn what module requires the package.");
-            return CommandResult::dataWithExitCode(new UnstructuredData($packages), self::EXIT_FAILURE);
+            return CommandResult::dataWithExitCode(new UnstructuredData($packages), self::EXIT_FAILURE_WITH_CLARITY);
         }
         $this->logger()->success("There are no outstanding security updates for your dependencies.");
     }

--- a/tests/integration/SecurityUpdatesTest.php
+++ b/tests/integration/SecurityUpdatesTest.php
@@ -16,7 +16,7 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
     public function testInsecureDrupalPackage()
     {
         list($expected_package, $expected_version) = $this->isDrupalGreaterThanOrEqualTo('9.0.0') ? ['drupal/semver_example', '2.2.0'] : ['drupal/alinks', '1.0.0'];
-        $this->drush('pm:security', [], ['format' => 'json'], self::EXIT_ERROR);
+        $this->drush('pm:security', [], ['format' => 'json'], self::EXIT_ERROR_WITH_CLARITY);
         $this->assertContains('One or more of your dependencies has an outstanding security update.', $this->getErrorOutput());
         $this->assertContains("$expected_package", $this->getErrorOutput());
         $security_advisories = $this->getOutputFromJSON();
@@ -37,7 +37,7 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
      */
     public function testInsecurePhpPackage()
     {
-        $this->drush('pm:security-php', [], ['format' => 'json'], self::EXIT_ERROR);
+        $this->drush('pm:security-php', [], ['format' => 'json'], self::EXIT_ERROR_WITH_CLARITY);
         $this->assertContains('One or more of your dependencies has an outstanding security update.', $this->getErrorOutput());
         $this->assertContains('Run composer why david-garcia/phpwhois', $this->getErrorOutput());
         $security_advisories = $this->getOutputFromJSON();

--- a/tests/unish/UnishTestCase.php
+++ b/tests/unish/UnishTestCase.php
@@ -15,7 +15,7 @@ abstract class UnishTestCase extends TestCase
     // Unix exit codes.
     const EXIT_SUCCESS  = 0;
     const EXIT_ERROR = 1;
-    const EXIT_ERROR_WITH_CLARITY = 1;
+    const EXIT_ERROR_WITH_CLARITY = 3;
     const UNISH_EXITCODE_USER_ABORT = 75; // Same as DRUSH_EXITCODE_USER_ABORT
     const INTEGRATION_TEST_ENV = 'default';
 

--- a/tests/unish/UnishTestCase.php
+++ b/tests/unish/UnishTestCase.php
@@ -15,6 +15,7 @@ abstract class UnishTestCase extends TestCase
     // Unix exit codes.
     const EXIT_SUCCESS  = 0;
     const EXIT_ERROR = 1;
+    const EXIT_ERROR_WITH_CLARITY = 1;
     const UNISH_EXITCODE_USER_ABORT = 75; // Same as DRUSH_EXITCODE_USER_ABORT
     const INTEGRATION_TEST_ENV = 'default';
 


### PR DESCRIPTION
We have duplicated exit code constants due to our legacy of Unish being quite separate from Drush. Seems like we could get rid of that one day.