### PR TITLE
Fix entity command batch progress bar

### DIFF
--- a/src/Drupal/Commands/core/EntityCommands.php
+++ b/src/Drupal/Commands/core/EntityCommands.php
@@ -67,7 +67,7 @@ class EntityCommands extends DrushCommands
             $this->io()->progressStart(count($result));
             foreach (array_chunk($result, $options['chunks'], true) as $chunk) {
                 drush_op([$this, 'doDelete'], $entity_type, $chunk);
-                $this->io()->progressAdvance($options['chunks']);
+                $this->io()->progressAdvance(count($chunk));
             }
             $this->io()->progressFinish();
             $this->logger()->success(dt("Deleted !type entity Ids: !ids", ['!type' => $entity_type, '!ids' => implode(', ', array_values($result))]));
@@ -130,7 +130,7 @@ class EntityCommands extends DrushCommands
             $this->io()->progressStart(count($result));
             foreach (array_chunk($result, $options['chunks'], true) as $chunk) {
                 drush_op([$this, 'doSave'], $entity_type, $chunk);
-                $this->io()->progressAdvance($options['chunks']);
+                $this->io()->progressAdvance(count($chunk));
             }
             $this->io()->progressFinish();
             $this->logger()->success(dt("Saved !type entity ids: !ids", ['!type' => $entity_type, '!ids' => implode(', ', array_values($result))]));


### PR DESCRIPTION
Let's assume there are only 5 entities, but chunk size is set as 250. The progress bar shows "5" => "0%" for one second and immediately switch to "250" => "100%". While the progress should only rise by the actual number of entity IDs in the current `$chunk`.