### PR TITLE
Update sql:sanitize help text to use sql-sanitize-confirms event

### DIFF
--- a/src/Drupal/Commands/sql/SanitizeCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeCommands.php
@@ -17,7 +17,7 @@ class SanitizeCommands extends DrushCommands implements CustomEventAwareInterfac
      *
      * Commandfiles may add custom operations by implementing:
      *
-     *     - `@hook on-event sql-sanitize-message`. Display summary to user before confirmation.
+     *     - `@hook on-event sql-sanitize-confirms`. Display summary to user before confirmation.
      *     - `@hook post-command sql-sanitize`. Run queries or call APIs to perform sanitizing
      *
      * Several working commandfiles may be found at https://github.com/drush-ops/drush/tree/10.x/src/Drupal/Commands/sql


### PR DESCRIPTION
According to the `SanitizePluginInterface`, I think the help text on the `sql:sanitize` command should reference the `sql-sanitize-confirms` event and not `sql-sanitize-message`.

https://github.com/drush-ops/drush/blob/69ccd328836dde979dcbbeea8ca40ab0b336515f/src/Drupal/Commands/sql/SanitizePluginInterface.php#L24

