### PR TITLE
Ensure that that --db-prefix option works on Drupal 9

### DIFF
--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -165,6 +165,7 @@ class SqlCommands extends DrushCommands implements StdinAwareInterface
      * @option file-delete Delete the --file after running it.
      * @option extra Add custom options to the connect string (e.g. --extra=--skip-column-names)
      * @option db-prefix Enable replacement of braces in your query.
+     * @option quote-identifier Process Drupal 9's quoted identifiers when db-prefix is enabled.
      * @validate-file-exists file
      * @aliases sqlq,sql-query
      * @usage drush sql:query "SELECT * FROM users WHERE uid=1"
@@ -180,7 +181,7 @@ class SqlCommands extends DrushCommands implements StdinAwareInterface
      * @bootstrap max configuration
      *
      */
-    public function query($query = '', $options = ['result-file' => null, 'file' => self::REQ, 'file-delete' => false, 'extra' => self::REQ, 'db-prefix' => false])
+    public function query($query = '', $options = ['result-file' => null, 'file' => self::REQ, 'file-delete' => false, 'extra' => self::REQ, 'db-prefix' => false, 'quote-identifier' => false])
     {
         $filename = $options['file'];
         // Enable prefix processing when db-prefix option is used.

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -376,6 +376,18 @@ class SqlBase implements ConfigAwareInterface
     {
     }
 
+    /**
+     * Process the init commands. Removing or adding commands as necessary.
+     *
+     * @param array $init_commands
+     *   The original init commands.
+     *
+     * @return array
+     *   The modified init commands.
+     */
+    public function processInitCommands(array $init_commands) {
+        return $init_commands;
+    }
 
     public function queryPrefix($query)
     {
@@ -388,8 +400,11 @@ class SqlBase implements ConfigAwareInterface
                 $prefix_commands = '';
                 // Apply init commands to maintain parity with Drupal's PDO.
                 if (!empty($connection_options['init_commands'])) {
-                    $separator = ";\n";
-                    $prefix_commands = implode($separator, $connection_options['init_commands']) . $separator;
+                    $init_commands = $this->processInitCommands($connection_options['init_commands']);
+                    if ($init_commands) {
+                        $separator = ";\n";
+                        $prefix_commands = implode($separator, $init_commands) . $separator;
+                    }
                 }
                 $query = $connection->prefixTables($query);
                 if ($this->getOption('quote-identifier')) {

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -385,7 +385,8 @@ class SqlBase implements ConfigAwareInterface
      * @return array
      *   The modified init commands.
      */
-    public function processInitCommands(array $init_commands) {
+    public function processInitCommands(array $init_commands)
+    {
         return $init_commands;
     }
 

--- a/src/Sql/SqlPgsql.php
+++ b/src/Sql/SqlPgsql.php
@@ -43,7 +43,9 @@ class SqlPgsql extends SqlBase
 
     public function command()
     {
-        return 'psql -q';
+        // Stop as soon as there's an error anywhere in the script. Ensures the
+        // appropriate exit code is used upon failure.
+        return 'psql -v ON_ERROR_STOP=1 -q';
     }
 
     public function getEnv()

--- a/src/Sql/SqlSqlite.php
+++ b/src/Sql/SqlSqlite.php
@@ -27,6 +27,26 @@ class SqlSqlite extends SqlBase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function processInitCommands(array $init_commands) {
+        if (isset($init_commands['wal'])) {
+            /*
+             * Remove the WAL journal mode from the init command as it prints
+             * out the string "wal" whenever it's executed, and can affect the
+             * expected output.
+             * https://www.sqlite.org/wal.html#activating_and_configuring_wal_mode
+             *
+             * Luckily the WAL journal mode is persistent, so once it's set once,
+             * it'll keep running under WAL mode until it's changed.
+             * https://www.sqlite.org/wal.html#persistence_of_wal_mode
+             */
+            unset($init_commands['wal']);
+        }
+        return $init_commands;
+    }
+
+    /**
      * Create a new database.
      *
      * @param boolean $quoted

--- a/src/Sql/SqlSqlite.php
+++ b/src/Sql/SqlSqlite.php
@@ -29,7 +29,8 @@ class SqlSqlite extends SqlBase
     /**
      * {@inheritdoc}
      */
-    public function processInitCommands(array $init_commands) {
+    public function processInitCommands(array $init_commands)
+    {
         if (isset($init_commands['wal'])) {
             /*
              * Remove the WAL journal mode from the init command as it prints

--- a/tests/functional/SqlQueryTest.php
+++ b/tests/functional/SqlQueryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Unish;
+
+/**
+ * Tests sql:query command
+ *
+ *   Tests the sql:query command.
+ *
+ * @group commands
+ * @group sql
+ */
+class SqlQueryTest extends CommandUnishTestCase
+{
+
+    /**
+    * Test that the db-prefix option executes successfully.
+    */
+    public function testSqlQueryDbPrefix()
+    {
+        $sql_query = 'SELECT uid FROM {users} WHERE uid = 1';
+
+        // Test that it fails without the db-prefix option.
+        $this->drush('sql:query', [$sql_query], [], null, null, self::EXIT_ERROR);
+        $this->assertStringContainsString('Query failed.', $this->getErrorOutput());
+        $this->assertOutputEquals('');
+
+        $this->drush('sql:query', [$sql_query], ['db-prefix' => null]);
+        $this->assertOutputEquals('1');
+    }
+
+    /**
+    * Test that the quote-identifier option works as appropriate.
+    */
+    public function testSqlQueryQuoteIdentifier()
+    {
+        if (!$this->isDrupalGreaterThanOrEqualTo('9.0')) {
+            $this->markTestSkipped('The quote identifier feature is only available on Drupal 9.0+');
+        }
+
+        // Test that it fails without the 'quote-identifier' option present.
+        $this->drush('sql:query', ['SELECT [uid] FROM {users} WHERE [uid] = 1'], ['db-prefix' => null], null, null, self::EXIT_ERROR);
+        $this->assertStringContainsString('Query failed.', $this->getErrorOutput());
+        $this->assertOutputEquals('');
+
+        // Test that it resolves the quoted uid field.
+        $this->drush('sql:query', ['SELECT [uid] FROM {users} WHERE [uid] = 1'], ['db-prefix' => null, 'quote-identifier' => null]);
+        $this->assertOutputEquals('1');
+
+        // Test that potential identifiers within strings are left untouched by default.
+        $this->drush('sql:query', ["SELECT '[quoted-field]' AS field_name FROM {users}"], ['db-prefix' => null]);
+        $this->assertStringContainsString('[quoted-field]', $this->getOutput());
+
+        // Test that the identifiers within strings are explicitly quoted.
+        // Expected behaviour as there's no support for arguments like in PDO.
+        $this->drush('sql:query', ["SELECT '[quoted-field]' AS field_name FROM {users}"], ['db-prefix' => null, 'quote-identifier' => null]);
+        $this->assertStringContainsString('"quoted-field"', $this->getOutput());
+    }
+}

--- a/tests/functional/SqlQueryTest.php
+++ b/tests/functional/SqlQueryTest.php
@@ -18,6 +18,8 @@ class SqlQueryTest extends CommandUnishTestCase
     */
     public function testSqlQueryDbPrefix()
     {
+        $this->setUpDrupal(1, true);
+
         $sql_query = 'SELECT uid FROM {users} WHERE uid = 1';
 
         // Test that it fails without the db-prefix option.
@@ -35,25 +37,32 @@ class SqlQueryTest extends CommandUnishTestCase
     public function testSqlQueryQuoteIdentifier()
     {
         if (!$this->isDrupalGreaterThanOrEqualTo('9.0')) {
-            $this->markTestSkipped('The quote identifier feature is only available on Drupal 9.0+');
+            static::markTestSkipped('The quote identifier feature is only available on Drupal 9.0+');
         }
 
-        // Test that it fails without the 'quote-identifier' option present.
-        $this->drush('sql:query', ['SELECT [uid] FROM {users} WHERE [uid] = 1'], ['db-prefix' => null], null, null, self::EXIT_ERROR);
-        $this->assertStringContainsString('Query failed.', $this->getErrorOutput());
-        $this->assertOutputEquals('');
+        $this->setUpDrupal(1, true);
+
+        $db_driver = $this->dbDriver();
+        if ($db_driver !== 'sqlite') {
+            // Test that it fails without the 'quote-identifier' option on
+            // non-sqlite databases as sqlite natively supports the syntax:
+            // https://sqlite.org/lang_keywords.html
+            $this->drush('sql:query', ['SELECT [uid] FROM {users} WHERE [uid] = 1'], ['db-prefix' => null], null, null, self::EXIT_ERROR);
+            $this->assertStringContainsString('Query failed.', $this->getErrorOutput());
+            $this->assertOutputEquals('');
+        }
 
         // Test that it resolves the quoted uid field.
         $this->drush('sql:query', ['SELECT [uid] FROM {users} WHERE [uid] = 1'], ['db-prefix' => null, 'quote-identifier' => null]);
         $this->assertOutputEquals('1');
 
         // Test that potential identifiers within strings are left untouched by default.
-        $this->drush('sql:query', ["SELECT '[quoted-field]' AS field_name FROM {users}"], ['db-prefix' => null]);
+        $this->drush('sql:query', ["SELECT '[quoted-field]' FROM {users}"], ['db-prefix' => null]);
         $this->assertStringContainsString('[quoted-field]', $this->getOutput());
 
         // Test that the identifiers within strings are explicitly quoted.
         // Expected behaviour as there's no support for arguments like in PDO.
-        $this->drush('sql:query', ["SELECT '[quoted-field]' AS field_name FROM {users}"], ['db-prefix' => null, 'quote-identifier' => null]);
+        $this->drush('sql:query', ["SELECT '[quoted-field]' FROM {users}"], ['db-prefix' => null, 'quote-identifier' => null]);
         $this->assertStringContainsString('"quoted-field"', $this->getOutput());
     }
 }


### PR DESCRIPTION
Fixes #4514

The breaking change in behaviour was because [Drupal 9](https://www.drupal.org/project/drupal/issues/2986452#comment-12783237) changed how it handled quoted identifiers.

They were previously quoted in tildes (in MySQL), however they now use double-quotes, however in order for the tables and fields to run using double-quotes, the database must be running in a specific mode, specifically the [`ANSI_QUOTES`](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html) mode. The `ANSI_QUOTES` mode is automatically set as part of the Drupal database's `init_commands` session prep command.

As part of the Drupal 9 support, I also added optional support for the new [`identifierQuotes`](https://www.drupal.org/node/2986894) feature under the `--quote-identifier` option.
