### PR TITLE
Fix default value of the field:create cardinality option

### DIFF
--- a/src/Drupal/Commands/field/FieldCreateCommands.php
+++ b/src/Drupal/Commands/field/FieldCreateCommands.php
@@ -346,7 +346,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         $cardinality = $this->io()->choice(
             'Allowed number of values',
             array_combine($choices, $choices),
-            1
+            0
         );
 
         $limit = FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED;


### PR DESCRIPTION
Since the Cancel option is removed from choice lists (#4907), the numerical indexes changed. Commands that use an indexed array for options and that have a default value will have to update that default value. I haven't found another occurrence of this issue in Drush core.