### PR TITLE
Fixes 4820: add init hooks for migrate:status, migrate:import, migrate:rollback

### DIFF
--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -495,6 +495,17 @@ class MigrateRunnerCommands extends DrushCommands
     }
 
     /**
+     * Process options for rollback().
+     *
+     * @hook init migrate:rollback
+     * @option migrationList The array of migrations to process, used internally.
+     */
+    public function initRollback(InputInterface $input, AnnotationData $annotationData)
+    {
+        $this->initImport($input, $annotationData);
+    }
+
+    /**
      * Rollback one or more migrations.
      *
      * @command migrate:rollback
@@ -530,16 +541,7 @@ class MigrateRunnerCommands extends DrushCommands
      */
     public function rollback(?string $migrationIds = null, array $options = ['all' => false, 'tag' => self::REQ, 'feedback' => self::REQ, 'idlist' => self::REQ, 'progress' => true]): void
     {
-        $tags = $options['tag'];
-        $all = $options['all'];
-
-        if (!$all && !$migrationIds && !$tags) {
-            throw new \Exception(dt('You must specify --all, --tag, or one or more migration names separated by commas'));
-        }
-
-        if (!$list = $this->getMigrationList($migrationIds, $options['tag'])) {
-            $this->logger()->error(dt('No migrations found.'));
-        }
+        $list = $options['migrationList'];
 
         $executableOptions = array_intersect_key(
             $options,

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -338,6 +338,32 @@ class MigrateRunnerCommands extends DrushCommands
     }
 
     /**
+     * Process options for import().
+     *
+     * @hook init migrate:import
+     * @option migrationList The array of migrations to process, used internally.
+     */
+    public function initImport(InputInterface $input, AnnotationData $annotationData)
+    {
+        $options = $input->getOptions();
+        $migrationIds = $input->getArgument('migrationIds');
+
+        $tags = $options['tag'];
+        $all = $options['all'];
+
+        if (!$all && !$migrationIds && !$tags) {
+            throw new \Exception(dt('You must specify --all, --tag or one or more migration names separated by commas'));
+        }
+
+        $list = $this->getMigrationList($migrationIds, $options['tag']);
+        if (!$list) {
+            throw new \Exception(dt('No migrations found.'));
+        }
+
+        $input->setOption('migrationList', $list);
+    }
+
+    /**
      * Perform one or more migration processes.
      *
      * @command migrate:import
@@ -388,17 +414,7 @@ class MigrateRunnerCommands extends DrushCommands
      */
     public function import(?string $migrationIds = null, array $options = ['all' => false, 'tag' => self::REQ, 'limit' => self::REQ, 'feedback' => self::REQ, 'idlist' => self::REQ, 'update' => false, 'force' => false, 'execute-dependencies' => false, 'timestamp' => false, 'total' => false, 'progress' => true, 'delete' => false]): void
     {
-        $tags = $options['tag'];
-        $all = $options['all'];
-
-        if (!$all && !$migrationIds && !$tags) {
-            throw new \Exception(dt('You must specify --all, --tag or one or more migration names separated by commas'));
-        }
-
-        if (!$list = $this->getMigrationList($migrationIds, $options['tag'])) {
-            throw new \Exception(dt('No migrations found.'));
-        }
-
+        $list = $options['migrationList'];
         $userData = [
             'options' => array_intersect_key($options, array_flip([
                 'limit',

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -502,6 +502,7 @@ class MigrateRunnerCommands extends DrushCommands
      */
     public function initRollback(InputInterface $input, AnnotationData $annotationData)
     {
+        // Do the same as hook init migrate:import.
         $this->initImport($input, $annotationData);
     }
 


### PR DESCRIPTION
Add `init` hooks for the `migrate:status`, `migrate:import`, and `migrate:rollback` commands.

Call `$this->getMigrationList()` in these hooks. Save the result as the new `migrationList` option.

Also move some validation to the `init` functions.

For `migrate:status`, also process the `fields` option.