### PR TITLE
drush core:status no longer works in Drush 11 with non-core db drivers

### DIFF
--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -111,6 +111,7 @@ abstract class SqlBase implements ConfigAwareInterface
             $instance->setConfig(Drush::config());
             return $instance;
         }
+        return null;
     }
 
     /*


### PR DESCRIPTION
`drush core:status` worked in Drush 10 with a non-core db driver, but on Drush 11 it fails with

`TypeError: Drush\Sql\SqlBase::getInstance(): Return value must be of type ?Drush\Sql\SqlBase, none returned in Drush\Sql\SqlBase::getInstance() (line 114 of /home/runner/work/drudbal/drudbal/vendor/drush/drush/src/Sql/SqlBase.php).`

This seems due to introduced return typehinting in the `getInstance()` method. It is set to `?self` but if the driver class is missing there is no return stament called hence the TypeError.