### PR TITLE
Issue #4935: Replace webmozart/path-util with symfony/filesystem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,12 +45,12 @@
     "league/container": "^3.4 || ^4",
     "psy/psysh": "~0.11",
     "symfony/event-dispatcher": "^4.0 || ^5.0 || ^6.0",
+    "symfony/filesystem": "^5.4",
     "symfony/finder": "^4.0 || ^5 || ^6",
     "symfony/polyfill-php80": "^1.23",
     "symfony/var-dumper": "^4.0 || ^5.0 || ^6.0",
     "symfony/yaml": "^4.0 || ^5.0 || ^6.0",
-    "webflo/drupal-finder": "^1.2",
-    "webmozart/path-util": "^2.1.0"
+    "webflo/drupal-finder": "^1.2"
   },
   "require-dev": {
     "composer/installers": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "44a4a9422530d4f23e065c0245690160",
+    "content-hash": "473b2835deec4e6c0f08898006166a62",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",
@@ -3221,115 +3221,6 @@
                 "source": "https://github.com/webflo/drupal-finder/tree/1.2.2"
             },
             "time": "2020-10-27T09:42:17+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
-            },
-            "time": "2022-06-03T18:03:27+00:00"
-        },
-        {
-            "name": "webmozart/path-util",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/path-util.git",
-                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
-                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "webmozart/assert": "~1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\PathUtil\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
-            "support": {
-                "issues": "https://github.com/webmozart/path-util/issues",
-                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
-            },
-            "abandoned": "symfony/filesystem",
-            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "packages-dev": [

--- a/drush.php
+++ b/drush.php
@@ -5,7 +5,7 @@ use Drush\Config\Environment;
 use Drush\Preflight\Preflight;
 use Drush\Runtime\Runtime;
 use Drush\Runtime\DependencyInjection;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * This script runs Drush.

--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -233,7 +233,7 @@ function drush_file_not_empty($file_to_test) {
  * the other.
  */
 function drush_is_nested_directory($base_dir, $test_is_nested) {
-  $common = Path::getLongestCommonBasePath([$test_is_nested, $base_dir]);
+  $common = Path::getLongestCommonBasePath($test_is_nested, $base_dir);
   return $common == Path::canonicalize($base_dir);
 }
 

--- a/includes/filesystem.inc
+++ b/includes/filesystem.inc
@@ -7,7 +7,7 @@
 use Drush\Drush;
 use Drush\Sql\SqlBase;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @defgroup filesystemfunctions Filesystem convenience functions.

--- a/src/Boot/DrupalBoot.php
+++ b/src/Boot/DrupalBoot.php
@@ -3,7 +3,7 @@
 namespace Drush\Boot;
 
 use Drush\Drush;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 abstract class DrupalBoot extends BaseBoot
 {

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -13,9 +13,9 @@ use Drush\Drupal\DrushLoggerServiceProvider;
 use Drush\Drupal\DrushServiceModifier;
 use Drush\Drush;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Webmozart\PathUtil\Path;
 
 class DrupalBoot8 extends DrupalBoot implements AutoloaderAwareInterface
 {

--- a/src/Commands/DrushCommands.php
+++ b/src/Commands/DrushCommands.php
@@ -19,9 +19,9 @@ use Robo\Contract\ConfigAwareInterface;
 use Robo\Contract\IOAwareInterface;
 use Robo\Common\IO;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Filesystem\Path;
 use Consolidation\SiteProcess\ProcessManagerAwareTrait;
 use Consolidation\SiteProcess\ProcessManagerAwareInterface;
-use Webmozart\PathUtil\Path;
 
 abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, ConfigAwareInterface, ProcessManagerAwareInterface
 {

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -17,10 +17,10 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Yaml\Yaml;
 use Traversable;
-use Webmozart\PathUtil\Path;
 
 class ArchiveDumpCommands extends DrushCommands
 {

--- a/src/Commands/core/ArchiveRestoreCommands.php
+++ b/src/Commands/core/ArchiveRestoreCommands.php
@@ -18,8 +18,8 @@ use Drush\Utils\FsUtils;
 use Exception;
 use PharData;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Throwable;
-use Webmozart\PathUtil\Path;
 
 class ArchiveRestoreCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {

--- a/src/Commands/core/MkCommands.php
+++ b/src/Commands/core/MkCommands.php
@@ -18,8 +18,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Yaml\Yaml;
-use Webmozart\PathUtil\Path;
 
 class MkCommands extends DrushCommands implements SiteAliasManagerAwareInterface, AutoloaderAwareInterface
 {

--- a/src/Commands/core/NotifyCommands.php
+++ b/src/Commands/core/NotifyCommands.php
@@ -6,7 +6,7 @@ use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\SiteProcess\Util\Escape;
 use Drush\Commands\DrushCommands;
 use Drush\Drush;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class NotifyCommands extends DrushCommands
 {

--- a/src/Commands/core/RunserverCommands.php
+++ b/src/Commands/core/RunserverCommands.php
@@ -7,7 +7,7 @@ use Drush\Drush;
 use Drupal\Core\Url;
 use Drush\Commands\DrushCommands;
 use Drush\Exec\ExecTrait;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class RunserverCommands extends DrushCommands
 {

--- a/src/Commands/core/SiteCommands.php
+++ b/src/Commands/core/SiteCommands.php
@@ -12,7 +12,7 @@ use Consolidation\OutputFormatters\StructuredData\UnstructuredListData;
 use Drush\Utils\StringUtils;
 use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Output\Output;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class SiteCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -16,7 +16,7 @@ use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 use Drush\Exec\ExecTrait;
 use Drush\Sql\SqlBase;
 use Drush\Utils\StringUtils;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class SiteInstallCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {

--- a/src/Commands/core/StatusCommands.php
+++ b/src/Commands/core/StatusCommands.php
@@ -15,7 +15,7 @@ use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 use Consolidation\OutputFormatters\Options\FormatterOptions;
 use Consolidation\AnnotatedCommand\CommandData;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class StatusCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {
@@ -136,18 +136,18 @@ class StatusCommands extends DrushCommands implements SiteAliasManagerAwareInter
         $status_table['php-os'] = PHP_OS;
         $status_table['php-version'] = PHP_VERSION;
         if ($phpIniFiles = EditCommands::phpIniFiles()) {
-            $status_table['php-conf'] = array_map('Webmozart\PathUtil\Path::canonicalize', $phpIniFiles);
+            $status_table['php-conf'] = array_map([Path::class, 'canonicalize'], $phpIniFiles);
         }
         $status_table['drush-script'] = Path::canonicalize($this->getConfig()->get('runtime.drush-script'));
         $status_table['drush-version'] = Drush::getVersion();
         $status_table['drush-temp'] = Path::canonicalize($this->getConfig()->tmp());
-        $status_table['drush-conf'] = array_map('Webmozart\PathUtil\Path::canonicalize', $this->getConfig()->configPaths());
+        $status_table['drush-conf'] = array_map([Path::class, 'canonicalize'], $this->getConfig()->configPaths());
         // List available alias files
         $alias_files = $this->siteAliasManager()->listAllFilePaths();
         sort($alias_files);
         $status_table['drush-alias-files'] = $alias_files;
         $alias_searchpaths = $this->siteAliasManager()->searchLocations();
-        $status_table['alias-searchpaths'] = array_map('Webmozart\PathUtil\Path::canonicalize', $alias_searchpaths);
+        $status_table['alias-searchpaths'] = array_map([Path::class, 'canonicalize'], $alias_searchpaths);
 
         $paths = self::pathAliases($options, $boot_manager, $boot_object);
         if (!empty($paths)) {
@@ -163,7 +163,7 @@ class StatusCommands extends DrushCommands implements SiteAliasManagerAwareInter
         // Store the paths into the '%paths' index; this will be
         // used by other code, but will not be included in the default output
         // of the drush status command.
-        $status_table['%paths'] = array_map('Webmozart\PathUtil\Path::canonicalize', array_filter($paths));
+        $status_table['%paths'] = array_map([Path::class, 'canonicalize'], array_filter($paths));
 
         return $status_table;
     }

--- a/src/Commands/generate/ApplicationFactory.php
+++ b/src/Commands/generate/ApplicationFactory.php
@@ -21,8 +21,8 @@ use Psr\Log\LoggerInterface;
 use Robo\ClassDiscovery\RelativeNamespaceDiscovery;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Twig\Loader\FilesystemLoader;
-use Webmozart\PathUtil\Path;
 
 class ApplicationFactory implements AutoloaderAwareInterface
 {

--- a/src/Commands/pm/SecurityUpdateCommands.php
+++ b/src/Commands/pm/SecurityUpdateCommands.php
@@ -11,7 +11,7 @@ use Drush\Commands\DrushCommands;
 use Drush\Drush;
 use Enlightn\SecurityChecker\SecurityChecker;
 use Exception;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Check Drupal Composer packages for security updates.

--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -9,7 +9,7 @@ use Drush\Exceptions\UserAbortException;
 use Consolidation\SiteAlias\SiteAlias;
 use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {

--- a/src/Config/ConfigLocator.php
+++ b/src/Config/ConfigLocator.php
@@ -8,7 +8,7 @@ use Consolidation\Config\Loader\ConfigLoaderInterface;
 use Drush\Config\Loader\YamlConfigLoader;
 use Consolidation\Config\Loader\ConfigProcessor;
 use Consolidation\Config\Util\EnvConfig;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Locate Drush configuration files and load them into the configuration

--- a/src/Config/DrushConfig.php
+++ b/src/Config/DrushConfig.php
@@ -6,7 +6,6 @@ use Robo\Config\Config;
 use Consolidation\Config\Util\ConfigOverlay;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
 // TODO: Not sure if we should have a reference to PreflightArgs here.
 // Maybe these constants should be in config, and PreflightArgs can
 // reference them from there as well.

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -6,7 +6,7 @@ use Composer\Autoload\ClassLoader;
 use Drush\Drush;
 use Drush\Utils\FsUtils;
 use Symfony\Component\Console\Terminal;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Store information about the environment

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -25,8 +25,8 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Yaml\Parser;
-use Webmozart\PathUtil\Path;
 
 class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteAliasManagerAwareInterface
 {

--- a/src/Drupal/Commands/config/ConfigExportCommands.php
+++ b/src/Drupal/Commands/config/ConfigExportCommands.php
@@ -12,7 +12,7 @@ use Drush\Commands\DrushCommands;
 use Drush\Drush;
 use Drush\Exceptions\UserAbortException;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class ConfigExportCommands extends DrushCommands
 {

--- a/src/Drupal/Commands/config/ConfigImportCommands.php
+++ b/src/Drupal/Commands/config/ConfigImportCommands.php
@@ -25,7 +25,7 @@ use Drupal\Core\Site\Settings;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drush\Commands\DrushCommands;
 use Drush\Exceptions\UserAbortException;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class ConfigImportCommands extends DrushCommands
 {

--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -20,7 +20,7 @@ use Drush\Drupal\Migrate\MigrateExecutable;
 use Drush\Drupal\Migrate\MigrateMessage;
 use Drush\Drupal\Migrate\MigrateUtils;
 use Drush\Utils\StringUtils;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Migrate runner commands.

--- a/src/Drupal/Commands/core/TwigCommands.php
+++ b/src/Drupal/Commands/core/TwigCommands.php
@@ -9,8 +9,8 @@ use Drush\Commands\DrushCommands;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drush\Drush;
 use Drush\Utils\StringUtils;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
-use Webmozart\PathUtil\Path;
 
 class TwigCommands extends DrushCommands
 {

--- a/src/Preflight/LegacyPreflight.php
+++ b/src/Preflight/LegacyPreflight.php
@@ -6,7 +6,7 @@ use Drush\Drush;
 use Drush\Config\Environment;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Prepare to bootstrap Drupal

--- a/src/Preflight/RedispatchToSiteLocal.php
+++ b/src/Preflight/RedispatchToSiteLocal.php
@@ -2,7 +2,7 @@
 
 namespace Drush\Preflight;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * RedispatchToSiteLocal forces an `exec` to the site-local Drush if it

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -8,8 +8,8 @@ use Consolidation\SiteProcess\ProcessManager as ConsolidationProcessManager;
 use Consolidation\SiteProcess\SiteProcess;
 use Drush\Drush;
 use Drush\Style\DrushStyle;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\Process;
-use Webmozart\PathUtil\Path;
 
 /**
  * The Drush ProcessManager adds a few Drush-specific service methods.

--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -9,8 +9,8 @@ use Drush\Utils\FsUtils;
 use Drush\Config\ConfigAwareTrait;
 use Robo\Contract\ConfigAwareInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\Process;
-use Webmozart\PathUtil\Path;
 use Consolidation\Config\Util\Interpolator;
 
 /**

--- a/src/Utils/FsUtils.php
+++ b/src/Utils/FsUtils.php
@@ -6,7 +6,7 @@ use Drush\Drush;
 use Drush\Sql\SqlBase;
 use finfo;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class FsUtils
 {

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -3,9 +3,9 @@
 namespace Unish;
 
 use PharData;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\Process;
 use Unish\Utils\FSUtils;
-use Webmozart\PathUtil\Path;
 
 /**
  * @group slow

--- a/tests/functional/CommandInfoAlterTest.php
+++ b/tests/functional/CommandInfoAlterTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @group commands

--- a/tests/functional/ConfigPullTest.php
+++ b/tests/functional/ConfigPullTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Tests for config-pull command. Sets up two Drupal sites.

--- a/tests/functional/ConfigTest.php
+++ b/tests/functional/ConfigTest.php
@@ -4,7 +4,7 @@ namespace Unish;
 
 use Composer\Semver\Comparator;
 use Drupal\Core\Serialization\Yaml;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Tests for Configuration Management commands for D8+.

--- a/tests/functional/ContainerTest.php
+++ b/tests/functional/ContainerTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Tests the Drush override of DrupalKernel.

--- a/tests/functional/DeployHookTest.php
+++ b/tests/functional/DeployHookTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  *  @group slow

--- a/tests/functional/FieldTest.php
+++ b/tests/functional/FieldTest.php
@@ -3,7 +3,7 @@
 namespace Unish;
 
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @group commands

--- a/tests/functional/FunctionalCoreTest.php
+++ b/tests/functional/FunctionalCoreTest.php
@@ -2,8 +2,8 @@
 
 namespace Unish;
 
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Yaml\Yaml;
-use Webmozart\PathUtil\Path;
 
 /**
  * Tests for core commands.

--- a/tests/functional/LanguageAddTest.php
+++ b/tests/functional/LanguageAddTest.php
@@ -4,7 +4,7 @@ namespace Unish;
 
 use Drupal\Core\Language\Language;
 use Drupal\language\Entity\ConfigurableLanguage;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  *  @group slow

--- a/tests/functional/LocaleTest.php
+++ b/tests/functional/LocaleTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  *  @group slow

--- a/tests/functional/PmEnLocaleImportTest.php
+++ b/tests/functional/PmEnLocaleImportTest.php
@@ -4,7 +4,7 @@ namespace Unish;
 
 use Drupal\Core\Language\Language;
 use Drupal\language\Entity\ConfigurableLanguage;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @group locale

--- a/tests/functional/QueueTest.php
+++ b/tests/functional/QueueTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @group commands

--- a/tests/functional/RedispatchTest.php
+++ b/tests/functional/RedispatchTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @group base

--- a/tests/functional/RoleTest.php
+++ b/tests/functional/RoleTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  *  @group slow

--- a/tests/functional/SqlDumpTest.php
+++ b/tests/functional/SqlDumpTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Tests for sql-dump commands.

--- a/tests/functional/UpdateDBTest.php
+++ b/tests/functional/UpdateDBTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  *  @group slow

--- a/tests/functional/UserTest.php
+++ b/tests/functional/UserTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  *  @group slow

--- a/tests/integration/CoreTest.php
+++ b/tests/integration/CoreTest.php
@@ -2,8 +2,8 @@
 
 namespace Unish;
 
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Yaml\Yaml;
-use Webmozart\PathUtil\Path;
 
 /**
  * Tests for core commands.

--- a/tests/integration/MigrateRunnerTest.php
+++ b/tests/integration/MigrateRunnerTest.php
@@ -3,7 +3,7 @@
 namespace Unish;
 
 use Drupal\migrate\Plugin\MigrationInterface;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @group commands

--- a/tests/integration/ModuleGeneratorTest.php
+++ b/tests/integration/ModuleGeneratorTest.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @group commands

--- a/tests/integration/SiteAliasConvertTest.php
+++ b/tests/integration/SiteAliasConvertTest.php
@@ -2,8 +2,8 @@
 
 namespace Unish;
 
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Yaml\Yaml;
-use Webmozart\PathUtil\Path;
 
 /**
  * @group commands

--- a/tests/integration/SqlCliTest.php
+++ b/tests/integration/SqlCliTest.php
@@ -8,7 +8,7 @@
 namespace Unish;
 
 use Drush\Sql\SqlBase;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @group commands

--- a/tests/unish/Controllers/RuntimeController.php
+++ b/tests/unish/Controllers/RuntimeController.php
@@ -11,9 +11,9 @@ use Drush\Runtime\DependencyInjection;
 use Drush\Runtime\Runtime;
 use PHPUnit\Framework\TestResult;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
-use Webmozart\PathUtil\Path;
 
 /**
  * The runtime controller manages the Drush runtime for Unish,

--- a/tests/unish/CreateEntityType.php
+++ b/tests/unish/CreateEntityType.php
@@ -2,7 +2,7 @@
 
 namespace Unish;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class CreateEntityType
 {

--- a/tests/unish/TestModuleHelperTrait.php
+++ b/tests/unish/TestModuleHelperTrait.php
@@ -3,7 +3,7 @@
 namespace Unish;
 
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Helper for installing testing modules.

--- a/tests/unish/UnishIntegrationTestCase.php
+++ b/tests/unish/UnishIntegrationTestCase.php
@@ -14,7 +14,6 @@ use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
 use Unish\Controllers\RuntimeController;
 use Drush\TestTraits\OutputUtilsTrait;
-use Webmozart\PathUtil\Path;
 
 /**
  * UnishIntegrationTestCase will prepare a single Drupal site and

--- a/tests/unish/UnishTestCase.php
+++ b/tests/unish/UnishTestCase.php
@@ -6,8 +6,8 @@ use Composer\Semver\Comparator;
 use Consolidation\SiteAlias\SiteAlias;
 use Consolidation\SiteProcess\SiteProcess;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Yaml\Yaml;
-use Webmozart\PathUtil\Path;
 use Consolidation\SiteProcess\ProcessManager;
 
 abstract class UnishTestCase extends TestCase

--- a/tests/unish/Utils/Fixtures.php
+++ b/tests/unish/Utils/Fixtures.php
@@ -3,7 +3,7 @@
 namespace Unish\Utils;
 
 use Drush\Config\Environment;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 trait Fixtures
 {

--- a/tests/unit/ConfigLocatorTest.php
+++ b/tests/unit/ConfigLocatorTest.php
@@ -3,7 +3,7 @@
 namespace Drush\Config;
 
 use PHPUnit\Framework\TestCase;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Test the config loader. Also exercises the EnvironmentConfigLoader.

--- a/tests/unit/MigrateRunnerTest.php
+++ b/tests/unit/MigrateRunnerTest.php
@@ -7,8 +7,8 @@ use Drupal\Core\Database\Driver\sqlite\Connection;
 use Drupal\migrate\Plugin\MigrationInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Path;
 use Unish\TestSqlIdMap;
-use Webmozart\PathUtil\Path;
 
 class MigrateRunnerTest extends TestCase
 {

--- a/tests/unit/MigrateRunnerTest.php
+++ b/tests/unit/MigrateRunnerTest.php
@@ -161,7 +161,7 @@ class MigrateRunnerTest extends TestCase
         if (Comparator::greaterThanOrEqualTo(\Drupal::VERSION, '9.4')) {
             /** @var \Composer\Autoload\ClassLoader $loader */
             $loader = require PHPUNIT_COMPOSER_INSTALL;
-            $loader->addPsr4('Drupal\sqlite\\', Path::join([dirname(__DIR__, 2), 'sut/core/modules/sqlite/src']));
+            $loader->addPsr4('Drupal\sqlite\\', Path::join(dirname(__DIR__, 2), 'sut/core/modules/sqlite/src'));
         }
         $connection = new Connection($pdo, $options);
 


### PR DESCRIPTION
`symfony/filesystem` as of v5.4 is pretty much a drop-in replacement for `webmozart/path-util`, at least for all the drush use-cases.