### PR TITLE
Use full path to drush instead of composer symlink

### DIFF
--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -81,10 +81,10 @@ class ProcessManager extends ConsolidationProcessManager
             return $defaultDrushScript;
         }
 
-        // If the target is a local Drupal site that has a vendor/bin/drush,
-        // then use that.
+        // If the target is a local Drupal site that has a
+        // vendor/drush/drush/drush, then use that.
         if ($siteAlias->hasRoot()) {
-            $localDrushScript = Path::join($siteAlias->root(), 'vendor/bin/drush');
+            $localDrushScript = Path::join($siteAlias->root(), 'vendor/drush/drush/drush');
             if (file_exists($localDrushScript)) {
                 return $localDrushScript;
             }


### PR DESCRIPTION
Hi,

I think it's safer to use the real path to drush script instead of composer's symlink. The symlink could be broken, during for example packaging in a format that don't support symlink (eg. zip).

We have take the habits to use full path to script when using drush, but it fail on some projet because drush use the symlink not the full path.

Open to discussion if there is some cons that I haven't anticipate.

Regards