### PR TITLE
Add YAML edit commands from YAML-CLI project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "consolidation/site-alias": "^3.1.3",
     "consolidation/site-process": "^4.1.3 || ^5",
     "enlightn/security-checker": "^1",
+    "grasmash/yaml-cli": "^3",
     "guzzlehttp/guzzle": "^6.3 || ^7.0",
     "league/container": "^3.4 || ^4",
     "psy/psysh": "~0.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb7c538821997a9476b29e01705ce17f",
+    "content-hash": "aeb0a971d297c9b05531b1e0de6ea712",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",
@@ -887,6 +887,62 @@
                 "source": "https://github.com/grasmash/expander/tree/2.0.3"
             },
             "time": "2022-04-25T22:17:46+00:00"
+        },
+        {
+            "name": "grasmash/yaml-cli",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grasmash/yaml-cli.git",
+                "reference": "4d9c4d97de16a881196e2310e868e3230202b4a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grasmash/yaml-cli/zipball/4d9c4d97de16a881196e2310e868e3230202b4a7",
+                "reference": "4d9c4d97de16a881196e2310e868e3230202b4a7",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^1.1.0 | ^2 | ^3",
+                "php": ">=5.6",
+                "symfony/console": "^4 | ^5",
+                "symfony/filesystem": "^4 | ^5",
+                "symfony/yaml": "^4 | ^5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.5.4",
+                "satooshi/php-coveralls": "^1.0",
+                "squizlabs/php_codesniffer": "^2.7"
+            },
+            "bin": [
+                "bin/yaml-cli"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Grasmash\\YamlCli\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Grasmick"
+                }
+            ],
+            "description": "A command line tool for reading and manipulating yaml files.",
+            "support": {
+                "issues": "https://github.com/grasmash/yaml-cli/issues",
+                "source": "https://github.com/grasmash/yaml-cli/tree/3.0.0"
+            },
+            "time": "2022-02-24T04:01:47+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -8737,5 +8793,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -13,11 +13,17 @@ use Drush\Commands\DrushCommands;
 use Drush\Config\ConfigAwareTrait;
 use Drush\Runtime\RedispatchHook;
 use Drush\Runtime\TildeExpansionHook;
+use Grasmash\YamlCli\Command\GetValueCommand;
+use Grasmash\YamlCli\Command\LintCommand;
+use Grasmash\YamlCli\Command\UnsetKeyCommand;
+use Grasmash\YamlCli\Command\UpdateKeyCommand;
+use Grasmash\YamlCli\Command\UpdateValueCommand;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Robo\ClassDiscovery\RelativeNamespaceDiscovery;
 use Robo\Contract\ConfigAwareInterface;
 use Symfony\Component\Console\Application as SymfonyApplication;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -310,6 +316,9 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
         // any of the configuration steps we do here.
         $this->configureIO($input, $output);
 
+        // Directly add the yaml-cli commands.
+        $this->addCommands($this->discoverYamlCliCommands());
+
         $commandClasses = array_unique(array_merge(
             $this->discoverCommandsFromConfiguration(),
             $this->discoverCommands($commandfileSearchpath, '\Drush'),
@@ -414,5 +423,29 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
         $output->writeln('', OutputInterface::VERBOSITY_QUIET);
 
         $this->doRenderThrowable($e, $output);
+    }
+
+    /**
+     * Get Yaml-CLI command instances.
+     */
+    public function discoverYamlCliCommands(): array
+    {
+        $classes_yaml = [
+            GetValueCommand::class,
+            LintCommand::class,
+            UpdateKeyCommand::class,
+            UnsetKeyCommand::class,
+            UpdateValueCommand::class
+        ];
+        foreach ($classes_yaml as $class_yaml) {
+            /** @var Command $instance */
+            $instance = new $class_yaml();
+            // Namespace the commands.
+            $name = $instance->getName();
+            $instance->setName('yaml:' . $name);
+            $instance->setAliases(['y:' . $name]);
+            $instances[] = $instance;
+        }
+        return $instances;
     }
 }


### PR DESCRIPTION
- Adds [grasmash/yaml-cli](https://github.com/grasmash/yaml-cli) as a dependency
- Adds all the commands from that project. These are directly added as Symfony Console commands (not Annotated Commands)
- Doesn't add any tests. We rely on the tests in the yaml-cli package.

Feedback welcome.

Fixes #5026 