### PR TITLE
Fix builtin class reference

### DIFF
--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -11,6 +11,7 @@ use Drush\Config\ConfigLocator;
 use Drush\Config\EnvironmentConfigLoader;
 use Consolidation\SiteAlias\SiteAliasManager;
 use DrupalFinder\DrupalFinder;
+use RuntimeException;
 
 /**
  * The Drush preflight determines what needs to be done for this request.


### PR DESCRIPTION
Fix fatal:
```
PHP Fatal error:  Uncaught Error: Class "Drush\Preflight\RuntimeException" not found in /Users/dchurch/dotfiles/drupal/drush/src/Preflight/Preflight.php:217
Stack trace:
#0 /Users/dchurch/dotfiles/drupal/drush/src/Runtime/Runtime.php(84): Drush\Preflight\Preflight->loadSymfonyCompatabilityAutoloader()
#1 /Users/dchurch/dotfiles/drupal/drush/src/Runtime/Runtime.php(51): Drush\Runtime\Runtime->doRun(Array, Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 /Users/dchurch/dotfiles/drupal/drush/drush.php(72): Drush\Runtime\Runtime->run(Array)
#3 {main}
  thrown in /Users/dchurch/dotfiles/drupal/drush/src/Preflight/Preflight.php on line 217
```