### PR TITLE
Add --extra-dump default value in sql:sync

### DIFF
--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -40,7 +40,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
      * @topics docs:aliases,docs:policy,docs:configuration,docs:example-sync-via-http
      * @throws \Exception
      */
-    public function sqlsync($source, $target, $options = ['no-dump' => false, 'no-sync' => false, 'runner' => self::REQ, 'create-db' => false, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'target-dump' => self::REQ, 'source-dump' => self::OPT])
+    public function sqlsync($source, $target, $options = ['no-dump' => false, 'no-sync' => false, 'runner' => self::REQ, 'create-db' => false, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'target-dump' => self::REQ, 'source-dump' => self::OPT, 'extra-dump' => self::REQ])
     {
         $manager = $this->siteAliasManager();
         $sourceRecord = $manager->get($source);


### PR DESCRIPTION
Was omitted accidentally in https://github.com/drush-ops/drush/issues/3512