### PR TITLE
Ensure a string is passed to strtolower() in PmCommands::pmList()

### DIFF
--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -235,7 +235,7 @@ class PmCommands extends DrushCommands
         $themes = $this->getThemeHandler()->rebuildThemeData();
         $both = array_merge($modules, $themes);
 
-        $package_filter = StringUtils::csvToArray((string) strtolower($options['package']));
+        $package_filter = StringUtils::csvToArray(strtolower((string) $options['package']));
         $type_filter = StringUtils::csvToArray(strtolower($options['type']));
         $status_filter = StringUtils::csvToArray(strtolower($options['status']));
 

--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -235,7 +235,7 @@ class PmCommands extends DrushCommands
         $themes = $this->getThemeHandler()->rebuildThemeData();
         $both = array_merge($modules, $themes);
 
-        $package_filter = StringUtils::csvToArray(strtolower($options['package']));
+        $package_filter = StringUtils::csvToArray((string) strtolower($options['package']));
         $type_filter = StringUtils::csvToArray(strtolower($options['type']));
         $status_filter = StringUtils::csvToArray(strtolower($options['status']));
 


### PR DESCRIPTION
## Steps to reproduce

On PHP 8.1, run:

```bash
$ ./vendor/bin/drush pml
```

You'll get:

> [error]  Message: /Deprecated function/: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /Drush\Drupal\Commands\pm\PmCommands->pmList()/ (line /239/ of /vendor/drush/drush/src/Drupal/Commands/pm/PmCommands.php/).
> Drush\Drupal\Commands\pm\PmCommands->pmList(Array) call_user_func_array(Array, Array) (Line: 257)>
> Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object) (Line: 212)
...