### PR TITLE
Fix #4671. Show DB connection error details during bootstrap.

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -189,7 +189,7 @@ class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
             $connection_options = $connection->getConnectionOptions();
             $connection->open($connection_options);
         } catch (\Exception $e) {
-            $this->logger->log(LogLevel::BOOTSTRAP, 'Unable to connect to database. More information may be available by running `drush status`. This may occur when Drush is trying to bootstrap a site that has not been installed or does not have a configured database. In this case you can select another site with a working database setup by specifying the URI to use with the --uri parameter on the command line. See `drush topic docs-aliases` for details.');
+            $this->logger->log(LogLevel::BOOTSTRAP, 'Unable to connect to database with message: ' . $e->getMessage() . '. More debug information is available by running `drush status`. This may occur when Drush is trying to bootstrap a site that has not been installed or does not have a configured database. In this case you can select another site with a working database setup by specifying the URI to use with the --uri parameter on the command line. See `drush topic docs-aliases` for details.');
             return false;
         }
         if (!$connection->schema()->tableExists('key_value')) {


### PR DESCRIPTION
Thanks for the report. 

The ultimate error isn't easy to improve as Symfony Console is throwing the Exception about command not found and we'd have to override a lot to take control and report back the SQL error.

This PR enhances the debug log message to show the actual connection error.

`drush status` tells you Bootstrap Successful when all is OK and tells you nothing when it isn't. I think we should say Unsuccessful in that case. Might need a major version to change this unfortunately.