### PR TITLE
Clear APCu cache, if installed, after site-install command.

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -154,6 +154,10 @@ class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAware
             throw $e;
         }
 
+        // Chained fast cache backend data may persist from a prior install.
+        if (function_exists('apcu_clear_cache')) {
+            apcu_clear_cache();
+        }
         if (empty($options['account-pass'])) {
             $this->logger()->success(dt('Installation complete.  User name: @name  User password: @pass', ['@name' => $options['account-name'], '@pass' => $account_pass]));
         } else {


### PR DESCRIPTION
When re-installing a site, e.g. during local development, caches are not cleared. This makes sense in so far as database tables are dropped prior to install, and so most of Drupal's db-backed caches will be empty by definition. However, the chained fast cache backend uses APCu if present/available. This backend is used by, among other things, the extension list API for storing definitions of installed modules.

This can result in cache data inconsistency when, for instance, modules are excluded from export in `$settings['config_exclude_modules']`. If an excluded module is installed, and then the site re-installed, Drupal will continue to see a modules list from the APCu cache which includes the module, though it wasn't actually installed from config. An edge case for sure, but an edge case nonetheless.

This could theoretically extend to other cache backends such as redis/memcached/etc., however I think it makes sense to accommodate for this condition in Drush core because Drupal core itself supports APCu. The other cache backend types are in contrib-land and would thus be reasonable to place on the developer to lifecycle themselves.