### PR TITLE
Move `backup-dir` under `drush.paths` in config docs.

### DIFF
--- a/docs/using-drush-configuration.md
+++ b/docs/using-drush-configuration.md
@@ -80,7 +80,8 @@ temporary sql dump files created during [sql:sync](https://www.drush.org/latest/
 defaults to `$HOME/drush-backups`.
 ```yml
 drush:
-  backup-dir: /tmp/drush-backups
+  paths:
+    backup-dir: /tmp/drush-backups
 ```
 
 #### Global options


### PR DESCRIPTION
Setting `drush.backup-dir` as outlined in the docs was not working for me. `FsUtils::getBackupDirParent()` seems to be looking for the config at `drush.paths.backup-dir`.
https://github.com/drush-ops/drush/blob/287400c51a2e3a83cb95440826ce12d2d95956f6/src/Utils/FsUtils.php#L63

This PR changes the docs to reflect that, although maybe `FsUtils` should be updated instead?