### PR TITLE
Remove grasmash/yaml-expander as it is not used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
     "consolidation/site-alias": "^3.1.3",
     "consolidation/site-process": "^4",
     "enlightn/security-checker": "^1",
-    "grasmash/yaml-expander": "^1.1.1",
     "guzzlehttp/guzzle": "^6.3 || ^7.0",
     "league/container": "^3.4",
     "psr/log": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7278bfee8f4740f6d4197054d6443858",
+    "content-hash": "ae1eb0419aef16c09a7f6ec6c34b0051",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",
@@ -920,58 +920,6 @@
                 "source": "https://github.com/grasmash/expander/tree/master"
             },
             "time": "2017-12-21T22:14:55+00:00"
-        },
-        {
-            "name": "grasmash/yaml-expander",
-            "version": "1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/grasmash/yaml-expander.git",
-                "reference": "3f0f6001ae707a24f4d9733958d77d92bf9693b1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/grasmash/yaml-expander/zipball/3f0f6001ae707a24f4d9733958d77d92bf9693b1",
-                "reference": "3f0f6001ae707a24f4d9733958d77d92bf9693b1",
-                "shasum": ""
-            },
-            "require": {
-                "dflydev/dot-access-data": "^1.1.0",
-                "php": ">=5.4",
-                "symfony/yaml": "^2.8.11|^3|^4"
-            },
-            "require-dev": {
-                "greg-1-anderson/composer-test-scenarios": "^1",
-                "phpunit/phpunit": "^4.8|^5.5.4",
-                "satooshi/php-coveralls": "^1.0.2|dev-master",
-                "squizlabs/php_codesniffer": "^2.7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Grasmash\\YamlExpander\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Matthew Grasmick"
-                }
-            ],
-            "description": "Expands internal property references in a yaml file.",
-            "support": {
-                "issues": "https://github.com/grasmash/yaml-expander/issues",
-                "source": "https://github.com/grasmash/yaml-expander/tree/master"
-            },
-            "time": "2017-12-16T16:06:03+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -8771,5 +8719,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Necessary for drush to work on Drupal 10.0.x

```
$ composer require drush/drush 11.x-dev

Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - grasmash/yaml-expander[1.1.1, ..., 1.2.0] require symfony/yaml ^2.8.11|^3 -> found symfony/yaml[v2.8.11, ..., 2.8.x-dev, v3.0.0-BETA1, ..., 3.4.x-dev] but the package is fixed to v5.4.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - grasmash/yaml-expander[1.3.0, ..., 1.x-dev] require symfony/yaml ^2.8.11|^3|^4 -> found symfony/yaml[v2.8.11, ..., 2.8.x-dev, v3.0.0-BETA1, ..., 3.4.x-dev, v4.0.0-BETA1, ..., 4.4.x-dev] but the package is fixed to v5.4.2 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - drush/drush 11.x-dev requires grasmash/yaml-expander ^1.1.1 -> satisfiable by grasmash/yaml-expander[1.1.1, ..., 1.x-dev].
    - Root composer.json requires drush/drush 11.x-dev -> satisfiable by drush/drush[11.x-dev].

```