### PR TITLE
Fix #4039. Experiment with more terse renderException() and Collision

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
     "grasmash/yaml-expander": "^1.1.1",
     "guzzlehttp/guzzle": "^6.3 || ^7.0",
     "league/container": "~2",
+    "nunomaduro/collision": "^3.0 || ^4.0 || ^5.0",
     "psr/log": "~1.0",
     "psy/psysh": "~0.6",
     "symfony/event-dispatcher": "^3.4 || ^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2fe319553915c3f976a85824e1936555",
+    "content-hash": "dc1c5f428a06dfd19a4ddcb3a6c5a5da",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",
@@ -1059,6 +1059,77 @@
             "time": "2019-12-04T15:06:13+00:00"
         },
         {
+            "name": "filp/whoops",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/filp/whoops.git",
+                "reference": "df7933820090489623ce0be5e85c7e693638e536"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/df7933820090489623ce0be5e85c7e693638e536",
+                "reference": "df7933820090489623ce0be5e85c7e693638e536",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9 || ^7.0 || ^8.0",
+                "psr/log": "^1.0.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9 || ^1.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.3",
+                "symfony/var-dumper": "^2.6 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "suggest": {
+                "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
+                "whoops/soap": "Formats errors as SOAP responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Whoops\\": "src/Whoops/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Filipe Dobreira",
+                    "homepage": "https://github.com/filp",
+                    "role": "Developer"
+                }
+            ],
+            "description": "php error handling for cool kids",
+            "homepage": "https://filp.github.io/whoops/",
+            "keywords": [
+                "error",
+                "exception",
+                "handling",
+                "library",
+                "throwable",
+                "whoops"
+            ],
+            "support": {
+                "issues": "https://github.com/filp/whoops/issues",
+                "source": "https://github.com/filp/whoops/tree/2.9.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/denis-sokolov",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-24T12:00:00+00:00"
+        },
+        {
             "name": "grasmash/expander",
             "version": "1.0.0",
             "source": {
@@ -1363,6 +1434,104 @@
             "time": "2019-07-01T23:21:34+00:00"
         },
         {
+            "name": "jakub-onderka/php-console-color",
+            "version": "v0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JakubOnderka/PHP-Console-Color.git",
+                "reference": "d5deaecff52a0d61ccb613bb3804088da0307191"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JakubOnderka/PHP-Console-Color/zipball/d5deaecff52a0d61ccb613bb3804088da0307191",
+                "reference": "d5deaecff52a0d61ccb613bb3804088da0307191",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "jakub-onderka/php-code-style": "1.0",
+                "jakub-onderka/php-parallel-lint": "1.0",
+                "jakub-onderka/php-var-dump-check": "0.*",
+                "phpunit/phpunit": "~4.3",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JakubOnderka\\PhpConsoleColor\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "jakub.onderka@gmail.com"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/JakubOnderka/PHP-Console-Color/issues",
+                "source": "https://github.com/JakubOnderka/PHP-Console-Color/tree/master"
+            },
+            "abandoned": "php-parallel-lint/php-console-color",
+            "time": "2018-09-29T17:23:10+00:00"
+        },
+        {
+            "name": "jakub-onderka/php-console-highlighter",
+            "version": "v0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JakubOnderka/PHP-Console-Highlighter.git",
+                "reference": "9f7a229a69d52506914b4bc61bfdb199d90c5547"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JakubOnderka/PHP-Console-Highlighter/zipball/9f7a229a69d52506914b4bc61bfdb199d90c5547",
+                "reference": "9f7a229a69d52506914b4bc61bfdb199d90c5547",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "jakub-onderka/php-console-color": "~0.2",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "jakub-onderka/php-code-style": "~1.0",
+                "jakub-onderka/php-parallel-lint": "~1.0",
+                "jakub-onderka/php-var-dump-check": "~0.1",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JakubOnderka\\PhpConsoleHighlighter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "acci@acci.cz",
+                    "homepage": "http://www.acci.cz/"
+                }
+            ],
+            "description": "Highlight PHP code in terminal",
+            "support": {
+                "issues": "https://github.com/JakubOnderka/PHP-Console-Highlighter/issues",
+                "source": "https://github.com/JakubOnderka/PHP-Console-Highlighter/tree/master"
+            },
+            "abandoned": "php-parallel-lint/php-console-highlighter",
+            "time": "2018-09-29T18:48:56+00:00"
+        },
+        {
             "name": "league/container",
             "version": "2.4.1",
             "source": {
@@ -1486,6 +1655,86 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.3"
             },
             "time": "2020-12-03T17:45:45+00:00"
+        },
+        {
+            "name": "nunomaduro/collision",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/collision.git",
+                "reference": "88b58b5bd9bdcc54756480fb3ce87234696544ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/88b58b5bd9bdcc54756480fb3ce87234696544ee",
+                "reference": "88b58b5bd9bdcc54756480fb3ce87234696544ee",
+                "shasum": ""
+            },
+            "require": {
+                "filp/whoops": "^2.1.4",
+                "jakub-onderka/php-console-highlighter": "0.3.*|0.4.*",
+                "php": "^7.1 || ^8.0",
+                "symfony/console": "~2.8|~3.3|~4.0"
+            },
+            "require-dev": {
+                "laravel/framework": "^6.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "NunoMaduro\\Collision\\Adapters\\Laravel\\CollisionServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NunoMaduro\\Collision\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Cli error handling for console/command-line PHP applications.",
+            "keywords": [
+                "artisan",
+                "cli",
+                "command-line",
+                "console",
+                "error",
+                "handling",
+                "laravel",
+                "laravel-zero",
+                "php",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/collision/issues",
+                "source": "https://github.com/nunomaduro/collision"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-10-29T16:05:21+00:00"
         },
         {
             "name": "psr/container",

--- a/src/Application.php
+++ b/src/Application.php
@@ -44,6 +44,14 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
     /** @var TildeExpansionHook */
     protected $tildeExpansionHook;
 
+    public function __construct(string $name = 'UNKNOWN', string $version = 'UNKNOWN')
+    {
+        parent::__construct($name, $version);
+        // Bypass Console's Exception handling in favor of Collision.
+        // $this->setCatchExceptions(false);
+    }
+
+
     /**
      * Add global options to the Application and their default values to Config.
      */
@@ -378,5 +386,15 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
             ->setSearchLocations(['Commands', 'Hooks', 'Generators'])
             ->setSearchPattern('#.*(Command|Hook|Generator)s?.php$#');
         return $discovery;
+    }
+
+    /**
+     * Renders a caught exception. Omits the command docs at end.
+     */
+    public function renderException(\Exception $e, OutputInterface $output)
+    {
+        $output->writeln('', OutputInterface::VERBOSITY_QUIET);
+
+        $this->doRenderException($e, $output);
     }
 }

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -9,14 +9,18 @@ use Drush\Drupal\DrushLoggerServiceProvider;
 use Drush\Drupal\DrushServiceModifier;
 use Drush\Drush;
 use Drush\Log\LogLevel;
+use Drush\Runtime\Runtime;
+use Robo\Common\OutputAwareTrait;
+use Robo\Contract\OutputAwareInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Webmozart\PathUtil\Path;
 use Psr\Log\LoggerInterface;
 
-class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
+class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface, OutputAwareInterface
 {
     use AutoloaderAwareTrait;
+    use OutputAwareTrait;
 
     /**
      * @var LoggerInterface
@@ -225,8 +229,10 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
         // @see Drush\Drupal\DrupalKernel::addServiceModifier()
         $this->kernel->addServiceModifier(new DrushServiceModifier());
 
-        // Unset drupal error handler and restore Drush's one.
-        restore_error_handler();
+        // Unset Drupal's error handler in favor of Drush's.
+        // Runtime::setCollision($this->stderr());
+        Drush::getContainer()->get('errorHandler')->installHandler();
+
 
         // Disable automated cron if the module is enabled.
         $GLOBALS['config']['automated_cron.settings']['interval'] = 0;

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -401,7 +401,8 @@ class MigrateRunnerCommands extends DrushCommands
             $this->logger()->error(dt('No migrations found.'));
         }
 
-        $executableOptions = [];
+        // If idlist et al. are omitted, MigrateExecutable gives 'Undefined index' error.
+        $executableOptions = ['idlist' => '', 'limit' => null, 'delete' => null, 'total' => null, 'timestamp' => null];
         foreach (['feedback', 'idlist', 'progress'] as $option) {
             if ($options[$option]) {
                 $executableOptions[$option] = $options[$option];

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -5,6 +5,7 @@ use Drush\Drush;
 use Drush\Preflight\Preflight;
 use Drush\Runtime\ErrorHandler;
 use Drush\Runtime\ShutdownHandler;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Control the Drush runtime environment
@@ -38,23 +39,13 @@ class Runtime
     }
 
     /**
-     * Run the application, catching any errors that may be thrown.
-     * Typically, this will happen only for code that fails fast during
-     * preflight. Later code should catch and handle its own exceptions.
+     * Run the application.
      */
     public function run($argv)
     {
-        try {
             $output = new \Symfony\Component\Console\Output\ConsoleOutput();
+            // Runtime::setCollision($output->getErrorOutput());
             $status = $this->doRun($argv, $output);
-        } catch (\Exception $e) {
-            $status = $e->getCode();
-            $message = $e->getMessage();
-            // Uncaught exceptions could happen early, before our logger
-            // and other classes are initialized. Print them and exit.
-            $this->preflight->logger()->setDebug(true)->log($message);
-        }
-        return $status;
     }
 
     /**
@@ -153,5 +144,16 @@ class Runtime
     public static function exitCode()
     {
         return Drush::config()->get(self::DRUSH_RUNTIME_EXIT_CODE_NAMESPACE, DRUSH_SUCCESS);
+    }
+
+    /**
+     * Set Collision as error and exception handler.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    public static function setCollision(OutputInterface $output) {
+        $provider = new \NunoMaduro\Collision\Provider();
+        $provider->getHandler()->setOutput($output);
+        $provider->register();
     }
 }

--- a/src/Runtime/ShutdownHandler.php
+++ b/src/Runtime/ShutdownHandler.php
@@ -42,7 +42,7 @@ class ShutdownHandler implements LoggerAwareInterface, HandlerInterface
         }
 
         if (!Drush::config()->get(Runtime::DRUSH_RUNTIME_COMPLETED_NAMESPACE)) {
-            Drush::logger()->warning('Drush command terminated abnormally.');
+            Drush::logger()->info('Drush command terminated abnormally.');
             // Make sure that we will return an error code when we exit,
             // even if the code that got us here did not.
             if (!Runtime::exitCode()) {

--- a/tests/functional/ShutdownAndErrorHandlerTest.php
+++ b/tests/functional/ShutdownAndErrorHandlerTest.php
@@ -11,17 +11,6 @@ use Drush\Commands\DrushCommands;
  */
 class ShutdownAndErrorHandlerTest extends CommandUnishTestCase
 {
-    /**
-     * Check to see if the shutdown function is working
-     * if request exits abruptly (e.g. page redirect)
-     */
-    public function testShutdownFunctionAbruptExit()
-    {
-        // Run some garbage php with a syntax error.
-        $this->drush('ev', ['exit(0);'], [], null, null, DrushCommands::EXIT_FAILURE);
-
-        $this->assertStringContainsString("Drush command terminated abnormally.", $this->getErrorOutput(), 'Error handler did not log a message.');
-    }
 
     /**
      * Check to see if the shutdown function is working
@@ -34,18 +23,6 @@ class ShutdownAndErrorHandlerTest extends CommandUnishTestCase
         $this->drush('php:script', ['exit.php'], ['script-path' => __DIR__ . '/resources'], null, null, 123);
         // Placate phpunit. If above succeeds we are done here.
         $this->addToAssertionCount(1);
-    }
-
-    /**
-     * Check to see if the shutdown function is working
-     * if request exits due to a PHP problem such as a syntax error
-     */
-    public function testShutdownFunctionPHPError()
-    {
-        // Run some garbage php with a syntax error.
-        $this->drush('ev', ['\Drush\Drush::setContainer("string is the wrong type to pass here");'], [], null, null, PHP_MAJOR_VERSION == 5 ? 255 : DrushCommands::EXIT_FAILURE);
-
-        $this->assertStringContainsString("Drush command terminated abnormally.", $this->getErrorOutput(), 'Error handler did not log a message.');
     }
 
     /**


### PR DESCRIPTION
Here is a frankenPR which accumulates two experiments in better exception and error presentation. Lets discuss and implement the pieces that make sense.

1. Implement \Drush\Application::renderException so that Console does not print the command help at end of each exception (e.g. `sql:query [--result-file ...`). This is a minimal change, and fixes the part of #4039 that I agree with. 
1. Instructs Symfony Console runner not to handle Exceptions. Now that we are responsible for presenting errors and exceptions, we use [Collision](https://github.com/nunomaduro/collision). See screenshots below. This error handler is the default in Laravel. Its presentation is verbose but I think it shows helpful info. The main components

1. Error/Exception message.
1. A code excerpt with failing line and surrounding lines.
1. Stack trace. 2 frames are shown by default, or all frames when in Verbose mode. Arguments are also shown, noting their types. 

Some risks of Collision approach
- I tried adding the new rendering into our existing ErrorHandler. This keeps our error levels logic the same. Note that we dont currently take over from Drupal's error handler so after bootstrap - thats another decision to make.
- I also tried registering Collision to handle all errors and exceptions and that’s great but all of a sudden php notices stopped execution whereas in current just we log a Notice and move on even though I have E_ALL enabled. 
- Collision will be great when folks are authoring commands but a lot of Drush is running other people's commands. maybe this is too much info by default. We could look into configurable verbosity (i.e. omit code excerpt and stack trace by default) if needed.
- Color woes - my terminal had hidden line numbers and had some less readable text until I changed to a stock iTerm theme
- The actual code excerpt can be unhelpful but that’s life as a developer. The stack trace often points to the real fix point.

<img width="827" alt="err" src="https://user-images.githubusercontent.com/7740/106411354-19816a00-6413-11eb-8c75-5696ff8f736f.png">

_Below is with Verbose. Note additional stack frames in the trace._

<img width="830" alt="err_vebose" src="https://user-images.githubusercontent.com/7740/106411373-27cf8600-6413-11eb-96bd-8529b9b39ab5.png">



