### PR TITLE
Make `pm:install` and `pm:uninstall` respect `--simulate` option

### DIFF
--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -67,11 +67,13 @@ class PmCommands extends DrushCommands
      *
      * @command pm:install
      * @param $modules A comma delimited list of modules.
-     * @option dry-run Display what modules would be installed but don't install them.
      * @aliases in, install, pm-install, en, pm-enable, pm:enable
      * @bootstrap root
+     *
+     * @usage drush pm:install --simulate content_moderation
+     *    Display what modules would be installed but don't install them.
      */
-    public function install(array $modules, array $options = ['dry-run' => false]): void
+    public function install(array $modules): void
     {
         $modules = StringUtils::csvToArray($modules);
         $todo = $this->addInstallDependencies($modules);
@@ -79,7 +81,7 @@ class PmCommands extends DrushCommands
         if (empty($todo)) {
             $this->logger()->notice(dt('Already enabled: !list', ['!list' => implode(', ', $modules)]));
             return;
-        } elseif ($options['dry-run']) {
+        } elseif (Drush::simulate()) {
             $this->output()->writeln(dt('The following module(s) will be enabled: !list', $todo_str));
             return;
         } elseif (array_values($todo) !== $modules) {
@@ -159,14 +161,16 @@ class PmCommands extends DrushCommands
      *
      * @command pm:uninstall
      * @param $modules A comma delimited list of modules.
-     * @option dry-run Display what modules would be uninstalled but don't uninstall them.
      * @aliases un,pmu,pm-uninstall
+     *
+     * @usage drush pm:uninstall --simulate field_ui
+     *      Display what modules would be uninstalled but don't uninstall them.
      */
-    public function uninstall(array $modules, array $options = ['dry-run' => false]): void
+    public function uninstall(array $modules): void
     {
         $modules = StringUtils::csvToArray($modules);
         $list = $this->addUninstallDependencies($modules);
-        if ($options['dry-run']) {
+        if (Drush::simulate()) {
             $this->output()->writeln(dt('The following extensions will be uninstalled: !list', ['!list' => implode(', ', $list)]));
             return;
         }

--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -67,16 +67,20 @@ class PmCommands extends DrushCommands
      *
      * @command pm:install
      * @param $modules A comma delimited list of modules.
+     * @option dry-run Display what modules would be installed but don't install them.
      * @aliases in, install, pm-install, en, pm-enable, pm:enable
      * @bootstrap root
      */
-    public function install(array $modules): void
+    public function install(array $modules, array $options = ['dry-run' => false]): void
     {
         $modules = StringUtils::csvToArray($modules);
         $todo = $this->addInstallDependencies($modules);
         $todo_str = ['!list' => implode(', ', $todo)];
         if (empty($todo)) {
             $this->logger()->notice(dt('Already enabled: !list', ['!list' => implode(', ', $modules)]));
+            return;
+        } elseif ($options['dry-run']) {
+            $this->output()->writeln(dt('The following module(s) will be enabled: !list', $todo_str));
             return;
         } elseif (array_values($todo) !== $modules) {
             $this->output()->writeln(dt('The following module(s) will be enabled: !list', $todo_str));
@@ -155,12 +159,18 @@ class PmCommands extends DrushCommands
      *
      * @command pm:uninstall
      * @param $modules A comma delimited list of modules.
+     * @option dry-run Display what modules would be uninstalled but don't uninstall them.
      * @aliases un,pmu,pm-uninstall
      */
-    public function uninstall(array $modules): void
+    public function uninstall(array $modules, array $options = ['dry-run' => false]): void
     {
         $modules = StringUtils::csvToArray($modules);
         $list = $this->addUninstallDependencies($modules);
+        if ($options['dry-run']) {
+            $this->output()->writeln(dt('The following extensions will be uninstalled: !list', ['!list' => implode(', ', $list)]));
+            return;
+        }
+
         if (array_values($list) !== $modules) {
             $this->output()->writeln(dt('The following extensions will be uninstalled: !list', ['!list' => implode(', ', $list)]));
             if (!$this->io()->confirm(dt('Do you want to continue?'))) {


### PR DESCRIPTION
In Drush 8 it was possible to pass `--no` to `pm:uninstall` to let it output only what modules would be uninstalled without actually uninstalling any modules. This was removed in Drush 9 after discussion in #205 (PR #1057 was declined as a result).

However, we had some automation that used this to see what would be uninstalled so that this could be reported for user verification, even in the case only a single module would be uninstalled. This is now broken and that command uninstalls the module when it's the only one being uninstalled.

To preserve the new desired behaviour but still easily allow automation to determine what changes would be made by running `pm:install` or `pm:uninstall` this PR adds a `--dry-run` option that will not actually perform any of the changes.

An alternative implementation would be to provide entirely separate commands, but that feels like overkill.