### PR TITLE
Allow comparing config snapshot with active config via config:status

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -307,8 +307,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
                 throw new \Exception(dt("Can't compare to snapshot before first import."));
             }
             $empty_message = dt('No differences between snapshot and active config.');
-        }
-        else {
+        } else {
             $directory = $this->getDirectory($options['label']);
             $storage = $this->getStorage($directory);
             $empty_message = dt('No differences between active store (DB) and sync directory.');
@@ -340,7 +339,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
                     $allowed_states
                 );
                 $config_list = array_filter($config_list, function ($state) use ($allowed_state_keys) {
-                     return in_array($state, $allowed_state_keys, TRUE);
+                     return in_array($state, $allowed_state_keys, true);
                 });
             }
         }
@@ -358,8 +357,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
         foreach ($config_list as $config => $state) {
             if ($options['format'] === 'table' && $state !== 'identical') {
                 $state_display = "<fg={$color_map[$state]};options=bold>{$state_map[$state]}</>";
-            }
-            else {
+            } else {
                 $state_display = $state_map[$state];
             }
             $rows[$config] = [


### PR DESCRIPTION
For some sites we don't install the Configuration Manager (config) module, which is currently the only place I know of that compares the snapshot and active config. This PR gives drush that ability.

There is a bit of an API change for the --state option to config:status, since the existing labels don't accurately describe the new behavior. This could be addressed without an API change, but then the help text would probably get a little more confusing.

I've also refactored the code a bit to delay the switch from a token (e.g. identical) to the label (e.g. Identical). It would probably be a good idea to add tests for the --state filter, but none appear to exist at the moment.