### PR TITLE
Fix running drush update:database with quiet option

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -65,6 +65,10 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
             'strict' => 0,
         ];
         $status_options = array_merge(Drush::redispatchOptions(), $status_options);
+
+        // Since output needs to be checked, this option must be removed
+        unset($status_options['quiet']);
+
         $process = $this->processManager()->drush($this->siteAliasManager()->getSelf(), 'updatedb:status', [], $status_options);
         $process->mustRun();
         if ($output = $process->getOutput()) {


### PR DESCRIPTION
drush updb -y --quiet did not run update hooks

closes #4805 