### PR TITLE
Issue 5105: Process batches generated during drush config:import.

### DIFF
--- a/src/Drupal/Commands/config/ConfigImportCommands.php
+++ b/src/Drupal/Commands/config/ConfigImportCommands.php
@@ -292,6 +292,12 @@ class ConfigImportCommands extends DrushCommands
                         $context = [];
                         do {
                             $config_importer->doSyncStep($step, $context);
+                            // Manually get and process any batches that may
+                            // have been created, e.g. via hook_install() when a
+                            // module is enabled.
+                            if (batch_get()) {
+                                drush_backend_batch_process();
+                            }
                             if (isset($context['message'])) {
                                 $this->logger()->notice(str_replace('Synchronizing', 'Synchronized', (string)$context['message']));
                             }


### PR DESCRIPTION
A module may choose to initiate a batch process from hook_install(). The batch process is executed when a module is enabled in UI, via /admin/modules, or via config sync via /admin/config/development/configuration. Additionally, `drush pm:enable mymodule` also executes the batch process. Update the `drush config:import` command to use the same technique as `drush pm:enable` to get and process batches after every sync step.