### PR TITLE
Add field:base-override-create command

### DIFF
--- a/src/Drupal/Commands/core/BaseFieldOverrideCreateCommands.php
+++ b/src/Drupal/Commands/core/BaseFieldOverrideCreateCommands.php
@@ -36,7 +36,7 @@ class BaseFieldOverrideCreateCommands extends DrushCommands
     /**
      * Create a new base field override
      *
-     * @command base-field-override:create
+     * @command base-field:override-create
      * @aliases base-field-override-create,bfoc
      *
      * @param string $entityType
@@ -56,11 +56,11 @@ class BaseFieldOverrideCreateCommands extends DrushCommands
      * @option show-machine-names
      *      Show machine names instead of labels in option lists.
      *
-     * @usage drush base-field-override:create
+     * @usage drush base-field:override-create
      *      Create a base field override by answering the prompts.
-     * @usage drush base-field-override:create taxonomy_term tag
+     * @usage drush base-field:override-create taxonomy_term tag
      *      Create a base field override and fill in the remaining information through prompts.
-     * @usage drush base-field-override:create taxonomy_term tag --field-name=name --field-label=Label --is-required=1
+     * @usage drush base-field:override-create taxonomy_term tag --field-name=name --field-label=Label --is-required=1
      *      Create a base field override in a completely non-interactive way.
      *
      * @see \Drupal\field_ui\Form\FieldConfigEditForm

--- a/src/Drupal/Commands/core/BaseFieldOverrideCreateCommands.php
+++ b/src/Drupal/Commands/core/BaseFieldOverrideCreateCommands.php
@@ -172,9 +172,9 @@ class BaseFieldOverrideCreateCommands extends DrushCommands
     {
         $this->logger()->success(
             sprintf(
-                'Successfully created base field override \'%s\' on %s type with bundle \'%s\'',
+                'Successfully created base field override \'%s\' on %s with bundle \'%s\'',
                 $baseFieldOverride->getName(),
-                $baseFieldOverride->getEntityTypeId(),
+                $baseFieldOverride->getTargetEntityTypeId(),
                 $baseFieldOverride->getTargetBundle()
             )
         );

--- a/src/Drupal/Commands/core/BaseFieldOverrideCreateCommands.php
+++ b/src/Drupal/Commands/core/BaseFieldOverrideCreateCommands.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Drupal\Core\Entity\EntityFieldManager;
+use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\Entity\BaseFieldOverride;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class BaseFieldOverrideCreateCommands extends DrushCommands
+{
+    use AskBundleTrait;
+    use ValidateEntityTypeTrait;
+
+    /** @var EntityTypeManagerInterface */
+    protected $entityTypeManager;
+    /** @var EntityTypeBundleInfo */
+    protected $entityTypeBundleInfo;
+    /** @var EntityFieldManager */
+    protected $entityFieldManager;
+
+    public function __construct(
+        EntityTypeManagerInterface $entityTypeManager,
+        EntityTypeBundleInfo $entityTypeBundleInfo,
+        EntityFieldManager $entityFieldManager
+    ) {
+        $this->entityTypeManager = $entityTypeManager;
+        $this->entityTypeBundleInfo = $entityTypeBundleInfo;
+        $this->entityFieldManager = $entityFieldManager;
+    }
+
+    /**
+     * Create a new base field override
+     *
+     * @command base-field-override:create
+     * @aliases base-field-override-create,bfoc
+     *
+     * @param string $entityType
+     *      The machine name of the entity type
+     * @param string $bundle
+     *      The machine name of the bundle
+     *
+     * @option field-name
+     *      A unique machine-readable name containing letters, numbers, and underscores.
+     * @option field-label
+     *      The field label
+     * @option field-description
+     *      The field description
+     * @option is-required
+     *      Whether the field is required
+     *
+     * @option show-machine-names
+     *      Show machine names instead of labels in option lists.
+     *
+     * @usage drush base-field-override:create
+     *      Create a base field override by answering the prompts.
+     * @usage drush base-field-override:create taxonomy_term tag
+     *      Create a base field override and fill in the remaining information through prompts.
+     * @usage drush base-field-override:create taxonomy_term tag --field-name=name --field-label=Label --is-required=1
+     *      Create a base field override in a completely non-interactive way.
+     *
+     * @see \Drupal\field_ui\Form\FieldConfigEditForm
+     * @see \Drupal\field_ui\Form\FieldStorageConfigEditForm
+     */
+    public function create(string $entityType, ?string $bundle = null, array $options = [
+        'field-name' => InputOption::VALUE_REQUIRED,
+        'field-label' => InputOption::VALUE_REQUIRED,
+        'field-description' => InputOption::VALUE_REQUIRED,
+        'is-required' => InputOption::VALUE_REQUIRED,
+        'show-machine-names' => InputOption::VALUE_OPTIONAL,
+    ]): void
+    {
+        $this->validateEntityType($entityType);
+
+        $this->input->setArgument('bundle', $bundle = $bundle ?? $this->askBundle());
+        $this->validateBundle($entityType, $bundle);
+
+        $fieldName = $this->input->getOption('field-name') ?? $this->askFieldName($entityType);
+        $this->input->setOption('field-name', $fieldName);
+
+        if ($fieldName === '') {
+            throw new \InvalidArgumentException(dt('The %optionName option is required.', [
+                '%optionName' => 'field-name',
+            ]));
+        }
+
+        /** @var BaseFieldOverride|BaseFieldDefinition $definition */
+        $definition = BaseFieldOverride::loadByName($entityType, $bundle, $fieldName)
+            ?? $this->getBaseFieldDefinition($entityType, $fieldName);
+
+        if ($definition === null) {
+            throw new \InvalidArgumentException(
+                t("Base field with name ':fieldName' does not exist on bundle ':bundle'.", [
+                    ':fieldName' => $fieldName,
+                    ':bundle' => $bundle,
+                ])
+            );
+        }
+
+        $this->input->setOption(
+            'field-label',
+            $this->input->getOption('field-label') ?? $this->askFieldLabel((string) $definition->getLabel())
+        );
+        $this->input->setOption(
+            'field-description',
+            $this->input->getOption('field-description') ?? $this->askFieldDescription($definition->getDescription())
+        );
+        $this->input->setOption(
+            'is-required',
+            (bool) ($this->input->getOption('is-required') ?? $this->askRequired($definition->isRequired()))
+        );
+
+        $fieldName = $this->input->getOption('field-name');
+        $fieldLabel = $this->input->getOption('field-label');
+        $fieldDescription = $this->input->getOption('field-description');
+        $isRequired = $this->input->getOption('is-required');
+
+        $baseFieldOverride = $this->createBaseFieldOverride($entityType, $bundle, $fieldName, $fieldLabel, $fieldDescription, $isRequired);
+
+        $this->logResult($baseFieldOverride);
+    }
+
+    protected function askFieldName(string $entityType): ?string
+    {
+        /** @var BaseFieldDefinition[] $definitions */
+        $definitions = $this->entityFieldManager->getBaseFieldDefinitions($entityType);
+        $choices = [];
+
+        foreach ($definitions as $definition) {
+            $label = $this->input->getOption('show-machine-names') ? $definition->getName() : $definition->getLabel()->render();
+            $choices[$definition->getName()] = $label;
+        }
+
+        return $this->io()->choice('Field name', $choices);
+    }
+
+    protected function askFieldLabel(string $default): string
+    {
+        return $this->io()->ask('Field label', $default);
+    }
+
+    protected function askFieldDescription(?string $default): ?string
+    {
+        return $this->io()->ask('Field description', $default);
+    }
+
+    protected function askRequired(bool $default): bool
+    {
+        return $this->io()->askQuestion(new ConfirmationQuestion('Required', $default));
+    }
+
+    protected function createBaseFieldOverride(string $entityType, string $bundle, string $fieldName, $fieldLabel, $fieldDescription, bool $isRequired): BaseFieldOverride
+    {
+        $definition = $this->getBaseFieldDefinition($entityType, $fieldName);
+        $override = BaseFieldOverride::loadByName($entityType, $bundle, $fieldName)
+            ?? BaseFieldOverride::createFromBaseFieldDefinition($definition, $bundle);
+
+        $override
+            ->setLabel($fieldLabel)
+            ->setDescription($fieldDescription)
+            ->setRequired($isRequired)
+            ->save();
+
+        return $override;
+    }
+
+    protected function logResult(BaseFieldOverride $baseFieldOverride): void
+    {
+        $this->logger()->success(
+            sprintf(
+                'Successfully created base field override \'%s\' on %s type with bundle \'%s\'',
+                $baseFieldOverride->getName(),
+                $baseFieldOverride->getEntityTypeId(),
+                $baseFieldOverride->getTargetBundle()
+            )
+        );
+    }
+
+    protected function getBaseFieldDefinition(string $entityType, string $fieldName): ?BaseFieldDefinition
+    {
+        /** @var BaseFieldDefinition[] $definitions */
+        $definitions = $this->entityFieldManager->getBaseFieldDefinitions($entityType);
+
+        return $definitions[$fieldName] ?? null;
+    }
+}

--- a/src/Drupal/Commands/core/BaseFieldOverrideCreateCommands.php
+++ b/src/Drupal/Commands/core/BaseFieldOverrideCreateCommands.php
@@ -2,8 +2,8 @@
 
 namespace Drush\Drupal\Commands\core;
 
-use Drupal\Core\Entity\EntityFieldManager;
-use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\Entity\BaseFieldOverride;
@@ -18,15 +18,15 @@ class BaseFieldOverrideCreateCommands extends DrushCommands
 
     /** @var EntityTypeManagerInterface */
     protected $entityTypeManager;
-    /** @var EntityTypeBundleInfo */
+    /** @var EntityTypeBundleInfoInterface */
     protected $entityTypeBundleInfo;
-    /** @var EntityFieldManager */
+    /** @var EntityFieldManagerInterface */
     protected $entityFieldManager;
 
     public function __construct(
         EntityTypeManagerInterface $entityTypeManager,
-        EntityTypeBundleInfo $entityTypeBundleInfo,
-        EntityFieldManager $entityFieldManager
+        EntityTypeBundleInfoInterface $entityTypeBundleInfo,
+        EntityFieldManagerInterface $entityFieldManager
     ) {
         $this->entityTypeManager = $entityTypeManager;
         $this->entityTypeBundleInfo = $entityTypeBundleInfo;

--- a/src/Drupal/Commands/core/BaseFieldOverrideCreateCommands.php
+++ b/src/Drupal/Commands/core/BaseFieldOverrideCreateCommands.php
@@ -36,8 +36,8 @@ class BaseFieldOverrideCreateCommands extends DrushCommands
     /**
      * Create a new base field override
      *
-     * @command base-field:override-create
-     * @aliases base-field-override-create,bfoc
+     * @command field:base-field-override-create
+     * @aliases field-base-field-override-create,base-field-override-create,bfoc
      *
      * @param string $entityType
      *      The machine name of the entity type
@@ -56,11 +56,11 @@ class BaseFieldOverrideCreateCommands extends DrushCommands
      * @option show-machine-names
      *      Show machine names instead of labels in option lists.
      *
-     * @usage drush base-field:override-create
+     * @usage drush field:base-field-override-create
      *      Create a base field override by answering the prompts.
-     * @usage drush base-field:override-create taxonomy_term tag
+     * @usage drush field:base-field-override-create taxonomy_term tag
      *      Create a base field override and fill in the remaining information through prompts.
-     * @usage drush base-field:override-create taxonomy_term tag --field-name=name --field-label=Label --is-required=1
+     * @usage drush field:base-field-override-create taxonomy_term tag --field-name=name --field-label=Label --is-required=1
      *      Create a base field override in a completely non-interactive way.
      *
      * @see \Drupal\field_ui\Form\FieldConfigEditForm

--- a/src/Drupal/Commands/core/FieldBaseOverrideCreateCommands.php
+++ b/src/Drupal/Commands/core/FieldBaseOverrideCreateCommands.php
@@ -65,6 +65,8 @@ class FieldBaseOverrideCreateCommands extends DrushCommands
      *
      * @see \Drupal\field_ui\Form\FieldConfigEditForm
      * @see \Drupal\field_ui\Form\FieldStorageConfigEditForm
+     *
+     * @version 11.0
      */
     public function create(?string $entityType = null, ?string $bundle = null, array $options = [
         'field-name' => InputOption::VALUE_REQUIRED,

--- a/src/Drupal/Commands/core/FieldBaseOverrideCreateCommands.php
+++ b/src/Drupal/Commands/core/FieldBaseOverrideCreateCommands.php
@@ -132,7 +132,7 @@ class FieldBaseOverrideCreateCommands extends DrushCommands
         $choices = [];
 
         foreach ($definitions as $definition) {
-            $label = $this->input->getOption('show-machine-names') ? $definition->getName() : $definition->getLabel()->render();
+            $label = $this->input->getOption('show-machine-names') ? $definition->getName() : (string) $definition->getLabel();
             $choices[$definition->getName()] = $label;
         }
 

--- a/src/Drupal/Commands/core/FieldBaseOverrideCreateCommands.php
+++ b/src/Drupal/Commands/core/FieldBaseOverrideCreateCommands.php
@@ -11,10 +11,10 @@ use Drush\Commands\DrushCommands;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-class BaseFieldOverrideCreateCommands extends DrushCommands
+class FieldBaseOverrideCreateCommands extends DrushCommands
 {
-    use AskBundleTrait;
-    use ValidateEntityTypeTrait;
+    use EntityTypeBundleAskTrait;
+    use EntityTypeBundleValidationTrait;
 
     /** @var EntityTypeManagerInterface */
     protected $entityTypeManager;
@@ -36,8 +36,8 @@ class BaseFieldOverrideCreateCommands extends DrushCommands
     /**
      * Create a new base field override
      *
-     * @command field:base-field-override-create
-     * @aliases field-base-field-override-create,base-field-override-create,bfoc
+     * @command field:base-override-create
+     * @aliases field-base-override-create,base-field-override-create,bfoc
      *
      * @param string $entityType
      *      The machine name of the entity type
@@ -66,7 +66,7 @@ class BaseFieldOverrideCreateCommands extends DrushCommands
      * @see \Drupal\field_ui\Form\FieldConfigEditForm
      * @see \Drupal\field_ui\Form\FieldStorageConfigEditForm
      */
-    public function create(string $entityType, ?string $bundle = null, array $options = [
+    public function create(?string $entityType = null, ?string $bundle = null, array $options = [
         'field-name' => InputOption::VALUE_REQUIRED,
         'field-label' => InputOption::VALUE_REQUIRED,
         'field-description' => InputOption::VALUE_REQUIRED,
@@ -74,6 +74,7 @@ class BaseFieldOverrideCreateCommands extends DrushCommands
         'show-machine-names' => InputOption::VALUE_OPTIONAL,
     ]): void
     {
+        $this->input->setArgument('entityType', $entityType = $entityType ?? $this->askEntityType());
         $this->validateEntityType($entityType);
 
         $this->input->setArgument('bundle', $bundle = $bundle ?? $this->askBundle());

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -49,6 +49,14 @@ services:
       - '@entity_type.bundle.info'
     tags:
       -  { name: drush.command }
+  base-field-override.create.commands:
+    class: \Drush\Drupal\Commands\core\BaseFieldOverrideCreateCommands
+    arguments:
+      - '@entity_type.manager'
+      - '@entity_type.bundle.info'
+      - '@entity_field.manager'
+    tags:
+      -  { name: drush.command }
   link.hooks:
     class: \Drush\Drupal\Commands\core\LinkHooks
     arguments:

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -49,6 +49,14 @@ services:
       - '@entity_type.bundle.info'
     tags:
       -  { name: drush.command }
+  field.base-override-create.commands:
+    class: \Drush\Drupal\Commands\core\FieldBaseOverrideCreateCommands
+    arguments:
+      - '@entity_type.manager'
+      - '@entity_type.bundle.info'
+      - '@entity_field.manager'
+    tags:
+      - { name: drush.command }
   field.base-info.commands:
     class: \Drush\Drupal\Commands\core\FieldBaseInfoCommands
     arguments:

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -49,8 +49,8 @@ services:
       - '@entity_type.bundle.info'
     tags:
       -  { name: drush.command }
-  base-field.override-create.commands:
-    class: \Drush\Drupal\Commands\core\BaseFieldOverrideCreateCommands
+  field.base-override-create.commands:
+    class: \Drush\Drupal\Commands\core\FieldBaseOverrideCreateCommands
     arguments:
       - '@entity_type.manager'
       - '@entity_type.bundle.info'

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -49,7 +49,7 @@ services:
       - '@entity_type.bundle.info'
     tags:
       -  { name: drush.command }
-  base-field-override.create.commands:
+  base-field.override-create.commands:
     class: \Drush\Drupal\Commands\core\BaseFieldOverrideCreateCommands
     arguments:
       - '@entity_type.manager'

--- a/tests/functional/FieldTest.php
+++ b/tests/functional/FieldTest.php
@@ -93,13 +93,16 @@ class FieldTest extends CommandUnishTestCase
         $this->assertStringContainsString(" The field Test has been deleted from the Alpha bundle.", $this->getErrorOutputRaw());
     }
 
-    public function testFieldBaseCreateAndInfo()
+    public function testFieldBaseInfo()
     {
         $this->drush('field:base-info', ['user'], ['format' => 'json', 'fields' => '*']);
         $json = $this->getOutputFromJSON();
         $this->assertArrayHasKey('name', $json);
         $this->assertSame('Name', $json['name']['label']);
+    }
 
+    public function testFieldBaseCreateOverride()
+    {
         $options = [
           'field-name' => 'name',
           'field-label' => 'Handle',

--- a/tests/functional/FieldTest.php
+++ b/tests/functional/FieldTest.php
@@ -93,11 +93,23 @@ class FieldTest extends CommandUnishTestCase
         $this->assertStringContainsString(" The field Test has been deleted from the Alpha bundle.", $this->getErrorOutputRaw());
     }
 
-    public function testFieldBaseInfo()
+    public function testFieldBaseCreateAndInfo()
     {
         $this->drush('field:base-info', ['user'], ['format' => 'json', 'fields' => '*']);
         $json = $this->getOutputFromJSON();
         $this->assertArrayHasKey('name', $json);
         $this->assertSame('Name', $json['name']['label']);
+
+        $options = [
+          'field-name' => 'name',
+          'field-label' => 'Handle',
+          'field-description' => 'The way this person wishes to called',
+          'is-required' => true,
+        ];
+        $this->drush('field:base-override-create', ['user', 'user'], $options);
+        $this->drush('config:get', ['core.base_field_override.user.user.name'], ['format' => 'json']);
+        $json = $this->getOutputFromJSON();
+        $this->assertSame('Handle', $json['label']);
+        $this->assertSame(true, $json['required']);
     }
 }


### PR DESCRIPTION
This PR adds a command to create a [base field override](https://www.drupal.org/project/base_field_override_ui). It has already been used in multiple projects as part of the [wmscaffold module](https://github.com/wieni/wmscaffold) and is in my opinion stable enough to be considered to be merged in Drush.

## Remarks
- `AskBundleTrait` and `ValidateEntityTypeTrait` are also included in https://github.com/drush-ops/drush/pull/4926, https://github.com/drush-ops/drush/pull/4928 and https://github.com/drush-ops/drush/pull/4930. 

## Test scenarios
- `./vendor/bin/drush bfoc` => _Not enough arguments (missing: "entityType")._
- `./vendor/bin/drush bfoc node` => Asks for bundle
- `./vendor/bin/drush bfoc node --no-interaction` => _The bundle argument is required._
- `./vendor/bin/drush bfoc node article` => Asks for field name
- `./vendor/bin/drush bfoc node article --no-interaction` => _The field-name option is required._
- `./vendor/bin/drush bfoc node article --no-interaction --field-name=title` => _Successfully created base field override 'title' on node with bundle 'article'_ (with existing values), if the field doesn't exist _Base field with name 'some_name' does not exist on bundle 'article'._
- `./vendor/bin/drush bfoc node article --field-name=title --field-label="Better title" --is-required=0` => _Successfully created base field override 'title' on node with bundle 'article'_ (with passed values)

## TODO
- [ ] Add tests