### PR TITLE
PHP 8.1 deprecation messages when the user has no mail or uid

### DIFF
--- a/src/Drupal/Commands/core/UserCommands.php
+++ b/src/Drupal/Commands/core/UserCommands.php
@@ -354,7 +354,7 @@ class UserCommands extends DrushCommands
     protected function getAccounts(string $names = '', array $options = []): array
     {
         $accounts = [];
-        if ($mails = StringUtils::csvToArray($options['mail'])) {
+        if (isset($options['mail']) && $mails = StringUtils::csvToArray($options['mail'])) {
             foreach ($mails as $mail) {
                 if ($account = user_load_by_mail($mail)) {
                     $accounts[$account->id()] = $account;
@@ -363,7 +363,7 @@ class UserCommands extends DrushCommands
                 }
             }
         }
-        if ($uids = StringUtils::csvToArray($options['uid'])) {
+        if (isset($options['uid']) && $uids = StringUtils::csvToArray($options['uid'])) {
             foreach ($uids as $uid) {
                 if ($account = User::load($uid)) {
                     $accounts[$account->id()] = $account;


### PR DESCRIPTION
With PHP 8.1 I'm running

```
drush user:role:add moderator john
```

and I'm getting:

> explode(): Passing null to parameter #2 ($string) of type string is deprecated in /Drush\Utils\StringUtils::csvToArray()

The error pops up for both, lack of `--uid` and lack of `--mail`