### PR TITLE
Issue #5066 - PHP 8.1 null vs. \strlen()

### DIFF
--- a/src/TestTraits/DrushTestTrait.php
+++ b/src/TestTraits/DrushTestTrait.php
@@ -75,8 +75,8 @@ trait DrushTestTrait
             $cmd[] = $this->convertKeyValueToFlag($key, $value);
         }
 
-        $cmd[] = $suffix;
-        $exec = array_filter($cmd, 'strlen'); // Remove NULLs
+        $cmd[] = (string) $suffix;
+        $exec = array_filter($cmd, 'strlen'); // Removes empty strings.
 
         $cmd = implode(' ', $exec);
         $this->execute($cmd, $expected_return, $cd, $env);


### PR DESCRIPTION
Issue #5066 - PHP 8.1 null vs. \strlen()