### PR TITLE
Drush 7 for PHP 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,11 @@
       "Unish":        "tests/"
     }
   },
+  "config": {
+    "platform": {
+      "php": "5.3.29"
+    }
+  },
   "extra": {
     "branch-alias": {
         "dev-master": "7.0.x-dev"


### PR DESCRIPTION
Add config.platform.php so that "composer install" will produce a compatible vendor.

Pantheon is still installing Drush 7 globally for a few Really Old Sites that are still running PHP 5. Figured a trivial post-EOL Drush release was simpler than adding conditionals to the Pantheon Dockerfile.