### PR TITLE
Run theme post updates when supported by core

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -269,7 +269,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         $update_registry = \Drupal::service('update.post_update_registry');
         // https://www.drupal.org/project/drupal/issues/3259188 Support theme's
         // having post update functions when it is supported in Drupal core.
-        if (method_exists('getUpdateFunctions', $update_registry)) {
+        if (method_exists($update_registry, 'getUpdateFunctions')) {
             \Drupal::service('update.post_update_registry')->getUpdateFunctions($extension);
         }
         else {

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -271,8 +271,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         // having post update functions when it is supported in Drupal core.
         if (method_exists($update_registry, 'getUpdateFunctions')) {
             \Drupal::service('update.post_update_registry')->getUpdateFunctions($extension);
-        }
-        else {
+        } else {
             \Drupal::service('update.post_update_registry')->getModuleUpdateFunctions($extension);
         }
 

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -265,11 +265,19 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
             return;
         }
 
-        list($module, $name) = explode('_post_update_', $function, 2);
-        $filename = $module . '.post_update';
-        \Drupal::moduleHandler()->loadInclude($module, 'php', $filename);
+        list($extension, $name) = explode('_post_update_', $function, 2);
+        $update_registry = \Drupal::service('update.post_update_registry');
+        // https://www.drupal.org/project/drupal/issues/3259188 Support theme's
+        // having post update functions when it is supported in Drupal core.
+        if (method_exists('getUpdateFunctions', $update_registry)) {
+            \Drupal::service('update.post_update_registry')->getUpdateFunctions($extension);
+        }
+        else {
+            \Drupal::service('update.post_update_registry')->getModuleUpdateFunctions($extension);
+        }
+
         if (function_exists($function)) {
-            if (empty($context['results'][$module][$name]['type'])) {
+            if (empty($context['results'][$extension][$name]['type'])) {
                 Drush::logger()->notice("Update started: $function");
             }
             try {
@@ -306,10 +314,10 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
             $context['finished'] = $context['sandbox']['#finished'];
             unset($context['sandbox']['#finished']);
         }
-        if (!isset($context['results'][$module][$name])) {
-            $context['results'][$module][$name] = [];
+        if (!isset($context['results'][$extension][$name])) {
+            $context['results'][$extension][$name] = [];
         }
-        $context['results'][$module][$name] = array_merge($context['results'][$module][$name], $ret);
+        $context['results'][$extension][$name] = array_merge($context['results'][$extension][$name], $ret);
 
         // Log the message that was returned.
         if (!empty($ret['results']['query'])) {


### PR DESCRIPTION
Core is likely to add support for post updates in themes. See https://www.drupal.org/project/drupal/issues/3259188

This PR changes drush to support this in a BC compatible way.

I think this should go back to 10.x too depending on which branches https://www.drupal.org/project/drupal/issues/3259188 ends up in.