### PR TITLE
Add ability to set a time limit

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -217,8 +217,9 @@ function _drush_batch_worker() {
   $current_set =& _batch_current_set();
   $set_changed = TRUE;
 
+  $start = microtime(TRUE);
   if (empty($current_set['start'])) {
-    $current_set['start'] = microtime(TRUE);
+    $current_set['start'] = $start;
   }
   $queue = _batch_queue($current_set);
   while (!$current_set['success']) {
@@ -290,6 +291,17 @@ function _drush_batch_worker() {
     // is reached.
     if (drush_memory_limit() > 0 && (memory_get_usage() * 1.6) >= drush_memory_limit()) {
       Drush::logger()->notice(dt("Batch process has consumed in excess of 60% of available memory. Starting new thread"));
+      // Record elapsed wall clock time.
+      $current_set['elapsed'] = round((microtime(TRUE) - $current_set['start']) * 1000, 2);
+      break;
+    }
+
+    // Long running processes in Drupal often have memory leaks due to static
+    // caches. The environment variable DRUSH_BATCH_PROCESS_TIME_LIMIT can be
+    // used to limit the about of time each thread runs for.
+    $time_limit = drush_batch_process_time_limit();
+    if ($time_limit > 0 && round((microtime(TRUE) - $start) * 1000) >= $time_limit) {
+      Drush::logger()->notice(dt("Batch process has lasted longer than @secs seconds. Starting new thread", ['@secs' => $time_limit]));
       // Record elapsed wall clock time.
       $current_set['elapsed'] = round((microtime(TRUE) - $current_set['start']) * 1000, 2);
       break;

--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -240,6 +240,20 @@ function drush_memory_limit() {
   return $size;
 }
 
+/**
+ * Get the Drush batch process time limit value in seconds.
+ */
+function drush_batch_process_time_limit() {
+  $value = trim(getenv('DRUSH_BATCH_PROCESS_TIME_LIMIT')) ?: '0';
+  $last = strtolower($value[strlen($value)-1]);
+  $time = (int) rtrim($value, 'SsMm');
+  switch ($last) {
+    case 'm':
+      $time *= 60;
+  }
+
+  return $time;
+}
 
 /**
  * Form an associative array from a linear array.

--- a/tests/unit/DrushBatchProcessTimeLimitTest.php
+++ b/tests/unit/DrushBatchProcessTimeLimitTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Unish;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for drush_batch_process_time_limit()
+ *
+ * @group base
+ */
+class DrushBatchProcessTimeLimitTest extends TestCase
+{
+
+    /**
+     * Test various DRUSH_BATCH_PROCESS_TIME_LIMIT values.
+     *
+     * @dataProvider timeProvider
+     * @runInSeparateProcess
+     */
+    public function testFlags($expected, $env = null)
+    {
+        include_once __DIR__ . '/../../includes/drush.inc';
+        if (isset($env)) {
+            putenv("DRUSH_BATCH_PROCESS_TIME_LIMIT=" . $env);
+        }
+        $this->assertEquals($expected, drush_batch_process_time_limit());
+    }
+
+    public function timeProvider()
+    {
+        return [
+            'Not set' => [0],
+            '0' => [0, 0],
+            '0s' => [0, '0s'],
+            '10' => [10, '10'],
+            '10s' => [10, '10s'],
+            '1m' => [60, '1m'],
+            '1 m' => [60, '1 m'],
+            '10M' => [600, '10M'],
+        ];
+    }
+}


### PR DESCRIPTION
Adds the ability to set a time limit for a spawned batch process - DRUSH_BATCH_PROCESS_TIME_LIMIT - to something like "100s" - so after 100 seconds it'll spawn a new process. At the moment it is configured to default to 0 - ie. no time limit but maybe we should consider setting this to something like 10 minutes by default.

This is one way of addressing #1947 