### PR TITLE
Remove pm:info usage example from role:perm:add annotation

### DIFF
--- a/src/Drupal/Commands/core/RoleCommands.php
+++ b/src/Drupal/Commands/core/RoleCommands.php
@@ -68,8 +68,6 @@ class RoleCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
      *   Allow anon users to post comments.
      * @usage drush role:perm:add anonymous 'post comments,access content'
      *   Allow anon users to post comments and access content.
-     * @usage drush pm:info --fields=permissions --format=csv aggregator
-     *   Discover the permissions associated with  given module (then use this command as needed).
      * @aliases rap,role-add-perm
      */
     public function roleAddPerm($machine_name, $permissions)


### PR DESCRIPTION
The `role:perm:add --help` text has an example of listing permissions with `pm:info`. This doesn't work anymore and should probably be removed or updated. This PR just removes it.