### PR TITLE
Fix PHP 8.1 compatibility for drush 8.x

### DIFF
--- a/commands/core/config.drush.inc
+++ b/commands/core/config.drush.inc
@@ -11,6 +11,7 @@ use Drupal\Core\Config\StorageComparer;
 use Drupal\Core\Config\ConfigImporter;
 use Drupal\Core\Config\ConfigException;
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Site\Settings;
 use Drupal\Component\Utility\NestedArray;
 use Drush\Config\StorageWrapper;
 use Drush\Config\CoreExtensionFilter;
@@ -410,6 +411,10 @@ function drush_config_export($destination = NULL) {
       drush_mkdir($destination_dir);
     }
   }
+  elseif ($config_directories === NULL) {
+    // For Drupal 8.8+ see https://www.drupal.org/node/3018145 change.
+    $destination_dir = Settings::get('config_sync_directory');
+  }
   else {
     $choices = drush_map_assoc(array_keys($config_directories));
     unset($choices[CONFIG_ACTIVE_DIRECTORY]);
@@ -464,6 +469,10 @@ function drush_config_export($destination = NULL) {
 }
 
 function _drush_config_export($destination, $destination_dir, $branch) {
+  if (!defined('CONFIG_SYNC_DIRECTORY')) {
+    // For Drupal 8.8+ see https://www.drupal.org/node/3018145 change.
+    define('CONFIG_SYNC_DIRECTORY', Settings::get('config_sync_directory'));
+  }
   $commit = drush_get_option('commit');
   $comment = drush_get_option('message', 'Exported configuration.');
   if (count(glob($destination_dir . '/*')) > 0) {
@@ -593,6 +602,10 @@ function drush_config_import_validate() {
  */
 function drush_config_import($source = NULL) {
   global $config_directories;
+  if (!defined('CONFIG_SYNC_DIRECTORY')) {
+    // For Drupal 8.8+ see https://www.drupal.org/node/3018145 change.
+    define('CONFIG_SYNC_DIRECTORY', Settings::get('config_sync_directory'));
+  }
 
   // Determine source directory.
   if ($target = drush_get_option('source')) {

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -36,6 +36,7 @@ use Drush\Log\LogLevel;
  * @see _drush_batch_worker().
  */
 class DrushBatchContext extends ArrayObject {
+  #[\ReturnTypeWillChange]
   function offsetSet($name, $value) {
     if ($name == 'message') {
       drush_log(strip_tags($value), LogLevel::OK);

--- a/includes/command.inc
+++ b/includes/command.inc
@@ -998,10 +998,14 @@ function drush_adjust_args_if_shebang_script(&$args) {
     // The drush.launcher script may add --php or --php-options at the
     // head of the argument list; skip past those.
     $base_arg_number = 1;
-    while (substr($args[$base_arg_number], 0, 5) == '--php') {
+    while (isset($args[$base_arg_number]) && substr($args[$base_arg_number], 0, 5) == '--php') {
       ++$base_arg_number;
     }
-    if (_drush_is_drush_shebang_script($args[$base_arg_number])) {
+    if (!isset($args[$base_arg_number])) {
+      // No arguments passed.
+      return;
+    }
+    elseif (_drush_is_drush_shebang_script($args[$base_arg_number])) {
       // If $args[1] is a drush "shebang" script, we will insert
       // the option "--bootstrap-to-first-arg" and the command
       // "php-script" at the beginning of  @args, so the command


### PR DESCRIPTION
The only notice I get using 8.4.8 with PHP 8.1rc2

```
$ drush st
PHP Deprecated:  Return type of DrushBatchContext::offsetSet($name, $value) should either be compatible with ArrayObject::offsetSet(mixed $key, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/bin/drush/includes/batch.inc on line 39

Deprecated: Return type of DrushBatchContext::offsetSet($name, $value) should either be compatible with ArrayObject::offsetSet(mixed $key, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/bin/drush/includes/batch.inc on line 39
 Drupal version         :  9.3.0-dev             
...
Drush version          :  8.4.8  
```