### PR TITLE
Warn if modules passed to pm-uninstall are not enabled

### DIFF
--- a/src/Drupal/Commands/pm/PmCommands.php
+++ b/src/Drupal/Commands/pm/PmCommands.php
@@ -170,17 +170,17 @@ class PmCommands extends DrushCommands
     {
         $modules = StringUtils::csvToArray($modules);
 
-        $enabled_modules = array_filter($modules, function ($module) {
+        $installed_modules = array_filter($modules, function ($module) {
             return $this->getModuleHandler()->moduleExists($module);
         });
-        if ($enabled_modules === []) {
-            throw new \Exception(dt('The following module(s) are not enabled: !list. No modules to uninstall.', ['!list' => implode(', ', $modules)]));
+        if ($installed_modules === []) {
+            throw new \Exception(dt('The following module(s) are not installed: !list. No modules to uninstall.', ['!list' => implode(', ', $modules)]));
         }
-        if ($enabled_modules !== $modules) {
-            $this->logger()->warning(dt('The following module(s) are not enabled and will not be uninstalled: !list', ['!list' => implode(', ', array_diff($modules, $enabled_modules))]));
+        if ($installed_modules !== $modules) {
+            $this->logger()->warning(dt('The following module(s) are not installed and will not be uninstalled: !list', ['!list' => implode(', ', array_diff($modules, $installed_modules))]));
         }
 
-        $list = $this->addUninstallDependencies($enabled_modules);
+        $list = $this->addUninstallDependencies($installed_modules);
         if (Drush::simulate()) {
             $this->output()->writeln(dt('The following extensions will be uninstalled: !list', ['!list' => implode(', ', $list)]));
             return;

--- a/tests/functional/PmInUnListInfoTest.php
+++ b/tests/functional/PmInUnListInfoTest.php
@@ -74,7 +74,7 @@ class PmInUnListInfoTest extends CommandUnishTestCase
         // Test uninstall of installed module.
         $this->drush('pm-uninstall', ['drush_empty_module']);
         $out = $this->getErrorOutput();
-        $this->assertStringContainsString('Successfully installed', $out);
+        $this->assertStringContainsString('Successfully uninstalled', $out);
 
         $this->drush('pm-list', [], ['status' => 'disabled', 'type' => 'module']);
         $out = $this->getOutput();

--- a/tests/functional/PmInUnListInfoTest.php
+++ b/tests/functional/PmInUnListInfoTest.php
@@ -81,7 +81,7 @@ class PmInUnListInfoTest extends CommandUnishTestCase
         $this->assertStringContainsString('drush_empty_module', $out);
 
         // Test uninstall of uninstalled module.
-        $this->drush('pm-uninstall', ['drush_empty_module']);
+        $this->drush('pm-uninstall', ['drush_empty_module'], [], null, null, self::EXIT_ERROR);
         $out = $this->getErrorOutput();
         $this->assertStringContainsString('The following module(s) are not enabled', $out);
     }

--- a/tests/functional/PmInUnListInfoTest.php
+++ b/tests/functional/PmInUnListInfoTest.php
@@ -71,10 +71,18 @@ class PmInUnListInfoTest extends CommandUnishTestCase
         $this->assertEquals($extensionProperties['drush_empty_module']['status'], 'Enabled');
         $this->assertEquals($extensionProperties['drush_empty_module']['type'], 'module');
 
-        // Test module uninstall.
+        // Test uninstall of installed module.
         $this->drush('pm-uninstall', ['drush_empty_module']);
+        $out = $this->getOutput();
+        $this->assertStringContainsString('Successfully uninstalled', $out);
+
         $this->drush('pm-list', [], ['status' => 'disabled', 'type' => 'module']);
         $out = $this->getOutput();
         $this->assertStringContainsString('drush_empty_module', $out);
+
+        // Test uninstall of uninstalled module.
+        $this->drush('pm-uninstall', ['drush_empty_module']);
+        $out = $this->getOutput();
+        $this->assertStringContainsString('The following module(s) are not enabled', $out);
     }
 }

--- a/tests/functional/PmInUnListInfoTest.php
+++ b/tests/functional/PmInUnListInfoTest.php
@@ -74,7 +74,7 @@ class PmInUnListInfoTest extends CommandUnishTestCase
         // Test uninstall of installed module.
         $this->drush('pm-uninstall', ['drush_empty_module']);
         $out = $this->getErrorOutput();
-        $this->assertStringContainsString('Successfully uninstalled', $out);
+        $this->assertStringContainsString('Successfully installed', $out);
 
         $this->drush('pm-list', [], ['status' => 'disabled', 'type' => 'module']);
         $out = $this->getOutput();
@@ -83,6 +83,6 @@ class PmInUnListInfoTest extends CommandUnishTestCase
         // Test uninstall of uninstalled module.
         $this->drush('pm-uninstall', ['drush_empty_module'], [], null, null, self::EXIT_ERROR);
         $out = $this->getErrorOutput();
-        $this->assertStringContainsString('The following module(s) are not enabled', $out);
+        $this->assertStringContainsString('The following module(s) are not installed', $out);
     }
 }

--- a/tests/functional/PmInUnListInfoTest.php
+++ b/tests/functional/PmInUnListInfoTest.php
@@ -73,7 +73,7 @@ class PmInUnListInfoTest extends CommandUnishTestCase
 
         // Test uninstall of installed module.
         $this->drush('pm-uninstall', ['drush_empty_module']);
-        $out = $this->getOutput();
+        $out = $this->getErrorOutput();
         $this->assertStringContainsString('Successfully uninstalled', $out);
 
         $this->drush('pm-list', [], ['status' => 'disabled', 'type' => 'module']);
@@ -82,7 +82,7 @@ class PmInUnListInfoTest extends CommandUnishTestCase
 
         // Test uninstall of uninstalled module.
         $this->drush('pm-uninstall', ['drush_empty_module']);
-        $out = $this->getOutput();
+        $out = $this->getErrorOutput();
         $this->assertStringContainsString('The following module(s) are not enabled', $out);
     }
 }


### PR DESCRIPTION
Now it prints _'Successfully uninstalled: \<moduleName\>'_ which is confusing IMO.