### PR TITLE
Re-add global paths in example.drush.yml

### DIFF
--- a/examples/example.drush.yml
+++ b/examples/example.drush.yml
@@ -9,6 +9,12 @@ drush:
     config:
       # Load any personal config files. Is silently skipped if not found. Filename must be drush.yml
       - ${env.HOME}/.drush/config/drush.yml
+    include:
+      - '${env.HOME}/.drush/commands'
+      - /usr/share/drush/commands
+    alias-path:
+      - '${env.HOME}/.drush/sites'
+      - /etc/drush/sites
 
 # Global options.
 options:


### PR DESCRIPTION
This broke acli https://github.com/acquia/cli/issues/508