### PR TITLE
Update endpoint in SecurityUpdateCommands

### DIFF
--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -101,9 +101,8 @@ class SecurityUpdateCommands extends DrushCommands
      */
     protected function fetchAdvisoryComposerJson()
     {
-        // We use the v2 branch for now, as per https://github.com/drupal-composer/drupal-security-advisories/pull/11.
         $client = new Client(['handler' => $this->getStack()]);
-        $response = $client->get('https://raw.githubusercontent.com/drupal-composer/drupal-security-advisories/8.x-v2/composer.json');
+        $response = $client->get('https://raw.githubusercontent.com/drupal-composer/drupal-security-advisories/9.x/composer.json');
         $security_advisories_composer_json = json_decode($response->getBody(), true);
         return $security_advisories_composer_json;
     }


### PR DESCRIPTION
I did some maintenance work on  drupal-composer/drupal-security-advisories and published security advisories for Drupal 9 on 9.x. The same advisories are published on 8.x-v2 for a while, this should not break older Drush releases.
