### PR TITLE
Use compatible method to create Response

### DIFF
--- a/lib/Drush/Boot/DrupalBoot8.php
+++ b/lib/Drush/Boot/DrupalBoot8.php
@@ -211,7 +211,7 @@ class DrupalBoot8 extends DrupalBoot {
     parent::terminate();
 
     if ($this->kernel) {
-      $response = Response::create('');
+      $response = new Response('');
       $this->kernel->terminate($this->request, $response);
     }
   }


### PR DESCRIPTION
Response is created via undocumented method even in 3.4 https://symfony.com/doc/3.4/components/http_foundation.html#response