### PR TITLE
Replace non-existant LogLevel::FAILURE with PSR levels

### DIFF
--- a/includes/drush.inc
+++ b/includes/drush.inc
@@ -1320,7 +1320,7 @@ function _drush_log_to_logger($logger, $entry) {
     $logger->log($log_level, $message, $context);
 }
 
-function drush_log_has_errors($types = array(LogLevel::WARNING, LogLevel::ERROR, LogLevel::FAILED)) {
+function drush_log_has_errors($types = array(LogLevel::WARNING, LogLevel::ERROR, LogLevel::CRITICAL, LogLevel::ALERT, LogLevel::EMERGENCY)) {
   $log =& drush_get_context('DRUSH_LOG', array());
   foreach ($log as $entry) {
     if (in_array($entry['type'], $types)) {


### PR DESCRIPTION
When moving to PSR logging `failure` was translated to `LogLevel::FAILURE` 
which is not valid log level. This sometimes causes a fatal error. To resolve this
we change the non-existent log level to the possible PSR log levels indicating
an error.

Fixes #3190