### PR TITLE
Cast to string when passing to MailFormatHelper::htmlToText()

### DIFF
--- a/src/Drupal/Commands/core/DeployHookCommands.php
+++ b/src/Drupal/Commands/core/DeployHookCommands.php
@@ -174,7 +174,7 @@ class DeployHookCommands extends DrushCommands implements SiteAliasManagerAwareI
         // Module names can include '_deploy', so deploy functions like
         // module_deploy_deploy_name() are ambiguous. Check every occurrence.
         $components = explode('_', $function);
-        foreach (array_keys($components, 'deploy', TRUE) as $position) {
+        foreach (array_keys($components, 'deploy', true) as $position) {
             $module = implode('_', array_slice($components, 0, $position));
             $name = implode('_', array_slice($components, $position + 1));
             $filename = $module . '.deploy';

--- a/src/Drupal/DrupalUtil.php
+++ b/src/Drupal/DrupalUtil.php
@@ -20,7 +20,7 @@ class DrupalUtil
             $data = \Drupal::service('renderer')->renderRoot($data);
         }
 
-        $data = MailFormatHelper::htmlToText($data);
+        $data = MailFormatHelper::htmlToText((string) $data);
         return $data;
     }
 }


### PR DESCRIPTION
When running `drush core:requirements` on PHP 8.1 I'm getting:

```
[error]  Message: /Deprecated function/: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in Drupal\Component\Utility\Html::escape() (line 424 of /core/lib/Drupal/Component/Utility/Html.php/).
Drupal\Component\Utility\Html::escape(NULL) (Line: 262)
Drupal\Component\Render\FormattableMarkup::placeholderEscape(NULL) (Line: 232)
Drupal\Component\Render\FormattableMarkup::placeholderFormat('%profile_name (%profile-%version)', Array) (Line: 195)
Drupal\Core\StringTranslation\TranslatableMarkup->render() (Line: 15)
Drupal\Core\StringTranslation\TranslatableMarkup->__toString()
str_replace('', '', Object) (Line: 69)
Drupal\Component\Utility\Xss::filter(Object, Array) (Line: 117)
Drupal\Core\Mail\MailFormatHelper::htmlToText(Object) (Line: 23)
Drush\Drupal\DrupalUtil::drushRender(Object) (Line: 125)
Drush\Drupal\Commands\core\DrupalCommands->requirements(Array)
...
```

The issue is that we're passing `TranslatableMarkup` instances.