### PR TITLE
Don't blacklist internal/symfony

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -6,7 +6,6 @@
   "directories": ["commands", "includes", "lib", "src", "misc"],
   "blacklist": [
     "windrush_build/",
-    "Internal/Symfony/",
     "TestTraits/"
   ],
   "files": ["drush.complete.sh", "drush.info", "drush.launcher", "drush.php"],


### PR DESCRIPTION
Don't blacklist internal/symfony as its used by the yaml dumper

https://github.com/drush-ops/drush/issues/5047