### PR TITLE
Update role examples to use single quotes

### DIFF
--- a/src/Drupal/Commands/core/UserCommands.php
+++ b/src/Drupal/Commands/core/UserCommands.php
@@ -168,7 +168,7 @@ class UserCommands extends DrushCommands
      * @option $uid A comma delimited list of user ids to lookup (an alternative to names).
      * @option $mail A comma delimited list of emails to lookup (an alternative to names).
      * @aliases urol,user-add-role
-     * @usage drush user-add-role "editor" user3
+     * @usage drush user-add-role 'editor' user3
      *   Add the editor role to user3
      */
     public function addRole(string $role, string $names = '', $options = ['uid' => self::REQ, 'mail' => self::REQ]): void
@@ -195,8 +195,8 @@ class UserCommands extends DrushCommands
      * @option $uid A comma delimited list of user ids to lookup (an alternative to names).
      * @option $mail A comma delimited list of emails to lookup (an alternative to names).
      * @aliases urrol,user-remove-role
-     * @usage drush user:remove-role "power user" user3
-     *   Remove the "power user" role from user3
+     * @usage drush user:remove-role 'power user' user3
+     *   Remove the 'power user' role from user3
      */
     public function removeRole(string $role, string $names = '', $options = ['uid' => self::REQ, 'mail' => self::REQ]): void
     {
@@ -220,7 +220,7 @@ class UserCommands extends DrushCommands
      * @option password The password for the new account
      * @option mail The email address for the new account
      * @aliases ucrt,user-create
-     * @usage drush user:create newuser --mail="person@example.com" --password="letmein"
+     * @usage drush user:create newuser --mail='person@example.com' --password='letmein'
      *   Create a new user account with the name newuser, the email address person@example.com, and the password letmein
      */
     public function create(string $name, $options = ['password' => self::REQ, 'mail' => self::REQ])
@@ -299,7 +299,7 @@ class UserCommands extends DrushCommands
      * @param string $name The name of the account to modify.
      * @param string $password The new password for the account.
      * @aliases upwd,user-password
-     * @usage drush user:password someuser "correct horse battery staple"
+     * @usage drush user:password someuser 'correct horse battery staple'
      *   Set the password for the username someuser. See https://xkcd.com/936
      */
     public function password(string $name, string $password): void

--- a/src/Drupal/Commands/core/UserCommands.php
+++ b/src/Drupal/Commands/core/UserCommands.php
@@ -168,7 +168,7 @@ class UserCommands extends DrushCommands
      * @option $uid A comma delimited list of user ids to lookup (an alternative to names).
      * @option $mail A comma delimited list of emails to lookup (an alternative to names).
      * @aliases urol,user-add-role
-     * @usage drush user-add-role 'editor' user3
+     * @usage drush user:role:add 'editor' user3
      *   Add the editor role to user3
      */
     public function addRole(string $role, string $names = '', $options = ['uid' => self::REQ, 'mail' => self::REQ]): void
@@ -190,13 +190,13 @@ class UserCommands extends DrushCommands
      * @command user:role:remove
      *
      * @validate-entity-load user_role role
-     * @param string $role The name of the role to add
+     * @param string $role The machine name of the role to remove
      * @param string $names A comma delimited list of user names.
      * @option $uid A comma delimited list of user ids to lookup (an alternative to names).
      * @option $mail A comma delimited list of emails to lookup (an alternative to names).
      * @aliases urrol,user-remove-role
-     * @usage drush user:remove-role 'power user' user3
-     *   Remove the 'power user' role from user3
+     * @usage drush user:role:remove 'power_user' user3
+     *   Remove the 'power_user' role from user3
      */
     public function removeRole(string $role, string $names = '', $options = ['uid' => self::REQ, 'mail' => self::REQ]): void
     {


### PR DESCRIPTION
Fixes: #5324.

## Problem

The `user:password` example uses double quotes:

```
$ drush user:password -h
Set the password for the user account with the specified name.

Examples:
 drush user:password someuser "correct horse battery staple"
```

... but you cannot use double quotes to create passwords containing special character (for example `f!oobar12345`) but have to use single quotes:

> Strings in single quotes are not expanded by bash.

Otherwise you get an error:

```
$ drush user:password your.user "!foobar12345"
bash: !foobar12345: event not found
```

From https://superuser.com/questions/133780/in-bash-how-do-i-escape-an-exclamation-mark

## Solution

Use single quotes.

To stay consistent, I updated the other instances in examples to use single quotes as well. Also, I noticed that a few examples were not correct, so I updated them as well.