### PR TITLE
Update Drush 8 EOL date to November 2023

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -50,7 +50,7 @@ Drupal Compatibility
     <td> Drush 8 </td>
     <td> 5.4.5+ </td>
     <!-- Released Nov 2015 -->
-    <td> Nov 2022 </td>
+    <td> Nov 2023 </td>
     <td>✅</td> <td><b>⚠️</b></td> <td></td>
   </tr>
   <tr>


### PR DESCRIPTION
Drupal 7's End-of-Life was extended to November 1, 2023: https://www.drupal.org/psa-2022-02-23

@greg-1-anderson:

> Yes, the documentation is out of date. Drush 8 will continue to be supported for the lifetime of Drupal 7.

From https://github.com/drush-ops/drush/issues/5092#issuecomment-1065959827.