### PR TITLE
Fixes #5253: Drush user-cancel command blocks the user account instead of deletion.

### DIFF
--- a/src/Drupal/Commands/core/UserCommands.php
+++ b/src/Drupal/Commands/core/UserCommands.php
@@ -283,7 +283,7 @@ class UserCommands extends DrushCommands
                 $this->logger()->warning(dt('All content created by !name will be deleted.', ['!name' => $account->getAccountName()]));
             }
             if ($this->io()->confirm('Cancel user account?: ')) {
-                $method = $options['delete-content'] ? 'user_cancel_delete' : 'user_cancel_block';
+                $method = $options['delete-content'] ? 'user_cancel_delete' : 'user_cancel_reassign';
                 user_cancel([], $account->id(), $method);
                 drush_backend_batch_process();
                 // Drupal logs a message for us.


### PR DESCRIPTION
Fixes #5253 