### PR TITLE
Remove psr/log as direct dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
     "enlightn/security-checker": "^1",
     "guzzlehttp/guzzle": "^6.3 || ^7.0",
     "league/container": "^3.4 || ^4",
-    "psr/log": "~1.0",
     "psy/psysh": "~0.11",
     "symfony/event-dispatcher": "^4.0 || ^5.0 || ^6.0",
     "symfony/finder": "^4.0 || ^5 || ^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb0314015a7d949f11cf54e1ceb56502",
+    "content-hash": "ed9631751b0f789c52bb89dfd2d43f39",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",


### PR DESCRIPTION
See https://www.drupal.org/node/3266017. Various consolidation components need psr/log v2 or v3 compat before drush's `test_81_drupal10_highest` tests will pass.