### PR TITLE
Add field:delete command

### DIFF
--- a/src/Drupal/Commands/core/EntityTypeBundleAskTrait.php
+++ b/src/Drupal/Commands/core/EntityTypeBundleAskTrait.php
@@ -11,8 +11,26 @@ use Symfony\Component\Console\Input\InputInterface;
  * @property EntityTypeBundleInfoInterface $entityTypeBundleInfo
  * @property EntityTypeManagerInterface $entityTypeManager
  */
-trait AskBundleTrait
+trait EntityTypeBundleAskTrait
 {
+    protected function askEntityType(): ?string
+    {
+        $entityTypeDefinitions = $this->entityTypeManager->getDefinitions();
+        $choices = [];
+
+        foreach ($entityTypeDefinitions as $entityTypeDefinition) {
+            $choices[$entityTypeDefinition->id()] = $this->input->getOption('show-machine-names')
+                ? $entityTypeDefinition->id()
+                : $entityTypeDefinition->getLabel();
+        }
+
+        if (!$answer = $this->io()->choice('Entity type', $choices)) {
+            throw new \InvalidArgumentException(t('The entityType argument is required.'));
+        }
+
+        return $answer;
+    }
+
     protected function askBundle(): ?string
     {
         $entityTypeId = $this->input->getArgument('entityType');

--- a/src/Drupal/Commands/core/EntityTypeBundleValidationTrait.php
+++ b/src/Drupal/Commands/core/EntityTypeBundleValidationTrait.php
@@ -7,7 +7,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 /**
  * @property EntityTypeManagerInterface $entityTypeManager
  */
-trait ValidateEntityTypeTrait
+trait EntityTypeBundleValidationTrait
 {
     protected function validateEntityType(string $entityTypeId): void
     {

--- a/src/Drupal/Commands/core/FieldCreateCommands.php
+++ b/src/Drupal/Commands/core/FieldCreateCommands.php
@@ -26,9 +26,9 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class FieldCreateCommands extends DrushCommands implements CustomEventAwareInterface
 {
-    use AskBundleTrait;
+    use EntityTypeBundleAskTrait;
     use CustomEventAwareTrait;
-    use ValidateEntityTypeTrait;
+    use EntityTypeBundleValidationTrait;
 
     /** @var FieldTypePluginManagerInterface */
     protected $fieldTypePluginManager;
@@ -120,7 +120,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
      * @see \Drupal\field_ui\Form\FieldConfigEditForm
      * @see \Drupal\field_ui\Form\FieldStorageConfigEditForm
      */
-    public function create(string $entityType, ?string $bundle = null, array $options = [
+    public function create(?string $entityType = null, ?string $bundle = null, array $options = [
         'field-name' => InputOption::VALUE_REQUIRED,
         'field-label' => InputOption::VALUE_REQUIRED,
         'field-description' => InputOption::VALUE_OPTIONAL,
@@ -136,6 +136,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         'existing' => false,
     ]): void
     {
+        $this->input->setArgument('entityType', $entityType = $entityType ?? $this->askEntityType());
         $this->validateEntityType($entityType);
 
         $this->input->setArgument('bundle', $bundle = $bundle ?? $this->askBundle());

--- a/src/Drupal/Commands/core/FieldDeleteCommands.php
+++ b/src/Drupal/Commands/core/FieldDeleteCommands.php
@@ -11,8 +11,8 @@ use Symfony\Component\Console\Input\InputOption;
 
 class FieldDeleteCommands extends DrushCommands
 {
-    use AskBundleTrait;
-    use ValidateEntityTypeTrait;
+    use EntityTypeBundleAskTrait;
+    use EntityTypeBundleValidationTrait;
 
     /** @var EntityTypeManagerInterface */
     protected $entityTypeManager;
@@ -52,12 +52,14 @@ class FieldDeleteCommands extends DrushCommands
      *      Delete a field in a non-interactive way.
      *
      * @version 11.0
+     * @see \Drupal\field_ui\Form\FieldConfigDeleteForm
      */
-    public function delete(string $entityType, ?string $bundle = null, array $options = [
+    public function delete(?string $entityType = null, ?string $bundle = null, array $options = [
         'field-name' => InputOption::VALUE_REQUIRED,
         'show-machine-names' => InputOption::VALUE_OPTIONAL,
     ]): void
     {
+        $this->input->setArgument('entityType', $entityType = $entityType ?? $this->askEntityType());
         $this->validateEntityType($entityType);
 
         $this->input->setArgument('bundle', $bundle = $bundle ?? $this->askBundle());
@@ -118,6 +120,14 @@ class FieldDeleteCommands extends DrushCommands
                 : $fieldConfig->get('label');
 
             $choices[$fieldConfig->get('field_name')] = $label;
+        }
+
+        if ($choices === []) {
+            throw new \InvalidArgumentException(
+                t("Bundle ':bundle' has no fields.", [
+                    ':bundle' => $bundle,
+                ])
+            );
         }
 
         return $this->io()->choice('Choose a field to delete', $choices);

--- a/src/Drupal/Commands/core/FieldDeleteCommands.php
+++ b/src/Drupal/Commands/core/FieldDeleteCommands.php
@@ -81,6 +81,15 @@ class FieldDeleteCommands extends DrushCommands
                 'bundle' => $bundle,
             ]);
 
+        if ($results === []) {
+            throw new \InvalidArgumentException(
+                t("Field with name ':fieldName' does not exist on bundle ':bundle'.", [
+                    ':fieldName' => $fieldName,
+                    ':bundle' => $bundle,
+                ])
+            );
+        }
+
         $this->deleteFieldConfig(reset($results));
 
         // Fields are purged on cron. However field module prevents disabling modules

--- a/src/Drupal/Commands/core/FieldDeleteCommands.php
+++ b/src/Drupal/Commands/core/FieldDeleteCommands.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\FieldConfigInterface;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Input\InputOption;
+
+class FieldDeleteCommands extends DrushCommands
+{
+    use AskBundleTrait;
+    use ValidateEntityTypeTrait;
+
+    /** @var EntityTypeManagerInterface */
+    protected $entityTypeManager;
+    /** @var EntityTypeBundleInfo */
+    protected $entityTypeBundleInfo;
+
+    public function __construct(
+        EntityTypeManagerInterface $entityTypeManager,
+        EntityTypeBundleInfo $entityTypeBundleInfo
+    ) {
+        $this->entityTypeManager = $entityTypeManager;
+        $this->entityTypeBundleInfo = $entityTypeBundleInfo;
+    }
+
+    /**
+     * Delete a field
+     *
+     * @command field:delete
+     * @aliases field-delete,fd
+     *
+     * @param string $entityType
+     *      The machine name of the entity type
+     * @param string $bundle
+     *      The machine name of the bundle
+     *
+     * @option field-name
+     *      The machine name of the field
+     *
+     * @option show-machine-names
+     *      Show machine names instead of labels in option lists.
+     *
+     * @usage drush field:delete
+     *      Delete a field by answering the prompts.
+     * @usage drush field-delete taxonomy_term tag
+     *      Delete a field and fill in the remaining information through prompts.
+     * @usage drush field-delete taxonomy_term tag --field-name=field_tag_label
+     *      Delete a field in a completely non-interactive way.
+     *
+     * @version 11.0
+     */
+    public function delete(string $entityType, ?string $bundle = null, array $options = [
+        'field-name' => InputOption::VALUE_REQUIRED,
+        'show-machine-names' => InputOption::VALUE_OPTIONAL,
+    ]): void
+    {
+        $this->validateEntityType($entityType);
+
+        $this->input->setArgument('bundle', $bundle = $bundle ?? $this->askBundle());
+        $this->validateBundle($entityType, $bundle);
+
+        $fieldName = $this->input->getOption('field-name') ?? $this->askExisting($entityType, $bundle);
+        $this->input->setOption('field-name', $fieldName);
+
+        /** @var FieldConfig[] $results */
+        $results = $this->entityTypeManager
+            ->getStorage('field_config')
+            ->loadByProperties([
+                'field_name' => $fieldName,
+                'entity_type' => $entityType,
+                'bundle' => $bundle,
+            ]);
+
+        $this->deleteFieldConfig(reset($results));
+
+        // Fields are purged on cron. However field module prevents disabling modules
+        // when field types they provided are used in a field until it is fully
+        // purged. In the case that a field has minimal or no content, a single call
+        // to field_purge_batch() will remove it from the system. Call this with a
+        // low batch limit to avoid administrators having to wait for cron runs when
+        // removing fields that meet this criteria.
+        field_purge_batch(10);
+    }
+
+    protected function askExisting(string $entityType, string $bundle): string
+    {
+        $choices = [];
+        /** @var FieldConfigInterface[] $fieldConfigs */
+        $fieldConfigs = $this->entityTypeManager
+            ->getStorage('field_config')
+            ->loadByProperties([
+                'entity_type' => $entityType,
+                'bundle' => $bundle,
+            ]);
+
+        foreach ($fieldConfigs as $fieldConfig) {
+            $label = $this->input->getOption('show-machine-names')
+                ? $fieldConfig->get('field_name')
+                : $fieldConfig->get('label');
+
+            $choices[$fieldConfig->get('field_name')] = $label;
+        }
+
+        return $this->io()->choice('Choose a field to delete', $choices);
+    }
+
+    protected function deleteFieldConfig(FieldConfigInterface $fieldConfig): void
+    {
+        $fieldStorage = $fieldConfig->getFieldStorageDefinition();
+        $bundles = $this->entityTypeBundleInfo->getBundleInfo($fieldConfig->getTargetEntityTypeId());
+        $bundleLabel = $bundles[$fieldConfig->getTargetBundle()]['label'];
+
+        if ($fieldStorage && !$fieldStorage->isLocked()) {
+            $fieldConfig->delete();
+
+            // If there is only one bundle left for this field storage, it will be
+            // deleted too, notify the user about dependencies.
+            if (count($fieldStorage->getBundles()) <= 1) {
+                $fieldStorage->delete();
+            }
+
+            $message = 'The field :field has been deleted from the :type content type.';
+        } else {
+            $message = 'There was a problem removing the :field from the :type content type.';
+        }
+
+        $this->logger()->success(
+            t($message, [':field' => $fieldConfig->label(), ':type' => $bundleLabel])
+        );
+    }
+}

--- a/src/Drupal/Commands/core/FieldDeleteCommands.php
+++ b/src/Drupal/Commands/core/FieldDeleteCommands.php
@@ -49,7 +49,7 @@ class FieldDeleteCommands extends DrushCommands
      * @usage drush field-delete taxonomy_term tag
      *      Delete a field and fill in the remaining information through prompts.
      * @usage drush field-delete taxonomy_term tag --field-name=field_tag_label
-     *      Delete a field in a completely non-interactive way.
+     *      Delete a field in a non-interactive way.
      *
      * @version 11.0
      */
@@ -138,7 +138,7 @@ class FieldDeleteCommands extends DrushCommands
                 $fieldStorage->delete();
             }
 
-            $message = 'The field :field has been deleted from the :type content type.';
+            $message = 'The field :field has been deleted from the :type bundle.';
         } else {
             $message = 'There was a problem removing the :field from the :type content type.';
         }

--- a/src/Drupal/Commands/core/FieldDeleteCommands.php
+++ b/src/Drupal/Commands/core/FieldDeleteCommands.php
@@ -66,6 +66,12 @@ class FieldDeleteCommands extends DrushCommands
         $fieldName = $this->input->getOption('field-name') ?? $this->askExisting($entityType, $bundle);
         $this->input->setOption('field-name', $fieldName);
 
+        if ($fieldName === '') {
+            throw new \InvalidArgumentException(dt('The %optionName option is required.', [
+                '%optionName' => 'field-name',
+            ]));
+        }
+
         /** @var FieldConfig[] $results */
         $results = $this->entityTypeManager
             ->getStorage('field_config')

--- a/src/Drupal/Commands/core/FieldInfoCommands.php
+++ b/src/Drupal/Commands/core/FieldInfoCommands.php
@@ -10,9 +10,9 @@ use Drush\Commands\DrushCommands;
 
 class FieldInfoCommands extends DrushCommands
 {
-    use AskBundleTrait;
+    use EntityTypeBundleAskTrait;
+    use EntityTypeBundleValidationTrait;
     use FieldDefinitionRowsOfFieldsTrait;
-    use ValidateEntityTypeTrait;
 
     /** @var EntityTypeManagerInterface */
     protected $entityTypeManager;
@@ -66,10 +66,11 @@ class FieldInfoCommands extends DrushCommands
      *
      * @version 11.0
      */
-    public function info(string $entityType, ?string $bundle = null, array $options = [
+    public function info(?string $entityType = null, ?string $bundle = null, array $options = [
         'format' => 'table',
     ]): RowsOfFields
     {
+        $this->input->setArgument('entityType', $entityType = $entityType ?? $this->askEntityType());
         $this->validateEntityType($entityType);
 
         $this->input->setArgument('bundle', $bundle = $bundle ?? $this->askBundle());

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -42,6 +42,13 @@ services:
       - '@entity_type.bundle.info'
     tags:
       -  { name: drush.command }
+  field.delete.commands:
+    class: \Drush\Drupal\Commands\core\FieldDeleteCommands
+    arguments:
+      - '@entity_type.manager'
+      - '@entity_type.bundle.info'
+    tags:
+      -  { name: drush.command }
   link.hooks:
     class: \Drush\Drupal\Commands\core\LinkHooks
     arguments:

--- a/tests/functional/FieldCreateTest.php
+++ b/tests/functional/FieldCreateTest.php
@@ -27,7 +27,7 @@ class FieldCreateTest extends CommandUnishTestCase
     {
         // Arguments.
         $this->drush('field:create', [], [], null, null, self::EXIT_ERROR);
-        $this->assertStringContainsString('Not enough arguments (missing: "entityType")', $this->getErrorOutputRaw());
+        $this->assertStringContainsString('The entityType argument is required', $this->getErrorOutputRaw());
         $this->drush('field:create', ['foo'], [], null, null, self::EXIT_ERROR);
         $this->assertStringContainsString('Entity type with id \'foo\' does not exist.', $this->getErrorOutputRaw());
         $this->drush('field:create', ['user'], [], null, null, self::EXIT_ERROR);
@@ -79,13 +79,13 @@ class FieldCreateTest extends CommandUnishTestCase
 
     public function testFieldDelete()
     {
-        $this->drush('field:delete', ['user'], [], null, null, self::EXIT_ERROR);
-        $this->assertStringContainsString('The bundle argument is required.', $this->getErrorOutputRaw());
-        $this->drush('field:delete', ['user', 'user'], [], null, null, self::EXIT_ERROR);
-        $this->assertStringContainsString('The field-name option is required.', $this->getErrorOutputRaw());
-
         $this->drush('field:create', ['unish_article', 'alpha'], ['field-label' => 'Test', 'field-name' => 'field_test5', 'field-description' => 'baz', 'field-type' => 'entity_reference', 'is-required' => true, 'field-widget' => 'entity_reference_autocomplete', 'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, 'target-type' => 'unish_article', 'target-bundle' => 'beta']);
         $this->assertStringContainsString("Successfully created field 'field_test5' on unish_article type with bundle 'alpha'", $this->getSimplifiedErrorOutput());
+
+        $this->drush('field:delete', ['unish_article'], [], null, null, self::EXIT_ERROR);
+        $this->assertStringContainsString('The bundle argument is required.', $this->getErrorOutputRaw());
+        $this->drush('field:delete', ['unish_article', 'alpha'], [], null, null, self::EXIT_ERROR);
+        $this->assertStringContainsString('The field-name option is required.', $this->getErrorOutputRaw());
 
         $this->drush('field:delete', ['unish_article', 'alpha'], ['field-name' => 'field_testZZZZZ'], null, null, self::EXIT_ERROR);
         $this->assertStringContainsString("Field with name 'field_testZZZZZ' does not exist on bundle 'alpha'", $this->getErrorOutputRaw());

--- a/tests/functional/FieldCreateTest.php
+++ b/tests/functional/FieldCreateTest.php
@@ -31,7 +31,7 @@ class FieldCreateTest extends CommandUnishTestCase
         $this->drush('field:create', ['foo'], [], null, null, self::EXIT_ERROR);
         $this->assertStringContainsString('Entity type with id \'foo\' does not exist.', $this->getErrorOutputRaw());
         $this->drush('field:create', ['user'], [], null, null, self::EXIT_ERROR);
-        $this->assertStringNotContainsString('The bundle argument is required.', $this->getErrorOutputRaw());
+        $this->assertStringContainsString('The bundle argument is required.', $this->getErrorOutputRaw());
         $this->drush('field:create', ['user', 'user'], [], null, null, self::EXIT_ERROR);
         $this->assertStringNotContainsString('bundle', $this->getErrorOutputRaw());
 
@@ -75,5 +75,21 @@ class FieldCreateTest extends CommandUnishTestCase
         $this->assertSame(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, $json['cardinality']);
         $this->assertFalse($json['translatable']);
         $this->assertArrayHasKey('beta', $json['target_bundles']);
+    }
+
+    public function testFieldDelete()
+    {
+        $this->drush('field:delete', ['user'], [], null, null, self::EXIT_ERROR);
+        $this->assertStringContainsString('The bundle argument is required.', $this->getErrorOutputRaw());
+        $this->drush('field:delete', ['user', 'user'], [], null, null, self::EXIT_ERROR);
+        $this->assertStringContainsString('The field-name option is required.', $this->getErrorOutputRaw());
+
+        $this->drush('field:create', ['unish_article', 'alpha'], ['field-label' => 'Test', 'field-name' => 'field_test5', 'field-description' => 'baz', 'field-type' => 'entity_reference', 'is-required' => true, 'field-widget' => 'entity_reference_autocomplete', 'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, 'target-type' => 'unish_article', 'target-bundle' => 'beta']);
+        $this->assertStringContainsString("Successfully created field 'field_test5' on unish_article type with bundle 'alpha'", $this->getSimplifiedErrorOutput());
+
+        $this->drush('field:delete', ['unish_article', 'alpha'], ['field-name' => 'field_testZZZZZ'], null, null, self::EXIT_ERROR);
+        $this->assertStringContainsString("Field with name 'field_testZZZZZ' does not exist on bundle 'alpha'", $this->getErrorOutputRaw());
+        $this->drush('field:delete', ['unish_article', 'alpha'], ['field-name' => 'field_test5']);
+        $this->assertStringContainsString(" The field Test has been deleted from the Alpha bundle.", $this->getErrorOutputRaw());
     }
 }


### PR DESCRIPTION
This PR adds a command to delete fields, similar to the [field-delete command that was present in Drush 8](https://drushcommands.com/drush-8x/field/field-delete/). It has already been used in multiple projects as part of the [wmscaffold module](https://github.com/wieni/wmscaffold) and is in my opinion stable enough to be considered to be merged in Drush.

## Remarks
- `AskBundleTrait` and `ValidateEntityTypeTrait` are also included in https://github.com/drush-ops/drush/pull/4928, https://github.com/drush-ops/drush/pull/4929 and https://github.com/drush-ops/drush/pull/4930. 

## Test scenarios
- `./vendor/bin/drush fd` => _Not enough arguments (missing: "entityType")._
- `./vendor/bin/drush fd node` => Asks for bundle
- `./vendor/bin/drush fd node --no-interaction` => _The bundle argument is required._
- `./vendor/bin/drush fd node article` => Asks for field name
- `./vendor/bin/drush fd node article --no-interaction` => _The field-name option is required._
- `./vendor/bin/drush fd node article --no-interaction --field-name=field_test` => Deletes _field_test_. If that field does not exist: _Field with name 'field_test' does not exist on bundle 'article'._

## TODO
- [ ] Add tests