### PR TITLE
Remove dual autoloader feature from global Drush installs

### DIFF
--- a/drush.php
+++ b/drush.php
@@ -10,7 +10,8 @@ use Webmozart\PathUtil\Path;
 /**
  * This script runs Drush.
  *
- * Responsibilities of this script:
+ * ## Responsibilities of this script ##
+ *
  *   - Locate and include the Composer autoload file for Drush.
  *   - Set up the environment (record user home directory, cwd, etc.).
  *   - Call the Preflight object to do all necessary setup and execution.
@@ -21,6 +22,7 @@ use Webmozart\PathUtil\Path;
  * This script will only be tested via the functional tests.
  *
  * The Drush bootstrap goes through the following steps:
+ *
  *   - (ArgsPreprocessor) Preprocess the commandline arguments, considering only:
  *     - The named alias `@sitealias` (removed from arguments if present)
  *     - The --root option (read and retained)
@@ -38,6 +40,74 @@ use Webmozart\PathUtil\Path;
  *     - Run commands and command hooks via annotated commands library
  *     - Catch 'command not found' exception, bootstrap Drupal and run again
  *   - Return status code
+ *
+ * ## Viable Drush configurations ##
+ *
+ * As of Drush 12, only a site-local Drush will bootstrap Drupal. Any
+ * other installation configuration may only be used as a launcher. A
+ * site-local Drush may also be used as a launcher. The built-in launcher
+ * may be used to run certain Drush commands that do not require an
+ * existing site to bootstrap, such as the `archive:restore` command.
+ * Beyond that, the built-in launcher may only be used to run commands
+ * in a remote Drupal site, or in another local site with a site-local
+ * Drush.
+ *
+ * The following directory layouts are supported:
+ *
+ * Drush binary in site-local configuration in recommended Drupal site: (typical)
+ *
+ *         drupal
+ *         ├── web
+ *         │   ├── core
+ *         │   └── index.php
+ *         └── vendor
+ *             ├── autoload.php
+ *   [*1]      ├── bin
+ *             │   └── drush.php -> ../drush/drush/drush.php
+ *   [*2]      └── drush
+ *                 └── drush
+ *                     └── drush.php
+ *
+ * Drush binary in site-local configuration in a legacy Drupal site: (unusual)
+ *
+ *         drupal
+ *         ├── core
+ *         ├── index.php
+ *         └── vendor
+ *             ├── autoload.php
+ *   [*1]      ├── bin
+ *             │   └── drush.php -> ../drush/drush/drush.php
+ *   [*2]      └── drush
+ *                 └── drush
+ *                     └── drush.php
+ *
+ * Drush project: (Only used when developing Drush; `composer install --dev`)
+ *
+ *   [*3]    drush
+ *           ├── drush.php
+ *           ├── sut
+ *           │   ├── core
+ *           │   └── index.php
+ *           └── vendor
+ *               └── autoload.php
+ *
+ * Global Drush: (Only usable as a launcher; `composer install --no-dev`)
+ *
+ *   [*3]    drush
+ *           ├── drush.php
+ *           └── vendor
+ *               └── autoload.php
+ *
+ * The possible locations that __DIR__ may point to in the supported
+ * configurations are indicated by [*1], [*2] and [*3] in the diagrams
+ * above.
+ *
+ * Note that in the case of the Drush project, the Drupal site used for
+ * testing during development, called the "System Under Test", or "sut",
+ * counts as a site-local configuration, since the `vendor` directory is
+ * common between Drush and Drupal. Drush uses information from the
+ * project root to find the Drupal root, so it does not matter what the
+ * 'web' directory is called.
  */
 
 // We use PWD if available because getcwd() resolves symlinks, which  could take

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -43,41 +43,6 @@ class Environment
     }
 
     /**
-     * Load the autoloader for the selected Drupal site.
-     */
-    public function loadSiteAutoloader(string $root): ClassLoader
-    {
-        $autloadFilePath = "$root/autoload.php";
-        if (!file_exists($autloadFilePath)) {
-            return $this->loader;
-        }
-
-        if ($this->siteLoader) {
-            return $this->siteLoader;
-        }
-
-        $this->siteLoader = require $autloadFilePath;
-        if ($this->siteLoader === false) {
-            // Nothing more to do. See https://github.com/drush-ops/drush/issues/3741.
-            return $this->loader;
-        }
-        if ($this->siteLoader === true) {
-            // The autoloader was already required. Assume that Drush and Drupal share an autoloader per
-            // "Point autoload.php to the proper vendor directory" - https://www.drupal.org/node/2404989
-            $this->siteLoader = $this->loader;
-        }
-
-        // Ensure that the site's autoloader has highest priority. Usually,
-        // the first classloader registered gets the first shot at loading classes.
-        // We want Drupal's classloader to be used first when a class is loaded,
-        // and have Drush's classloader only be called as a fallback measure.
-        $this->siteLoader->unregister();
-        $this->siteLoader->register(true);
-
-        return $this->siteLoader;
-    }
-
-    /**
      * Return the name of the user running drush.
      */
     protected function getUsername(): string

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -77,9 +77,6 @@ class Runtime
         $this->preflight->logger()->log('Commandfile search paths: ' . implode(',', $commandfileSearchpath));
         $this->preflight->config()->set('runtime.commandfile.paths', $commandfileSearchpath);
 
-        // Require the Composer autoloader for Drupal (if different)
-        $loader = $this->preflight->loadSiteAutoloader();
-
         // Load the Symfony compatability layer autoloader
         $this->preflight->loadSymfonyCompatabilityAutoloader();
 
@@ -93,7 +90,7 @@ class Runtime
             $this->preflight->config(),
             $input,
             $output,
-            $loader,
+            $this->preflight->environment()->loader(),
             $this->preflight->drupalFinder(),
             $this->preflight->aliasManager()
         );
@@ -116,7 +113,7 @@ class Runtime
         // Configure the application object and register all of the commandfiles
         // from the search paths we found above.  After this point, the input
         // and output objects are ready & we can start using the logger, etc.
-        $application->configureAndRegisterCommands($input, $output, $commandfileSearchpath, $loader);
+        $application->configureAndRegisterCommands($input, $output, $commandfileSearchpath, $this->preflight->environment()->loader());
 
         // Run the Symfony Application
         // Predispatch: call a remote Drush command if applicable (via a 'pre-init' hook)

--- a/tests/unish/Controllers/RuntimeController.php
+++ b/tests/unish/Controllers/RuntimeController.php
@@ -120,9 +120,6 @@ class RuntimeController
         $commandfileSearchpath = $this->preflight->getCommandFilePaths();
         $this->preflight->config()->set('runtime.commandfile.paths', $commandfileSearchpath);
 
-        // Require the Composer autoloader for Drupal (if different)
-        $loader = $this->preflight->loadSiteAutoloader();
-
         // Load the Symfony compatability layer autoloader
         $this->preflight->loadSymfonyCompatabilityAutoloader();
 


### PR DESCRIPTION
Do not allow Drush to combine autoload files from a non-site-local Drupal; only bootstrap Drupal sites with a shared vendor.

Something I did on the train for Drush 12.