### PR TITLE
Auto-discover non-Drupal commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Unish\\": "tests/unish"
+      "Unish\\": "tests/unish",
+      "Custom\\Library\\": "tests/fixtures/lib"
     },
     "classmap": [
         "sut/core/modules/migrate/src"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,8 @@ It is recommended that you avoid global Drush commands, and favor site-wide comm
 
 ### Auto-discovered commands
 
+_Note_: Global commands auto-discovery it's experimental until Drush 10.5.0. 
+
 Such commands are auto-discovered by their class PSR4 namespace and class/file name suffix. Drush will auto-discover commands if:
 
 * The commands class is PSR4 auto-loadable.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,7 +118,7 @@ It is recommended that you avoid global Drush commands, and favor site-wide comm
 
 ### Auto-discovered commands
 
-_Note_: Global commands auto-discovery it's experimental until Drush 10.5.0. 
+_Note_: Global commands auto-discovery is experimental until Drush 10.5.0. 
 
 Such commands are auto-discovered by their class PSR4 namespace and class/file name suffix. Drush will auto-discover commands if:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -86,7 +86,12 @@ Using `require` in place of `conflict` is not recommended.
 A site-wide commandfile should have tests that run with each (major) version of Drush that is supported. You may model your test suite after the [example drush extension](https://github.com/drush-ops/example-drush-extension) project, which works on Drush ^8.2 and ^9.6.
 
 ## Global Drush Commands
-Commandfiles that are not part of any Drupal site are called 'global' commandfiles. Global commandfiles are not supported by default; in order to enable them, you must configure your `drush.yml` configuration file to add an `include` search location.
+
+Commandfiles that are not part of any Drupal site are called 'global' commandfiles.
+
+### Commands discovered by configuration
+
+Global commandfiles discoverable by configuration are not supported by default; in order to enable them, you must configure your `drush.yml` configuration file to add an `include` search location.
 
 For example:
 
@@ -110,3 +115,11 @@ It is recommended that you avoid global Drush commands, and favor site-wide comm
 
 !!! warning "Symlinked packages"
     While it is good practice to make your custom commands into a Composer package, please beware that symlinked packages (by using the composer repository type [Path](https://getcomposer.org/doc/05-repositories.md#path)) will **not** be discovered by Drush. When in development, it is recommended to [specify your package's](https://github.com/drush-ops/drush/blob/10.x/examples/example.drush.yml#L52-L67) path in your `drush.yml` to have quick access to your commands.
+
+### Auto-discovered commands
+
+Such commands are auto-discovered by their class PSR4 namespace and class/file name suffix. Drush will auto-discover commands if:
+
+* The commands class is PSR4 auto-loadable.
+* The commands class namespace ends with `*\Drush\Commands`, e.g. `My\Custom\Library\Drush\Commands`.
+* The class and file name ends with `*DrushCommands`, e.g. `FooDrushCommands`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -121,5 +121,13 @@ It is recommended that you avoid global Drush commands, and favor site-wide comm
 Such commands are auto-discovered by their class PSR4 namespace and class/file name suffix. Drush will auto-discover commands if:
 
 * The commands class is PSR4 auto-loadable.
-* The commands class namespace ends with `*\Drush\Commands`, e.g. `My\Custom\Library\Drush\Commands`.
+* The commands class namespace, relative to base namespace, is `Drush\Commands`. For instance, if a Drush command provider third party library maps this PSR4 autoload entry:
+  ```json
+  "autoload": {
+    "psr-4": {
+      "My\\Custom\\Library\\": "src"
+    }
+  }
+  ```
+  then the Drush global commands class namespace should be `My\Custom\Library\Drush\Commands` and the class file should be located under the `src/Drush/Commands` directory.
 * The class and file name ends with `*DrushCommands`, e.g. `FooDrushCommands`.

--- a/docs/generators.md
+++ b/docs/generators.md
@@ -17,10 +17,18 @@ See [Woot module](https://github.com/drush-ops/drush/blob/10.x/tests/functional/
 
 Generators that don't ship inside Drupal modules are called *global* generators. In general, it is better to use modules to carry your generators. If you still prefer using a global generator, please note:
 
-1. The file's namespace should be `\Drush\Generators`.
-1. The filename must have a name like Generators/FooGenerator.php
-    1. The prefix `Foo` can be whatever string you want. The file must end in `Generator.php`
-    1. The enclosing directory must be named `Generators`
-1. The directory above Generators must be one of:
+1. The generator class should be PSR4 auto-loadable.
+1. The generator class namespace, relative to base namespace, should be `Drush\Generators`. For instance, if a Drush generator provider third party library maps this PSR4 autoload entry:
+   ```json
+   "autoload": {
+     "psr-4": {
+       "My\\Custom\\Library\\": "src"
+     }
+   }
+   ```
+   then the Drush global generator class namespace should be `My\Custom\Library\Drush\Generators` and the class file should be located under the `src/Drush/Generators` directory.
+1. The global generator namespace should start with `\Drush\Generators` but this might be subject to change in the following release.
+1. The filename must have a name like FooGenerator.php. The prefix `Foo` can be whatever string you want. The file must end in `Generator.php`
+1. When the namespace starts with `\Drush\Generators`, the directory above Generators must be one of:
     1.  A Folder listed in the *--include* option. include may be provided via config or via CLI.
     1.  `../drush`, `/drush` or `/sites/all/drush`. These paths are relative to Drupal root.

--- a/src/Commands/generate/GenerateCommands.php
+++ b/src/Commands/generate/GenerateCommands.php
@@ -3,15 +3,20 @@
 namespace Drush\Commands\generate;
 
 use Consolidation\SiteProcess\Util\Escape;
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\Command\GeneratorInterface;
 use DrupalCodeGenerator\GeneratorDiscovery;
 use DrupalCodeGenerator\Helper\Dumper;
 use DrupalCodeGenerator\Helper\Renderer;
+use Drush\Boot\AutoloaderAwareInterface;
+use Drush\Boot\AutoloaderAwareTrait;
 use Drush\Commands\DrushCommands;
 use Drush\Commands\generate\Helper\InputHandler;
 use Drush\Commands\generate\Helper\OutputHandler;
 use Drush\Commands\help\ListCommands;
-use Drush\Drush;
 use Drush\Drupal\DrushServiceModifier;
+use Drush\Drush;
+use Robo\ClassDiscovery\RelativeNamespaceDiscovery;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Filesystem\Filesystem;
@@ -19,8 +24,9 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * Drush generate command.
  */
-class GenerateCommands extends DrushCommands
+class GenerateCommands extends DrushCommands implements AutoloaderAwareInterface
 {
+    use AutoloaderAwareTrait;
 
     /**
      * Generate boilerplate code for modules/plugins/services etc.
@@ -125,7 +131,8 @@ class GenerateCommands extends DrushCommands
         }
 
         $global_paths = array_filter($global_paths, 'file_exists');
-        $global_generators =  $discovery->getGenerators($global_paths, '\Drush\Generators');
+        $global_generators_deprecated =  $discovery->getGenerators($global_paths, '\Drush\Generators');
+        $global_generators = $this->discoverPsr4Generators();
 
         $module_generators = [];
 
@@ -137,7 +144,13 @@ class GenerateCommands extends DrushCommands
         }
 
         /** @var \Symfony\Component\Console\Command\Command[] $generators */
-        $generators = array_merge($dcg_generators, $drush_generators, $global_generators, $module_generators);
+        $generators = array_merge(
+            $dcg_generators,
+            $drush_generators,
+            $global_generators,
+            $global_generators_deprecated,
+            $module_generators
+        );
 
         foreach ($generators as $generator) {
             $sub_names = explode(':', $generator->getName());
@@ -157,5 +170,26 @@ class GenerateCommands extends DrushCommands
 
         $application->setAutoExit(false);
         return $application;
+    }
+
+    protected function discoverPsr4Generators(): array
+    {
+        $generators = (new RelativeNamespaceDiscovery($this->autoloader()))
+          ->setRelativeNamespace('Drush\Generators')
+          ->setSearchPattern('/.*Generator\.php$/')
+          ->getClasses();
+
+        return array_map(
+            function (string $class): GeneratorInterface {
+                return new $class;
+            },
+            array_filter($generators, function (string $class): bool {
+                $reflectionClass = new \ReflectionClass($class);
+                return $reflectionClass->isSubclassOf(BaseGenerator::class)
+                  && !$reflectionClass->isAbstract()
+                  && !$reflectionClass->isInterface()
+                  && !$reflectionClass->isTrait();
+            })
+        );
     }
 }

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -110,7 +110,7 @@ class Runtime
         // Configure the application object and register all of the commandfiles
         // from the search paths we found above.  After this point, the input
         // and output objects are ready & we can start using the logger, etc.
-        $application->configureAndRegisterCommands($input, $output, $commandfileSearchpath);
+        $application->configureAndRegisterCommands($input, $output, $commandfileSearchpath, $loader);
 
         // Run the Symfony Application
         // Predispatch: call a remote Drush command if applicable (via a 'pre-init' hook)

--- a/tests/fixtures/lib/Drush/Commands/CustomDrushCommands.php
+++ b/tests/fixtures/lib/Drush/Commands/CustomDrushCommands.php
@@ -7,7 +7,7 @@ use Drush\Commands\DrushCommands;
 class CustomDrushCommands extends DrushCommands
 {
     /**
-     * A custom command provided by a custom non-Drupal library
+     * Auto-discoverable custom command
      *
      * @command custom_cmd
      */

--- a/tests/fixtures/lib/Drush/Commands/CustomDrushCommands.php
+++ b/tests/fixtures/lib/Drush/Commands/CustomDrushCommands.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Custom\Library\Drush\Commands;
+
+use Drush\Commands\DrushCommands;
+
+class CustomDrushCommands extends DrushCommands
+{
+    /**
+     * A custom command provided by a custom non-Drupal library
+     *
+     * @command custom_cmd
+     */
+    public function customCommand(): void
+    {
+        $this->io()->text('Hello world!');
+    }
+}

--- a/tests/fixtures/lib/Drush/Generators/CustomGenerator.php
+++ b/tests/fixtures/lib/Drush/Generators/CustomGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Custom\Library\Drush\Generators;
+
+use DrupalCodeGenerator\Command\BaseGenerator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CustomGenerator extends BaseGenerator
+{
+    protected $name = 'custom-testing-generator';
+    protected $description = 'Custom testing generator';
+
+    public function interact(InputInterface $input, OutputInterface $output)
+    {
+        $this->addFile('drush/foo.bar');
+    }
+}

--- a/tests/integration/CustomLibraryCommandsAndGeneratorsTest.php
+++ b/tests/integration/CustomLibraryCommandsAndGeneratorsTest.php
@@ -5,17 +5,20 @@ namespace Unish;
 /**
  * @group commands
  */
-class CustomLibraryCommandsTest extends UnishIntegrationTestCase
+class CustomLibraryCommandsAndGeneratorsTest extends UnishIntegrationTestCase
 {
     /**
      * Tests that commands provided by custom libraries are registered.
      */
-    public function testCustomLibraryCommands(): void
+    public function testCustomLibraryCommandsAndGenerators(): void
     {
         $this->drush('list');
         $this->assertStringContainsString('custom_cmd', $this->getOutput());
         $this->assertStringContainsString('Auto-discoverable custom command', $this->getOutput());
         $this->drush('custom_cmd');
         $this->assertStringContainsString('Hello world!', $this->getOutput());
+        $this->drush('generate', ['list']);
+        $this->assertStringContainsString('custom-testing-generator', $this->getOutput());
+        $this->assertStringContainsString('Custom testing generator', $this->getOutput());
     }
 }

--- a/tests/integration/CustomLibraryCommandsTest.php
+++ b/tests/integration/CustomLibraryCommandsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Unish;
+
+/**
+ * @group commands
+ */
+class CustomLibraryCommandsTest extends UnishIntegrationTestCase
+{
+    /**
+     * Tests that commands provided by custom libraries are registered.
+     */
+    public function testCustomLibraryCommands(): void
+    {
+        $this->drush('list');
+        $this->assertStringContainsString('custom_cmd', $this->getOutput());
+        $this->assertStringContainsString('A custom command provided by a custom non-Drupal library', $this->getOutput());
+        $this->drush('custom_cmd');
+        $this->assertStringContainsString('Hello world!', $this->getOutput());
+    }
+
+}

--- a/tests/integration/CustomLibraryCommandsTest.php
+++ b/tests/integration/CustomLibraryCommandsTest.php
@@ -18,5 +18,4 @@ class CustomLibraryCommandsTest extends UnishIntegrationTestCase
         $this->drush('custom_cmd');
         $this->assertStringContainsString('Hello world!', $this->getOutput());
     }
-
 }

--- a/tests/integration/CustomLibraryCommandsTest.php
+++ b/tests/integration/CustomLibraryCommandsTest.php
@@ -14,7 +14,7 @@ class CustomLibraryCommandsTest extends UnishIntegrationTestCase
     {
         $this->drush('list');
         $this->assertStringContainsString('custom_cmd', $this->getOutput());
-        $this->assertStringContainsString('A custom command provided by a custom non-Drupal library', $this->getOutput());
+        $this->assertStringContainsString('Auto-discoverable custom command', $this->getOutput());
         $this->drush('custom_cmd');
         $this->assertStringContainsString('Hello world!', $this->getOutput());
     }

--- a/tests/unish/Controllers/RuntimeController.php
+++ b/tests/unish/Controllers/RuntimeController.php
@@ -153,7 +153,7 @@ class RuntimeController
         // Configure the application object and register all of the commandfiles
         // from the search paths we found above.  After this point, the input
         // and output objects are ready & we can start using the logger, etc.
-        $this->application->configureAndRegisterCommands($this->input, $this->output, $commandfileSearchpath);
+        $this->application->configureAndRegisterCommands($this->input, $this->output, $commandfileSearchpath, $loader);
     }
 
     protected function handleBootstrap()


### PR DESCRIPTION
True, there is a way to discover such commands by adding their paths in Drush configuration. But I want to be able to have such commands available automatically, when I `composer require` a 3rd party library Drush commands provider.

This PR uses the Robo `RelativeNamespaceDiscovery` to grab the Drush commands living in 3rd party libraries, loadable via PSR4. Such a class should comply with the following requirements:

* The commands class namespace ends with `*\Drush\Commands`, e.g. `My\Custom\Library\Drush\Commands`.
* The class and file name ends with `*DrushCommands`, e.g. `FooDrushCommands`.
