### PR TITLE
Fix install link for drush 8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Drush is a command line shell and Unix scripting interface for Drupal. Drush cor
 
 Resources
 -----------
-* [Installing (and Upgrading)](http://docs.drush.org/en/master/install/)
+* [Installing (and Upgrading)](http://docs.drush.org/en/8.x/install/)
 * [General Documentation](http://docs.drush.org)
 * [API Documentation](http://api.drush.org)
 * [Drush Commands](http://drushcommands.com)


### PR DESCRIPTION
# Motivation

On https://github.com/drush-ops/drush/tree/8.x
the readme link for "Installing (and Upgrading)" goes to https://docs.drush.org/en/master/install/ which does not work as intended.

## Before

<img width="300" alt="Screen Shot 2021-06-03 at 9 21 13 AM" src="https://user-images.githubusercontent.com/1970586/120651896-43907a80-c44d-11eb-8302-8af1451a9c55.png">

<img width="300" alt="Screen Shot 2021-06-03 at 9 21 22 AM" src="https://user-images.githubusercontent.com/1970586/120651919-48552e80-c44d-11eb-8eea-c54c97b23352.png">

## After

Link should go to http://docs.drush.org/en/8.x/install/