### PR TITLE
Enable custom Logger(s).

### DIFF
--- a/src/Commands/DrushCommands.php
+++ b/src/Commands/DrushCommands.php
@@ -2,6 +2,7 @@
 
 namespace Drush\Commands;
 
+use Drush\Log\DrushLoggerManager;
 use Drush\Log\Logger;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Consolidation\AnnotatedCommand\CommandData;
@@ -63,7 +64,7 @@ abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, 
     /**
      * Returns a logger object.
      */
-    protected function logger(): ?Logger
+    protected function logger(): ?DrushLoggerManager
     {
         return $this->logger;
     }

--- a/src/Log/DrushLoggerManager.php
+++ b/src/Log/DrushLoggerManager.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drush\Log;
+
+use Consolidation\Log\ConsoleLogLevel;
+use Consolidation\Log\LoggerManager;
+
+class DrushLoggerManager extends LoggerManager implements SuccessInterface
+{
+    public function success(string $message, array $context = array())
+    {
+        $this->log(ConsoleLogLevel::SUCCESS, $message, $context);
+    }
+}

--- a/src/Log/Logger.php
+++ b/src/Log/Logger.php
@@ -20,12 +20,11 @@
 
 namespace Drush\Log;
 
-use Consolidation\Log\ConsoleLogLevel;
 use Drush\Drush;
 use Robo\Log\RoboLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Logger extends RoboLogger implements SuccessInterface
+class Logger extends RoboLogger
 {
     public function __construct(OutputInterface $output)
     {
@@ -72,10 +71,5 @@ class Logger extends RoboLogger implements SuccessInterface
             }
             return str_replace('@size', round($size, 2), $unit);
         }
-    }
-
-    public function success($message, array $context = array())
-    {
-        $this->log(ConsoleLogLevel::SUCCESS, $message, $context);
     }
 }

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -99,12 +99,6 @@ class Runtime
             $this->preflight->aliasManager()
         );
 
-//        Just as an example of a custom logger.
-//        $loggerManager = $container->get('logger');
-//        $verbosityLevelMap = [ConsoleLogLevel::SUCCESS => OutputInterface::VERBOSITY_NORMAL];
-//        $formatLevelMap = [ConsoleLogLevel::SUCCESS => LogLevel::INFO];
-//        $loggerManager->reset()->add('foo', new ConsoleLogger($output, $verbosityLevelMap, $formatLevelMap));
-
         // Our termination handlers are set up via dependency injection,
         // as they require classes that are set up in the DI container.
         // We therefore cannot configure them any earlier than this.

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -2,11 +2,15 @@
 
 namespace Drush\Runtime;
 
+use Consolidation\Log\ConsoleLogLevel;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Drush\Application;
 use Drush\Commands\DrushCommands;
 use Drush\Drush;
 use Drush\Preflight\Preflight;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Control the Drush runtime environment
@@ -94,6 +98,12 @@ class Runtime
             $this->preflight->drupalFinder(),
             $this->preflight->aliasManager()
         );
+
+        // Just as an example of a custom logger.
+        $loggerManager = $container->get('logger');
+        $verbosityLevelMap = [ConsoleLogLevel::SUCCESS => OutputInterface::VERBOSITY_NORMAL];
+        $formatLevelMap = [ConsoleLogLevel::SUCCESS => LogLevel::INFO];
+        $loggerManager->reset()->add('foo', new ConsoleLogger($output, $verbosityLevelMap, $formatLevelMap));
 
         // Our termination handlers are set up via dependency injection,
         // as they require classes that are set up in the DI container.

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -2,15 +2,11 @@
 
 namespace Drush\Runtime;
 
-use Consolidation\Log\ConsoleLogLevel;
-use Psr\Log\LogLevel;
-use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Drush\Application;
 use Drush\Commands\DrushCommands;
 use Drush\Drush;
 use Drush\Preflight\Preflight;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Control the Drush runtime environment

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -99,11 +99,11 @@ class Runtime
             $this->preflight->aliasManager()
         );
 
-        // Just as an example of a custom logger.
-        $loggerManager = $container->get('logger');
-        $verbosityLevelMap = [ConsoleLogLevel::SUCCESS => OutputInterface::VERBOSITY_NORMAL];
-        $formatLevelMap = [ConsoleLogLevel::SUCCESS => LogLevel::INFO];
-        $loggerManager->reset()->add('foo', new ConsoleLogger($output, $verbosityLevelMap, $formatLevelMap));
+//        Just as an example of a custom logger.
+//        $loggerManager = $container->get('logger');
+//        $verbosityLevelMap = [ConsoleLogLevel::SUCCESS => OutputInterface::VERBOSITY_NORMAL];
+//        $formatLevelMap = [ConsoleLogLevel::SUCCESS => LogLevel::INFO];
+//        $loggerManager->reset()->add('foo', new ConsoleLogger($output, $verbosityLevelMap, $formatLevelMap));
 
         // Our termination handlers are set up via dependency injection,
         // as they require classes that are set up in the DI container.

--- a/sut/drush/Commands/SimpleSutCommands.php
+++ b/sut/drush/Commands/SimpleSutCommands.php
@@ -5,8 +5,12 @@ use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareInterface;
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareTrait;
+use Consolidation\Log\ConsoleLogLevel;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Drush\Drush;
+use Drush\Symfony\DrushArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Drush\Commands\DrushCommands;
@@ -30,4 +34,23 @@ class SimpleSutCommands extends DrushCommands
     {
         $this->logger()->notice(dt("This is an example site-wide command committed to the repository in the SUT inside of the 'drush/Commands' directory."));
     }
+
+    /**
+     * Replace Drush logger with a custom one.
+     *
+     * In a real-world implementation, you would likely use `@hook *` instead of `@hook sut:simple`.
+     *
+     * @hook init sut:simple
+     */
+    public function customLogger(DrushArgvInput $argv, AnnotationData $annotationData): void
+    {
+        $verbosityLevelMap = [ConsoleLogLevel::SUCCESS => OutputInterface::VERBOSITY_NORMAL];
+        $formatLevelMap = [ConsoleLogLevel::SUCCESS => \Psr\Log\LogLevel::INFO];
+        // One could use Monolog if desired.
+        // Drush expects custom loggers to log to stderr.
+        $newLogger = new ConsoleLogger(Drush::output(), $verbosityLevelMap, $formatLevelMap);
+        $drushLoggerManager = $this->logger();
+        $drushLoggerManager->reset()->add('foo', $newLogger);
+    }
 }
+

--- a/sut/drush/Commands/SimpleSutCommands.php
+++ b/sut/drush/Commands/SimpleSutCommands.php
@@ -25,7 +25,7 @@ use Drush\Utils\StringUtils;
 class SimpleSutCommands extends DrushCommands
 {
     /**
-     * Show a fabulous picture.
+     * Show a message.
      *
      * @command sut:simple
      * @hidden
@@ -47,7 +47,7 @@ class SimpleSutCommands extends DrushCommands
         $verbosityLevelMap = [ConsoleLogLevel::SUCCESS => OutputInterface::VERBOSITY_NORMAL];
         $formatLevelMap = [ConsoleLogLevel::SUCCESS => \Psr\Log\LogLevel::INFO];
         // One could use Monolog if desired.
-        // Drush expects custom loggers to log to stderr.
+        // Drush expects custom loggers to always write to stderr, so dont use ConsoleLogger directly,
         $newLogger = new ConsoleLogger(Drush::output(), $verbosityLevelMap, $formatLevelMap);
         $drushLoggerManager = $this->logger();
         $drushLoggerManager->reset()->add('foo', $newLogger);

--- a/tests/integration/CustomLoggerTest.php
+++ b/tests/integration/CustomLoggerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Unish;
+
+class CustomLoggerTest extends UnishIntegrationTestCase
+{
+    public function testCustomLogger()
+    {
+        // Uses standard Drush logger.
+        $this->drush('version', [], ['debug' => true]);
+        $this->assertStringContainsString('sec', $this->getErrorOutputRaw());
+
+        // sut:simple has been hooked so that a custom logger is use. It doesn't show timing information during --debug.
+        $this->drush('sut:simple', [], ['debug' => true, 'simulate' => true]);
+        $this->assertStringNotContainsString('sec', $this->getOutput());
+    }
+}


### PR DESCRIPTION
Refs #4422 and implements the suggestion at https://github.com/consolidation/log/issues/20#issuecomment-1008483330. DrushLoggerManager is a slightly customized version of the Consolidation/Log/LoggerManager.

The changes in Runtime.php illustrate my guess as to when and how a site would swap a custom Logger for Drush's. I think that we could refactor our front controller (i.e. [$runtime->run()](https://github.com/drush-ops/drush/blob/77cb2ef52fcc58c6c9ce248c3655a5b4c9f8c06a/drush.php#L72)) such that a site could replace that controller with one that swaps in own Logger. Is that a promising way to go?