### PR TITLE
Fix handling of missing source rows in migrate:import

### DIFF
--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -233,7 +233,7 @@ class MigrateRunnerCommands extends DrushCommands
      * @option timestamp Show progress ending timestamp in progress messages
      * @option total Show total processed item number in progress messages
      * @option progress Show progress bar
-     * @option delete Delete destination records missed from the source
+     * @option delete Delete destination records missed from the source. Not compatible with --limit and --idlist options, and high_water_property source configuration key.
      *
      * @usage migrate:import --all
      *   Perform all migrations

--- a/tests/functional/MigrateRunnerTest.php
+++ b/tests/functional/MigrateRunnerTest.php
@@ -220,7 +220,7 @@ class MigrateRunnerTest extends CommandUnishTestCase
 
         $this->assertStringContainsString('[notice] 2 items are missing from source and will be rolled back', $this->getErrorOutput());
         $this->assertStringContainsString("[notice] Rolled back 2 items - done with 'test_migration'", $this->getErrorOutput());
-        $this->assertStringContainsString('[notice] Processed 3 items (0 created, 3 updated, 0 failed, 0 ignored)', $this->getErrorOutput());
+        $this->assertStringContainsString('[notice] Processed 0 items (0 created, 0 updated, 0 failed, 0 ignored)', $this->getErrorOutput());
         $this->drush('sql:query', ['SELECT title FROM node_field_data']);
         $this->assertEquals(['Item 1', 'Item 3', 'Item 5'], $this->getOutputAsList());
     }


### PR DESCRIPTION
With this PR:
1. Update option is not forced on all migrations. It has to be explicitly specified on command line.
2. `track_changes` works as expected: only modified items will be updated
3. Time to complete migration is significantly reduced in some cases (especially for larger sources)

Changes introduced in this PR:

1. Handling of missing source rows is moved post import so that we get a chance to collect source rows without having to perform another dedicated iteration through source.
1. By collecting existing source rows during the import we:
    - Remove the need for dedicated iteration through all source items reducing the time required to complete migration.
    - Avoid modifying status in migrate map table which was forcing unnecessary updates of all source rows. This again reduces the time required to complete migration.
1. Deletion of missing rows is limited only to migrations that process all source rows. Options that limit number of source rows are not compatible with deleting missing rows because it's not possible to reliably determine which items still exist in the source and should not be deleted. Examples:
    - Running `--idlist` along with `--delete` would cause all items not explicitly listed with `--idlist` option to be deleted. 
    - Running `--limit` along with `--delete` may in some cases cause all items above the limit to be deleted.
    - If `highwater_mark_property` is used with any source that extends `SqlBase` plugin, it will fetch from database only items above the highwater mark. Rows below highwater mark will be considered missing and marked for deletion.

Resolves #4750 