### PR TITLE
Add EOL dates for Drush 8 and Drush 10

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -50,8 +50,8 @@ Drupal Compatibility
     <td> Drush 8 </td>
     <td> 5.4.5+ </td>
     <!-- Released Nov 2015 -->
-    <td> Nov 2021 </td>
-    <td>✓</td> <td>✓</td> <td><b>✓️</b></td> <td></td>
+    <td> Nov 2022 </td>
+    <td>✅</td> <td>✅</td> <td><b>⚠</b></td> <td></td>
   </tr>
   <tr>
     <td> Drush 7 </td>
@@ -91,3 +91,4 @@ Drupal Compatibility
     </tr>
     
 </table>
+

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,15 +29,15 @@ Drupal Compatibility
     <td> Drush 11 </td>
     <td> 7.4+ </td>
     <!-- TBD -->
-    <td> <i>TBD</i> </td>
+    <td> TBD </td>
     <td></td> <td></td> <td></td> <td><b>✅</b></td>
   </tr>
   <tr>
     <td> Drush 10 </td>
     <td> 7.1+ </td>
     <!-- Released Oct 2019 -->
-    <td> <i>TBD</i> </td>
-    <td></td> <td></td> <td>✅</td> <td><b>✅</b></td>
+    <td> Nov 2021 </td>
+    <td></td> <td></td> <td>✓</td> <td><b>✓</b></td>
   </tr>
   <tr>
     <td> Drush 9 </td>
@@ -50,8 +50,8 @@ Drupal Compatibility
     <td> Drush 8 </td>
     <td> 5.4.5+ </td>
     <!-- Released Nov 2015 -->
-    <td> ❶ </td>
-    <td>✅</td> <td>✅</td> <td><b>⚠️</b></td> <td></td>
+    <td> Nov 2021 </td>
+    <td>✓</td> <td>✓</td> <td><b>✓️</b></td> <td></td>
   </tr>
   <tr>
     <td> Drush 7 </td>
@@ -91,5 +91,3 @@ Drupal Compatibility
     </tr>
     
 </table>
-
-❶: EOL date for Drush 8 tbd, but estimated to be in concert with <a href="https://www.drupal.org/psa-2019-02-25">Drupal 7 EOL</a>.</td>


### PR DESCRIPTION
I propose we EOL Drush 8 [in concert with Drupal 8](https://www.drupal.org/psa-2021-2021-06-29), which is Nov 2, 2021. ﻿We might still accept bug fixes after that date, but the diligence level goes down. 

I also propose an EOL for Drush 10 at same time, and asking folks to upgrade to a nearly identical Drush 11.

This gets us to just 1 supported version of Drush :1st_place_medal: 