### PR TITLE
Simplify compatiblity matrix now that Drupal 8 is EOL.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -23,56 +23,56 @@ Drupal Compatibility
     <th rowspan="2"> End Of Life </th>
     <th colspan="5"> Drupal versions </th>
   </tr>
-    <th>7</th> <th>-8.3</th> <th>8.4+</th> <th>9</th>
+    <th>7</th> <th>8</th> <th>9</th>
   </tr>
   <tr>
     <td> Drush 11 </td>
     <td> 7.4+ </td>
     <!-- TBD -->
     <td> TBD </td>
-    <td></td> <td></td> <td></td> <td><b>✅</b></td>
+    <td></td> <td></td> <td><b>✅</b></td>
   </tr>
   <tr>
     <td> Drush 10 </td>
     <td> 7.1+ </td>
     <!-- Released Oct 2019 -->
     <td> Jan 2022 </td>
-    <td></td> <td></td> <td>✓</td> <td><b>✓</b></td>
+    <td></td> <td>✓</td> <td><b>✓</b></td>
   </tr>
   <tr>
     <td> Drush 9 </td>
     <td> 5.6+ </td>
     <!-- Released Jan 2018 -->
     <td> May 2020 </td>
-    <td></td> <td></td> <td>✓</td> <td></td>
+    <td></td> <td>✓</td> <td></td>
   </tr>
   <tr>
     <td> Drush 8 </td>
     <td> 5.4.5+ </td>
     <!-- Released Nov 2015 -->
     <td> Nov 2022 </td>
-    <td>✅</td> <td>✅</td> <td><b>⚠️</b></td> <td></td>
+    <td>✅</td> <td><b>⚠️</b></td> <td></td>
   </tr>
   <tr>
     <td> Drush 7 </td>
     <td> 5.3.0+ </td>
     <!-- Released May 2015 -->
     <td> Jul 2017 </td>
-    <td>✓</td> <td></td> <td></td> <td></td>
+    <td>✓</td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 6 </td>
     <td> 5.3.0+ </td>
     <!-- Released Aug 2013 -->
     <td> Dec 2015 </td>
-    <td>✓</td> <td></td> <td></td> <td></td>
+    <td>✓</td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 5 </td>
     <td> 5.2.0+ </td>
     <!-- Released March 2012 -->
     <td> May 2015 </td>
-    <td>✓</td> <td></td> <td></td> <td></td>
+    <td>✓</td> <td></td> <td></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Since Drupal 8 is EOL and Drupal 8.0 through 8.3 are now very very old, there seems to be little reason to make fine distinctions between Symfony 2 and Symfony 3 in the support matrix. Unless we are concerned about frustrating users trying to reconfigure Drupal 8.2 installations to work with unsupported Drush versions, we might as well clean up the table and make it a bit easier to read.