### PR TITLE
Move example.drush.yml and example.site.yml content to a markdown

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -29,7 +29,7 @@ Set up and test for a valid Drupal root, either through the --root options, or e
 
 @bootstrap site
 ------------------------------
-Set up a Drupal site directory and the correct environment variables to allow Drupal to find the configuration file. If no site is specified with the --uri options, Drush will assume the site is 'default', which mimics Drupal's behaviour.  Note that it is necessary to specify a full URI, e.g. --uri=http://example.com, in order for certain Drush commands and Drupal modules to behave correctly. See the [example Config file](https://github.com/drush-ops/drush/blob/10.x/examples/example.drush.yml) for more information. Any code that needs to modify or interact with a specific Drupal site's settings.php file should bootstrap to this phase.
+Set up a Drupal site directory and the correct environment variables to allow Drupal to find the configuration file. If no site is specified with the --uri options, Drush will assume the site is 'default', which mimics Drupal's behaviour.  Note that it is necessary to specify a full URI, e.g. --uri=http://example.com, in order for certain Drush commands and Drupal modules to behave correctly. See the [Drush configuration](using-drush-configuration.md) for more information. Any code that needs to modify or interact with a specific Drupal site's settings.php file should bootstrap to this phase.
 
 @bootstrap configuration
 ---------------------------------------

--- a/docs/site-alias-manager.md
+++ b/docs/site-alias-manager.md
@@ -7,6 +7,6 @@ The [Site Alias Manager (SAM)](https://github.com/consolidation/site-alias/blob/
 - A commandfile gets access to the SAM by implementing the SiteAliasManagerAwareInterface and *use*ing the SiteAliasManagerAwareTrait trait. Then you gain access via `$this->siteAliasManager()`.
 - If an alias was used for the current request, it is available via $this->siteAliasManager()->getself().
 - The SAM generally deals in [SiteAlias](https://github.com/consolidation/site-alias/blob/main/src/SiteAlias.php) objects. That is how any given site alias is represented. See its methods for determining things like whether the alias points to a local host or remote host.
-- [An example site alias file](https://raw.githubusercontent.com/drush-ops/drush/10.x/examples/example.site.yml).
+- [Site alias docs](site-aliases.md).
 - [Dynamically alter site aliases](https://raw.githubusercontent.com/drush-ops/drush/10.x/examples/Commands/SiteAliasAlterCommands.php).
 - The SAM is also available for as [a standalone Composer project](https://github.com/consolidation/site-alias). More information available in the README there.

--- a/docs/site-aliases.md
+++ b/docs/site-aliases.md
@@ -1,0 +1,302 @@
+# Site aliases
+
+### Basic usage
+In its most basic form, the Drush site alias feature provides a way
+for teams to share short names that refer to the live and staging sites
+(usually remote) for a given Drupal site.
+
+Add an alias file called `$PROJECT/drush/sites/self.site.yml`,
+where `$PROJECT` is the project root (location of composer.json file). The site alias file should be named `self.site.yml` because this name is special, and is used to define the different environments (usually remote)
+of the current Drupal site.
+
+The contents of the alias file should look something like the example below:
+
+```yml
+# File: self.site.yml
+live:
+  host: server.domain.com
+  user: www-admin
+  root: /other/path/to/live/drupal
+  uri: http://example.com
+stage:
+  host: server.domain.com
+  user: www-admin
+  root: /other/path/to/stage/drupal
+  uri: http://stage.example.com
+```
+
+The top-level element names (`live` and `stage` in the example above) are
+used to identify the different environments available for this site. These
+may be used on the command line to select a different target environment
+to operate on by prepending an `@` character, e.g. `@live` or `@stage`.
+
+Following these steps, a cache:rebuild on the live environment would be:
+```bash
+  $ drush @live cache:rebuild
+```
+
+All of the available aliases for a site's environments may be listed via:
+```bash
+  $ drush site:alias @self
+```
+
+The elements of a site alias are:
+
+- **host**: The fully-qualified domain name of the remote system
+  hosting the Drupal instance. The `host` option
+  must be omitted for local sites, as this option controls various
+  operations, such as whether or not rsync parameters are for local or
+  remote machines, and so on.
+- **user**: The username to log in as when using ssh or docker. If each user
+   has to use own username, you can create an environment variable which holds
+   the value, and reference via ${env.PROJECT_SSH_USER} (for example). Or you may
+   omit the `user` item and specify a user in the `~/.ssh/config` file.
+- **root**: The Drupal root; must not be specified as a relative path.
+- **uri**: The value of --uri should always be the same as
+  when the site is being accessed from a web browser (e.g. http://example.com)
+
+Drush typically uses ssh to run commands on remote systems; all team members should
+install ssh keys on the target servers (e.g. via `ssh-add`).
+
+### Advanced usage
+It is also possible to create site alias files that reference other
+sites on the same local system. Site alias files for other local sites
+are usually stored in the directory `~/.drush/sites`; however, Drush does
+not search this location for alias files by default. To use this location,
+you must add the path in your [Drush configuration file](using-drush-configuration.md). For example,
+to re-add both of the default user alias path from Drush 8, put the following
+in your `~/.drush/drush.yml` configuration file:
+
+```yml
+drush:
+  paths:
+    alias-path:
+      - '${env.HOME}/.drush/sites'
+      - /etc/drush/sites
+```
+
+The command `drush core:init` will automatically configure your
+~/.drush/drush.yml configuration file to add `~/.drush/sites` and
+`/etc/drush/sites` as locations where alias files may be placed.
+
+A canonical alias named _example_ that points to a local
+Drupal site named at http://example.com like this:
+
+```yml
+# File: example.site.yml
+dev:
+  root: /path/to/drupal
+  uri: http://example.com
+```
+
+Note that the first part of the filename (in this case _example_
+defines the name of the site alias, and the top-level key _dev_
+defines the name of the environment.
+
+With these definitions in place, it is possible to run commands targeting
+the dev environment of the target site via:
+```bash
+  $ drush @example.dev status
+```
+This command is equivalent to the longer form:
+```bash
+  $ drush --root=/path/to/drupal --uri=http://example.com status
+```
+See [Additional Site Alias Options](#additional-site-alias-options) for more information.
+
+### Converting Legacy Alias Files
+
+To convert legacy alias (*.aliases.drushrc.php) to yml, run the
+[site:alias-convert](commands/site_alias-convert.md) command.
+
+### Altering aliases:
+
+See [examples/Commands/SiteAliasAlterCommands.php](https://www.drush.org/latest/examples/SiteAliasAlterCommands.php/)) for an example.
+
+### Environment variables
+
+Site aliases may reference environment variables, just like any Drush config
+file. For example, `${env.PROJECT_SSH_USER}` will be replaced by the value
+of the `PROJECT_SSH_USER` environment value.
+
+SSH site aliases may set environment variables via the `env-var` key.
+See below.
+
+### Additional Site Alias Options
+
+Aliases are commonly used to define short names for
+local or remote Drupal installations; however, an alias
+is really nothing more than a collection of options.
+
+- **docker**: When specified, Drush executes via `docker-compose` exec rather than `ssh`.
+  - **service**: the name of the container to run on.
+  - **exec**:
+    - **options**: Options for the exec subcommand.
+- **os**: The operating system of the remote server.  Valid values
+  are _Windows_ and _Linux_. Set this value for all remote
+  aliases where the remote's OS differs from the local. This is especially relevant
+  for the [sql:sync](commands/sql_sync.md) command.
+- **ssh**: Contains settings used to control how ssh commands are generated
+  when running remote commands.
+  - **options**: Contains additional commandline options for the `ssh` command
+  itself, e.g. `-p 100`
+  - **tty**: Usually, Drush will decide whether or not to create a tty (via
+  the `ssh --t` option) based on whether the local Drush command is running
+  interactively or not. To force Drush to always or never create a tty,
+  set the `ssh.tty` option to _true_ or _false_, respectively.
+- **paths**: An array of aliases for common rsync targets.
+  Relative aliases are always taken from the Drupal root.
+  - **files**: Path to _files_ directory.  This will be looked up if not
+    specified.
+  - **drush-script**: Path to the remote Drush command.
+- **command**: These options will only be set if the alias
+  is used with the specified command.  In the advanced example below, the option
+  `--no-dump` will be selected whenever the `@stage` alias
+  is used in any of the following ways:
+    - `drush @stage sql-sync @self @live`
+    - `drush sql-sync @stage @live`
+    - `drush sql-sync @live @stage`
+- **env-vars**: An array of key / value pairs that will be set as environment
+  variables.
+
+Complex example:
+
+```yml
+# File: remote.site.yml
+live:
+  host: server.domain.com
+  user: www-admin
+  root: /other/path/to/drupal
+  uri: http://example.com
+  ssh:
+    options: '-p 100'
+  paths:
+    drush-script: '/path/to/drush'
+  env-vars:
+    PATH: /bin:/usr/bin:/home/www-admin/.composer/vendor/bin
+    DRUPAL_ENV: live
+  command:
+    site:
+      install:
+        options:
+          admin-password: 'secret-secret'
+```
+
+### Site Alias Files for Service Providers
+
+There are a number of service providers that manage Drupal sites as a
+service. Drush allows service providers to create collections of site alias
+files to reference all of the sites available to a single user. In order
+to do this, a new location must be defined in your Drush configuration
+file:
+
+```yml
+drush:
+  paths:
+    alias-path:
+      - '${env.HOME}/.drush/sites/provider-name'
+```
+
+Site aliases stored in this directory may then be referenced by its
+full alias name, including its location, e.g.:
+```bash
+  $ drush @provider-name.example.dev
+```
+Such alias files may still be referenced by their shorter name, e.g.
+`@example.dev`. Note that it is necessary to individually list every
+location where site alias files may be stored; Drush never does recursive
+(deep) directory searches for alias files.
+
+The `site:alias` command may also be used to list all of the sites and
+environments in a given location, e.g.:
+```bash
+  $ drush site:alias @provider-name
+```
+Add the option `--format=list` to show only the names of each site and
+environment without also showing the values in each alias record.
+
+### Wildcard Aliases for Service Providers
+
+Some service providers that manage Drupal sites allow customers to create
+multiple "environments" for a site. It is common for these providers to
+also have a feature to automatically create Drush aliases for all of a
+user's sites. Rather than write one record for every environment in that
+site, it is also possible to write a single _wildcard_ alias that represents
+all possible environments. This is possible if the contents of each
+environment alias are identical save for the name of the environment in
+one or more values. The variable `${env-name}` will be substituted with the
+environment name wherever it appears.
+
+Example wildcard record:
+
+```yml
+# File: remote-example.site.yml
+'*':
+  host: ${env-name}.server.domain.com
+  user: www-admin
+  root: /path/to/${env-name}
+  uri: http://${env-name}.remote-example.com
+```
+
+With a wildcard record, any environment name may be used, and will always
+match. This is not desirable in instances where the specified environment
+does not exist (e.g. if the user made a typo). An alias alter hook in a
+policy file may be used to catch these mistakes and report an error.
+See [SiteAliasAlterCommands](../examples/Commands/SiteAliasAlterCommands.php) for an example on how to do this.
+
+### Docker Compose and other transports
+
+The example below shows drush calling into a Docker hosted site. See the https://github.com/consolidation/site-alias and https://github.com/consolidation/site-process projects for more developer
+information about transports. 
+
+An example appears below. Edit to suit:
+
+```yml
+# File: mysite.site.yml
+local:
+This environment is an example of the DockerCompose transport.
+  docker:
+    service: drupal
+    exec:
+      options: --user USER
+stage:
+  uri: http://stage.example.com
+  root: /path/to/remote/drupal/root
+  host: mystagingserver.myisp.com
+  user: publisher
+  os: Linux
+  paths:
+   - files: sites/mydrupalsite.com/files
+   - custom: /my/custom/path
+  command:
+    sql:
+      sync:
+        options:
+          no-dump: true
+dev:
+  root: /path/to/docroot
+  uri: https://dev.example.com
+```
+
+### Example of rsync with exclude-paths
+
+Note that most options typically passed to rsync via `drush rsync` are
+"passthrough options", which is to say they appear after the `--` separator
+on the command line. Passthrough options are actually arguments, and
+it is not possible to set default arguments in an alias record. The
+`drush rsync` command does support two options, `--mode` and `--exclude-paths`,
+which are interpreted directly by Drush. Default values for these options
+may be specified in an alias record, as shown below.
+
+```yml
+dev:
+  root: /path/to/docroot
+  uri: https://dev.example.com
+  command:
+    core:
+      rsync:
+        options:
+          mode: rlptz
+          exclude-paths: 'css:imagecache:ctools:js:tmp:php:styles'
+```
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,5 +33,5 @@ $ drush rsync @staging:%files/ @live:%files
 $ drush sql:sync --structure-tables-key=custom @live @self
 ```
 
-See [example.site.yml](https://raw.githubusercontent.com/drush-ops/drush/10.x/examples/example.site.yml) for more information.
+See [Site aliases](site-aliases.md) for more information.
 

--- a/docs/using-drush-configuration.md
+++ b/docs/using-drush-configuration.md
@@ -1,11 +1,189 @@
 Drush Configuration
 ===================
+Drush configuration is useful to cut down on typing out lengthy and repetitive command line
+options, and to avoid mistakes.
 
-Drush users may provide configuration via: 
+#### Directories and Discovery
+drush.yml files are discovered as below, in order of precedence:
 
-1. yml files that are placed in specific directories. [See our example file](https://raw.githubusercontent.com/drush-ops/drush/10.x/examples/example.drush.yml) for more information. You may also add configuration to a site alias - [see example site alias](https://raw.githubusercontent.com/drush-ops/drush/10.x/examples/example.site.yml).
-1. Properly named environment variables are automatically used as configuration. To populate the `options.uri` config item, create an environment variable like so `DRUSH_OPTIONS_URI=http://example.com`. As you can see, variable names should be uppercased, prefixed with `DRUSH_`, and periods replaced with dashes. 
+1.  Drupal site folder (e.g. `sites/{example.com}/drush.yml`). [_default_ site does not yet work](https://github.com/drush-ops/drush/pull/4345).
+2.  `sites/all/drush`, `WEBROOT/drush`, or `PROJECTROOT/drush`.
+3.  In any location, as specified by the `--config` option.
+4.  User's .drush folder (i.e. `~/.drush/drush.yml`).
+5.  System-wide configuration folder (e.g. `/etc/drush/drush.yml` or `C:\ProgramData\Drush\drush.yml`).
 
-If you are authoring a commandfile and wish to access the user's configuration, see [Command Authoring](commands.md).
+If a configuration file is found in any of the above locations, it will be
+loaded and merged with other configuration files in the search list. Run `drush status --field=drush-conf` 
+to see all discovered config files.
 
-The Drush configuration system has been factored out of Drush and shared with the world at [https://github.com/consolidation/config](https://github.com/consolidation/config). Feel free to use it for your projects. Lots more usage information is there.
+#### Environment variables
+
+Your Drush config file may reference environment variables using a syntax like `${env.HOME}`.
+For example see the `drush.paths` examples below.
+
+An alternative way to populate Drush configuration is to define environment variables that
+correspond to config keys. For example, to populate the `options.uri` config item,
+create an environment variable `DRUSH_OPTIONS_URI=http://example.com`.
+As you can see, variable names should be uppercased, prefixed with `DRUSH_`, and periods
+replaced with dashes.
+
+### Config examples
+
+#### Specify config files to load
+```yml
+drush:
+  paths:
+    config:
+      # Load any personal config files. Is silently skipped if not found. Filename must be drush.yml
+      - ${env.HOME}/.drush/config/drush.yml
+```
+#### Specify folders to search for Drush command files.
+These locations are always merged with include paths defined on the command line or
+in other configuration files.  On the command line, paths may be separated
+by a colon `:` on Unix-based systems or a semi-colon `;` on Windows,
+or multiple `--include` options may be provided. Drush 8 and earlier did
+a deep search in `~/.drush` and `/usr/share/drush/commands` when loading
+command files.
+
+For testing, specify the namespace component in the key. e.g.:
+
+```yml
+drush:
+ include:
+   'Commands/example_drush_extension': '${env.PWD}'
+    include:
+      - '${env.HOME}/.drush/commands'
+      - /usr/share/drush/commands
+```
+
+#### Specify the folders to search for Drush alias files (*.site.yml). 
+These locations are always merged with alias paths defined on the command line
+ or in other configuration files.  On the command line, paths may be
+ separated by a colon `:` on Unix-based systems or a semi-colon `;` on
+ Windows, or multiple `--alias-path` options may be provided. Note that
+ Drush 8 and earlier did a deep search in `~/.drush` and `/etc/drush` when
+ loading alias files.
+```yml 
+drush:
+  alias-path:
+    - '${env.HOME}/.drush/sites'
+    - /etc/drush/sites
+```
+
+#### Cache directory 
+Specify a folder where Drush should store its file based caches. If unspecified, defaults to `$HOME/.drush`.
+```yml
+drush:  
+  cache-directory: /tmp/.drush
+```
+
+#### Backup directory
+Specify a folder where Drush should store backup files, including
+temporary sql dump files created during [sql:sync](https://www.drush.org/latest/commands/sql_sync/). If unspecified,
+defaults to `$HOME/drush-backups`.
+```yml
+drush:
+  backup-dir: /tmp/drush-backups
+```
+
+#### Global options
+```yml
+options:
+  # Specify the base_url that should be used when generating links.
+  uri: 'http://example.com/subdir'
+  
+  # Specify your Drupal core base directory (useful if you use symlinks).
+  root: '/home/USER/workspace/drupal'
+  
+  # Enable verbose mode.
+  verbose: true
+```
+
+#### Command-specific options
+```yml
+command:
+  sql:
+    dump:
+      options:
+        # Omit cache and similar tables (including during a sql:sync).
+          structure-tables-key: common
+  php:
+    script:
+      options:
+        # Additional folders to search for scripts.
+        script-path: 'sites/all/scripts:profiles/myprofile/scripts'
+  core:
+    rsync:
+      options:
+        # Ensure all rsync commands use verbose output.
+        verbose: true
+
+  site:
+    install:
+      options:
+        # Set a predetermined username and password when using site:install.
+        account-name: 'alice'
+        account-pass: 'secret'
+```
+
+#### Non-options
+```yml
+sql:
+  # An explicit list of tables which should be included in sql-dump and sql-sync.
+  tables:
+    common:
+      - user
+      - permissions
+      - role_permissions
+      - role
+  # List of tables whose *data* is skipped by the 'sql-dump' and 'sql-sync'
+  # commands when the "--structure-tables-key=common" option is provided.
+  # You may add specific tables to the existing array or add a new element.
+  structure-tables:
+    common:
+      - cache
+      - 'cache_*'
+      - history
+      - 'search_*'
+      - 'sessions'
+      - 'watchdog'
+  # List of tables to be omitted entirely from SQL dumps made by the 'sql-dump'
+  # and 'sql-sync' commands when the "--skip-tables-key=common" option is
+  # provided on the command line.  This is useful if your database contains
+  # non-Drupal tables used by some other application or during a migration for
+  # example.  You may add new tables to the existing array or add a new element.
+  skip-tables:
+    common:
+      - 'migration_*'
+
+ssh:
+  # Specify options to pass to ssh.  The default is to prohibit
+  # password authentication, and is included here, so you may add additional
+  # parameters without losing the default configuration.
+  options: '-o PasswordAuthentication=no'
+  # This string is valid for Bash shell. Override in case you need something different. See https://github.com/drush-ops/drush/issues/3816.
+  pipefail: 'set -o pipefail; '
+
+notify:
+  # Notify when command takes more than 30 seconds.
+  duration: 30
+  # Specify a command to run. Defaults to Notification Center (OSX) or libnotify (Linux)
+  cmd: /path/to/program
+  # See https://github.com/drush-ops/drush/blob/10.x/src/Commands/core/NotifyCommands.php for more settings.
+
+xh:
+  # Start profiling via xhprof/tideways and show a link to the run report.
+  link: http://xhprof.local
+  # See https://github.com/drush-ops/drush/blob/10.x/src/Commands/core/XhprofCommands.php for more settings.
+  profile-builtins: true
+  profile-cpu: false
+  profile-memory: false
+```
+
+### Misc
+- If you are authoring a commandfile and wish to access the user's configuration, see [Command Authoring](commands.md).
+- [Setting boolean options broke with Symfony 3](https://github.com/drush-ops/drush/issues/2956). This will be fixed
+  in a future release.  
+- Version-specific configuration. Limit the version of Drush that will load a configuration file by placing
+the Drush major version number in the filename, e.g. `drush10.yml`.
+- The Drush configuration system has been factored out of Drush and shared with the world at [https://github.com/consolidation/config](https://github.com/consolidation/config). Feel free to use it for your projects. Lots more usage information is there.

--- a/examples/example.drush.yml
+++ b/examples/example.drush.yml
@@ -1,182 +1,33 @@
+#
+# A minimalist Drush config file.
+# See https://www.drush.org/latest/using-drush-configuration/ for lots more documentation.
+#
 
-#
-# Examples of valid statements for a Drush runtime config (drush.yml) file.
-#
-# Use this file to cut down on typing out lengthy and repetitive command line
-# options in the Drush commands you use and to avoid mistakes.
-#
-# The Drush configuration system has been factored out and shared with
-# the world at https://github.com/consolidation/config. Feel free to use it
-# for your projects. Lots more usage information is there.
-
-# Directories and Discovery
-#
-# Rename this file to drush.yml and copy it to one of the places listed below
-# in order of precedence:
-#
-# 1.  Drupal site folder (e.g. sites/{example.com}/drush.yml). 'default' site does not work.
-# 2.  Drupal /drush and sites/all/drush folders, or the /drush folder
-#       in the directory above the Drupal root.
-# 3.  In any location, as specified by the --config (-c) option.
-# 4.  User's .drush folder (i.e. ~/.drush/drush.yml).
-# 5.  System wide configuration folder (e.g. /etc/drush/drush.yml or C:\ProgramData\Drush\drush.yml).
-#
-# If a configuration file is found in any of the above locations, it will be
-# loaded and merged with other configuration files in the search list.
-#
-# Version-specific configuration
-#
-# Drush started using yml files for configuration in version 9; earlier versions
-# of Drush will never attempt to load a drush.yml file. It is also possible
-# to limit the version of Drush that will load a configuration file by placing
-# the Drush major version number in the filename, e.g. drush10.yml.
-
-# Environment variables
-#
-# Your Drush config file may reference environment variables using a syntax like ${env.HOME}.
-# For example see the drush.paths examples below.
-#
-# An alternative way to populate Drush configuration is to define environment variables that
-# correspond to config keys. For example, to populate the options.uri config item,
-# create an environment variable `DRUSH_OPTIONS_URI=http://example.com`.
-# As you can see, variable names should be uppercased, prefixed with `DRUSH_`, and periods
-# replaced with dashes.
-
+# Preflight configuration.
 drush:
   paths:
-    # Specify config files to load.
     config:
       # Load any personal config files. Is silently skipped if not found. Filename must be drush.yml
       - ${env.HOME}/.drush/config/drush.yml
 
-
-    # Specify folders to search for Drush command files.  These locations
-    # are always merged with include paths defined on the command line or
-    # in other configuration files.  On the command line, paths may be separated
-    # by a colon (:) on Unix-based systems or a semi-colon (;) on Windows,
-    # or multiple --include options may be provided. Drush 8 and earlier did
-    # a deep search in ~/.drush and /usr/share/drush/commands when loading
-    # command files.
-    #
-    # For testing, specify the namespace component in the key. e.g.:
-    #
-    # drush:
-    #  include:
-    #    'Commands/example_drush_extension': '${env.PWD}'
-    include:
-      - '${env.HOME}/.drush/commands'
-      - /usr/share/drush/commands
-
-    # Specify the folders to search for Drush alias files (*.site.yml). These
-    # locations are always merged with alias paths defined on the command line
-    # or in other configuration files.  On the command line, paths may be
-    # separated by a colon (:) on Unix-based systems or a semi-colon (;) on
-    # Windows, or multiple --alias-path options may be provided. Note that
-    # Drush 8 and earlier did a deep search in ~/.drush and /etc/drush when
-    # loading alias files.
-    alias-path:
-      - '${env.HOME}/.drush/sites'
-      - /etc/drush/sites
-
-    # Specify a folder where Drush should store its file based caches. If unspecified, defaults to $HOME/.drush.
-    #cache-directory: /tmp/.drush
-    
-    # Specify a folder where Drush should store backup files, including
-    # temporary sql dump files created during sql:sync. If unspecified,
-    # defaults to $HOME/drush-backups
-    # backup-dir: /tmp/drush-backups
-
-# This section is for setting global options.
+# Global options.
 options:
   # Specify the base_url that should be used when generating links.
-  # Not recommended if you have more than one Drupal site on your system.
 # uri: 'http://example.com/subdir'
 
-  # Specify your Drupal core base directory (useful if you use symlinks).
-  # Not recommended if you have more than one Drupal root on your system.
-# root: '/home/USER/workspace/drupal-6'
-
-  # Enable verbose mode.
-# verbose: true
-
-# This section is for setting command-specific options.
+# Command-specific options.
 command:
   sql:
     dump:
       options:
         # Uncomment to omit cache and similar tables (including during a sql:sync).
-#         structure-tables-key: common
-  php:
-    script:
-      options:
-        # Additional folders to search for scripts.
-#       script-path: 'sites/all/scripts:profiles/myprofile/scripts'
-  core:
-    rsync:
-      options:
-        # Ensure all rsync commands use verbose output.
-#       verbose: true
+#       structure-tables-key: common
 
-  site:
-    install:
-      options:
-        # Set a predetermined username and password when using site-install.
-#       account-name: 'alice'
-#       account-pass: 'secret'
-
-
-#
-# The sections below are configuration thats consulted by various commands, outside
-# of the option system.
-#
-
-sql:
-  # An explicit list of tables which should be included in sql-dump and sql-sync.
-  tables:
-    common:
-      - user
-      - permissions
-      - role_permissions
-      - role
-  # List of tables whose *data* is skipped by the 'sql-dump' and 'sql-sync'
-  # commands when the "--structure-tables-key=common" option is provided.
-  # You may add specific tables to the existing array or add a new element.
-  structure-tables:
-    common:
-      - cache
-      - 'cache_*'
-      - history
-      - 'search_*'
-      - 'sessions'
-      - 'watchdog'
-  # List of tables to be omitted entirely from SQL dumps made by the 'sql-dump'
-  # and 'sql-sync' commands when the "--skip-tables-key=common" option is
-  # provided on the command line.  This is useful if your database contains
-  # non-Drupal tables used by some other application or during a migration for
-  # example.  You may add new tables to the existing array or add a new element.
-  skip-tables:
-    common:
-      - 'migration_*'
-
+# Non-options.
 ssh:
-  # Specify options to pass to ssh in backend invoke.  The default is to prohibit
+  # Specify options to pass to ssh.  The default is to prohibit
   # password authentication, and is included here, so you may add additional
   # parameters without losing the default configuration.
   options: '-o PasswordAuthentication=no'
   # This string is valid for Bash shell. Override in case you need something different. See https://github.com/drush-ops/drush/issues/3816.
   pipefail: 'set -o pipefail; '
-
-notify:
-  # Notify when command takes more than 30 seconds.
-# duration: 30
-  # Specify a command to run. Defaults to Notification Center (OSX) or libnotify (Linux)
-# cmd: /path/to/program
-  # See src/Commands/core/NotifyCommands.php for more configuration settings.
-
-xh:
-  # Start profiling via xhprof/tideways and show a link to the run report.
-# link: http://xhprof.local
-  # See src/Commands/core/XhprofCommands.php for more configuration settings.
-  profile-builtins: true
-  profile-cpu: false
-  profile-memory: false

--- a/examples/example.site.yml
+++ b/examples/example.site.yml
@@ -1,4 +1,7 @@
 #
+# A minimalist Drush config file.
+# See https://www.drush.org/latest/site-aliases/ for lots more documentation.
+#
 # Example of valid statements for an alias file.
 
 # Basic Alias File Usage

--- a/mkdocs_base.yml
+++ b/mkdocs_base.yml
@@ -59,6 +59,7 @@ nav:
     - Cron: cron.md
     - Drush configuration: using-drush-configuration.md
     - Drupal configuration: config-exporting.md
+    - Site aliases: site-aliases.md
     - Output Formats, Fields & Filters: output-formats-filters.md
     - Migrate: migrate.md
     - REPL (a custom shell for Drupal): repl.md

--- a/src/Commands/OptionsCommands.php
+++ b/src/Commands/OptionsCommands.php
@@ -50,8 +50,8 @@ class OptionsCommands
 
     /**
      * @hook option @optionset_table_selection
-     * @option skip-tables-key A key in the $skip_tables array. @see example.drush.yml
-     * @option structure-tables-key A key in the $structure_tables array. @see example.drush.yml
+     * @option skip-tables-key A key in the $skip_tables array. @see [Site aliases](../site-aliases.md)
+     * @option structure-tables-key A key in the $structure_tables array. @see [Site aliases](../site-aliases.md)
      * @option tables-key A key in the $tables array.
      * @option skip-tables-list A comma-separated list of tables to exclude completely.
      * @option structure-tables-list A comma-separated list of tables to include for structure, but not data.

--- a/src/Commands/core/DocsCommands.php
+++ b/src/Commands/core/DocsCommands.php
@@ -53,12 +53,12 @@ class DocsCommands extends DrushCommands
     }
 
     /**
-     * Drush configuration example.
+     * Drush configuration.
      *
      * @command docs:configuration
      * @aliases docs-configuration
      * @hidden
-     * @topic ../../../examples/example.drush.yml
+     * @topic ../../../docs/using-drush-configuration.md
      */
     public function config()
     {
@@ -111,7 +111,7 @@ class DocsCommands extends DrushCommands
      * @command docs:aliases
      * @aliases docs-aliases
      * @hidden
-     * @topic ../../../examples/example.site.yml
+     * @topic ../../../docs/site-aliases.md
      */
     public function siteAliases()
     {
@@ -137,7 +137,7 @@ class DocsCommands extends DrushCommands
      * @command docs:bootstrap
      * @aliases docs-bootstrap
      * @hidden
-     * @topic ../../..//docs/bootstrap.md
+     * @topic ../../../docs/bootstrap.md
      */
     public function bootstrap()
     {

--- a/src/Commands/core/RsyncCommands.php
+++ b/src/Commands/core/RsyncCommands.php
@@ -40,8 +40,8 @@ class RsyncCommands extends DrushCommands implements SiteAliasManagerAwareInterf
      * Rsync Drupal code or files to/from another server using ssh.
      *
      * @command core:rsync
-     * @param $source A site alias and optional path. See rsync documentation and example.site.yml.
-     * @param $target A site alias and optional path. See rsync documentation and example.site.yml.
+     * @param $source A site alias and optional path. See rsync documentation and [Site aliases](../site-aliases.md).
+     * @param $target A site alias and optional path. See rsync documentation and [Site aliases](../site-aliases.md).
      * @param $extra Additional parameters after the ssh statement.
      * @optionset_ssh
      * @option exclude-paths List of paths to exclude, seperated by : (Unix-based systems) or ; (Windows).

--- a/src/Commands/core/SiteCommands.php
+++ b/src/Commands/core/SiteCommands.php
@@ -148,6 +148,7 @@ class SiteCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
      *   List the files to be converted but do not actually do anything.
      * @bootstrap max
      * @aliases sa-convert,sac
+     * @topics docs:aliases
      * @return array
      */
     public function siteAliasConvert($destination, $options = ['format' => 'yaml', 'sources' => self::REQ])

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -221,7 +221,7 @@ class SqlCommands extends DrushCommands implements StdinAwareInterface
      * @usage drush sql:dump --result-file=../18.sql
      *   Save SQL dump to the directory above Drupal root.
      * @usage drush sql:dump --skip-tables-key=common
-     *   Skip standard tables. See examples/example.drush.yml
+     *   Skip standard tables. See [Drush configuration](../using-drush-configuration)
      * @usage drush sql:dump --extra-dump=--no-data
      *   Pass extra option to <info>mysqldump</info> command.
      * @hidden-options create-db


### PR DESCRIPTION
Markdown is more readable with hyperlinks, formatting, etc. The old pages are left behind in a minimal state with a link to the web. If we get rid of `drush init` in drush 11, we can probably get rid of these 2 example files.