### PR TITLE
Temporarily allow skip-progress-bar option on migrate commands

### DIFF
--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -233,6 +233,7 @@ class MigrateRunnerCommands extends DrushCommands
      * @option timestamp Show progress ending timestamp in progress messages
      * @option total Show total processed item number in progress messages
      * @option progress Show progress bar
+     * @option skip-progress-bar Deprecated, please use --no-progress.
      * @option delete Delete destination records missed from the source
      *
      * @usage migrate:import --all
@@ -274,6 +275,12 @@ class MigrateRunnerCommands extends DrushCommands
 
         if (!$list = $this->getMigrationList($migrationIds, $options['tag'])) {
             throw new \Exception(dt('No migrations found.'));
+        }
+
+        // Temporarly increase compatibility with migrate_tools migrate:import.
+        // TODO Remove on next major drush core version, 11.x.
+        if (!empty($options['skip-progress-bar'])) {
+            $options['progress'] = false;
         }
 
         $userData = [
@@ -368,6 +375,7 @@ class MigrateRunnerCommands extends DrushCommands
      * @option feedback Frequency of progress messages, in items processed
      * @option idlist Comma-separated list of IDs to rollback. As an ID may have more than one column, concatenate the columns with the colon ':' separator
      * @option progress Show progress bar
+     * @option skip-progress-bar Deprecated, please use --no-progress.
      *
      * @usage migrate:rollback --all
      *   Rollback all migrations
@@ -400,6 +408,12 @@ class MigrateRunnerCommands extends DrushCommands
 
         if (!$list = $this->getMigrationList($migrationIds, $options['tag'])) {
             $this->logger()->error(dt('No migrations found.'));
+        }
+
+        // Temporarly increase compatibility with migrate_tools migrate:import.
+        // TODO Remove on next major drush core version, 11.x.
+        if (!empty($options['skip-progress-bar'])) {
+            $options['progress'] = false;
         }
 
         $executableOptions = [];

--- a/src/Drupal/Migrate/MigrateExecutable.php
+++ b/src/Drupal/Migrate/MigrateExecutable.php
@@ -168,6 +168,7 @@ class MigrateExecutable extends MigrateExecutableBase
         // Cannot use the progress bar when:
         // - `--no-progress` option is used,
         // - `--feedback` option is used,
+        // - `--skip-progress-bar` option is used,
         // - The migration source plugin is configured to skips count.
         $this->exposeProgressBar = $options['progress'] && !$this->feedback && empty($migration->getSourceConfiguration()['skip_count']);
 

--- a/tests/functional/MigrateRunnerTest.php
+++ b/tests/functional/MigrateRunnerTest.php
@@ -397,6 +397,12 @@ class MigrateRunnerTest extends CommandUnishTestCase
         $this->assertNoProgressBar();
         $this->drush('migrate:rollback', ['test_migration'], ['no-progress' => null]);
         $this->assertNoProgressBar();
+        // Check that progress bar won't show when --skip-progress-bar is passed.
+        // TODO Remove on next major drush core version, 11.x.
+        $this->drush('migrate:import', ['test_migration'], ['skip-progress-bar' => null]);
+        $this->assertNoProgressBar();
+        $this->drush('migrate:rollback', ['test_migration'], ['skip-progress-bar' => null]);
+        $this->assertNoProgressBar();
 
         // Check that progress bar won't show when --feedback is passed.
         $this->drush('migrate:import', ['test_migration'], ['feedback' => 10]);


### PR DESCRIPTION
`migrate_tools` had a `--skip-progress-bar` option, that is equivalent to drush core `--no-progress` option, in both `migrate:import and `migrate:rollback`.

Temporarily allowing `--skip-progress-bar` increases compatibility on the CLI while both sets of commands are tried to be unified.

Supporting this option during drush `10.x`, can help improve the change over drush core migrate commands.
Later on `11.x`, this compatibility commit can be reverted.