### PR TITLE
Add field:info command

### DIFF
--- a/src/Drupal/Commands/core/AskBundleTrait.php
+++ b/src/Drupal/Commands/core/AskBundleTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * @property InputInterface $input
+ * @property EntityTypeBundleInfoInterface $entityTypeBundleInfo
+ * @property EntityTypeManagerInterface $entityTypeManager
+ */
+trait AskBundleTrait
+{
+    protected function askBundle(): ?string
+    {
+        $entityTypeId = $this->input->getArgument('entityType');
+        $entityTypeDefinition = $this->entityTypeManager->getDefinition($entityTypeId);
+        $bundleEntityType = $entityTypeDefinition->getBundleEntityType();
+        $bundleInfo = $this->entityTypeBundleInfo->getBundleInfo($entityTypeId);
+        $choices = [];
+
+        if (empty($bundleInfo)) {
+            if ($bundleEntityType) {
+                throw new \InvalidArgumentException(
+                    t('Entity type with id \':entityType\' does not have any bundles.', [':entityType' => $entityTypeId])
+                );
+            }
+
+            return null;
+        }
+
+        foreach ($bundleInfo as $bundle => $data) {
+            $label = $this->input->getOption('show-machine-names') ? $bundle : $data['label'];
+            $choices[$bundle] = $label;
+        }
+
+        if (!$answer = $this->io()->choice('Bundle', $choices)) {
+            throw new \InvalidArgumentException(t('The bundle argument is required.'));
+        }
+
+        return $answer;
+    }
+}

--- a/src/Drupal/Commands/core/FieldDefinitionRowsOfFieldsTrait.php
+++ b/src/Drupal/Commands/core/FieldDefinitionRowsOfFieldsTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+
+trait FieldDefinitionRowsOfFieldsTrait
+{
+    public function renderArray($key, $value, FormatterOptions $options)
+    {
+        if (is_array($value)) {
+            return implode(', ', $value);
+        }
+
+        return $value;
+    }
+
+    public function renderBoolean($key, $value, FormatterOptions $options)
+    {
+        if (is_bool($value)) {
+            return $value ? '✔' : '';
+        }
+
+        return $value;
+    }
+
+    protected function getRowsOfFieldsByFieldDefinitions(array $fieldDefinitions): RowsOfFields
+    {
+        $rows = [];
+
+        foreach ($fieldDefinitions as $field) {
+            $storage = $field->getFieldStorageDefinition();
+            $handlerSettings = $field->getSetting('handler_settings');
+
+            $rows[$field->getName()] = [
+                'label' => $field->getLabel(),
+                'description' => $field->getDescription(),
+                'field_name' => $field->getName(),
+                'field_type' => $field->getType(),
+                'required' => $field->isRequired(),
+                'translatable' => $field->isTranslatable(),
+                'cardinality' => $storage->getCardinality(),
+                'default_value' => empty($field->getDefaultValueLiteral()) ? null : $field->getDefaultValueLiteral(),
+                'default_value_callback' => $field->getDefaultValueCallback(),
+                'allowed_values' => $storage->getSetting('allowed_values'),
+                'allowed_values_function' => $storage->getSetting('allowed_values_function'),
+                'handler' => $field->getSetting('handler'),
+                'target_bundles' => $handlerSettings['target_bundles'] ?? null,
+            ];
+        }
+
+        $result = new RowsOfFields($rows);
+        $result->addRendererFunction([$this, 'renderArray']);
+        $result->addRendererFunction([$this, 'renderBoolean']);
+
+        return $result;
+    }
+}

--- a/src/Drupal/Commands/core/FieldInfoCommands.php
+++ b/src/Drupal/Commands/core/FieldInfoCommands.php
@@ -28,7 +28,7 @@ class FieldInfoCommands extends DrushCommands
     }
 
     /**
-     * List all fields of an entity bundle
+     * List all configurable fields of an entity bundle
      *
      * @command field:info
      * @aliases field-info,fi
@@ -63,6 +63,8 @@ class FieldInfoCommands extends DrushCommands
      *      List all fields.
      * @usage drush field:info
      *      List all fields and fill in the remaining information through prompts.
+     *
+     * @version 11.0
      */
     public function info(string $entityType, ?string $bundle = null, array $options = [
         'format' => 'table',

--- a/src/Drupal/Commands/core/FieldInfoCommands.php
+++ b/src/Drupal/Commands/core/FieldInfoCommands.php
@@ -11,6 +11,7 @@ use Drush\Commands\DrushCommands;
 class FieldInfoCommands extends DrushCommands
 {
     use AskBundleTrait;
+    use FieldDefinitionRowsOfFieldsTrait;
     use ValidateEntityTypeTrait;
 
     /** @var EntityTypeManagerInterface */
@@ -79,58 +80,6 @@ class FieldInfoCommands extends DrushCommands
                 'bundle' => $bundle,
             ]);
 
-        $rows = $this->getRows($fieldDefinitions);
-
-        $result = new RowsOfFields($rows);
-        $result->addRendererFunction([$this, 'renderArray']);
-        $result->addRendererFunction([$this, 'renderBoolean']);
-
-        return $result;
-    }
-
-    public function renderArray($key, $value, FormatterOptions $options)
-    {
-        if (is_array($value)) {
-            return implode(', ', $value);
-        }
-
-        return $value;
-    }
-
-    public function renderBoolean($key, $value, FormatterOptions $options)
-    {
-        if (is_bool($value)) {
-            return $value ? '✔' : '';
-        }
-
-        return $value;
-    }
-
-    protected function getRows(array $fieldDefinitions): array
-    {
-        $rows = [];
-
-        foreach ($fieldDefinitions as $field) {
-            $storage = $field->getFieldStorageDefinition();
-            $handlerSettings = $field->getSetting('handler_settings');
-
-            $rows[$field->getName()] = [
-                'label' => $field->getLabel(),
-                'description' => $field->getDescription(),
-                'field_name' => $field->getName(),
-                'field_type' => $field->getType(),
-                'required' => $field->isRequired(),
-                'translatable' => $field->isTranslatable(),
-                'cardinality' => $storage->getCardinality(),
-                'default_value' => empty($field->getDefaultValueLiteral()) ? null : $field->getDefaultValueLiteral(),
-                'default_value_callback' => $field->getDefaultValueCallback(),
-                'allowed_values' => $storage->getSetting('allowed_values'),
-                'allowed_values_function' => $storage->getSetting('allowed_values_function'),
-                'handler' => $field->getSetting('handler'),
-                'target_bundles' => $handlerSettings['target_bundles'] ?? null,
-            ];
-        }
-
-        return $rows;
+        return $this->getRowsOfFieldsByFieldDefinitions($fieldDefinitions);
     }
 }

--- a/src/Drupal/Commands/core/FieldInfoCommands.php
+++ b/src/Drupal/Commands/core/FieldInfoCommands.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Commands\DrushCommands;
+
+class FieldInfoCommands extends DrushCommands
+{
+    use AskBundleTrait;
+    use ValidateEntityTypeTrait;
+
+    /** @var EntityTypeManagerInterface */
+    protected $entityTypeManager;
+    /** @var EntityTypeBundleInfo */
+    protected $entityTypeBundleInfo;
+
+    public function __construct(
+        EntityTypeManagerInterface $entityTypeManager,
+        EntityTypeBundleInfo $entityTypeBundleInfo
+    ) {
+        $this->entityTypeManager = $entityTypeManager;
+        $this->entityTypeBundleInfo = $entityTypeBundleInfo;
+    }
+
+    /**
+     * List all fields of an entity bundle
+     *
+     * @command field:info
+     * @aliases field-info,fi
+     *
+     * @param string $entityType
+     *      The machine name of the entity type
+     * @param string $bundle
+     *      The machine name of the bundle
+     *
+     * @option show-machine-names
+     *      Show machine names instead of labels in option lists.
+     *
+     * @default-fields field_name,required,field_type,cardinality
+     * @field-labels
+     *      label: Label
+     *      description: Description
+     *      field_name: Field name
+     *      field_type: Field type
+     *      required: Required
+     *      translatable: Translatable
+     *      cardinality: Cardinality
+     *      default_value: Default value
+     *      default_value_callback: Default value callback
+     *      allowed_values: Allowed values
+     *      allowed_values_function: Allowed values function
+     *      handler: Selection handler
+     *      target_bundles: Target bundles
+     * @filter-default-field field_name
+     * @table-style default
+     *
+     * @usage drush field-info taxonomy_term tag
+     *      List all fields.
+     * @usage drush field:info
+     *      List all fields and fill in the remaining information through prompts.
+     */
+    public function info(string $entityType, ?string $bundle = null, array $options = [
+        'format' => 'table',
+    ]): RowsOfFields
+    {
+        $this->validateEntityType($entityType);
+
+        $this->input->setArgument('bundle', $bundle = $bundle ?? $this->askBundle());
+        $this->validateBundle($entityType, $bundle);
+
+        $fieldDefinitions = $this->entityTypeManager
+            ->getStorage('field_config')
+            ->loadByProperties([
+                'entity_type' => $entityType,
+                'bundle' => $bundle,
+            ]);
+
+        $rows = $this->getRows($fieldDefinitions);
+
+        $result = new RowsOfFields($rows);
+        $result->addRendererFunction([$this, 'renderArray']);
+        $result->addRendererFunction([$this, 'renderBoolean']);
+
+        return $result;
+    }
+
+    public function renderArray($key, $value, FormatterOptions $options)
+    {
+        if (is_array($value)) {
+            return implode(', ', $value);
+        }
+
+        return $value;
+    }
+
+    public function renderBoolean($key, $value, FormatterOptions $options)
+    {
+        if (is_bool($value)) {
+            return $value ? '✔' : '';
+        }
+
+        return $value;
+    }
+
+    protected function getRows(array $fieldDefinitions): array
+    {
+        $rows = [];
+
+        foreach ($fieldDefinitions as $field) {
+            $storage = $field->getFieldStorageDefinition();
+            $handlerSettings = $field->getSetting('handler_settings');
+
+            $rows[$field->getName()] = [
+                'label' => $field->getLabel(),
+                'description' => $field->getDescription(),
+                'field_name' => $field->getName(),
+                'field_type' => $field->getType(),
+                'required' => $field->isRequired(),
+                'translatable' => $field->isTranslatable(),
+                'cardinality' => $storage->getCardinality(),
+                'default_value' => empty($field->getDefaultValueLiteral()) ? null : $field->getDefaultValueLiteral(),
+                'default_value_callback' => $field->getDefaultValueCallback(),
+                'allowed_values' => $storage->getSetting('allowed_values'),
+                'allowed_values_function' => $storage->getSetting('allowed_values_function'),
+                'handler' => $field->getSetting('handler'),
+                'target_bundles' => $handlerSettings['target_bundles'] ?? null,
+            ];
+        }
+
+        return $rows;
+    }
+}

--- a/src/Drupal/Commands/core/ValidateEntityTypeTrait.php
+++ b/src/Drupal/Commands/core/ValidateEntityTypeTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * @property EntityTypeManagerInterface $entityTypeManager
+ */
+trait ValidateEntityTypeTrait
+{
+    protected function validateEntityType(string $entityTypeId): void
+    {
+        if (!$this->entityTypeManager->hasDefinition($entityTypeId)) {
+            throw new \InvalidArgumentException(
+                t("Entity type with id ':entityType' does not exist.", [':entityType' => $entityTypeId])
+            );
+        }
+    }
+
+    protected function validateBundle(string $entityTypeId, string $bundle): void
+    {
+        if (!$entityTypeDefinition = $this->entityTypeManager->getDefinition($entityTypeId)) {
+            return;
+        }
+
+        $bundleEntityType = $entityTypeDefinition->getBundleEntityType();
+
+        if ($bundleEntityType === null && $bundle === $entityTypeId) {
+            return;
+        }
+
+        $bundleDefinition = $this->entityTypeManager
+            ->getStorage($bundleEntityType)
+            ->load($bundle);
+
+        if (!$bundleDefinition) {
+            throw new \InvalidArgumentException(
+                t("Bundle ':bundle' does not exist on entity type with id ':entityType'.", [
+                    ':bundle' => $bundle,
+                    ':entityType' => $entityTypeId,
+                ])
+            );
+        }
+    }
+}

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -35,6 +35,13 @@ services:
       - [ setContentTranslationManager, [ '@?content_translation.manager' ] ]
     tags:
       -  { name: drush.command }
+  field.info.commands:
+    class: \Drush\Drupal\Commands\core\FieldInfoCommands
+    arguments:
+      - '@entity_type.bundle.info'
+      - '@entity_type.manager'
+    tags:
+      -  { name: drush.command }
   link.hooks:
     class: \Drush\Drupal\Commands\core\LinkHooks
     arguments:

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -38,8 +38,8 @@ services:
   field.info.commands:
     class: \Drush\Drupal\Commands\core\FieldInfoCommands
     arguments:
-      - '@entity_type.bundle.info'
       - '@entity_type.manager'
+      - '@entity_type.bundle.info'
     tags:
       -  { name: drush.command }
   link.hooks:

--- a/tests/functional/FieldCreateTest.php
+++ b/tests/functional/FieldCreateTest.php
@@ -8,7 +8,7 @@ use Webmozart\PathUtil\Path;
 /**
  * @group commands
  */
-class FieldTest extends CommandUnishTestCase
+class FieldCreateTest extends CommandUnishTestCase
 {
 
     public function setup(): void

--- a/tests/functional/FieldCreateTest.php
+++ b/tests/functional/FieldCreateTest.php
@@ -60,7 +60,8 @@ http://dev/admin/structure/unish_article_types/manage/alpha/fields/unish_article
         $this->assertStringContainsString('Field with name \'field_test3\' already exists on bundle \'beta\'', $this->getErrorOutputRaw());
     }
 
-    public function testFieldInfo() {
+    public function testFieldInfo()
+    {
         $this->drush('field:create', ['unish_article', 'alpha'], ['field-label' => 'Test', 'field-name' => 'field_test4', 'field-description' => 'baz', 'field-type' => 'entity_reference', 'is-required' => true, 'field-widget' => 'entity_reference_autocomplete', 'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, 'target-type' => 'unish_article', 'target-bundle' => 'beta']);
         $this->assertStringContainsString("Successfully created field 'field_test4' on unish_article type with bundle 'alpha'", $this->getSimplifiedErrorOutput());
 


### PR DESCRIPTION
This PR adds a command to show information about fields, similar to the [field-info command that was present in Drush 8](https://drushcommands.com/drush-8x/field/field-info/). It has already been used in multiple projects as part of the [wmscaffold module](https://github.com/wieni/wmscaffold) and is in my opinion stable enough to be considered to be merged in Drush.

## Remarks
- `AskBundleTrait` and `ValidateEntityTypeTrait` are also included in https://github.com/drush-ops/drush/pull/4926, https://github.com/drush-ops/drush/pull/4929 and https://github.com/drush-ops/drush/pull/4930. 
- `FieldDefinitionRowsOfFieldsTrait` is also included in https://github.com/drush-ops/drush/pull/4930.

## Test scenarios
- `./vendor/bin/drush fi` => _Not enough arguments (missing: "entityType")._
- `./vendor/bin/drush fi node` => Asks for bundle
- `./vendor/bin/drush fi node --no-interaction` => _The bundle argument is required._
- `./vendor/bin/drush fi node article` => Lists the default columns
- `./vendor/bin/drush fi node article --fields=field_name,field_type` => Lists only the field name and field type columns

## TODO
- [ ] Add tests