### PR TITLE
Add sql:sanitize option to ignore admins in users_field_data

### DIFF
--- a/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
@@ -74,7 +74,7 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
             $messages[] = dt('User emails sanitized.');
         }
 
-        if ($this->isEnabled($options['ignore-admins']) && $options['ignore-admins'] === 'yes') {
+        if (in_array('ignore-admins', $options)) {
             $admins = $this->database->query("SELECT entity_id FROM user__roles WHERE roles_target_id='administrator'")->fetchCol();
             $query->condition('uid', $admins, 'NOT IN');
             $messages[] = dt('Admin user data preserved.');
@@ -98,9 +98,9 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
      *   By default, passwords are randomized. Specify <info>no</info> to disable that. Specify any other value to set all passwords
      *   to that value.
      * @option ignore-admins
-     *   By default, all users are sanitized. Specify <info>yes</info> to skip sanitizing accounts with the administrator role.
+     *   By default, all users are sanitized. Add option to skip sanitizing accounts with the administrator role.
      */
-    public function options($options = ['sanitize-email' => 'user+%uid@localhost.localdomain', 'sanitize-password' => null, 'ignore-admins' => null])
+    public function options($options = ['sanitize-email' => 'user+%uid@localhost.localdomain', 'sanitize-password' => null, 'ignore-admins' => false])
     {
     }
 
@@ -118,7 +118,7 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
         if ($this->isEnabled($options['sanitize-email'])) {
             $messages[] = dt('Sanitize user emails.');
         }
-        if ($this->isEnabled($options['ignore-admins'])) {
+        if (in_array('ignore-admins', $options)) {
             $messages[] = dt('Preserve admin user data.');
         }
     }

--- a/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
@@ -74,9 +74,10 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
             $messages[] = dt('User emails sanitized.');
         }
 
-        if ($this->isEnabled($options['ignore-admins'])) {
+        if ($this->isEnabled($options['ignore-admins']) && $options['ignore-admins'] === 'yes') {
             $admins = $this->database->query("SELECT entity_id FROM user__roles WHERE roles_target_id='administrator'")->fetchCol();
             $query->condition('uid', $admins, 'NOT IN');
+            $messages[] = dt('Admin user data preserved.');
         }
 
         if ($messages) {
@@ -116,6 +117,9 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
         }
         if ($this->isEnabled($options['sanitize-email'])) {
             $messages[] = dt('Sanitize user emails.');
+        }
+        if ($this->isEnabled($options['ignore-admins'])) {
+            $messages[] = dt('Preserve admin user data.');
         }
     }
 

--- a/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
@@ -77,7 +77,7 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
         if (in_array('ignore-admins', $options)) {
             $admins = $this->database->query("SELECT entity_id FROM user__roles WHERE roles_target_id='administrator'")->fetchCol();
             $query->condition('uid', $admins, 'NOT IN');
-            $messages[] = dt('Admin user data preserved.');
+            $messages[] = dt('Admin emails and passwords preserved.');
         }
 
         if ($messages) {
@@ -119,7 +119,7 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
             $messages[] = dt('Sanitize user emails.');
         }
         if (in_array('ignore-admins', $options)) {
-            $messages[] = dt('Preserve admin user data.');
+            $messages[] = dt('Preserve admin emails and passwords.');
         }
     }
 

--- a/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
@@ -74,6 +74,11 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
             $messages[] = dt('User emails sanitized.');
         }
 
+        if ($this->isEnabled($options['ignore-admins'])) {
+            $admins = $this->database->query("SELECT entity_id FROM user__roles WHERE roles_target_id='administrator'")->fetchCol();
+            $query->condition('uid', $admins, 'NOT IN');
+        }
+
         if ($messages) {
             $query->execute();
             $this->entityTypeManager->getStorage('user')->resetCache();
@@ -91,8 +96,10 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
      * @option sanitize-password
      *   By default, passwords are randomized. Specify <info>no</info> to disable that. Specify any other value to set all passwords
      *   to that value.
+     * @option ignore-admins
+     *   By default, all users are sanitized. Specify <info>yes</info> to skip sanitizing accounts with the administrator role.
      */
-    public function options($options = ['sanitize-email' => 'user+%uid@localhost.localdomain', 'sanitize-password' => null])
+    public function options($options = ['sanitize-email' => 'user+%uid@localhost.localdomain', 'sanitize-password' => null, 'ignore-admins' => null])
     {
     }
 

--- a/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
@@ -76,10 +76,10 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
 
         if (array_key_exists('ignored-roles', $options)) {
             $roles = explode(',', $options['ignored-roles']);
-            $admins = $this->database->query("SELECT entity_id FROM user__roles WHERE roles_target_id IN (:roles[])",
+            $ignored_roles = $this->database->query("SELECT entity_id FROM user__roles WHERE roles_target_id IN (:roles[])",
                 [':roles[]' => $roles]
             )->fetchCol();
-            $query->condition('uid', $admins, 'NOT IN');
+            $query->condition('uid', $ignored_roles, 'NOT IN');
             $messages[] = dt('User emails and passwords for the specified roles preserved.');
         }
 

--- a/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
@@ -74,7 +74,7 @@ class SanitizeUserTableCommands extends DrushCommands implements SanitizePluginI
             $messages[] = dt('User emails sanitized.');
         }
 
-        if (array_key_exists('ignored-roles', $options)) {
+        if (!empty($options['ignored-roles'])) {
             $roles = explode(',', $options['ignored-roles']);
             $ignored_roles = $this->database->query("SELECT entity_id FROM user__roles WHERE roles_target_id IN (:roles[])",
                 [':roles[]' => $roles]


### PR DESCRIPTION
This change adds a sql:sanitize option to ignore admins in users_field_data table when sanitizing. This is useful, for example, if sanitizing a database of customer data and importing to a QA environment where multiple Drupal administrators need to test. 

In the particular use case where this requirement came about, the site uses a third-party auth system which matches to Drupal users on email address, so if the emails are wiped, admins can't get in. 