### PR TITLE
Add url option to the core:route command

### DIFF
--- a/src/Drupal/Commands/core/DrupalCommands.php
+++ b/src/Drupal/Commands/core/DrupalCommands.php
@@ -151,7 +151,7 @@ class DrupalCommands extends DrushCommands
      * @option path An internal path or URL.
      * @version 10.5
      */
-    public function route($options = ['name' => self::REQ, 'path' => self::REQ,'format' => 'yaml'])
+    public function route($options = ['name' => self::REQ, 'path' => self::REQ, 'format' => 'yaml'])
     {
         $route = $items = null;
         $provider = $this->getRouteProvider();

--- a/src/Drupal/Commands/core/DrupalCommands.php
+++ b/src/Drupal/Commands/core/DrupalCommands.php
@@ -149,12 +149,18 @@ class DrupalCommands extends DrushCommands
      * @option path An internal path.
      * @version 10.5
      */
-    public function route($options = ['name' => self::REQ, 'path' => self::REQ, 'format' => 'yaml'])
+    public function route($options = ['name' => self::REQ, 'path' => self::REQ, 'url' => self::REQ, 'format' => 'yaml'])
     {
         $route = $items = null;
         $provider = $this->getRouteProvider();
         if ($path = $options['path']) {
             $name = Url::fromUserInput($path)->getRouteName();
+            $route = $provider->getRouteByName($name);
+        } elseif ($url = $options['url']) {
+            $path = \parse_url($url, PHP_URL_PATH);
+            // Strip base path.
+            $path = substr_replace($path, '', 0, \strlen(base_path()));
+            $name = Url::fromUserInput('/' . $path)->getRouteName();
             $route = $provider->getRouteByName($name);
         } elseif ($name = $options['name']) {
             $route = $provider->getRouteByName($name);

--- a/src/Drupal/Commands/core/DrupalCommands.php
+++ b/src/Drupal/Commands/core/DrupalCommands.php
@@ -145,24 +145,23 @@ class DrupalCommands extends DrushCommands
      *   View details about the <info>update.status</info> route.
      * @usage drush route --path=/user/1
      *   View details about the <info>entity.user.canonical</info> route.
-     * @usage drush route --url=https://example.com/node
+     * @usage drush route --url=https://example.com/node/1
      *   View details about the <info>entity.node.canonical</info> route.
      * @option name A route name.
-     * @option path An internal path.
+     * @option path An internal path or URL.
      * @version 10.5
      */
-    public function route($options = ['name' => self::REQ, 'path' => self::REQ, 'url' => self::REQ, 'format' => 'yaml'])
+    public function route($options = ['name' => self::REQ, 'path' => self::REQ,'format' => 'yaml'])
     {
         $route = $items = null;
         $provider = $this->getRouteProvider();
         if ($path = $options['path']) {
+            if (filter_var($path, FILTER_VALIDATE_URL)) {
+                $path = parse_url($path, PHP_URL_PATH);
+                // Strip base path.
+                $path = '/' . substr_replace($path, '', 0, strlen(base_path()));
+            }
             $name = Url::fromUserInput($path)->getRouteName();
-            $route = $provider->getRouteByName($name);
-        } elseif ($url = $options['url']) {
-            $path = \parse_url($url, PHP_URL_PATH);
-            // Strip base path.
-            $path = substr_replace($path, '', 0, \strlen(base_path()));
-            $name = Url::fromUserInput('/' . $path)->getRouteName();
             $route = $provider->getRouteByName($name);
         } elseif ($name = $options['name']) {
             $route = $provider->getRouteByName($name);

--- a/src/Drupal/Commands/core/DrupalCommands.php
+++ b/src/Drupal/Commands/core/DrupalCommands.php
@@ -145,6 +145,8 @@ class DrupalCommands extends DrushCommands
      *   View details about the <info>update.status</info> route.
      * @usage drush route --path=/user/1
      *   View details about the <info>entity.user.canonical</info> route.
+     * @usage drush route --url=https://example.com/node
+     *   View details about the <info>entity.node.canonical</info> route.
      * @option name A route name.
      * @option path An internal path.
      * @version 10.5


### PR DESCRIPTION
## Motivation
`drush route --path` is one of may favorite Drush commands. However, it feels a bit boring to manually extract path from URL.

## Proposed solution
Add `url` option. So that the URL copied from the browser address bar can be pasted directly to the command line.

Example:
```
drush route --url=https://example.com/node/1
```
