### PR TITLE
Add nodetype:create & vocabulary:create commands

### DIFF
--- a/src/Drupal/Commands/core/BundleMachineNameAskTrait.php
+++ b/src/Drupal/Commands/core/BundleMachineNameAskTrait.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * @property InputInterface $input
+ * @property EntityTypeManagerInterface $entityTypeManager
+ */
+trait BundleMachineNameAskTrait
+{
+    protected function askMachineName(string $entityTypeId): string
+    {
+        $label = $this->input->getOption('label');
+        $suggestion = null;
+        $machineName = null;
+
+        if ($label) {
+            $suggestion = $this->generateMachineName($label);
+        }
+
+        while (!$machineName) {
+            $answer = $this->io()->ask('Machine-readable name', $suggestion);
+
+            if (preg_match('/[^a-z0-9_]+/', $answer)) {
+                $this->logger()->error('The machine-readable name must contain only lowercase letters, numbers, and underscores.');
+                continue;
+            }
+
+            if (strlen($answer) > EntityTypeInterface::BUNDLE_MAX_LENGTH) {
+                $this->logger()->error('Field name must not be longer than :maxLength characters.', [':maxLength' => EntityTypeInterface::BUNDLE_MAX_LENGTH]);
+                continue;
+            }
+
+            if ($this->bundleExists($entityTypeId, $answer)) {
+                $this->logger()->error('A bundle with this name already exists.');
+                continue;
+            }
+
+            $machineName = $answer;
+        }
+
+        return $machineName;
+    }
+
+    protected function generateMachineName(string $source): string
+    {
+        // Only lowercase alphanumeric characters and underscores
+        $machineName = preg_replace('/[^_a-z0-9]/i', '_', $source);
+        // Maximum one subsequent underscore
+        $machineName = preg_replace('/_+/', '_', $machineName);
+        // Only lowercase
+        $machineName = strtolower($machineName);
+        // Maximum length
+        $machineName = substr($machineName, 0, EntityTypeInterface::BUNDLE_MAX_LENGTH);
+
+        return $machineName;
+    }
+
+    protected function bundleExists(string $entityTypeId, string $id): bool
+    {
+        if ($entityTypeDefinition = $this->entityTypeManager->getDefinition($entityTypeId)) {
+            if ($bundleEntityType = $entityTypeDefinition->getBundleEntityType()) {
+                $bundleDefinition = $this->entityTypeManager
+                    ->getStorage($bundleEntityType)
+                    ->load($id);
+            }
+        }
+
+        return isset($bundleDefinition);
+    }
+}

--- a/src/Drupal/Commands/core/LanguageHooks.php
+++ b/src/Drupal/Commands/core/LanguageHooks.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\CommandData;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\language\Entity\ContentLanguageSettings;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+class LanguageHooks extends DrushCommands
+{
+    /** @var ModuleHandlerInterface */
+    protected $moduleHandler;
+    /** @var LanguageManagerInterface */
+    protected $languageManager;
+
+    public function __construct(
+        ModuleHandlerInterface $moduleHandler,
+        LanguageManagerInterface $languageManager
+    ) {
+        $this->moduleHandler = $moduleHandler;
+        $this->languageManager = $languageManager;
+    }
+
+    /** @hook option nodetype:create */
+    public function hookOption(Command $command, AnnotationData $annotationData): void
+    {
+        if (!$this->isInstalled()) {
+            return;
+        }
+
+        $command->addOption(
+            'default-language',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            'The default language of new nodes.'
+        );
+
+        $command->addOption(
+            'show-language-selector',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            'Whether to show the language selector on create and edit pages.'
+        );
+    }
+
+    /** @hook on-event node-type-set-options */
+    public function hookSetOptions(InputInterface $input): void
+    {
+        if (!$this->isInstalled()) {
+            return;
+        }
+
+        $this->ensureOption('default-language', [$this, 'askLanguageDefault'], true);
+        $this->ensureOption('show-language-selector', [$this, 'askLanguageShowSelector'], true);
+    }
+
+    /** @hook on-event nodetype-create */
+    public function hookCreate(array &$values): void
+    {
+        if (!$this->isInstalled()) {
+            return;
+        }
+
+        $values['langcode'] = $this->input->getOption('default-language');
+        $values['dependencies']['module'][] = 'language';
+    }
+
+    /** @hook post-command nodetype:create */
+    public function hookPostFieldCreate($result, CommandData $commandData): void
+    {
+        if (!$this->isInstalled()) {
+            return;
+        }
+
+        $bundle = $this->input->getOption('machine-name');
+        $defaultLanguage = $this->input->getOption('default-language');
+        $showLanguageSelector = (bool) $this->input->getOption('show-language-selector');
+
+        $config = ContentLanguageSettings::loadByEntityTypeBundle('node', $bundle);
+        $config->setDefaultLangcode($defaultLanguage)
+            ->setLanguageAlterable($showLanguageSelector)
+            ->save();
+    }
+
+    protected function askLanguageDefault(): string
+    {
+        $options = [
+            LanguageInterface::LANGCODE_SITE_DEFAULT => dt("Site's default language (@language)", ['@language' => \Drupal::languageManager()->getDefaultLanguage()->getName()]),
+            'current_interface' => dt('Interface text language selected for page'),
+            'authors_default' => dt("Author's preferred language"),
+        ];
+
+        $languages = $this->languageManager->getLanguages(LanguageInterface::STATE_ALL);
+
+        foreach ($languages as $langcode => $language) {
+            $options[$langcode] = $language->isLocked()
+                ? dt('- @name -', ['@name' => $language->getName()])
+                : $language->getName();
+        }
+
+        return $this->io()->choice('Default language', $options, 1);
+    }
+
+    protected function askLanguageShowSelector(): bool
+    {
+        return $this->io()->confirm('Show language selector on create and edit pages', false);
+    }
+
+    protected function isInstalled(): bool
+    {
+        return $this->moduleHandler->moduleExists('language');
+    }
+
+    protected function ensureOption(string $name, callable $asker, bool $required): void
+    {
+        $value = $this->input->getOption($name);
+
+        if ($value === null) {
+            $value = $asker();
+        }
+
+        if ($required && $value === null) {
+            throw new \InvalidArgumentException(dt('The %optionName option is required.', [
+                '%optionName' => $name,
+            ]));
+        }
+
+        $this->input->setOption($name, $value);
+    }
+}

--- a/src/Drupal/Commands/core/MenuUiHooks.php
+++ b/src/Drupal/Commands/core/MenuUiHooks.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Menu\MenuParentFormSelectorInterface;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+class MenuUiHooks extends DrushCommands
+{
+    /** @var ModuleHandlerInterface */
+    protected $moduleHandler;
+    /** @var MenuParentFormSelectorInterface */
+    protected $menuParentFormSelector;
+
+    public function __construct(
+        ModuleHandlerInterface $moduleHandler,
+        MenuParentFormSelectorInterface $menuParentFormSelector
+    ) {
+        $this->moduleHandler = $moduleHandler;
+        $this->menuParentFormSelector = $menuParentFormSelector;
+    }
+
+    /** @hook option nodetype:create */
+    public function hookOption(Command $command, AnnotationData $annotationData): void
+    {
+        if (!$this->isInstalled()) {
+            return;
+        }
+
+        $command->addOption(
+            'menus-available',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            'The menus available to place links in for this content type.'
+        );
+
+        $command->addOption(
+            'menu-default-parent',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            'The menu item to be the default parent for a new link in the content authoring form.'
+        );
+    }
+
+    /** @hook on-event node-type-set-options */
+    public function hookSetOptions(InputInterface $input): void
+    {
+        if (!$this->isInstalled()) {
+            return;
+        }
+
+        $this->ensureOption('menus-available', [$this, 'askMenus'], true);
+        $menus = $this->input->getOption('menus-available');
+        if (is_string($menus)) {
+            $menus = explode(',', $menus);
+            $this->input->setOption('menus-available', $menus);
+        }
+
+        if ($menus === []) {
+            return;
+        }
+
+        $this->ensureOption('menu-default-parent', [$this, 'askDefaultParent'], true);
+    }
+
+    /** @hook on-event nodetype-create */
+    public function hookCreate(array &$values): void
+    {
+        if (!$this->isInstalled()) {
+            return;
+        }
+
+        $values['third_party_settings']['menu_ui']['available_menus'] = $this->input->getOption('menus-available');
+        $values['third_party_settings']['menu_ui']['parent'] = $this->input->getOption('menu-default-parent') ?? '';
+        $values['dependencies']['module'][] = 'menu_ui';
+    }
+
+    protected function askMenus(): array
+    {
+        $menus = menu_ui_get_menus();
+        $choices = ['_none' => '- None -'];
+
+        foreach ($menus as $name => $label) {
+            $label = $this->input->getOption('show-machine-names') ? $name : $label;
+            $choices[$name] = $label;
+        }
+
+        $question = (new ChoiceQuestion('Available menus', $choices, '_none'))
+            ->setMultiselect(true);
+
+        return array_filter(
+            $this->io()->askQuestion($question) ?: [],
+            function (string $value) {
+                return $value !== '_none';
+            }
+        );
+    }
+
+    protected function askDefaultParent(): string
+    {
+        $menus = $this->input->getOption('menus-available');
+        $menus = array_intersect_key(menu_ui_get_menus(), array_flip($menus));
+        $options = $this->menuParentFormSelector->getParentSelectOptions('', $menus);
+
+        return $this->io()->choice('Default parent item', $options, 1);
+    }
+
+    protected function isInstalled(): bool
+    {
+        return $this->moduleHandler->moduleExists('menu_ui');
+    }
+
+    protected function ensureOption(string $name, callable $asker, bool $required): void
+    {
+        $value = $this->input->getOption($name);
+
+        if ($value === null) {
+            $value = $asker();
+        }
+
+        if ($required && $value === null) {
+            throw new \InvalidArgumentException(dt('The %optionName option is required.', [
+                '%optionName' => $name,
+            ]));
+        }
+
+        $this->input->setOption($name, $value);
+    }
+}

--- a/src/Drupal/Commands/core/NodeTypeCreateCommands.php
+++ b/src/Drupal/Commands/core/NodeTypeCreateCommands.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\Events\CustomEventAwareInterface;
+use Consolidation\AnnotatedCommand\Events\CustomEventAwareTrait;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
+use Drupal\node\Entity\NodeType;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class NodeTypeCreateCommands extends DrushCommands implements CustomEventAwareInterface
+{
+    use BundleMachineNameAskTrait;
+    use CustomEventAwareTrait;
+
+    /** @var EntityTypeManagerInterface */
+    protected $entityTypeManager;
+    /** @var EntityFieldManagerInterface */
+    protected $entityFieldManager;
+
+    public function __construct(
+        EntityTypeManagerInterface $entityTypeManager,
+        EntityFieldManagerInterface $entityFieldManager
+    ) {
+        $this->entityTypeManager = $entityTypeManager;
+        $this->entityFieldManager = $entityFieldManager;
+    }
+
+    /**
+     * Create a new node type
+     *
+     * @command nodetype:create
+     * @aliases nodetype-create,ntc
+     *
+     * @option show-machine-names
+     *      Show machine names instead of labels in option lists.
+     *
+     * @option label
+     *      The human-readable name of this content type.
+     * @option machine-name
+     *      A unique machine-readable name for this content type. It must only contain
+     *      lowercase letters, numbers, and underscores.
+     * @option description
+     *      This text will be displayed on the Add new content page.
+     *
+     * @option title-label
+     *      The label of the title field
+     * @option preview-before-submit
+     *      Preview before submitting (disabled, optional or required)
+     * @option submission-guidelines
+     *      Explanation or submission guidelines. This text will be displayed at the top
+     *      of the page when creating or editing content of this type.
+     *
+     * @option status
+     *      The default value of the Published field
+     * @option promote
+     *      The default value of the Promoted to front page field
+     * @option sticky
+     *      The default value of the Sticky at top of lists field
+     * @option create-revision
+     *      The default value of the Create new revision field
+     *
+     * @option display-submitted
+     *      Display author username and publish date
+     *
+     * @usage drush nodetype:create
+     *      Create a node type by answering the prompts.
+     *
+     * @validate-module-enabled node
+     *
+     * @version 11.0
+     * @see \Drupal\node\NodeTypeForm
+     */
+    public function create(array $options = [
+        'label' => InputOption::VALUE_REQUIRED,
+        'machine-name' => InputOption::VALUE_REQUIRED,
+        'description' => InputOption::VALUE_OPTIONAL,
+        'title-label' => InputOption::VALUE_OPTIONAL,
+        'preview-before-submit' => InputOption::VALUE_OPTIONAL,
+        'submission-guidelines' => InputOption::VALUE_OPTIONAL,
+        'status' => InputOption::VALUE_OPTIONAL,
+        'promote' => InputOption::VALUE_OPTIONAL,
+        'sticky' => InputOption::VALUE_OPTIONAL,
+        'create-revision' => InputOption::VALUE_OPTIONAL,
+        'display-submitted' => InputOption::VALUE_OPTIONAL,
+        'show-machine-names' => InputOption::VALUE_OPTIONAL,
+    ]): void
+    {
+        $this->ensureOption('label', [$this, 'askLabel'], true);
+        $this->ensureOption('machine-name', [$this, 'askNodeTypeMachineName'], true);
+        $this->ensureOption('description', [$this, 'askDescription'], false);
+
+        // Submission form settings
+        $this->ensureOption('title-label', [$this, 'askSubmissionTitleLabel'], true);
+        $this->ensureOption('preview-before-submit', [$this, 'askSubmissionPreviewMode'], true);
+        $this->ensureOption('submission-guidelines', [$this, 'askSubmissionHelp'], false);
+
+        // Publishing options
+        $this->ensureOption('status', [$this, 'askPublished'], true);
+        $this->ensureOption('promote', [$this, 'askPromoted'], true);
+        $this->ensureOption('sticky', [$this, 'askSticky'], true);
+        $this->ensureOption('create-revision', [$this, 'askCreateRevision'], true);
+
+        // Display settings
+        $this->ensureOption('display-submitted', [$this, 'askDisplaySubmitted'], true);
+
+        // Command files may set additional options as desired.
+        $handlers = $this->getCustomEventHandlers('node-type-set-options');
+        foreach ($handlers as $handler) {
+            $handler($this->input);
+        }
+
+        $bundle = $this->input()->getOption('machine-name');
+        $definition = $this->entityTypeManager->getDefinition('node');
+        $storage = $this->entityTypeManager->getStorage('node_type');
+
+        $values = [
+            $definition->getKey('status') => true,
+            $definition->getKey('bundle') => $bundle,
+            'name' => $this->input()->getOption('label'),
+            'description' => $this->input()->getOption('description') ?? '',
+            'new_revision' => $this->input()->getOption('create-revision'),
+            'help' => $this->input()->getOption('submission-guidelines') ?? '',
+            'preview_mode' => $this->input()->getOption('preview-before-submit'),
+            'display_submitted' => $this->input()->getOption('display-submitted'),
+        ];
+
+        // Command files may customize $values as desired.
+        $handlers = $this->getCustomEventHandlers('nodetype-create');
+        foreach ($handlers as $handler) {
+            $handler($values);
+        }
+
+        $type = $storage->create($values);
+        $type->save();
+
+        // Update title field definition.
+        $fields = $this->entityFieldManager->getFieldDefinitions('node', $bundle);
+        $titleField = $fields['title'];
+        $titleLabel = $this->input()->getOption('title-label');
+
+        if ($titleLabel && $titleLabel !== $titleField->getLabel()) {
+            $titleField->getConfig($bundle)
+                ->setLabel($titleLabel)
+                ->save();
+        }
+
+        // Update workflow options
+        foreach (['status', 'promote', 'sticky'] as $fieldName) {
+            $node = $this->entityTypeManager->getStorage('node')->create(['type' => $bundle]);
+            $value = (bool) $this->input()->getOption($fieldName);
+
+            if ($node->get($fieldName)->value != $value) {
+                $fields[$fieldName]
+                    ->getConfig($bundle)
+                    ->setDefaultValue($value)
+                    ->save();
+            }
+        }
+
+        $this->entityTypeManager->clearCachedDefinitions();
+        $this->logResult($type);
+    }
+
+    protected function askNodeTypeMachineName(): string
+    {
+        return $this->askMachineName('node');
+    }
+
+    protected function askLabel(): string
+    {
+        return $this->io()->ask('Human-readable name', null, [static::class, 'validateRequired']);
+    }
+
+    protected function askDescription(): ?string
+    {
+        return $this->io()->ask('Description');
+    }
+
+    protected function askSubmissionTitleLabel(): string
+    {
+        return $this->io()->ask('Title field label', 'Title');
+    }
+
+    protected function askSubmissionPreviewMode(): int
+    {
+        $options = [
+            DRUPAL_DISABLED => dt('Disabled'),
+            DRUPAL_OPTIONAL => dt('Optional'),
+            DRUPAL_REQUIRED => dt('Required'),
+        ];
+
+        return $this->io()->choice('Preview before submitting', $options, DRUPAL_OPTIONAL);
+    }
+
+    protected function askSubmissionHelp(): ?string
+    {
+        return $this->io()->ask('Explanation or submission guidelines');
+    }
+
+    protected function askPublished(): bool
+    {
+        return $this->io()->confirm('Published', true);
+    }
+
+    protected function askPromoted(): bool
+    {
+        return $this->io()->confirm('Promoted to front page', true);
+    }
+
+    protected function askSticky(): bool
+    {
+        return $this->io()->confirm('Sticky at top of lists', false);
+    }
+
+    protected function askCreateRevision(): bool
+    {
+        return $this->io()->confirm('Create new revision', true);
+    }
+
+    protected function askDisplaySubmitted(): bool
+    {
+        return $this->io()->confirm('Display author and date information', true);
+    }
+
+    protected function ensureOption(string $name, callable $asker, bool $required): void
+    {
+        $value = $this->input->getOption($name);
+
+        if ($value === null) {
+            $value = $asker();
+        }
+
+        if ($required && $value === null) {
+            throw new \InvalidArgumentException(dt('The %optionName option is required.', [
+                '%optionName' => $name,
+            ]));
+        }
+
+        $this->input->setOption($name, $value);
+    }
+
+    protected function logResult(NodeType $type): void
+    {
+        $this->logger()->success(
+            sprintf('Successfully created node type with bundle \'%s\'', $type->id())
+        );
+
+        $this->logger()->success(
+            'Further customisation can be done at the following url:'
+            . PHP_EOL
+            . Url::fromRoute('entity.node_type.edit_form', ['node_type' => $type->id()])
+                ->setAbsolute(true)
+                ->toString()
+        );
+    }
+
+    public static function validateRequired(?string $value): string
+    {
+        // FALSE is not considered as empty value because question helper use
+        // it as negative answer on confirmation questions.
+        if ($value === null || $value === '') {
+            throw new \UnexpectedValueException('This value is required.');
+        }
+
+        return $value;
+    }
+}

--- a/src/Drupal/Commands/core/VocabularyCreateCommands.php
+++ b/src/Drupal/Commands/core/VocabularyCreateCommands.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+use Consolidation\AnnotatedCommand\AnnotationData;
+use Consolidation\AnnotatedCommand\Events\CustomEventAwareInterface;
+use Consolidation\AnnotatedCommand\Events\CustomEventAwareTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Url;
+use Drupal\language\Entity\ContentLanguageSettings;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drush\Commands\DrushCommands;
+use Drush\Drupal\Commands\core\BundleMachineNameAskTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class VocabularyCreateCommands extends DrushCommands implements CustomEventAwareInterface
+{
+    use BundleMachineNameAskTrait;
+    use CustomEventAwareTrait;
+
+    /** @var EntityTypeManagerInterface */
+    protected $entityTypeManager;
+
+    public function __construct(
+        EntityTypeManagerInterface $entityTypeManager
+    ) {
+        $this->entityTypeManager = $entityTypeManager;
+    }
+
+    /**
+     * Create a new vocabulary
+     *
+     * @command vocabulary:create
+     * @aliases vocabulary-create,vc
+     *
+     * @option label
+     *      The human-readable name of this vocabulary.
+     * @option machine-name
+     *      A unique machine-readable name. Can only contain lowercase letters, numbers, and underscores.
+     * @option description
+     *      Describe this vocabulary.
+     *
+     * @option show-machine-names
+     *      Show machine names instead of labels in option lists.
+     *
+     * @usage drush vocabulary:create
+     *      Create a taxonomy vocabulary by answering the prompts.
+     *
+     * @validate-module-enabled taxonomy
+     *
+     * @version 11.0
+     * @see \Drupal\taxonomy\VocabularyForm
+     */
+    public function create(array $options = [
+        'label' => InputOption::VALUE_REQUIRED,
+        'machine-name' => InputOption::VALUE_REQUIRED,
+        'description' => InputOption::VALUE_OPTIONAL,
+        'show-machine-names' => InputOption::VALUE_OPTIONAL,
+    ]): void
+    {
+        $this->ensureOption('label', [$this, 'askLabel'], true);
+        $this->ensureOption('machine-name', [$this, 'askVocabularyMachineName'], true);
+        $this->ensureOption('description', [$this, 'askDescription'], false);
+
+        // Command files may set additional options as desired.
+        $handlers = $this->getCustomEventHandlers('vocabulary-set-options');
+        foreach ($handlers as $handler) {
+            $handler($this->input);
+        }
+
+        $bundle = $this->input->getOption('machine-name');
+        $definition = $this->entityTypeManager->getDefinition('taxonomy_term');
+        $storage = $this->entityTypeManager->getStorage('taxonomy_vocabulary');
+
+        $values = [
+            $definition->getKey('bundle') => $bundle,
+            'status' => true,
+            'name' => $this->input()->getOption('label'),
+            'description' => $this->input()->getOption('description') ?? '',
+            'hierarchy' => 0,
+            'weight' => 0,
+        ];
+
+        // Command files may customize $values as desired.
+        $handlers = $this->getCustomEventHandlers('vocabulary-create');
+        foreach ($handlers as $handler) {
+            $handler($values);
+        }
+
+        $type = $storage->create($values);
+        $type->save();
+
+        $this->entityTypeManager->clearCachedDefinitions();
+        $this->logResult($type);
+    }
+
+    protected function askVocabularyMachineName(): string
+    {
+        return $this->askMachineName('taxonomy_vocabulary');
+    }
+
+    protected function askLabel(): string
+    {
+        return $this->io()->ask('Human-readable name', null, [static::class, 'validateRequired']);
+    }
+
+    protected function askDescription(): ?string
+    {
+        return $this->io()->ask('Description');
+    }
+
+    protected function ensureOption(string $name, callable $asker, bool $required): void
+    {
+        $value = $this->input->getOption($name);
+
+        if ($value === null) {
+            $value = $asker();
+        }
+
+        if ($required && $value === null) {
+            throw new \InvalidArgumentException(dt('The %optionName option is required.', [
+                '%optionName' => $name,
+            ]));
+        }
+
+        $this->input->setOption($name, $value);
+    }
+
+    protected function logResult(Vocabulary $type): void
+    {
+        $this->logger()->success(
+            sprintf("Successfully created vocabulary with bundle '%s'", $type->id())
+        );
+
+        $this->logger()->success(
+            'Further customisation can be done at the following url:'
+            . PHP_EOL
+            . Url::fromRoute('entity.taxonomy_vocabulary.edit_form', ['taxonomy_vocabulary' => $type->id()])
+                ->setAbsolute(true)
+                ->toString()
+        );
+    }
+
+    public static function validateRequired(?string $value): string
+    {
+        // FALSE is not considered as empty value because question helper use
+        // it as negative answer on confirmation questions.
+        if ($value === null || $value === '') {
+            throw new \UnexpectedValueException('This value is required.');
+        }
+
+        return $value;
+    }
+}

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -105,6 +105,12 @@ services:
     arguments: ['@config.factory', '@module_handler', '@entity_type.manager', '@renderer']
     tags:
       -  { name: drush.command }
+  vocabulary-create.commands:
+    class: \Drush\Drupal\Commands\core\VocabularyCreateCommands
+    arguments:
+      - '@entity_type.manager'
+    tags:
+      -  { name: drush.command }
   watchdog.commands:
     class: \Drush\Drupal\Commands\core\WatchdogCommands
     tags:

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -40,9 +40,23 @@ services:
     arguments: ['@language_manager', '@module_handler']
     tags:
       -  { name: drush.command }
+  language.hooks:
+    class: \Drush\Drupal\Commands\core\LanguageHooks
+    arguments:
+      - '@module_handler'
+      - '@language_manager'
+    tags:
+      - { name: drush.command }
   locale.commands:
     class: \Drush\Drupal\Commands\core\LocaleCommands
     arguments: ['@language_manager', '@config.factory', '@module_handler', '@state']
+    tags:
+      -  { name: drush.command }
+  menu_ui.hooks:
+    class: \Drush\Drupal\Commands\core\MenuUiHooks
+    arguments:
+      - '@module_handler'
+      - '@menu.parent_form_selector'
     tags:
       -  { name: drush.command }
   messenger.commands:
@@ -53,6 +67,13 @@ services:
   migrate_runner.commands:
     class: Drush\Drupal\Commands\core\MigrateRunnerCommands
     arguments: ['@date.formatter', '@keyvalue']
+    tags:
+      -  { name: drush.command }
+  nodetype-create.commands:
+    class: \Drush\Drupal\Commands\core\NodeTypeCreateCommands
+    arguments:
+      - '@entity_type.manager'
+      - '@entity_field.manager'
     tags:
       -  { name: drush.command }
   queue.commands:


### PR DESCRIPTION
This PR adds two commands, one to create a node type (bundle) and another to create a vocabulary (taxonomy bundle). It has already been used in multiple projects as part of the [wmscaffold module](https://github.com/wieni/wmscaffold) and is in my opinion stable enough to be considered to be merged in Drush.

## Test scenarios
### `nodetype:create`
- `./vendor/bin/drush nodetype:create` => Asks for _Human-readable name_.
- `./vendor/bin/drush nodetype:create --no-interaction` => _The label option is required._
- `./vendor/bin/drush nodetype:create --no-interaction --label=Article --machine-name=article` => _Successfully created node type with bundle 'article'_, if bundle already exists _'node_type' entity with ID 'article' already exists._
- `./vendor/bin/drush nodetype:create --no-interaction --label=Article --machine-name=article --menus-available=admin,main` => _Successfully created node type with bundle 'article'_, if menu_ui module is not installed _The "--menus-available" option does not exist._
- `./vendor/bin/drush nodetype:create --no-interaction --label=Article --machine-name=article --default-language=site_default` => _Successfully created node type with bundle 'article'_, if language module is not installed _The "--default-language" option does not exist._

### `vocabulary:create`
- `./vendor/bin/drush vocabulary:create` => Asks for _Human-readable name_.
- `./vendor/bin/drush vocabulary:create --no-interaction` => _The label option is required._
- `./vendor/bin/drush vocabulary:create --no-interaction --label=Tag --machine-name=tag` => _Successfully created vocabulary with bundle 'tag'_, if bundle already exists _'taxonomy_vocabulary' entity with ID 'tag' already exists._
- `./vendor/bin/drush vocabulary:create --no-interaction --label=Tag --machine-name=tag --default-language=site_default` => _Successfully created vocabulary with bundle 'tag'_, if language module is not installed _The "--default-language" option does not exist._

## TODO
- [ ] Add tests