### PR TITLE
Add drush command to clear the locale status

### DIFF
--- a/src/Drupal/Commands/core/LocaleCommands.php
+++ b/src/Drupal/Commands/core/LocaleCommands.php
@@ -81,6 +81,18 @@ class LocaleCommands extends DrushCommands
     }
 
     /**
+     * Clears the translation status.
+     *
+     * @command locale:clear-status
+     * @aliases locale-clear-status
+     * @validate-module-enabled locale
+     */
+    public function clearStatus(): void
+    {
+        locale_translation_clear_status();
+    }
+
+    /**
      * Imports the available translation updates.
      *
      * @see TranslationStatusForm::buildForm()

--- a/src/Drupal/Commands/core/LocaleCommands.php
+++ b/src/Drupal/Commands/core/LocaleCommands.php
@@ -86,6 +86,7 @@ class LocaleCommands extends DrushCommands
      * @command locale:clear-status
      * @aliases locale-clear-status
      * @validate-module-enabled locale
+     * @version 11.5
      */
     public function clearStatus(): void
     {


### PR DESCRIPTION
Updating modules does not automatically clear the locale status. This causes problems in our automatic deployments, because that means the `locale:update` command will sometimes try to use `.po` files for older versions of modules. 

We use `drupal-composer/drupal-l10n` to include the correct `.po` files in our build and don't allow downloading the `.po` files inside the production container. 

When we clear the locale status before running `locale:update`, it always uses the correct files.

We could potentially add this to our own scripts, but we think this is also useful for other Drush users.