### PR TITLE
Remove timeout for runserver command

### DIFF
--- a/src/Commands/core/RunserverCommands.php
+++ b/src/Commands/core/RunserverCommands.php
@@ -75,6 +75,7 @@ class RunserverCommands extends DrushCommands
         $router = Path::join(DRUSH_BASE_PATH, '/misc/d8-rs-router.php');
         $php = $this->getConfig()->get('php', 'php');
         $process = $this->processManager()->process([$php, '-S', $addr . ':' . $uri['port'], $router]);
+        $process->setTimeout(null);
         $process->setWorkingDirectory(Drush::bootstrapManager()->getRoot());
         $process->setTty(Tty::isTtySupported());
         if ($options['quiet']) {


### PR DESCRIPTION
Running the server should never time out.

Would be great to backport that to Drush 10 as well.