### PR TITLE
Remove unused param and only set tty when we can

### DIFF
--- a/src/Commands/core/SshCommands.php
+++ b/src/Commands/core/SshCommands.php
@@ -51,7 +51,6 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
 
         $process = $this->processManager()->siteProcess($alias, $code);
         if (Tty::isTtySupported()) {
-            // @todo is this is still needed?
             $process->setTty($options['tty']);
         }
         // The transport handles the chdir during processArgs().

--- a/src/Commands/core/SshCommands.php
+++ b/src/Commands/core/SshCommands.php
@@ -52,7 +52,7 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
         $process = $this->processManager()->siteProcess($alias, $code);
         if (Tty::isTtySupported()) {
             // @todo is this is still needed?
-            $process->setTty(false);
+            $process->setTty($options['tty']);
         }
         // The transport handles the chdir during processArgs().
         $fallback = $alias->hasRoot() ? $alias->root() : null;

--- a/src/Commands/core/SshCommands.php
+++ b/src/Commands/core/SshCommands.php
@@ -3,6 +3,7 @@
 namespace Drush\Commands\core;
 
 use Consolidation\SiteProcess\Util\Shell;
+use Consolidation\SiteProcess\Util\Tty;
 use Drush\Commands\DrushCommands;
 use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
@@ -31,7 +32,7 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
      * @aliases ssh,site-ssh
      * @topics docs:aliases
      */
-    public function ssh(array $code, $options = ['cd' => self::REQ, 'tty' => false]): void
+    public function ssh(array $code, $options = ['cd' => self::REQ]): void
     {
         $alias = $this->siteAliasManager()->getSelf();
 
@@ -49,7 +50,10 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
         }
 
         $process = $this->processManager()->siteProcess($alias, $code);
-        $process->setTty($options['tty']);
+        if (Tty::isTtySupported()) {
+            // @todo is this is still needed?
+            $process->setTty(false);
+        }
         // The transport handles the chdir during processArgs().
         $fallback = $alias->hasRoot() ? $alias->root() : null;
         $process->setWorkingDirectory($options['cd'] ?: $fallback);

--- a/tests/functional/SiteSshTest.php
+++ b/tests/functional/SiteSshTest.php
@@ -24,7 +24,7 @@ class SiteSshTest extends CommandUnishTestCase
         ];
         $this->drush('ssh', [], $options, 'user@server/path/to/drupal#sitename');
         $output = $this->getErrorOutput();
-        $expected = "[notice] Simulating: ssh -t -o PasswordAuthentication=no user@server 'cd /path/to/drupal && bash -l'";
+        $expected = "[notice] Simulating: ssh -o PasswordAuthentication=no user@server 'cd /path/to/drupal && bash -l'";
         $this->assertStringContainsString($expected, $output);
     }
 


### PR DESCRIPTION
Fixes a Drupal 10 test failure "TTY mode requires /dev/tty to be read/writable.". Example https://app.circleci.com/pipelines/github/drush-ops/drush/4320/workflows/70530dae-ef77-43cd-9fe9-d8f9713a71fa/jobs/25996/tests#failed-test-0
