### PR TITLE
Validate migration IDs

### DIFF
--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -774,7 +774,6 @@ class MigrateRunnerCommands extends DrushCommands
     {
         $argName = $commandData->annotationData()->get('validate-migration-id') ?: 'migrationId';
         $migrationId = $commandData->input()->getArgument($argName);
-        /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
         if (!$this->getMigrationPluginManager()->hasDefinition($migrationId)) {
             return new CommandError(dt('Migration "@id" does not exist', ['@id' => $migrationId]));
         }

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -775,8 +775,7 @@ class MigrateRunnerCommands extends DrushCommands
         $argName = $commandData->annotationData()->get('validate-migration-id', null) ?: 'migrationId';
         $migrationId = $commandData->input()->getArgument($argName);
         /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
-        $migration = $this->getMigrationPluginManager()->createInstance($migrationId);
-        if (!$migration) {
+        if (!$this->getMigrationPluginManager()->hasDefinition($migrationId)) {
             $msg = dt('Migration "@id" does not exist', ['@id' => $migrationId]);
             return new CommandError($msg);
         }

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -432,7 +432,7 @@ class MigrateRunnerCommands extends DrushCommands
      * @topics docs:migrate
      *
      * @validate-module-enabled migrate
-     * @validate-migration-name
+     * @validate-migration-id
      */
     public function stop(string $migrationId): void
     {
@@ -468,7 +468,7 @@ class MigrateRunnerCommands extends DrushCommands
      * @topics docs:migrate
      *
      * @validate-module-enabled migrate
-     * @validate-migration-name
+     * @validate-migration-id
      */
     public function resetStatus(string $migrationId): void
     {
@@ -507,7 +507,7 @@ class MigrateRunnerCommands extends DrushCommands
      * @topics docs:migrate
      *
      * @validate-module-enabled migrate
-     * @validate-migration-name
+     * @validate-migration-id
      *
      * @field-labels
      *   level: Level
@@ -612,7 +612,7 @@ class MigrateRunnerCommands extends DrushCommands
      * @topics docs:migrate
      *
      * @validate-module-enabled migrate
-     * @validate-migration-name
+     * @validate-migration-id
      *
      * @field-labels
      *   machine_name: Field name
@@ -759,20 +759,20 @@ class MigrateRunnerCommands extends DrushCommands
     }
 
     /**
-     * Validate that a migration name is valid.
+     * Validates a migration id is valid.
      *
      * If the argument to be validated is not named migrationId, pass the
      * argument name as the value of the annotation.
      *
-     * @hook validate @validate-migration-name
+     * @hook validate @validate-migration-id
      *
      * @param \Consolidation\AnnotatedCommand\CommandData $commandData
      *
      * @return \Consolidation\AnnotatedCommand\CommandError|null
      */
-    public function validateMigrationName(CommandData $commandData)
+    public function validateMigrationId(CommandData $commandData)
     {
-        $arg_name = $commandData->annotationData()->get('validate-migration-name', null) ?: 'migrationId';
+        $arg_name = $commandData->annotationData()->get('validate-migration-id', null) ?: 'migrationId';
         $migration_name = $commandData->input()->getArgument($arg_name);
         /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
         $migration = $this->getMigrationPluginManager()->createInstance($migration_name);

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -468,21 +468,18 @@ class MigrateRunnerCommands extends DrushCommands
      * @topics docs:migrate
      *
      * @validate-module-enabled migrate
+     * @validate-migration-name
      */
     public function resetStatus(string $migrationId): void
     {
         /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
         $migration = $this->getMigrationPluginManager()->createInstance($migrationId);
-        if ($migration) {
-            $status = $migration->getStatus();
-            if ($status == MigrationInterface::STATUS_IDLE) {
-                $this->logger()->warning(dt('Migration @id is already Idle', ['@id' => $migrationId]));
-            } else {
-                $migration->setStatus(MigrationInterface::STATUS_IDLE);
-                $this->logger()->success(dt('Migration @id reset to Idle', ['@id' => $migrationId]));
-            }
+        $status = $migration->getStatus();
+        if ($status == MigrationInterface::STATUS_IDLE) {
+            $this->logger()->warning(dt('Migration @id is already Idle', ['@id' => $migrationId]));
         } else {
-            throw new \InvalidArgumentException(dt('Migration @id does not exist', ['@id' => $migrationId]));
+            $migration->setStatus(MigrationInterface::STATUS_IDLE);
+            $this->logger()->success(dt('Migration @id reset to Idle', ['@id' => $migrationId]));
         }
     }
 

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -615,6 +615,7 @@ class MigrateRunnerCommands extends DrushCommands
      * @topics docs:migrate
      *
      * @validate-module-enabled migrate
+     * @validate-migration-name
      *
      * @field-labels
      *   machine_name: Field name

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -772,12 +772,11 @@ class MigrateRunnerCommands extends DrushCommands
      */
     public function validateMigrationId(CommandData $commandData)
     {
-        $argName = $commandData->annotationData()->get('validate-migration-id', null) ?: 'migrationId';
+        $argName = $commandData->annotationData()->get('validate-migration-id') ?: 'migrationId';
         $migrationId = $commandData->input()->getArgument($argName);
         /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
         if (!$this->getMigrationPluginManager()->hasDefinition($migrationId)) {
-            $msg = dt('Migration "@id" does not exist', ['@id' => $migrationId]);
-            return new CommandError($msg);
+            return new CommandError(dt('Migration "@id" does not exist', ['@id' => $migrationId]));
         }
     }
 }

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -759,7 +759,7 @@ class MigrateRunnerCommands extends DrushCommands
     }
 
     /**
-     * Validates a migration id is valid.
+     * Validates a migration ID is valid.
      *
      * If the argument to be validated is not named migrationId, pass the
      * argument name as the value of the annotation.

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -772,12 +772,12 @@ class MigrateRunnerCommands extends DrushCommands
      */
     public function validateMigrationId(CommandData $commandData)
     {
-        $arg_name = $commandData->annotationData()->get('validate-migration-id', null) ?: 'migrationId';
-        $migration_name = $commandData->input()->getArgument($arg_name);
+        $argName = $commandData->annotationData()->get('validate-migration-id', null) ?: 'migrationId';
+        $migrationId = $commandData->input()->getArgument($argName);
         /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
-        $migration = $this->getMigrationPluginManager()->createInstance($migration_name);
+        $migration = $this->getMigrationPluginManager()->createInstance($migrationId);
         if (!$migration) {
-            $msg = dt('Migration "@id" does not exist', ['@id' => $migration_name]);
+            $msg = dt('Migration "@id" does not exist', ['@id' => $migrationId]);
             return new CommandError($msg);
         }
     }

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -510,6 +510,7 @@ class MigrateRunnerCommands extends DrushCommands
      * @topics docs:migrate
      *
      * @validate-module-enabled migrate
+     * @validate-migration-name
      *
      * @field-labels
      *   level: Level
@@ -526,10 +527,6 @@ class MigrateRunnerCommands extends DrushCommands
     {
         /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
         $migration = $this->getMigrationPluginManager()->createInstance($migrationId);
-        if (!$migration) {
-            throw new \InvalidArgumentException(dt('Migration @id does not exist', ['@id' => $migrationId]));
-        }
-
         $idMap = $migration->getIdMap();
         $sourceIdKeys = $this->getSourceIdKeys($idMap);
         $table = [];

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -435,6 +435,10 @@ class MigrateRunnerCommands extends DrushCommands
     {
         /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
         $migration = $this->getMigrationPluginManager()->createInstance($migrationId);
+        if (!$migration) {
+            $this->logger()->error(dt('Migration @id does not exist', ['@id' => $migrationId]));
+            return;
+        }
         switch ($migration->getStatus()) {
             case MigrationInterface::STATUS_IDLE:
                 $this->logger()->warning(dt('Migration @id is idle', ['@id' => $migrationId]));


### PR DESCRIPTION
**Describe the bug**
`migrate:stop`, `migrate:messages` and `migrate:fields-source` are not handling the case when an invalid migrate name is passed.

**To Reproduce**
Try `vendor/bin/drush migrate:stop unexisting_migration`
Change it for `migrate:messages` and `migrate:fields-source` to get similar results.

**Expected behavior**
An error message is presented.

**Actual behavior**
An unhandled error is reached, triggering a php fatal error.

**Workaround**
No.

### System Configuration
| Q               | A
| --------------- | ---
| Drush version?  | 10.x e436955b5556113dda0af8a3c4225f0b209ed329
| Drupal version? | 9.x
| PHP version     | 7.3
| OS?             | Linux

**Additional information**
Add any other context about the problem here.

Here the full output I get without the extra change on this pull request.

    $ vendor/bin/drush migrate:stop unexisting_migration
     [error]  Error: Call to a member function getStatus() on bool in Drush\Drupal\Commands\core\MigrateRunnerCommands->stop() (line 438 of vendor/drush/drush/src/Drupal/Commands/core/MigrateRunnerCommands.php) #0 [internal function]: Drush\Drupal\Commands\core\MigrateRunnerCommands->stop('unexisting_migr...', Array)
    #1 vendor/consolidation/annotated-command/src/CommandProcessor.php(257): call_user_func_array(Array, Array)
    #2 vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object(Consolidation\AnnotatedCommand\CommandData))
    #3 vendor/consolidation/annotated-command/src/CommandProcessor.php(176): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
    #4 vendor/consolidation/annotated-command/src/AnnotatedCommand.php(311): Consolidation\AnnotatedCommand\CommandProcessor->process(Object(Symfony\Component\Console\Output\ConsoleOutput), Array, Array, Object(Consolidation\AnnotatedCommand\CommandData)) 
    #5 vendor/symfony/console/Command/Command.php(255): Consolidation\AnnotatedCommand\AnnotatedCommand->execute(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
    #6 vendor/symfony/console/Application.php(1027): Symfony\Component\Console\Command\Command->run(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
    #7 vendor/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand(Object(Consolidation\AnnotatedCommand\AnnotatedCommand), Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
    #8 vendor/symfony/console/Application.php(149): Symfony\Component\Console\Application->doRun(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
    #9 vendor/drush/drush/src/Runtime/Runtime.php(118): Symfony\Component\Console\Application->run(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
    #10 vendor/drush/drush/src/Runtime/Runtime.php(48): Drush\Runtime\Runtime->doRun(Array, Object(Symfony\Component\Console\Output\ConsoleOutput))
    #11 vendor/drush/drush/drush.php(72): Drush\Runtime\Runtime->run(Array)
    #12 vendor/drush/drush/drush(4): require('...')
    #13 {main}. 
    Error: Call to a member function getStatus() on bool in vendor/drush/drush/src/Drupal/Commands/core/MigrateRunnerCommands.php on line 438 #0 [internal function]: Drush\Drupal\Commands\core\MigrateRunnerCommands->stop('unexisting_migr...', Array)
    #1 vendor/consolidation/annotated-command/src/CommandProcessor.php(257): call_user_func_array(Array, Array)
    #2 vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object(Consolidation\AnnotatedCommand\CommandData))
    #3 vendor/consolidation/annotated-command/src/CommandProcessor.php(176): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
    #4 vendor/consolidation/annotated-command/src/AnnotatedCommand.php(311): Consolidation\AnnotatedCommand\CommandProcessor->process(Object(Symfony\Component\Console\Output\ConsoleOutput), Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
    #5 vendor/symfony/console/Command/Command.php(255): Consolidation\AnnotatedCommand\AnnotatedCommand->execute(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
    #6 vendor/symfony/console/Application.php(1027): Symfony\Component\Console\Command\Command->run(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
    #7 vendor/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand(Object(Consolidation\AnnotatedCommand\AnnotatedCommand), Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
    #8 vendor/symfony/console/Application.php(149): Symfony\Component\Console\Application->doRun(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
    #9 vendor/drush/drush/src/Runtime/Runtime.php(118): Symfony\Component\Console\Application->run(Object(Drush\Symfony\DrushArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
    #10 vendor/drush/drush/src/Runtime/Runtime.php(48): Drush\Runtime\Runtime->doRun(Array, Object(Symfony\Component\Console\Output\ConsoleOutput))
    #11 vendor/drush/drush/drush.php(72): Drush\Runtime\Runtime->run(Array)
    #12 vendor/drush/drush/drush(4): require('...')
    #13 {main}
    Error: Call to a member function getStatus() on bool in Drush\Drupal\Commands\core\MigrateRunnerCommands->stop() (line 438 of vendor/drush/drush/src/Drupal/Commands/core/MigrateRunnerCommands.php).
     [warning] Drush command terminated abnormally.

Instead, once the changes are in place, this is the new output.

    $ vendor/bin/drush migrate:stop unexisting_migration
     [error]  Migration unexisting_migration does not exist 
