### PR TITLE
Execute drush with symlinked root results in recursive loop

### DIFF
--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -340,7 +340,7 @@ class Preflight
             if (!$foundRoot && $fallbackPath && is_dir($fallbackPath . '/sut') && is_dir($fallbackPath . '/vendor')) {
                 $foundRoot = $this->drupalFinder->locateRoot($fallbackPath);
             }
-            return $this->drupalFinder()->getDrupalRoot();
+            return FsUtils::realpath($this->drupalFinder()->getDrupalRoot());
         }
         return $originalSelection;
     }

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -6,6 +6,7 @@ use Drush\Config\ConfigLocator;
 use Drush\Config\EnvironmentConfigLoader;
 use Consolidation\SiteAlias\SiteAliasManager;
 use DrupalFinder\DrupalFinder;
+use Drush\Utils\FsUtils;
 
 /**
  * The Drush preflight determines what needs to be done for this request.

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -4,9 +4,9 @@ namespace Drush\Preflight;
 use Drush\Config\Environment;
 use Drush\Config\ConfigLocator;
 use Drush\Config\EnvironmentConfigLoader;
+use Drush\Utils\FsUtils;
 use Consolidation\SiteAlias\SiteAliasManager;
 use DrupalFinder\DrupalFinder;
-use Drush\Utils\FsUtils;
 
 /**
  * The Drush preflight determines what needs to be done for this request.


### PR DESCRIPTION
When executing drush with a symlinked root, results in a recursive loop:

Command to reproduce:
`drush @subsite -r /[symlinked_directory]/htdocs status --debug`


Output:
`Drush Launcher Version: 0.7.2
ROOT: /[symlinked_directory]/htdocs/web/sites/pbleiner
DRUSH VERSION: 10
DRUPAL ROOT: /[symlinked_directory]/htdocs/web
COMPOSER ROOT: /[symlinked_directory]/htdocs
VENDOR ROOT: /[symlinked_directory]/htdocs/vendor
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.
[preflight] Redispatch to site-local Drush: '/[symlinked_directory]/htdocs/vendor/drush/drush/drush'.`