### PR TITLE
Fix error from diff preview against ignored config.

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -536,6 +536,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
      *   The source config storage service.
      * @param StorageInterface $destination
      *   The destination config storage service.
+     * @throws \Exception
      */
     public static function copyConfig(StorageInterface $source, StorageInterface $destination)
     {
@@ -549,7 +550,12 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
 
         // Export all the configuration.
         foreach ($source->listAll() as $name) {
-            $destination->write($name, $source->read($name));
+            try {
+                $destination->write($name, $source->read($name));
+            }
+            catch (\TypeError $e) {
+                throw new \Exception(dt('Source not found for @name.', ['@name' => $name]));
+            }
         }
 
         // Export configuration collections.

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -552,8 +552,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
         foreach ($source->listAll() as $name) {
             try {
                 $destination->write($name, $source->read($name));
-            }
-            catch (\TypeError $e) {
+            } catch (\TypeError $e) {
                 throw new \Exception(dt('Source not found for @name.', ['@name' => $name]));
             }
         }


### PR DESCRIPTION
If you use the config_ignore module, and inadvertently have ignored config in your sync directory, `drush config-import --preview=diff' will fail with a nondescript type error when the source can't be found. This outputs a more helpful message.