### PR TITLE
Minimize .phar size

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -2,16 +2,24 @@
   "alias": "drush.phar",
   "chmod": "0755",
   "compactors": [],
-  "directories": ["commands", "docs", "examples", "includes", "lib", "src", "misc"],
-  "files": ["drush.api.php", "drush.complete.sh", "drush.info", "drush.launcher", "drush.php", "drush_logo-black.png", "README.md"],
+  "compression": "GZ",
+  "directories": ["commands", "includes", "lib", "src", "misc"],
+  "blacklist": [
+    "windrush_build/",
+    "Internal/Symfony/",
+    "TestTraits/"
+  ],
+  "files": ["drush.complete.sh", "drush.info", "drush.launcher", "drush.php"],
   "finder": [
     {
       "name": "*.php",
       "exclude": [
+        "examples",
         "isolation",
         "phing",
         "test",
         "tests",
+        "test_old",
         "Test",
         "Tests",
         "Tester"

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
   },
   "scripts": {
     "phar:install-tools": "curl -LSs https://box-project.github.io/box2/installer.php | php",
-    "phar:build": "php box.phar build",
+    "phar:build": "php box.phar compile",
     "lint": [
       "find includes -name '*.inc' -print0 | xargs -0 -n1 php -l",
       "find lib/Drush -name '*.php' -print0 | xargs -0 -n1 php -l"


### PR DESCRIPTION
- docs and examples not useful out of phar
- apply GZ compression, zlib is PHP requirement
- clean-up extra files from vendor

Fixes #4856 