### PR TITLE
[PHP 8.2] Fix deprecated `${var}` string interpolation patterns

### DIFF
--- a/src/Psysh/DrushHelpCommand.php
+++ b/src/Psysh/DrushHelpCommand.php
@@ -108,7 +108,7 @@ class DrushHelpCommand extends BaseCommand
                     $namespaces[$namespace] = [];
                 }
 
-                $namespaces[$namespace][] = sprintf("    <info>%-${width}s</info> %s%s", $name, $command->getDescription(), $aliases);
+                $namespaces[$namespace][] = sprintf("    <info>%-{$width}s</info> %s%s", $name, $command->getDescription(), $aliases);
             }
 
             $messages = [];


### PR DESCRIPTION
PHP 8.2 deprecates string interpolation patterns that place the dollar sign outside the curly braces. This fixes such patterns by replacing them with proper curly braced patterns.

Fix: `Drush\Psysh\DrushHelpCommand::execute()`

Reference:
 - [PHP.Watch: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated)
 - [wiki.php.net RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)