### PR TITLE
Bootstrap levels are `int` in DrupalBootLevels

### DIFF
--- a/src/Attributes/Bootstrap.php
+++ b/src/Attributes/Bootstrap.php
@@ -15,7 +15,7 @@ class Bootstrap
      *   The level to bootstrap to.
      */
     public function __construct(
-        #[ExpectedValues(valuesFromClass: DrupalBootLevels::class)] public string $level,
+        #[ExpectedValues(valuesFromClass: DrupalBootLevels::class)] public int $level,
     ) {
     }
 


### PR DESCRIPTION
When using PHPStan, there is an error with the following code:

Code:
```
#[CLI\Bootstrap(level: DrupalBootLevels::NONE)]
```

Error:
```
Parameter $level of attribute class Drush\Attributes\Bootstrap constructor expects string, int given. 
```

All constants are integers. When passing a stringified zero (`'0`) the attribute fails. So it's documented as a string but actually wants an integer.

