### PR TITLE
Update DrushTestTrait.php

### DIFF
--- a/src/TestTraits/DrushTestTrait.php
+++ b/src/TestTraits/DrushTestTrait.php
@@ -90,7 +90,7 @@ trait DrushTestTrait
      * @param string $value The option value (or empty)
      * @return string
      */
-    protected function convertKeyValueToFlag(string $key, string $value)
+    protected function convertKeyValueToFlag(string $key, ?string $value)
     {
         if (!isset($value)) {
             return "--$key";


### PR DESCRIPTION
If `$value` is optional, we need to allow null values. I have migrate_upgrade failing tests ATM in Drush 11 because it has a non-argument flag `--configure-only`. I have to set a null value. Empty string won't work. But a null value doesn't work with just a string. Needs the optional null.