### PR TITLE
Replace core:config with core:edit in examples

### DIFF
--- a/src/Commands/core/EditCommands.php
+++ b/src/Commands/core/EditCommands.php
@@ -21,17 +21,17 @@ class EditCommands extends DrushCommands implements SiteAliasManagerAwareInterfa
      * @bootstrap max
      * @param $filter A substring for filtering the list of files. Omit this argument to choose from loaded files.
      * @optionset_get_editor
-     * @usage drush core:config
+     * @usage drush core:edit
      *   Pick from a list of config/alias/settings files. Open selected in editor.
      * @usage drush --bg core-config
      *   Return to shell prompt as soon as the editor window opens.
-     * @usage drush core:config etc
+     * @usage drush core:edit etc
      *   Edit the global configuration file.
-     * @usage drush core:config demo.alia
+     * @usage drush core:edit demo.alia
      * Edit a particular alias file.
-     * @usage drush core:config sett
+     * @usage drush core:edit sett
      *   Edit settings.php for the current Drupal site.
-     * @usage drush core:config --choice=2
+     * @usage drush core:edit --choice=2
      *  Edit the second file in the choice list.
      * @aliases conf,config,core-edit
      */


### PR DESCRIPTION
Seems like a typo.