### PR TITLE
Allow to specify/override ssh default-command

### DIFF
--- a/docs/using-drush-configuration.md
+++ b/docs/using-drush-configuration.md
@@ -159,6 +159,10 @@ ssh:
   # password authentication, and is included here, so you may add additional
   # parameters without losing the default configuration.
   options: '-o PasswordAuthentication=no'
+  # Specify the default command used when `drush ssh` is invoked without arguments.
+  default-command: ['bash', '-l']
+  # Enable tty mode when using default command.
+  default-command-tty: true
   # This string is valid for Bash shell. Override in case you need something different. See https://github.com/drush-ops/drush/issues/3816.
   pipefail: 'set -o pipefail; '
 

--- a/examples/example.drush.yml
+++ b/examples/example.drush.yml
@@ -35,5 +35,9 @@ ssh:
   # password authentication, and is included here, so you may add additional
   # parameters without losing the default configuration.
   options: '-o PasswordAuthentication=no'
+  # Uncomment to override the default command used when `drush ssh` is invoked without arguments.
+#  default-command: ['bash', '-l']
+  # Uncomment to override tty mode when using default command.
+#  default-command-tty: true
   # This string is valid for Bash shell. Override in case you need something different. See https://github.com/drush-ops/drush/issues/3816.
   pipefail: 'set -o pipefail; '

--- a/src/Commands/core/SshCommands.php
+++ b/src/Commands/core/SshCommands.php
@@ -37,12 +37,11 @@ class SshCommands extends DrushCommands implements SiteAliasManagerAwareInterfac
         $alias = $this->siteAliasManager()->getSelf();
 
         if (empty($code)) {
-            $code[] = 'bash';
-            $code[] = '-l';
+            $code = $this->getConfig()->get('ssh.default-command') ?? ['bash', '-l'];
 
             // We're calling an interactive 'bash' shell, so we want to
             // force tty to true.
-            $options['tty'] = true;
+            $options['tty'] = $this->getConfig()->get('ssh.default-command-tty', true);
         }
 
         if ((count($code) == 1)) {

--- a/tests/functional/resources/alias-fixtures/example.site.yml
+++ b/tests/functional/resources/alias-fixtures/example.site.yml
@@ -21,5 +21,6 @@ live:
   uri: https://example.com
   ssh:
     options: '-o PasswordAuthentication=example'
+    default-command: ['sh', '-l']
   paths:
     drush-script: '/example/path/to/drush'


### PR DESCRIPTION
To be able to use `drush ssh` without arguments on hosts that don´t have bash installed, this PR allows to set the default command via config. 