### PR TITLE
Return values instead of keys in discoverCommandsFromConfiguration.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -351,7 +351,7 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
             }
         }
         $this->loadCommandClasses($commandList);
-        return array_keys($commandList);
+        return array_values($commandList);
     }
 
     /**

--- a/tests/fixtures/drush-extensions/DrushExtensionsCommands.php
+++ b/tests/fixtures/drush-extensions/DrushExtensionsCommands.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drush\Commands\drush_extensions;
+
+use Drush\Commands\DrushCommands;
+
+class DrushExtensionsCommands extends DrushCommands
+{
+    /**
+     * Command to load from this file using drush config.
+     *
+     * @command drush-extensions-hello
+     * @bootstrap none
+     * @hidden
+     */
+    public function customCommand(): void
+    {
+        $this->io()->text('Hello world!');
+    }
+}

--- a/tests/fixtures/drush-extensions/drush.yml
+++ b/tests/fixtures/drush-extensions/drush.yml
@@ -1,0 +1,8 @@
+#
+# Drush configuration file used to configure the System Unter Test (sut)
+#
+# Docs at https://github.com/drush-ops/drush/blob/master/examples/example.drush.yml
+#
+drush:
+  commands:
+    '\Drush\Commands\drush_extensions\DrushExtensionsCommands': '${env.FIXTURES_DIR}/drush-extensions/DrushExtensionsCommands.php'

--- a/tests/integration/CommandsFromConfigurationTest.php
+++ b/tests/integration/CommandsFromConfigurationTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Unish;
+
+/**
+ * @group commands
+ */
+class CommandsFromConfigurationTest extends UnishIntegrationTestCase
+{
+    /**
+     * Tests that commands provided by custom libraries are registered.
+     */
+    public function testCommandsFromConfiguration(): void
+    {
+        $this->drush('drush-extensions-hello', [], ['help' => null], self::EXIT_ERROR);
+        $this->assertStringContainsString('Command drush-extensions-hello was not found.', $this->getErrorOutput());
+        $this->drush('drush-extensions-hello', [], [
+            'help' => null,
+            'config' => '/Users/kporras07/development/pantheon/drush/tests/fixtures/drush-extensions/drush.yml',
+        ]);
+        $this->assertStringContainsString('Command to load from this file using drush config.', $this->getOutput());
+        /*$this->drush('drush-extensions-hello', [], [
+            'config' => '/Users/kporras07/development/pantheon/drush/tests/fixtures/drush-extensions/drush.yml',
+        ]);
+        $this->assertStringContainsString('Hello world!', $this->getOutput());*/
+    }
+}

--- a/tests/integration/CommandsFromConfigurationTest.php
+++ b/tests/integration/CommandsFromConfigurationTest.php
@@ -13,15 +13,15 @@ class CommandsFromConfigurationTest extends UnishIntegrationTestCase
     public function testCommandsFromConfiguration(): void
     {
         $this->drush('drush-extensions-hello', [], ['help' => null], self::EXIT_ERROR);
-        $this->assertStringContainsString('Command drush-extensions-hello is not defined.', $this->getErrorOutput());
+        $this->assertStringContainsString('Command "drush-extensions-hello" is not defined.', $this->getErrorOutput());
         $this->drush('drush-extensions-hello', [], [
             'help' => null,
-            'config' => '/Users/kporras07/development/pantheon/drush/tests/fixtures/drush-extensions/drush.yml',
+            'config' => getenv('FIXTURES_DIR') . '/drush-extensions/drush.yml',
         ]);
         $this->assertStringContainsString('Command to load from this file using drush config.', $this->getOutput());
-        /*$this->drush('drush-extensions-hello', [], [
-            'config' => '/Users/kporras07/development/pantheon/drush/tests/fixtures/drush-extensions/drush.yml',
+        $this->drush('drush-extensions-hello', [], [
+            'config' => getenv('FIXTURES_DIR') . '/drush-extensions/drush.yml',
         ]);
-        $this->assertStringContainsString('Hello world!', $this->getOutput());*/
+        $this->assertStringContainsString('Hello world!', $this->getOutput());
     }
 }

--- a/tests/integration/CommandsFromConfigurationTest.php
+++ b/tests/integration/CommandsFromConfigurationTest.php
@@ -13,7 +13,7 @@ class CommandsFromConfigurationTest extends UnishIntegrationTestCase
     public function testCommandsFromConfiguration(): void
     {
         $this->drush('drush-extensions-hello', [], ['help' => null], self::EXIT_ERROR);
-        $this->assertStringContainsString('Command drush-extensions-hello was not found.', $this->getErrorOutput());
+        $this->assertStringContainsString('Command drush-extensions-hello is not defined.', $this->getErrorOutput());
         $this->drush('drush-extensions-hello', [], [
             'help' => null,
             'config' => '/Users/kporras07/development/pantheon/drush/tests/fixtures/drush-extensions/drush.yml',

--- a/tests/unish/UnishTestCase.php
+++ b/tests/unish/UnishTestCase.php
@@ -71,6 +71,7 @@ abstract class UnishTestCase extends TestCase
         self::setEnv(['ETC_PREFIX' => $unish_sandbox]);
         self::setEnv(['SHARE_PREFIX' => $unish_sandbox]);
         self::setEnv(['TEMP' => Path::join($unish_sandbox, 'tmp')]);
+        self::setEnv(['FIXTURES_DIR' => Path::join(dirname(__DIR__), 'fixtures')]);
     }
 
     /**


### PR DESCRIPTION
discoverCommandsFromConfiguration function was returning keys from $commandList instead of values. This caused that the returned values were the path to the command file instead of the class and therefore the classes (and commands) are not loaded.

The fix included in this PR makes the commands to load again.