### PR TITLE
Fix fatal error on Drupal 10 w/ symfony/console:6.2+

### DIFF
--- a/src-symfony-compatibility/v6/Style/DrushStyle.php
+++ b/src-symfony-compatibility/v6/Style/DrushStyle.php
@@ -27,7 +27,7 @@ class DrushStyle extends SymfonyStyle
     {
         // Display the choices without their keys.
         $choices_values = array_values($choices);
-        $return = parent::choice($question, $choices_values, $default);
+        $return = parent::choice($question, $choices_values, $default, $multiSelect);
 
         return array_search($return, $choices);
     }

--- a/src-symfony-compatibility/v6/Style/DrushStyle.php
+++ b/src-symfony-compatibility/v6/Style/DrushStyle.php
@@ -23,7 +23,7 @@ class DrushStyle extends SymfonyStyle
         return parent::confirm($question, $default);
     }
 
-    public function choice(string $question, array $choices, mixed $default = null): mixed
+    public function choice(string $question, array $choices, mixed $default = null, bool $multiSelect = false): mixed
     {
         // Display the choices without their keys.
         $choices_values = array_values($choices);


### PR DESCRIPTION
On Drupal 10 (with symfony/console 6.2.x) I'm getting this fatal:

```
PHP Fatal error:  Declaration of Drush\Style\DrushStyle::choice(string $question, array $choices, mixed $default = null): mixed must be compatible with Symfony\Component\Console\Style\SymfonyStyle::choice(string $question, array $choices, mixed $default = null, bool $multiSelect = false): mixed 
```

This is to fix that signature difference

