### PR TITLE
Always use latest PHP release in CI for tip test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
       - checkout
       - run: cp .docker/zz-php.ini /usr/local/etc/php/conf.d/
       - run: php --version
-      - run: composer config platform.php 8.0.0
+      - run: composer config platform.php --unset
       - run: composer require --dev drupal/core-recommended:9.3.x-dev --no-update
       - run: composer update
       - run: composer lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
   test_80_drupal93_highest:
     <<: *defaults
     docker:
-      - image: wodby/php:8.0
+      - image: wodby/php:latest
         environment:
           - MYSQL_HOST=127.0.0.1
           - UNISH_DB_URL=mysql://root:@127.0.0.1


### PR DESCRIPTION
This will move us to PHP 8.1 as soon as it is released, and so on. I think that’s the best option given what I see at https://github.com/wodby/php#docker-images /cc @andypost 