### PR TITLE
Allow to set the URL for the security advisories composer url via env variable

### DIFF
--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -102,7 +102,7 @@ class SecurityUpdateCommands extends DrushCommands
     protected function fetchAdvisoryComposerJson()
     {
         $client = new Client(['handler' => $this->getStack()]);
-        $security_advisories_composer_url = getenv('DRUSH_SECURITY_ADVISORIES_URL') ? getenv('DRUSH_SECURITY_ADVISORIES_URL') : 'https://raw.githubusercontent.com/drupal-composer/drupal-security-advisories/9.x/composer.json';
+        $security_advisories_composer_url = getenv('DRUSH_SECURITY_ADVISORIES_URL') ?? 'https://raw.githubusercontent.com/drupal-composer/drupal-security-advisories/9.x/composer.json';
         $response = $client->get($security_advisories_composer_url);
         $security_advisories_composer_json = json_decode($response->getBody(), true);
         return $security_advisories_composer_json;

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -102,7 +102,8 @@ class SecurityUpdateCommands extends DrushCommands
     protected function fetchAdvisoryComposerJson()
     {
         $client = new Client(['handler' => $this->getStack()]);
-        $response = $client->get('https://raw.githubusercontent.com/drupal-composer/drupal-security-advisories/9.x/composer.json');
+        $security_advisories_composer_url = getenv('DRUSH_SECURITY_ADVISORIES_URL') ? getenv('DRUSH_SECURITY_ADVISORIES_URL') : 'https://raw.githubusercontent.com/drupal-composer/drupal-security-advisories/9.x/composer.json';
+        $response = $client->get($security_advisories_composer_url);
         $security_advisories_composer_json = json_decode($response->getBody(), true);
         return $security_advisories_composer_json;
     }

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -95,6 +95,11 @@ class SecurityUpdateCommands extends DrushCommands
     /**
      * Fetches the generated composer.json from drupal-security-advisories.
      *
+     * This function fetches the generated composer.json from the
+     * drupal-security-advisories repository or fetches it from another source
+     * if the environment variable DRUSH_SECURITY_ADVISORIES_URL is set. The
+     * environment variable is not a supported API.
+     *
      * @return mixed
      *
      * @throws \Exception

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -107,7 +107,7 @@ class SecurityUpdateCommands extends DrushCommands
     protected function fetchAdvisoryComposerJson()
     {
         $client = new Client(['handler' => $this->getStack()]);
-        $security_advisories_composer_url = getenv('DRUSH_SECURITY_ADVISORIES_URL') ?? 'https://raw.githubusercontent.com/drupal-composer/drupal-security-advisories/9.x/composer.json';
+        $security_advisories_composer_url = getenv('DRUSH_SECURITY_ADVISORIES_URL') ?: 'https://raw.githubusercontent.com/drupal-composer/drupal-security-advisories/9.x/composer.json';
         $response = $client->get($security_advisories_composer_url);
         $security_advisories_composer_json = json_decode($response->getBody(), true);
         return $security_advisories_composer_json;


### PR DESCRIPTION
The URL which is used in the drush pm:security command is hard-coded and links to the drupal-security-advisories repo ( https://github.com/drupal-composer/drupal-security-advisories ). I really would like to have an easy option to use a different url if needed.

This PR sets the url for the source of the security check command to the environment variable DRUSH_SECURITY_ADVISORIES_URL if set, otherwise use the default url.