### PR TITLE
Fix 'The path must be a string. Got: NULL'

### DIFF
--- a/src/Drupal/Commands/config/ConfigExportCommands.php
+++ b/src/Drupal/Commands/config/ConfigExportCommands.php
@@ -116,8 +116,10 @@ class ConfigExportCommands extends DrushCommands
 
     public function doExport($options, $destination_dir)
     {
+        $sync_directory = Settings::get('config_sync_directory');
+
         // Prepare the configuration storage for the export.
-        if ($destination_dir ==  Path::canonicalize(Settings::get('config_sync_directory'))) {
+        if ($sync_directory !== null && $destination_dir == Path::canonicalize($sync_directory)) {
             $target_storage = $this->getConfigStorageSync();
         } else {
             $target_storage = new FileStorage($destination_dir);


### PR DESCRIPTION
When running `drush cex --destination="../config/sync"` with the `config_sync_directory` setting missing from settings.php, the following error appears:

```
The path must be a string. Got: NULL
```