### PR TITLE
Allow resetting the status of multiple migrations

### DIFF
--- a/src/Drupal/Commands/core/MigrateRunnerCommands.php
+++ b/src/Drupal/Commands/core/MigrateRunnerCommands.php
@@ -609,9 +609,7 @@ class MigrateRunnerCommands extends DrushCommands
             foreach ($migrations as $migrationId => $migration) {
                 /** @var MigrationInterface $migration */
                 $status = $migration->getStatus();
-                if ($status == MigrationInterface::STATUS_IDLE) {
-                    $this->logger()->warning(dt('Migration @id is already Idle', ['@id' => $migrationId]));
-                } else {
+                if ($status !== MigrationInterface::STATUS_IDLE) {
                     $migration->setStatus(MigrationInterface::STATUS_IDLE);
                     $this->logger()->success(dt('Migration @id reset to Idle', ['@id' => $migrationId]));
                 }


### PR DESCRIPTION
This PR adds the `all` and `tag` options to the `migrate:reset-status` command, together with the ability to pass a comma separated list of migration ids as argument.