### PR TITLE
Provide global defaults for profiler

### DIFF
--- a/examples/example.drush.yml
+++ b/examples/example.drush.yml
@@ -177,3 +177,6 @@ xh:
   # Start profiling via xhprof/tideways and show a link to the run report.
 # link: http://xhprof.local
   # See src/Commands/core/XhprofCommands.php for more configuration settings.
+  profile-builtins: true
+  profile-cpu: false
+  profile-memory: false

--- a/src/Commands/core/XhprofCommands.php
+++ b/src/Commands/core/XhprofCommands.php
@@ -4,7 +4,7 @@ namespace Drush\Commands\core;
 
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\CommandData;
-use Drush\Drush;
+use Drush\Config\DrushConfig;
 use Symfony\Component\Console\Input\InputInterface;
 use Drush\Commands\DrushCommands;
 
@@ -48,10 +48,11 @@ class XhprofCommands extends DrushCommands
      */
     public function xhprofPost($result, CommandData $commandData)
     {
-        if (self::xhprofIsEnabled()) {
+        $config = $this->getConfig();
+        if (self::xhprofIsEnabled($config)) {
             $namespace = 'Drush';
             $run_id = self::xhprofFinishRun($namespace);
-            $url = $this->getConfig()->get('xh.link') . '/index.php?run=' . urlencode($run_id) . '&source=' . urlencode($namespace);
+            $url = $config->get('xh.link') . '/index.php?run=' . urlencode($run_id) . '&source=' . urlencode($namespace);
             $this->logger()->notice(dt('XHProf run saved. View report at !url', ['!url' => $url]));
         }
     }
@@ -63,32 +64,43 @@ class XhprofCommands extends DrushCommands
      */
     public function xhprofInitialize(InputInterface $input, AnnotationData $annotationData)
     {
-        if (self::xhprofIsEnabled()) {
-            $config = $this->getConfig()->get('xh');
+        $config = $this->getConfig();
+        if (self::xhprofIsEnabled($config)) {
             $flags = self::xhprofFlags($config);
             self::xhprofEnable($flags);
         }
     }
 
-    public static function xhprofIsEnabled()
+    /**
+     * Determines if any profiler could be enabled.
+     *
+     * @param \Drush\Config\DrushConfig $config
+     *
+     * @return bool
+     *   TRUE when xh.link configured, FALSE otherwise.
+     *
+     * @throws \Exception
+     *   When no available profiler extension enabled.
+     */
+    public static function xhprofIsEnabled(DrushConfig $config)
     {
-        if (Drush::config()->get('xh.link')) {
-            if (!extension_loaded('xhprof') && !extension_loaded('tideways_xhprof')) {
-                if (extension_loaded('tideways')) {
-                    throw new \Exception(dt('You are using an older incompatible version of the tideways extension. Please upgrade to the new tideways_xhprof extension.'));
-                } else {
-                    throw new \Exception(dt('You must enable the xhprof or tideways_xhprof PHP extensions in your CLI PHP in order to profile.'));
-                }
-            }
-            return true;
+        if (!$config->get('xh.link')) {
+            return false;
         }
-        return false;
+        if (!extension_loaded('xhprof') && !extension_loaded('tideways_xhprof')) {
+            if (extension_loaded('tideways')) {
+                throw new \Exception(dt('You are using an older incompatible version of the tideways extension. Please upgrade to the new tideways_xhprof extension.'));
+            } else {
+                throw new \Exception(dt('You must enable the xhprof or tideways_xhprof PHP extensions in your CLI PHP in order to profile.'));
+            }
+        }
+        return true;
     }
 
     /**
      * Determines flags.
      */
-    public static function xhprofFlags(array $config)
+    public static function xhprofFlags(DrushConfig $config)
     {
         if (extension_loaded('tideways_xhprof')) {
             $map = [
@@ -105,13 +117,13 @@ class XhprofCommands extends DrushCommands
         }
 
         $flags = 0;
-        if (!(isset($config['profile-builtins']) ? $config['profile-builtins']: self::XH_PROFILE_BUILTINS)) {
+        if (!$config->get('xh.profile-builtins', !self::XH_PROFILE_BUILTINS)) {
             $flags |= $map['no-builtins'];
         }
-        if (isset($config['profile-cpu']) ? $config['profile-cpu'] : self::XH_PROFILE_CPU) {
+        if ($config->get('xh.profile-cpu', self::XH_PROFILE_CPU)) {
             $flags |= $map['cpu'];
         }
-        if (isset($config['profile-memory']) ? $config['profile-memory'] : self::XH_PROFILE_MEMORY) {
+        if ($config->get('xh.profile-memory', self::XH_PROFILE_MEMORY)) {
             $flags |= $map['memory'];
         }
         return $flags;

--- a/tests/unit/XhProfTest.php
+++ b/tests/unit/XhProfTest.php
@@ -3,6 +3,7 @@
 namespace Unish;
 
 use Drush\Commands\core\XhprofCommands;
+use Drush\Config\DrushConfig;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,7 +21,11 @@ class XhProfTest extends TestCase
    */
     public function testFlags($name, $options, $expected)
     {
-        $this->assertEquals($expected, XhprofCommands::xhprofFlags($options), $name);
+        $config = new DrushConfig();
+        foreach ($options as $key => $value) {
+            $config->set('xh.' . $key, $value);
+        }
+        $this->assertEquals($expected, XhprofCommands::xhprofFlags($config), $name);
     }
 
   /**


### PR DESCRIPTION
Defaults for `xh` config is missing but `\Drush\Commands\core\XhprofCommands::xhprofFlags()` expects array as argument

It prevents to fail command as #4704