### PR TITLE
Escape ampersand in doc text for config:status

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -293,7 +293,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
      *   Display all content types that would be created in active storage on configuration import.
      * @usage drush config:status --state=Any --format=list
      *   List all config names.
-     * @usage drush config:status 2>&1 | grep "No differences"
+     * @usage drush config:status 2>&amp;1 | grep "No differences"
      *   Check there are no differences between database and exported config. Useful for CI.
      * @field-labels
      *   name: Name


### PR DESCRIPTION
Escape the ampersand in the documentation text for config:status.
drush-ops#4827