### PR TITLE
The system_migrate_prepare_row() hook implementation not picked-up

### DIFF
--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -397,8 +397,11 @@ class MigrateRunnerCommands extends DrushCommands
 
         // Include the file providing a migrate_prepare_row hook implementation.
         require_once Path::join(DRUSH_BASE_PATH, 'src/Drupal/Migrate/migrate_runner.inc');
+        // If the 'migrate_prepare_row' hook implementations are already cached,
+        // make sure that system_migrate_prepare_row() is picked-up.
+        \Drupal::moduleHandler()->resetImplementations();
 
-        foreach ($list as $tag => $migrations) {
+        foreach ($list as $migrations) {
             array_walk($migrations, [static::class, 'executeMigration'], $userData);
         }
     }

--- a/tests/functional/MigrateRunnerTest.php
+++ b/tests/functional/MigrateRunnerTest.php
@@ -148,6 +148,13 @@ class MigrateRunnerTest extends CommandUnishTestCase
         // @see \Drupal\woot\EventSubscriber\PreRowDeleteTestSubscriber::onPreRowDelete()
         $this->drush('state:set', ['woot.test_migrate_trigger_failures', true]);
 
+        // Warm-up the 'migrate_prepare_row' hook implementations cache to test
+        // that system_migrate_prepare_row() is picked-up during import. See
+        // MigrateEvents::DRUSH_MIGRATE_PREPARE_ROW test, later.
+        // @see system_migrate_prepare_row()
+        // @see \Drupal\woot\EventSubscriber\ProcessRowTestSubscriber::onPrepareRow()
+        $this->drush('php:eval', ['\Drupal::moduleHandler()->invokeAll("migrate_prepare_row");']);
+
         // Expect that this command will fail because the 2nd row fails.
         // @see \Drupal\woot\Plugin\migrate\process\TestFailProcess
         $this->drush('migrate:import', ['test_migration'], [], null, null, self::EXIT_ERROR);

--- a/tests/functional/MigrateRunnerTest.php
+++ b/tests/functional/MigrateRunnerTest.php
@@ -153,7 +153,7 @@ class MigrateRunnerTest extends CommandUnishTestCase
         // MigrateEvents::DRUSH_MIGRATE_PREPARE_ROW test, later.
         // @see system_migrate_prepare_row()
         // @see \Drupal\woot\EventSubscriber\ProcessRowTestSubscriber::onPrepareRow()
-        $this->drush('php:eval', ['\Drupal::moduleHandler()->invokeAll("migrate_prepare_row");']);
+        $this->drush('php:eval', ["Drupal::moduleHandler()->invokeAll('migrate_prepare_row');"]);
 
         // Expect that this command will fail because the 2nd row fails.
         // @see \Drupal\woot\Plugin\migrate\process\TestFailProcess


### PR DESCRIPTION
Fixes #4679 