### PR TITLE
Add "project" to pm:list

### DIFF
--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -148,6 +148,7 @@ class PmCommands extends DrushCommands
      * @option package Only show extensions having a given project packages (e.g. Development).
      * @field-labels
      *   package: Package
+     *   project: Project
      *   display_name: Name
      *   name: Name
      *   type: Type
@@ -216,6 +217,7 @@ class PmCommands extends DrushCommands
 
             $row = [
                 'package' => $extension->info['package'],
+                'project' => isset($extension->info['project']) ? $extension->info['project'] : '',
                 'display_name' => $extension->info['name']. ' ('. $extension->getName(). ')',
                 'name' => $extension->getName(),
                 'type' => $extension->getType(),

--- a/tests/functional/PmEnDisUnListInfoTest.php
+++ b/tests/functional/PmEnDisUnListInfoTest.php
@@ -56,6 +56,15 @@ class EnDisUnListInfoCase extends CommandUnishTestCase
         $out = $this->getOutput();
         $this->assertStringNotContainsString('drush_empty_module', $out, 'Drush Empty Module is not part of core package');
 
+        // Check output fields in pm-list
+        $this->drush('pm-list', [], ['fields' => '*', 'format' => 'json']);
+        $extensionProperties = $this->getOutputFromJSON();
+        $this->assertTrue(isset($extensionProperties['drush_empty_module']));
+        $this->assertEquals($extensionProperties['drush_empty_module']['project'], 'drush_empty_module');
+        $this->assertEquals($extensionProperties['drush_empty_module']['package'], 'Other');
+        $this->assertEquals($extensionProperties['drush_empty_module']['status'], 'Enabled');
+        $this->assertEquals($extensionProperties['drush_empty_module']['type'], 'module');
+
         // Test module uninstall.
         $this->drush('pm-uninstall', ['drush_empty_module']);
         $this->drush('pm-list', [], ['status' => 'disabled', 'type' => 'module']);


### PR DESCRIPTION
We have a need to get information about modules in a Drupal site. We're using a remote call, and the target might be running various versions of Drupal + Drush. We'd like to know which project a module is associated with, and since pm:info no longer exists in current versions of Drush, and whereas the project information is readily available in the extension information, this seemed like a low-impact solution that is generally useful.

Note that the default fields do not change in this PR, so the default output does not change either (you only get `project` if you request it via `--fields`).