### PR TITLE
Fixes #4897: Drupal 6 - Drush 8 updb returns errors on PHP 8 if no up…

### DIFF
--- a/includes/drupal.inc
+++ b/includes/drupal.inc
@@ -160,7 +160,7 @@ function system_watchdog($log_entry) {
  * of the update process to the logging system.
  */
 function _drush_log_update_sql($ret) {
-  if (count($ret)) {
+  if (is_array($ret) && count($ret)) {
     foreach ($ret as $info) {
       if (is_array($info)) {
         if (!$info['success']) {


### PR DESCRIPTION
…dates should be run