### PR TITLE
--force option added to 'updatedb' command

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -29,12 +29,13 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
      * @command updatedb
      * @option cache-clear Clear caches upon completion.
      * @option post-updates Run post updates after hook_update_n and entity updates.
+     * @option force Do not ask 'Do you wish to run the specified pending updates?' question before running updates.
      * @bootstrap full
      * @topics docs:deploy
      * @kernel update
      * @aliases updb
      */
-    public function updatedb($options = ['cache-clear' => true, 'post-updates' => true]): int
+    public function updatedb($options = ['cache-clear' => true, 'post-updates' => true, 'force' => false]): int
     {
         $this->cache_clear = $options['cache-clear'];
         require_once DRUPAL_ROOT . '/core/includes/install.inc';
@@ -63,7 +64,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         if ($output = $process->getOutput()) {
             // We have pending updates - let's run em.
             $this->output()->writeln($output);
-            if (!$this->io()->confirm(dt('Do you wish to run the specified pending updates?'))) {
+            if (!$options['force'] && !$this->io()->confirm(dt('Do you wish to run the specified pending updates?'))) {
                 throw new UserAbortException();
             }
             if ($this->getConfig()->simulate()) {


### PR DESCRIPTION
Small change but really helpful for us. Would like to see it merged as soon as possible. Thank you!

## Motivation

"Do you wish to run the specified pending updates?" question is ok when running `drush updb` from shell.

But we use this command in CI-automation (with Jenkins). We want to have a way to apply database updates automatically in some dev environments. But if there are some updates Jenkins pipeline execution just freezes. With last line in log like this:
```
17:21:26 Do you wish to run the specified pending updates? (yes/no) [yes]:
```
So we really want to have `--force` option to be able to skip this question under such non-interactive shells.

Thank you!

## P.S.:

I intentionally left "Requirements check reports errors. Do you wish to continue?" question unaffected by this new option. Because this requirements question is much more serious and let it better stack instead of applying some incompatible updates silently even in dev environment.