### PR TITLE
Do not allow commands in parent classes

### DIFF
--- a/src/Runtime/DependencyInjection.php
+++ b/src/Runtime/DependencyInjection.php
@@ -166,6 +166,11 @@ class DependencyInjection
         $factory = $container->get('commandFactory');
         $factory->setIncludeAllPublicMethods(false);
         $factory->setIgnoreCommandsInTraits(true);
+        // Temporary: once we have a stable release of Annotated Command with
+        // this flag, we can call it invariantly.
+        if (method_exists($factory, 'setIgnoreCommandsInParentClasses')) {
+            $factory->setIgnoreCommandsInParentClasses(true);
+        }
         $factory->addCommandInfoAlterer(new DrushCommandInfoAlterer());
 
         $commandProcessor = $container->get('commandProcessor');


### PR DESCRIPTION
Set flag in the Annotated Command commandFactory, if it exists, to ignore commands in parent classes.

This prohibition was added in annotated-command v4.5.7, but it will be reverted to maintain backwards compatibility. See https://github.com/consolidation/annotated-command/pull/277. Once this revert happens, Drush should continue to disallow extending command classes, to avoid side effects in modules.