### PR TITLE
Module name error on deploy:hook when module name contains _deploy

### DIFF
--- a/src/Drupal/Commands/core/DeployHookCommands.php
+++ b/src/Drupal/Commands/core/DeployHookCommands.php
@@ -176,7 +176,8 @@ class DeployHookCommands extends DrushCommands implements SiteAliasManagerAwareI
             return;
         }
 
-        list($module, $name) = explode('_deploy_', $function, 2);
+        $name = end(explode('_deploy_', $function, 2));
+        $module = str_replace("_$name", '', $function);
         $filename = $module . '.deploy';
         \Drupal::moduleHandler()->loadInclude($module, 'php', $filename);
         if (function_exists($function)) {


### PR DESCRIPTION
Hello;

I noticed a rather specific error when the module's name contains the substring `_deploy` on its name.

Take `mymodule_deploy` as an example, with a `mymodule_deploy_deploy_myfunction` deploy hook and a `mymodule_deploy.deploy.php` file.

Running drush deploy:hook will fail with the following error:

```bash
[warning] Deploy hook function mymodule_deploy_deploy_myfunction not found in file mymodule.deploy.php
```

This is because `list($module, $name) = explode('_deploy_', $function, 2);` will set `$module` to just `mymodule` and not `mymodule_deploy` and, thus, the `$filename` will be wrong.

This is an uncommon but not rare scenario. In fact, it happened to me because I had a separate custom module dedicated to deploy hooks that had the `deploy` substring on the name.

The attached patch tries to solve this by first locating the deploy name and then substracting it from the function name in order to get the real module name.