### PR TITLE
Fix PHP 8.1 - allow empty yaml

### DIFF
--- a/src/internal-forks/Config/Yaml/Inline.php
+++ b/src/internal-forks/Config/Yaml/Inline.php
@@ -83,9 +83,7 @@ class Inline
         self::$objectForMap = (bool) (Yaml::PARSE_OBJECT_FOR_MAP & $flags);
         self::$constantSupport = (bool) (Yaml::PARSE_CONSTANT & $flags);
 
-        $value = trim($value);
-
-        if ('' === $value) {
+        if (is_null($value) || '' === trim($value)) {
             return '';
         }
 


### PR DESCRIPTION
One more fix for 10.x after  https://github.com/drush-ops/drush/pull/4840

It also needs https://github.com/consolidation/site-alias/pull/44

PS: 8.x branch is different https://github.com/drush-ops/drush/pull/4839