### PR TITLE
Add askRequired helper to DrushStyle

### DIFF
--- a/src/Drupal/Commands/field/FieldCreateCommands.php
+++ b/src/Drupal/Commands/field/FieldCreateCommands.php
@@ -248,7 +248,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         }
 
         while (!$fieldName) {
-            $answer = $this->io()->ask('Field name', $machineName, [static::class, 'validateRequired']);
+            $answer = $this->io()->ask('Field name', $machineName);
 
             if (!preg_match('/^[_a-z]+[_a-z0-9]*$/', $answer)) {
                 $this->logger()->error('Only lowercase alphanumeric characters and underscores are allowed, and only lowercase letters and underscore are allowed as the first character.');
@@ -273,7 +273,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
 
     protected function askFieldLabel(): string
     {
-        return $this->io()->ask('Field label', null, [static::class, 'validateRequired']);
+        return $this->io()->askRequired('Field label');
     }
 
     protected function askFieldDescription(): ?string
@@ -645,16 +645,5 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         }
 
         $this->input->setOption($name, $value);
-    }
-
-    public static function validateRequired(?string $value): string
-    {
-        // FALSE is not considered as empty value because question helper use
-        // it as negative answer on confirmation questions.
-        if ($value === null || $value === '') {
-            throw new \UnexpectedValueException('This value is required.');
-        }
-
-        return $value;
     }
 }

--- a/src/Style/DrushStyle.php
+++ b/src/Style/DrushStyle.php
@@ -4,6 +4,7 @@ namespace Drush\Style;
 
 use Drush\Drush;
 use Drush\Exceptions\UserAbortException;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 class DrushStyle extends SymfonyStyle
@@ -46,5 +47,24 @@ class DrushStyle extends SymfonyStyle
     public function caution($message)
     {
         $this->block($message, 'CAUTION', 'fg=black;bg=yellow', ' ! ', true);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function askRequired($question)
+    {
+        $question = new Question($question);
+        $question->setValidator(function (?string $value) {
+            // FALSE is not considered as empty value because question helper use
+            // it as negative answer on confirmation questions.
+            if ($value === null || $value === '') {
+                throw new \UnexpectedValueException('This value is required.');
+            }
+
+            return $value;
+        });
+
+        return $this->askQuestion($question);
     }
 }


### PR DESCRIPTION
Symfony doesn't provide a simple way to make a question required, if you want to do so you have to create a validator callback. Having to write this for multiple commands causes a lot of boilerplate, which is why I propose adding this method to DrushStyle.

So far there's only 1 use case in Drush core, but I have more use cases in contrib projects.