### PR TITLE
Use non-interactive for composer in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,13 @@ test_74_steps: &test74steps
   steps:
     - checkout
     - run: cp .docker/zz-php.ini /usr/local/etc/php/conf.d/
-    - run: composer install -n
+    - run: composer -n install
     - run: mkdir -p /tmp/results
-    - run: composer lint
-    - run: composer unit -- --log-junit /tmp/results/unit.junit.xml
-    - run: composer functional -- --log-junit /tmp/results/functional.junit.xml
+    - run: composer -n lint
+    - run: composer -n unit -- --log-junit /tmp/results/unit.junit.xml
+    - run: composer -n functional -- --log-junit /tmp/results/functional.junit.xml
     # @todo was getting missing key_value table failure when this comes before functional. See https://circleci.com/gh/drush-ops/drush/8828.
-    - run: composer integration -- --log-junit /tmp/results/integration.junit.xml
+    - run: composer -n integration -- --log-junit /tmp/results/integration.junit.xml
     - store_test_results:
         path: /tmp/results
     - store_artifacts:
@@ -42,8 +42,8 @@ jobs:
     steps:
       - checkout
       - run: cp .docker/zz-php.ini /usr/local/etc/php/conf.d/
-      - run: composer install -n
-      - run: composer cs
+      - run: composer -n install
+      - run: composer -n cs
 
   # Mergeable test:
   #   FAIL if merging test branch with 11.x produces conflicts
@@ -101,11 +101,11 @@ jobs:
     steps:
       - checkout
       - run: cp .docker/zz-php.ini /usr/local/etc/php/conf.d/
-      - run: composer require --dev drupal/core-recommended:9.2.8 --no-update
-      - run: composer require symfony/polyfill-php80:"1.23 as 1.20" --no-update
+      - run: composer -n require --dev drupal/core-recommended:9.2.8 --no-update
+      - run: composer -n require symfony/polyfill-php80:"1.23 as 1.20" --no-update
       - run: php --version
-      - run: composer update
-      - run: composer phpunit -- --testsuite integration --filter=testInsecureDrupalPackage --stop-on-skipped
+      - run: composer -n update
+      - run: composer -n phpunit -- --testsuite integration --filter=testInsecureDrupalPackage --stop-on-skipped
 
   # PHP 8 test with Drupal tip
   #   Determines whether a newer version of a dependency has broken Drush.
@@ -121,14 +121,14 @@ jobs:
       - checkout
       - run: cp .docker/zz-php.ini /usr/local/etc/php/conf.d/
       - run: php --version
-      - run: composer config platform.php --unset
-      - run: composer require --dev drupal/core-recommended:9.4.x-dev --no-update
-      - run: composer update
+      - run: composer -n config platform.php --unset
+      - run: composer -n require --dev drupal/core-recommended:9.4.x-dev --no-update
+      - run: composer -n update
       - run: mkdir -p /tmp/results
-      - run: composer lint
-      - run: composer unit -- --log-junit /tmp/results/unit.junit.xml
-      - run: composer functional -- --log-junit /tmp/results/functional.junit.xml
-      - run: composer integration -- --log-junit /tmp/results/integration.junit.xml
+      - run: composer -n lint
+      - run: composer -n unit -- --log-junit /tmp/results/unit.junit.xml
+      - run: composer -n functional -- --log-junit /tmp/results/functional.junit.xml
+      - run: composer -n integration -- --log-junit /tmp/results/integration.junit.xml
       - store_test_results:
           path: /tmp/results
       - store_artifacts:

--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,9 @@
     "files": ["tests/load.environment.php"]
   },
   "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+    },
     "optimize-autoloader": true,
     "preferred-install": "dist",
     "sort-packages": true,

--- a/src/Commands/core/RunserverCommands.php
+++ b/src/Commands/core/RunserverCommands.php
@@ -119,12 +119,12 @@ class RunserverCommands extends DrushCommands
     /**
      * Parse a URI or partial URI (including just a port, host IP or path).
      *
-     * @param string $uri
+     * @param $uri
      *   String that can contain partial URI.
      *
      *   URI array as returned by parse_url.
      */
-    public function parseUri(string $uri): array
+    public function parseUri(?string $uri): array
     {
         if (empty($uri)) {
             return [];

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -107,7 +107,7 @@ class MigrateRunnerCommands extends DrushCommands
      *   unprocessed: Unprocessed
      *   last_imported: Last Imported
      * @default-fields id,status,total,imported,unprocessed,last_imported
-     *
+     * @filter-default-field status
      * @return RowsOfFields
      *   Migrations status formatted as table.
      * @version 10.4


### PR DESCRIPTION
- Add --filter option to migrate:status
- Fixes #5015. Nullable string type hint on runserver's parseUri().
- Use non-interactive for composer in CI
