### PR TITLE
Docs: use valid severity in example usage

### DIFF
--- a/src/Drupal/Commands/core/WatchdogCommands.php
+++ b/src/Drupal/Commands/core/WatchdogCommands.php
@@ -201,7 +201,7 @@ class WatchdogCommands extends DrushCommands
      *   Delete messages with id 64.
      * @usage drush watchdog:delete "cron run succesful"
      *   Delete messages containing the string "cron run succesful".
-     * @usage drush watchdog:delete --severity=notice
+     * @usage drush watchdog:delete --severity=Notice
      *   Delete all messages with a severity of notice.
      * @usage drush watchdog:delete --type=cron
      *   Delete all messages of type cron.


### PR DESCRIPTION
`--severity=notice` gives an error message:

```console
$ drush watchdog:delete --severity=notice

In WatchdogCommands.php line 310:

  Unknown severity level: notice.
  Valid severity levels are: Emergency(0), Alert(1), Critical(2), Error(3), Warning(4), Notice(5), Info(6), Debug(7).


```

`--severity=Notice` works:

```console
$ drush watchdog:delete --severity=Notice
All messages with severity = 5 will be deleted.

 Do you want to continue? (yes/no) [yes]:
 > yes

 [success] 184 watchdog messages have been deleted.
```