### PR TITLE
entity:delete -> execute deletion of entities in small steps to avoid loading all at once

### DIFF
--- a/src/Drupal/Commands/core/EntityCommands.php
+++ b/src/Drupal/Commands/core/EntityCommands.php
@@ -106,4 +106,3 @@ class EntityCommands extends DrushCommands
         $storage->delete($entities);
     }
 }
-

--- a/src/Drupal/Commands/core/EntityCommands.php
+++ b/src/Drupal/Commands/core/EntityCommands.php
@@ -30,7 +30,7 @@ class EntityCommands extends DrushCommands
      *
      * @option bundle Restrict deletion to the specified bundle. Ignored when ids is specified.
      * @option exclude Exclude certain entities from deletion. Ignored when ids is specified.
-     * @option chunks Define how many entities will be deleted in the same step. Default is 10.
+     * @option chunks Define how many entities will be deleted in the same step.
      * @usage drush entity:delete node --bundle=article
      *   Delete all article entities.
      * @usage drush entity:delete shortcut
@@ -48,7 +48,7 @@ class EntityCommands extends DrushCommands
      * @aliases edel,entity-delete
      * @throws \Exception
      */
-    public function delete($entity_type, $ids = null, $options = ['bundle' => self::REQ, 'exclude' => self::REQ, 'chunks' => self::REQ])
+    public function delete($entity_type, $ids = null, $options = ['bundle' => self::REQ, 'exclude' => self::REQ, 'chunks' => 50])
     {
         $storage = $this->entityTypeManager->getStorage($entity_type);
         $query = $storage->getQuery();
@@ -75,11 +75,10 @@ class EntityCommands extends DrushCommands
         if (empty($result)) {
             $this->logger()->success(dt('No matching entities found.'));
         } else {
-            $chunks = $options['chunks'] ?? 50;
             $this->io()->progressStart(count($result));
-            foreach (array_chunk($result, $chunks, true) as $chunk) {
+            foreach (array_chunk($result, $options['chunks'], true) as $chunk) {
                 drush_op([$this, 'doDelete'], $entity_type, $chunk);
-                $this->io()->progressAdvance($chunks);
+                $this->io()->progressAdvance($options['chunks']);
             }
             $this->io()->progressFinish();
             $this->logger()->success(dt("\nDeleted !type entity Ids: !ids", ['!type' => $entity_type, '!ids' => implode(', ', array_values($result))]));

--- a/src/Drupal/Commands/core/EntityCommands.php
+++ b/src/Drupal/Commands/core/EntityCommands.php
@@ -5,8 +5,6 @@ namespace Drush\Drupal\Commands\core;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Commands\DrushCommands;
 use Drush\Utils\StringUtils;
-use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class EntityCommands extends DrushCommands
 {
@@ -26,7 +24,6 @@ class EntityCommands extends DrushCommands
      *
      * To delete configuration entities, see config:delete command.
      *
-     * @param \Symfony\Component\Console\Output\OutputInterface $output the symfony output interface.
      * @param string $entity_type An entity machine name.
      * @param string $ids A comma delimited list of Ids.
      * @param array $options
@@ -51,7 +48,7 @@ class EntityCommands extends DrushCommands
      * @aliases edel,entity-delete
      * @throws \Exception
      */
-    public function delete(OutputInterface $output, $entity_type, $ids = null, $options = ['bundle' => self::REQ, 'exclude' => self::REQ, 'chunks' => self::REQ])
+    public function delete($entity_type, $ids = null, $options = ['bundle' => self::REQ, 'exclude' => self::REQ, 'chunks' => self::REQ])
     {
         $storage = $this->entityTypeManager->getStorage($entity_type);
         $query = $storage->getQuery();
@@ -79,12 +76,12 @@ class EntityCommands extends DrushCommands
             $this->logger()->success(dt('No matching entities found.'));
         } else {
             $chunks = $options['chunks'] ?? 50;
-            $progress_bar = new ProgressBar($output, count($result));
+            $this->io()->progressStart(count($result));
             foreach (array_chunk($result, $chunks, true) as $chunk) {
                 drush_op([$this, 'doDelete'], $entity_type, $chunk);
-                $progress_bar->advance($chunks);
+                $this->io()->progressAdvance($chunks);
             }
-            $progress_bar->finish();
+            $this->io()->progressFinish();
             $this->logger()->success(dt("\nDeleted !type entity Ids: !ids", ['!type' => $entity_type, '!ids' => implode(', ', array_values($result))]));
         }
     }

--- a/src/Drupal/Commands/core/EntityCommands.php
+++ b/src/Drupal/Commands/core/EntityCommands.php
@@ -58,8 +58,7 @@ class EntityCommands extends DrushCommands
         if ($ids = StringUtils::csvToArray($ids)) {
             $idKey = $this->entityTypeManager->getDefinition($entity_type)->getKey('id');
             $query = $query->condition($idKey, $ids, 'IN');
-        }
-        elseif ($options['bundle'] || $options['exclude']) {
+        } elseif ($options['bundle'] || $options['exclude']) {
             if ($exclude = StringUtils::csvToArray($options['exclude'])) {
                 $idKey = $this->entityTypeManager->getDefinition($entity_type)->getKey('id');
                 $query = $query->condition($idKey, $exclude, 'NOT IN');
@@ -79,9 +78,9 @@ class EntityCommands extends DrushCommands
         if (empty($result)) {
             $this->logger()->success(dt('No matching entities found.'));
         } else {
-            $chunks = $options['chunks'] ?? 10;
+            $chunks = $options['chunks'] ?? 50;
             $progress_bar = new ProgressBar($output, count($result));
-            foreach (array_chunk($result, $chunks, TRUE) as $chunk) {
+            foreach (array_chunk($result, $chunks, true) as $chunk) {
                 drush_op([$this, 'doDelete'], $entity_type, $chunk);
                 $progress_bar->advance($chunks);
             }
@@ -106,5 +105,5 @@ class EntityCommands extends DrushCommands
         $entities = $storage->loadMultiple($ids);
         $storage->delete($entities);
     }
-
 }
+


### PR DESCRIPTION
When deleting lots of entities at once (+1000). It seems that the command hangs. I changed the command to process the deletions in small steps and added a progress bar to the output to inform the user. 