### PR TITLE
Mention PHP_CodeSniffer in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Drush is built by people like you! Please [join us](https://github.com/drush-ops
 * Do write comments. You don't have to comment every line, but if you come up with something that's a bit complex/weird, just leave a comment. Bear in mind that you will probably leave the project at some point and that other people will read your code. Undocumented huge amounts of code are nearly worthless!
 * We use [PSR-2](https://www.php-fig.org/psr/psr-2/) in the /src directory. [Drupal's coding standards](https://drupal.org/coding-standards) are still used in the includes directory (deprecated code).
 * Keep it compatible. Do not introduce changes to the public API, or configurations too casually. Don't make incompatible changes without good reasons!
+* Run `composer cs` to check the project for coding style issues and run `composer cbf` to fix them automatically where possible. These scripts use [`PHP_CodeSniffer`](https://github.com/squizlabs/PHP_CodeSniffer) in background.
 
 ## Documentation
 * The docs are on our [web site](https://www.drush.org). You may also read these from within Drush, with the `drush topic` command.


### PR DESCRIPTION
You mentioned the `composer cs` script in https://github.com/drush-ops/drush/pull/4853, but I don't see it documented anywhere. Now it's documented in CONTRIBUTING.md.