### PR TITLE
Fix issue using array_key_exists on SimpleXMLElement object

### DIFF
--- a/lib/Drush/UpdateService/Project.php
+++ b/lib/Drush/UpdateService/Project.php
@@ -202,7 +202,7 @@ class Project {
 
       // Extract general release info.
       foreach ($items as $item) {
-        if (array_key_exists($item, $release)) {
+        if (isset($release->{$item})) {
           $value = $release->xpath($item);
           $release_info[$item] = (string)$value[0];
         }


### PR DESCRIPTION
This fixes the following error when trying to use drush v8.x on php8 

```
Error: Uncaught TypeError: array_key_exists(): Argument #2 ($array) must be of type array, SimpleXMLElement given in phar:///home/seamus/buildkit/extern/drush8.phar/lib/Drush/UpdateService/Project.php:205
```

ping @greg-1-anderson 