### PR TITLE
Avoid notice for empty arg.

### DIFF
--- a/src/Preflight/ArgsPreprocessor.php
+++ b/src/Preflight/ArgsPreprocessor.php
@@ -69,7 +69,7 @@ class ArgsPreprocessor
                 continue;
             }
 
-            if ($opt[0] != '-') {
+            if (isset($opt[0]) && $opt[0] != '-') {
                 if (!$sawArg) {
                     $storage->setCommandName($opt);
                 }


### PR DESCRIPTION
An empty arg such as `/drush cset system.site name ""` was giving a notice.