### PR TITLE
Fix PHP 8.1 deprecation notice

### DIFF
--- a/src/Drupal/DrupalKernelTrait.php
+++ b/src/Drupal/DrupalKernelTrait.php
@@ -206,7 +206,7 @@ trait DrupalKernelTrait
      */
     protected function addDrushServiceProvider($serviceProviderName, $serviceYmlPath = '')
     {
-        if ($serviceYmlPath !== null && file_exists($serviceYmlPath)) {
+        if (($serviceYmlPath !== null) && file_exists($serviceYmlPath)) {
             $this->serviceYamls['app'][$serviceProviderName] = $serviceYmlPath;
         }
     }

--- a/src/Drupal/DrupalKernelTrait.php
+++ b/src/Drupal/DrupalKernelTrait.php
@@ -206,7 +206,7 @@ trait DrupalKernelTrait
      */
     protected function addDrushServiceProvider($serviceProviderName, $serviceYmlPath = '')
     {
-        if (file_exists($serviceYmlPath)) {
+        if ($serviceYmlPath !== null && file_exists($serviceYmlPath)) {
             $this->serviceYamls['app'][$serviceProviderName] = $serviceYmlPath;
         }
     }


### PR DESCRIPTION
This notice appears for me when uninstalling a module through a `drush cim`, using PHP 8.1.

```
 [error]  Message: /Deprecated function/: file_exists(): Passing null to parameter #1
($filename) of type string is deprecated in
/Drush\Drupal\DrupalKernel->addDrushServiceProvider()/ (line /209/ of
//Users/dieterholvoet/Projects/sites/whathappens/vendor/drush/drush/src/Drupal/DrupalKernelTrait.php/).
Drush\Drupal\DrupalKernel->addDrushServiceProvider('_drush.minimal', NULL)
(Line: 132)
Drush\Drupal\DrupalKernel->addModuleDrushServiceProvider('minimal',
'core/profiles/minimal/minimal.info.yml') (Line: 121)
Drush\Drupal\DrupalKernel->discoverServiceProviders() (Line: 1305)
Drupal\Core\DrupalKernel->initializeServiceProviders() (Line: 1211)
Drupal\Core\DrupalKernel->compileContainer() (Line: 900)
Drupal\Core\DrupalKernel->initializeContainer() (Line: 70)
Drush\Drupal\DrupalKernel->initializeContainer() (Line: 821)
Drupal\Core\DrupalKernel->updateModules(Array, Array) (Line: 617)
Drupal\Core\Extension\ModuleInstaller->updateKernel(Array) (Line: 527)
Drupal\Core\Extension\ModuleInstaller->uninstall(Array, ) (Line: 91)
Drupal\Core\ProxyClass\Extension\ModuleInstaller->uninstall(Array, ) (Line:
808)
Drupal\Core\Config\ConfigImporter->processExtension('module', 'uninstall',
'ckeditor5') (Line: 572)
Drupal\Core\Config\ConfigImporter->processExtensions(Array) (Line: 509)
Drupal\Core\Config\ConfigImporter->doSyncStep('processExtensions', Array)
(Line: 295)
Drush\Drupal\Commands\config\ConfigImportCommands->doImport(Object) (Line:
206)
drush_call_user_func_array(Array, Array) (Line: 197)
drush_op(Array, Object) (Line: 266)
Drush\Drupal\Commands\config\ConfigImportCommands->import(Array)
call_user_func_array(Array, Array) (Line: 257)
Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array,
Object) (Line: 212)
Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array,
Array, Object) (Line: 176)
Consolidation\AnnotatedCommand\CommandProcessor->process(Object, Array,
Array, Object) (Line: 350)
Consolidation\AnnotatedCommand\AnnotatedCommand->execute(Object, Object)
(Line: 255)
Symfony\Component\Console\Command\Command->run(Object, Object) (Line: 1027)
Symfony\Component\Console\Application->doRunCommand(Object, Object, Object)
(Line: 273)
Symfony\Component\Console\Application->doRun(Object, Object) (Line: 149)
Symfony\Component\Console\Application->run(Object, Object) (Line: 118)
Drush\Runtime\Runtime->doRun(Array, Object) (Line: 48)
Drush\Runtime\Runtime->run(Array) (Line: 72)
require('/Users/dieterholvoet/Projects/sites/whathappens/vendor/drush/drush/drush.php')
(Line: 4)
```