### PR TITLE
Improve documentation on migrate:fields-source return value

### DIFF
--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -724,7 +724,7 @@ class MigrateRunnerCommands extends DrushCommands
      * @default-fields machine_name,description
      *
      * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
-     *   Migration messages status formatted as table.
+     *   Source fields of the given migration.
      */
     public function fieldsSource(string $migrationId): RowsOfFields
     {


### PR DESCRIPTION
Seems to come from migrate:status. Adjusted to describe the actual use.