### PR TITLE
New no-dev option for security commands

### DIFF
--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -43,6 +43,7 @@ class SecurityUpdateCommands extends DrushCommands
      *
      * @command pm:security
      * @aliases sec,pm-security
+     * @option no-dev Only check production dependencies.
      * @usage drush pm:security --format=json
      *   Get security data in JSON format.
      * @usage HTTP_PROXY=tcp://localhost:8125 pm:security
@@ -59,11 +60,11 @@ class SecurityUpdateCommands extends DrushCommands
      *
      * @throws \Exception
      */
-    public function security()
+    public function security(array $options = ['no-dev' => false])
     {
         $security_advisories_composer_json = $this->fetchAdvisoryComposerJson();
         $composer_lock_data = $this->loadSiteComposerLock();
-        $updates = $this->calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json);
+        $updates = $this->calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json, $options['no-dev']);
         if ($updates) {
             $this->suggestComposerCommand($updates);
             return CommandResult::dataWithExitCode(new RowsOfFields($updates), self::EXIT_FAILURE_WITH_CLARITY);
@@ -131,12 +132,15 @@ class SecurityUpdateCommands extends DrushCommands
      *
      * @return array
      */
-    protected function calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json)
+    protected function calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json, bool $excludeDev = FALSE)
     {
         $updates = [];
-        $both = array_merge($composer_lock_data['packages-dev'], $composer_lock_data['packages']);
+        $packages = $composer_lock_data['packages'];
+        if (!$excludeDev) {
+            $packages = array_merge($composer_lock_data['packages-dev'], $packages);
+        }
         $conflict = $security_advisories_composer_json['conflict'];
-        foreach ($both as $package) {
+        foreach ($packages as $package) {
             $name = $package['name'];
             if (!empty($conflict[$name]) && Semver::satisfies($package['version'], $security_advisories_composer_json['conflict'][$name])) {
                 $updates[$name] = [
@@ -161,6 +165,7 @@ class SecurityUpdateCommands extends DrushCommands
      * @command pm:security-php
      * @validate-php-extension zip,json
      * @aliases sec-php,pm-security-php
+     * @option no-dev Only check production dependencies.
      * @bootstrap none
      *
      * @usage drush pm:security-php --format=json
@@ -168,9 +173,9 @@ class SecurityUpdateCommands extends DrushCommands
      * @usage HTTP_PROXY=tcp://localhost:8125 pm:security
      *   Proxy Guzzle requests through an http proxy.
      */
-    public function securityPhp($options = ['format' => 'yaml'])
+    public function securityPhp($options = ['format' => 'yaml', 'no-dev' => false])
     {
-        $result = (new SecurityChecker())->check(self::composerLockPath());
+        $result = (new SecurityChecker())->check(self::composerLockPath(), $options['no-dev']);
         if ($result) {
             $suggested_command = "composer why " . implode(' && composer why ', array_keys($result));
             $this->logger()->warning('One or more of your dependencies has an outstanding security update.');

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -132,7 +132,7 @@ class SecurityUpdateCommands extends DrushCommands
      *
      * @return array
      */
-    protected function calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json, bool $excludeDev = FALSE)
+    protected function calculateSecurityUpdates($composer_lock_data, $security_advisories_composer_json, bool $excludeDev = false)
     {
         $updates = [];
         $packages = $composer_lock_data['packages'];

--- a/tests/integration/SecurityUpdatesTest.php
+++ b/tests/integration/SecurityUpdatesTest.php
@@ -35,6 +35,15 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
     }
 
     /**
+     * Test that dev modules are correctly excluded.
+     */
+    public function testNoInsecureProductionDrupalPackage()
+    {
+        $this->drush('pm:security', [], ['format' => 'json', 'no-dev' => true], self::EXIT_SUCCESS);
+        $this->assertStringContainsString('There are no outstanding security updates for Drupal projects', $this->getErrorOutput());
+    }
+
+    /**
      * Test that insecure PHP packages are correctly identified.
      */
     public function testInsecurePhpPackage()
@@ -44,5 +53,14 @@ class SecurityUpdatesTest extends UnishIntegrationTestCase
         $this->assertStringContainsString('Run composer why david-garcia/phpwhois', $this->getErrorOutput());
         $security_advisories = $this->getOutputFromJSON();
         $this->arrayHasKey('david-garcia/phpwhois', $security_advisories);
+    }
+
+    /**
+     * Test that dev dependencies are correctly excluded.
+     */
+    public function testNoInsecureProductionPhpPackage()
+    {
+        $this->drush('pm:security-php', [], ['format' => 'json', 'no-dev' => true], self::EXIT_SUCCESS);
+        $this->assertStringContainsString('There are no outstanding security updates for your dependencies.', $this->getErrorOutput());
     }
 }


### PR DESCRIPTION
We use `drush sec` and `drush sec-php` to check for vulnerabilities on our websites automatically, but we don't want to be notified for vulnerabilities in development dependencies because these are never installed on the server.