### PR TITLE
Warning in PHP 8.1 when passing the bundle and no exclude options

### DIFF
--- a/src/Drupal/Commands/core/DeployHookCommands.php
+++ b/src/Drupal/Commands/core/DeployHookCommands.php
@@ -174,7 +174,7 @@ class DeployHookCommands extends DrushCommands implements SiteAliasManagerAwareI
         // Module names can include '_deploy', so deploy functions like
         // module_deploy_deploy_name() are ambiguous. Check every occurrence.
         $components = explode('_', $function);
-        foreach (array_keys($components, 'deploy', TRUE) as $position) {
+        foreach (array_keys($components, 'deploy', true) as $position) {
             $module = implode('_', array_slice($components, 0, $position));
             $name = implode('_', array_slice($components, $position + 1));
             $filename = $module . '.deploy';

--- a/src/Drupal/Commands/core/EntityCommands.php
+++ b/src/Drupal/Commands/core/EntityCommands.php
@@ -172,7 +172,7 @@ class EntityCommands extends DrushCommands
             $idKey = $this->entityTypeManager->getDefinition($entity_type)->getKey('id');
             $query = $query->condition($idKey, $ids, 'IN');
         } elseif ($options['bundle'] || $options['exclude']) {
-            if ($exclude = StringUtils::csvToArray($options['exclude'])) {
+            if ($exclude = StringUtils::csvToArray((string) $options['exclude'])) {
                 $idKey = $this->entityTypeManager->getDefinition($entity_type)->getKey('id');
                 $query = $query->condition($idKey, $exclude, 'NOT IN');
             }


### PR DESCRIPTION
Run:

```
./vendor/bin/drush entity:delete –bundle topic
```

In PHP 8.1 will get:

```
[error]  Message: /Deprecated function/: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /Drush\Utils\StringUtils::csvToArray()/ (line /25/ of //vendor/drush/drush/src/Utils/StringUtils.php/).
Drush\Utils\StringUtils::csvToArray(NULL) (Line: 175)
Drush\Drupal\Commands\core\EntityCommands->getQuery('taxonomy_term', Array, Array) (Line: 56)
Drush\Drupal\Commands\core\EntityCommands->delete('taxonomy_term', NULL, Array)
```