### PR TITLE
Add field:base-info command

### DIFF
--- a/src/Drupal/Commands/core/BaseFieldInfoCommands.php
+++ b/src/Drupal/Commands/core/BaseFieldInfoCommands.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Commands\DrushCommands;
+
+class BaseFieldInfoCommands extends DrushCommands
+{
+    use AskBundleTrait;
+    use FieldDefinitionRowsOfFieldsTrait;
+    use ValidateEntityTypeTrait;
+
+    /** @var EntityTypeManagerInterface */
+    protected $entityTypeManager;
+    /** @var EntityTypeBundleInfo */
+    protected $entityTypeBundleInfo;
+    /** @var EntityFieldManagerInterface */
+    protected $entityFieldManager;
+
+    public function __construct(
+        EntityTypeManagerInterface $entityTypeManager,
+        EntityTypeBundleInfo $entityTypeBundleInfo,
+        EntityFieldManagerInterface $entityFieldManager
+    ) {
+        $this->entityTypeManager = $entityTypeManager;
+        $this->entityTypeBundleInfo = $entityTypeBundleInfo;
+        $this->entityFieldManager = $entityFieldManager;
+    }
+
+    /**
+     * List all base fields of an entity type
+     *
+     * @command base-field:info
+     * @aliases base-field-info,bfi
+     *
+     * @param string $entityType
+     *      The machine name of the entity type
+     *
+     * @option show-machine-names
+     *      Show machine names instead of labels in option lists.
+     *
+     * @default-fields field_name,required,field_type,cardinality
+     * @field-labels
+     *      label: Label
+     *      description: Description
+     *      field_name: Field name
+     *      field_type: Field type
+     *      required: Required
+     *      translatable: Translatable
+     *      cardinality: Cardinality
+     *      default_value: Default value
+     *      default_value_callback: Default value callback
+     *      allowed_values: Allowed values
+     *      allowed_values_function: Allowed values function
+     *      handler: Selection handler
+     *      target_bundles: Target bundles
+     * @filter-default-field field_name
+     * @table-style default
+     *
+     * @usage drush base-field-info taxonomy_term
+     *      List all base fields.
+     * @usage drush base-field:info
+     *      List all base fields and fill in the remaining information through prompts.
+     */
+    public function info(string $entityType, array $options = [
+        'format' => 'table',
+    ]): RowsOfFields
+    {
+        $fieldDefinitions = $this->entityFieldManager->getBaseFieldDefinitions($entityType);
+
+        return $this->getRowsOfFieldsByFieldDefinitions($fieldDefinitions);
+    }
+}

--- a/src/Drupal/Commands/core/BaseFieldInfoCommands.php
+++ b/src/Drupal/Commands/core/BaseFieldInfoCommands.php
@@ -64,6 +64,8 @@ class BaseFieldInfoCommands extends DrushCommands
      *      List all base fields.
      * @usage drush base-field:info
      *      List all base fields and fill in the remaining information through prompts.
+     *
+     * @version 11.0
      */
     public function info(string $entityType, array $options = [
         'format' => 'table',

--- a/src/Drupal/Commands/core/FieldBaseInfoCommands.php
+++ b/src/Drupal/Commands/core/FieldBaseInfoCommands.php
@@ -2,27 +2,28 @@
 
 namespace Drush\Drupal\Commands\core;
 
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
-use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Commands\DrushCommands;
 
-class BaseFieldInfoCommands extends DrushCommands
+class FieldBaseInfoCommands extends DrushCommands
 {
-    use AskBundleTrait;
+    use EntityTypeBundleAskTrait;
+    use EntityTypeBundleValidationTrait;
     use FieldDefinitionRowsOfFieldsTrait;
-    use ValidateEntityTypeTrait;
 
     /** @var EntityTypeManagerInterface */
     protected $entityTypeManager;
-    /** @var EntityTypeBundleInfo */
+    /** @var EntityTypeBundleInfoInterface */
     protected $entityTypeBundleInfo;
     /** @var EntityFieldManagerInterface */
     protected $entityFieldManager;
 
     public function __construct(
         EntityTypeManagerInterface $entityTypeManager,
-        EntityTypeBundleInfo $entityTypeBundleInfo,
+        EntityTypeBundleInfoInterface $entityTypeBundleInfo,
         EntityFieldManagerInterface $entityFieldManager
     ) {
         $this->entityTypeManager = $entityTypeManager;
@@ -33,8 +34,8 @@ class BaseFieldInfoCommands extends DrushCommands
     /**
      * List all base fields of an entity type
      *
-     * @command base-field:info
-     * @aliases base-field-info,bfi
+     * @command field:base-info
+     * @aliases field-base-info,fbi
      *
      * @param string $entityType
      *      The machine name of the entity type
@@ -60,17 +61,20 @@ class BaseFieldInfoCommands extends DrushCommands
      * @filter-default-field field_name
      * @table-style default
      *
-     * @usage drush base-field-info taxonomy_term
+     * @usage drush field:base-info taxonomy_term
      *      List all base fields.
-     * @usage drush base-field:info
+     * @usage drush field:base-info
      *      List all base fields and fill in the remaining information through prompts.
      *
      * @version 11.0
      */
-    public function info(string $entityType, array $options = [
+    public function info(?string $entityType = null, array $options = [
         'format' => 'table',
     ]): RowsOfFields
     {
+        $this->input->setArgument('entityType', $entityType = $entityType ?? $this->askEntityType());
+        $this->validateEntityType($entityType);
+
         $fieldDefinitions = $this->entityFieldManager->getBaseFieldDefinitions($entityType);
 
         return $this->getRowsOfFieldsByFieldDefinitions($fieldDefinitions);

--- a/src/Drupal/Commands/core/FieldInfoCommands.php
+++ b/src/Drupal/Commands/core/FieldInfoCommands.php
@@ -2,9 +2,8 @@
 
 namespace Drush\Drupal\Commands\core;
 
-use Consolidation\OutputFormatters\Options\FormatterOptions;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
-use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Commands\DrushCommands;
 
@@ -16,12 +15,12 @@ class FieldInfoCommands extends DrushCommands
 
     /** @var EntityTypeManagerInterface */
     protected $entityTypeManager;
-    /** @var EntityTypeBundleInfo */
+    /** @var EntityTypeBundleInfoInterface */
     protected $entityTypeBundleInfo;
 
     public function __construct(
         EntityTypeManagerInterface $entityTypeManager,
-        EntityTypeBundleInfo $entityTypeBundleInfo
+        EntityTypeBundleInfoInterface $entityTypeBundleInfo
     ) {
         $this->entityTypeManager = $entityTypeManager;
         $this->entityTypeBundleInfo = $entityTypeBundleInfo;

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -49,6 +49,14 @@ services:
       - '@entity_type.bundle.info'
     tags:
       -  { name: drush.command }
+  base-field.info.commands:
+    class: \Drush\Drupal\Commands\core\BaseFieldInfoCommands
+    arguments:
+      - '@entity_type.manager'
+      - '@entity_type.bundle.info'
+      - '@entity_field.manager'
+    tags:
+      - { name: drush.command }
   link.hooks:
     class: \Drush\Drupal\Commands\core\LinkHooks
     arguments:

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -49,8 +49,8 @@ services:
       - '@entity_type.bundle.info'
     tags:
       -  { name: drush.command }
-  base-field.info.commands:
-    class: \Drush\Drupal\Commands\core\BaseFieldInfoCommands
+  field.base-info.commands:
+    class: \Drush\Drupal\Commands\core\FieldBaseInfoCommands
     arguments:
       - '@entity_type.manager'
       - '@entity_type.bundle.info'

--- a/tests/functional/FieldTest.php
+++ b/tests/functional/FieldTest.php
@@ -92,4 +92,20 @@ class FieldTest extends CommandUnishTestCase
         $this->drush('field:delete', ['unish_article', 'alpha'], ['field-name' => 'field_test5']);
         $this->assertStringContainsString(" The field Test has been deleted from the Alpha bundle.", $this->getErrorOutputRaw());
     }
+
+    public function testBaseFieldInfo()
+    {
+        // $this->drush('field:create', ['unish_article', 'alpha'], ['field-label' => 'Test', 'field-name' => 'field_test4', 'field-description' => 'baz', 'field-type' => 'entity_reference', 'is-required' => true, 'field-widget' => 'entity_reference_autocomplete', 'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, 'target-type' => 'unish_article', 'target-bundle' => 'beta']);
+        // $this->assertStringContainsString("Successfully created field 'field_test4' on unish_article type with bundle 'alpha'", $this->getSimplifiedErrorOutput());
+
+//        $this->drush('base-field:info', ['user'], ['format' => 'json', 'fields' => '*']);
+//        $json = $this->getOutputFromJSON();
+//        $this->assertSame('field_test4', $json['field_name']);
+//        $this->assertTrue($json['required']);
+//        $this->assertSame('entity_reference', $json['field_type']);
+//        $this->assertSame('baz', $json['description']);
+//        $this->assertSame(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, $json['cardinality']);
+//        $this->assertFalse($json['translatable']);
+//        $this->assertArrayHasKey('beta', $json['target_bundles']);
+    }
 }

--- a/tests/functional/FieldTest.php
+++ b/tests/functional/FieldTest.php
@@ -93,19 +93,11 @@ class FieldTest extends CommandUnishTestCase
         $this->assertStringContainsString(" The field Test has been deleted from the Alpha bundle.", $this->getErrorOutputRaw());
     }
 
-    public function testBaseFieldInfo()
+    public function testFieldBaseInfo()
     {
-        // $this->drush('field:create', ['unish_article', 'alpha'], ['field-label' => 'Test', 'field-name' => 'field_test4', 'field-description' => 'baz', 'field-type' => 'entity_reference', 'is-required' => true, 'field-widget' => 'entity_reference_autocomplete', 'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, 'target-type' => 'unish_article', 'target-bundle' => 'beta']);
-        // $this->assertStringContainsString("Successfully created field 'field_test4' on unish_article type with bundle 'alpha'", $this->getSimplifiedErrorOutput());
-
-//        $this->drush('base-field:info', ['user'], ['format' => 'json', 'fields' => '*']);
-//        $json = $this->getOutputFromJSON();
-//        $this->assertSame('field_test4', $json['field_name']);
-//        $this->assertTrue($json['required']);
-//        $this->assertSame('entity_reference', $json['field_type']);
-//        $this->assertSame('baz', $json['description']);
-//        $this->assertSame(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, $json['cardinality']);
-//        $this->assertFalse($json['translatable']);
-//        $this->assertArrayHasKey('beta', $json['target_bundles']);
+        $this->drush('field:base-info', ['user'], ['format' => 'json', 'fields' => '*']);
+        $json = $this->getOutputFromJSON();
+        $this->assertArrayHasKey('name', $json);
+        $this->assertSame('Name', $json['name']['label']);
     }
 }


### PR DESCRIPTION
This PR adds a command to show information about base fields, similar to https://github.com/drush-ops/drush/pull/4928. It has already been used in multiple projects as part of the [wmscaffold module](https://github.com/wieni/wmscaffold) and is in my opinion stable enough to be considered to be merged in Drush.

## Remarks
- `AskBundleTrait` and `ValidateEntityTypeTrait` are also included in https://github.com/drush-ops/drush/pull/4926, https://github.com/drush-ops/drush/pull/4928 and https://github.com/drush-ops/drush/pull/4929. 
- `FieldDefinitionRowsOfFieldsTrait` is also included in https://github.com/drush-ops/drush/pull/4928.

## Test scenarios
- `./vendor/bin/drush bfi` => _Not enough arguments (missing: "entityType")._
- `./vendor/bin/drush bfi node` => Lists the default columns
- `./vendor/bin/drush bfi node --fields=field_name,field_type` => Lists only the field name and field type columns

## TODO
- [ ] Add tests