### PR TITLE
#5072: Replace deprecated function call to module_load_include().

### DIFF
--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -116,7 +116,7 @@ class PmCommands extends DrushCommands
         require_once DRUSH_DRUPAL_CORE . '/includes/install.inc';
         $error = false;
         foreach ($modules as $module) {
-            module_load_install($module);
+            $this->moduleHandler->loadInclude($module, 'install');
             $requirements = $this->getModuleHandler()->invoke($module, 'requirements', ['install']);
             if (is_array($requirements) && drupal_requirements_severity($requirements) == REQUIREMENT_ERROR) {
                 $error = true;


### PR DESCRIPTION
The function "module_load_install()" was marked as deprecated in Drupal 9.4, and will be removed in Drupal 10.0.0.  See https://www.drupal.org/node/3220952 for more information.

This PR implements a call to ModuleHandler::loadInclude() instead.