### PR TITLE
Fix usage example in core:route command

### DIFF
--- a/src/Drupal/Commands/core/DrupalCommands.php
+++ b/src/Drupal/Commands/core/DrupalCommands.php
@@ -143,7 +143,7 @@ class DrupalCommands extends DrushCommands
      *   View all routes.
      * @usage drush route --name=update.status
      *   View details about the <info>update.status</info> route.
-     * @usage drush route --path=user/1
+     * @usage drush route --path=/user/1
      *   View details about the <info>entity.user.canonical</info> route.
      * @option name A route name.
      * @option path An internal path.


### PR DESCRIPTION
Currently the example causes the following error.

> The user-entered string 'user/1' must begin with a '/', '?', or '#'. 