### PR TITLE
Check for runtime.argv array size before use (#4887)

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -195,7 +195,8 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
         $command = $this->bootstrapAndFind($name);
         // Avoid exception when help is being built by https://github.com/bamarni/symfony-console-autocomplete.
         // @todo Find a cleaner solution.
-        if (Drush::config()->get('runtime.argv')[1] !== 'help') {
+        $argv = Drush::config()->get('runtime.argv');
+        if (count($argv) > 1 && $argv[1] !== 'help') {
             $this->checkObsolete($command);
         }
         return $command;


### PR DESCRIPTION
Otherwise we run into warnings when `drush` is run with no commands:

```shell
$ drush
 [warning] Undefined array key 1 Application.php:199
(...)
```

Closes: https://github.com/drush-ops/drush/issues/4887