### PR TITLE
Avoid unnecessary nesting of error message

### DIFF
--- a/src/Runtime/RedispatchHook.php
+++ b/src/Runtime/RedispatchHook.php
@@ -103,7 +103,7 @@ class RedispatchHook implements InitializeHookInterface, ConfigAwareInterface, S
         } else {
             $process->setTty($this->getConfig()->get('ssh.tty', $input->isInteractive()));
         }
-        $process->mustRun($process->showRealtime());
+        $process->run($process->showRealtime());
 
         return $this->exitEarly($process->getExitCode());
     }


### PR DESCRIPTION
Fix for #4626

**Expected behavior**
A clear concise error report.
```
In CacheCommands.php line 266:
                                           
  'eeee' cache is not a valid cache type.  
                                           

cache:clear [--cache-clear [CACHE-CLEAR]] [--no-cache-clear] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-d|--debug] [-y|--yes] [--no] [--remote-host REMOTE-HOST] [--remote-user REMOTE-USER] [-r|--root ROOT] [-l|--uri URI] [--simulate] [--pipe] [-D|--define DEFINE] [--notify [NOTIFY]] [--druplicon] [--xh-link XH-LINK] [--] <command> <type> [<args>]...

```

**Actual behavior**
There is some big red highlighted information (marked with the word RED below) that is useless.  The command syntax is printed twice.
```
In CacheCommands.php line 266:
                                           
  'eeee' cache is not a valid cache type.  
                                           

cache:clear [--cache-clear [CACHE-CLEAR]] [--no-cache-clear] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-d|--debug] [-y|--yes] [--no] [--remote-host REMOTE-HOST] [--remote-user REMOTE-USER] [-r|--root ROOT] [-l|--uri URI] [--simulate] [--pipe] [-D|--define DEFINE] [--notify [NOTIFY]] [--druplicon] [--xh-link XH-LINK] [--] <command> <type> [<args>]...


In Process.php line 235:
RED                                                                                                                                  
RED  The command "ssh -t -o LogLevel=QUIET svr01 'drush cc eeee --uri=default " failed.  
RED                                                                                                                                  
RED  Exit Code: 1(General error)                                                                                                     
RED                                                                                                                                  
RED  Working directory:                                                                                                              
RED                                                                                                                                  
RED  Output:                                                                                                                         
RED  ================                                                                                                                
RED                                                                                                                                  
RED                                                                                                                                  
RED  Error Output:                                                                                                                   
RED  ================                                                                                                               
RED                                                                                                                                  

cache:clear [--cache-clear [CACHE-CLEAR]] [--no-cache-clear] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-d|--debug] [-y|--yes] [--no] [--remote-host REMOTE-HOST] [--remote-user REMOTE-USER] [-r|--root ROOT] [-l|--uri URI] [--simulate] [--pipe] [-D|--define DEFINE] [--druplicon] [--notify [NOTIFY]] [--xh-link XH-LINK] [--] <command> <type> [<args>]...

```