### PR TITLE
Ensure all $args to csvToArray() are strings

### DIFF
--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -22,7 +22,8 @@ class StringUtils
         // Step 4: array_map(...) trims extra whitespace from each item
         // (handles csv strings with extra whitespace, e.g. 'a, b, c')
         //
-        return array_map('trim', array_filter(explode(',', is_array($args) ? implode(',', $args) : $args)));
+        $args = is_array($args) ? implode(',', array_map('strval', $args)) : (string) $args;
+        return array_map('trim', array_filter(explode(',', $args)));
     }
 
     /**


### PR DESCRIPTION
I'm getting 

```
[error]  Message: Deprecated function: explode(): Passing null to parameter #2 ($string) of type string is deprecated in Drush\Utils\StringUtils::csvToArray() (line 25 of vendor/drush/drush/src/Utils/StringUtils.php).
Drush\Utils\StringUtils::csvToArray(NULL) (Line: 175)
Drush\Drupal\Commands\core\EntityCommands->getQuery('taxonomy_term', Array, Array) (Line: 56)
Drush\Drupal\Commands\core\EntityCommands->delete('taxonomy_term', NULL, Array)
```

The reason is that `$options['exclude']` is passed as `null` to `StringUtils::csvToArray()`.

Let's make `StringUtils::csvToArray()` strong
