### PR TITLE
Add site name and Drupal version to php:cli startup message

### DIFF
--- a/src/Drupal/Commands/core/CliCommands.php
+++ b/src/Drupal/Commands/core/CliCommands.php
@@ -46,6 +46,14 @@ class CliCommands extends DrushCommands
         // Set the Drush specific history file path.
         $configuration->setHistoryFile($this->historyPath($options));
 
+        $configuration->setStartupMessage(
+            sprintf(
+                '<aside>%s (Drupal %s)</aside>',
+                \Drupal::config('system.site')->get('name'),
+                \Drupal::VERSION
+            )
+        );
+
         // Disable checking for updates. Our dependencies are managed with Composer.
         $configuration->setUpdateCheck(Checker::NEVER);
 


### PR DESCRIPTION
I think this would make more clear to users that PHP shell is running within Drupal context.
![drush-php](https://user-images.githubusercontent.com/673139/102044287-54debf80-3df8-11eb-9bf0-1cb447cca47e.png)
