### PR TITLE
Add "project" to pm:list (Drush 8 backport)

### DIFF
--- a/commands/core/views.d8.drush.inc
+++ b/commands/core/views.d8.drush.inc
@@ -68,7 +68,7 @@ function views_drush_command() {
     'outputformat' => array(
       'default' => 'table',
       'pipe-format' => 'list',
-      'field-default' => array('name', 'label', 'description', 'status', 'tag'),
+      'fields-default' => array('name', 'label', 'description', 'status', 'tag'),
       'field-labels' => array('name' => 'Machine Name', 'label' => 'Name', 'description' => 'Description', 'status' => 'Status', 'tag' => 'Tag'),
       'output-data-type' => 'format-table',
     ),

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -314,7 +314,8 @@ function pm_drush_command() {
     'outputformat' => array(
       'default' => 'table',
       'pipe-format' => 'list',
-      'field-labels' => array('package' => 'Package', 'name' => 'Name', 'type' => 'Type', 'status' => 'Status', 'version' => 'Version'),
+      'fields-default' => array('package', 'name', 'type', 'status', 'version'),
+      'field-labels' => array('package' => 'Package', 'project' => 'Project', 'name' => 'Name', 'display_name' => 'Display Name', 'type' => 'Type', 'status' => 'Status', 'version' => 'Version', 'path' => 'Path'),
       'output-data-type' => 'format-table',
     ),
     'aliases' => array('pml', 'pm:list'),
@@ -946,9 +947,12 @@ function drush_pm_list() {
     }
 
     $row['package'] = $extension->info['package'];
+    $row['project'] = isset($extension->info['project']) ? $extension->info['project'] : '';
+    $row['display_name'] = $extension->label;
     $row['name'] = $extension->label;
     $row['type'] = ucfirst(drush_extension_get_type($extension));
     $row['status'] = ucfirst($status);
+    $row['path'] = drush_extension_get_path($extension);
     // Suppress notice when version is not present.
     $row['version'] = @$extension->info['version'];
 

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -66,6 +66,15 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
       $this->assertEquals($output->{$key}, $value);
     }
 
+    // Check output fields in pm-list
+    $this->drush('pm-list', [], $options + ['format' => 'json']);
+    $extensionProperties = (array)$this->getOutputFromJSON();
+    $this->assertTrue(isset($extensionProperties[$moduleToTest]));
+    $moduleProperties = (array)$extensionProperties[$moduleToTest];
+    $this->assertEquals($moduleToTest, $moduleProperties['project']);
+    $this->assertEquals('Enabled', $moduleProperties['status']);
+    $this->assertEquals('Module', $moduleProperties['type']);
+
     // Test pm-projectinfo shows some project info.
     $this->drush('pm-projectinfo', array($moduleToTest), $options);
     $output = $this->getOutputFromJSON($moduleToTest);
@@ -86,7 +95,7 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
     if (UNISH_DRUPAL_MAJOR_VERSION >= 8) {
       $themeToCheck = 'stark';
       // UNISH_DRUPAL_MINOR_VERSION is something like ".8.0-alpha1".
-      if (UNISH_DRUPAL_MINOR_VERSION[1] <= 8) {
+      if (isset(UNISH_DRUPAL_MINOR_VERSION[1]) && UNISH_DRUPAL_MINOR_VERSION[1] <= 8) {
         $themeToCheck = 'classy';
         $this->markTestSkipped('Project "panels", used in this test, no longer works with earlier versions of Drupal 8.');
       }

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -94,7 +94,7 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
     if (UNISH_DRUPAL_MAJOR_VERSION >= 8) {
       $themeToCheck = 'stark';
       // UNISH_DRUPAL_MINOR_VERSION is something like ".8.0-alpha1".
-      if (isset(UNISH_DRUPAL_MINOR_VERSION[1]) && UNISH_DRUPAL_MINOR_VERSION[1] <= 8) {
+      if (isset(UNISH_DRUPAL_MINOR_VERSION) && UNISH_DRUPAL_MINOR_VERSION[1] <= 8) {
         $themeToCheck = 'classy';
         $this->markTestSkipped('Project "panels", used in this test, no longer works with earlier versions of Drupal 8.');
       }

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -69,7 +69,6 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
     // Check output fields in pm-list
     $this->drush('pm-list', [], $options + ['format' => 'json']);
     $extensionProperties = (array)$this->getOutputFromJSON();
-    $this->assertTrue(isset($extensionProperties[$moduleToTest]));
     $moduleProperties = (array)$extensionProperties[$moduleToTest];
     $this->assertEquals($moduleToTest, $moduleProperties['project']);
     $this->assertEquals('Enabled', $moduleProperties['status']);

--- a/tests/pmEnDisUnListInfoTest.php
+++ b/tests/pmEnDisUnListInfoTest.php
@@ -94,7 +94,7 @@ class EnDisUnListInfoCase extends CommandUnishTestCase {
     if (UNISH_DRUPAL_MAJOR_VERSION >= 8) {
       $themeToCheck = 'stark';
       // UNISH_DRUPAL_MINOR_VERSION is something like ".8.0-alpha1".
-      if (isset(UNISH_DRUPAL_MINOR_VERSION) && UNISH_DRUPAL_MINOR_VERSION[1] <= 8) {
+      if (UNISH_DRUPAL_MINOR_VERSION[1] <= 8) {
         $themeToCheck = 'classy';
         $this->markTestSkipped('Project "panels", used in this test, no longer works with earlier versions of Drupal 8.');
       }


### PR DESCRIPTION
This is a backport of #4694 for Drush 8.

Also adds 'display_name' and 'path' to the `pm:list` output for forward compatibility. The `name` field remains as-is in Drush 8 for compatibility, so the `name` field is different between Drush 8 (where it is the display name) and Drush 9+ (where it is the machine name). In json output mode, the key is the machine name in both Drush 8 and Drush 9+, though.

Also fixes a typo in the views command definition.
