### PR TITLE
Remove DrushBatchContext magic wrapper for batch .

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  *    Drush batch API.
@@ -26,28 +27,6 @@
 
 use Drupal\Core\Database\Database;
 use Drush\Drush;
-
-/**
- * Class extending ArrayObject to allow the batch API to perform logging when
- * some keys of the array change.
- *
- * It is used to wrap batch's $context array and set log messages when values
- * are assigned to keys 'message' or 'error_message'.
- *
- * @see _drush_batch_worker().
- */
-class DrushBatchContext extends ArrayObject {
-  #[\ReturnTypeWillChange]
-  function offsetSet($name, $value) {
-    if ($name == 'message') {
-      Drush::logger()->notice(strip_tags($value));
-    }
-    elseif ($name == 'error_message') {
-      Drush::logger()->error(strip_tags($value));
-    }
-    parent::offsetSet($name, $value);
-  }
-}
 
 /**
  * Process a Drupal batch by spawning multiple Drush processes.
@@ -111,7 +90,7 @@ function drush_batch_command($id) {
 function _drush_backend_batch_process($command = 'batch-process', $args = [], $options = []) {
   $result = NULL;
 
-  $batch =& batch_get();
+  $batch = &batch_get();
 
   if (isset($batch)) {
     $process_info = [
@@ -176,7 +155,7 @@ function _drush_backend_batch_process($command = 'batch-process', $args = [], $o
  *   A results array.
  */
 function _drush_batch_command($id) {
-  $batch =& batch_get();
+  $batch = &batch_get();
 
   $data = Database::getConnection()->select('batch', 'b')
     ->fields('b', ['batch'])
@@ -215,8 +194,8 @@ function _drush_batch_command($id) {
  * reached.
  */
 function _drush_batch_worker() {
-  $batch =& batch_get();
-  $current_set =& _batch_current_set();
+  $batch = &batch_get();
+  $current_set = &_batch_current_set();
   $set_changed = TRUE;
 
   if (empty($current_set['start'])) {
@@ -237,7 +216,7 @@ function _drush_batch_worker() {
     $finished = 1;
 
     if ($item = $queue->claimItem()) {
-      list($function, $args) = $item->data;
+      [$callback, $args] = $item->data;
 
       // Build the 'context' array and execute the function call.
       $batch_context = [
@@ -246,20 +225,17 @@ function _drush_batch_worker() {
         'finished' => &$finished,
         'message'  => &$task_message,
       ];
-      // Magic wrap to catch changes to 'message' key.
-      $batch_context = new DrushBatchContext($batch_context);
 
       // Tolerate recoverable errors.
       // See https://github.com/drush-ops/drush/issues/1930
       $halt_on_error = \Drush\Drush::config()->get('runtime.php.halt-on-error', TRUE);
       \Drush\Drush::config()->set('runtime.php.halt-on-error', FALSE);
-      $message = call_user_func_array($function, array_merge($args, [&$batch_context]));
-      if (!empty($message)) {
-        Drush::logger()->notice($message);
+      call_user_func_array($callback, array_merge($args, [&$batch_context]));
+      if (!empty($task_message)) {
+        Drush::logger()->notice(strip_tags($task_message));
       }
       \Drush\Drush::config()->set('runtime.php.halt-on-error', $halt_on_error);
 
-      $finished = $batch_context['finished'];
       if ($finished >= 1) {
         // Make sure this step is not counted twice when computing $current.
         $finished = 0;
@@ -371,8 +347,8 @@ function _drush_batch_finished() {
  */
 function _drush_batch_shutdown() {
   if ($batch = batch_get()) {
-      /** @var \Drupal\Core\Batch\BatchStorage $batch_storage */
-      $batch_storage = \Drupal::service('batch.storage');
-      $batch_storage->update($batch);
+    /** @var \Drupal\Core\Batch\BatchStorage $batch_storage */
+    $batch_storage = \Drupal::service('batch.storage');
+    $batch_storage->update($batch);
   }
 }

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -4,7 +4,6 @@ namespace Drush\Commands\core;
 
 use Drush\Log\SuccessInterface;
 use Drush\Drupal\DrupalUtil;
-use DrushBatchContext;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Consolidation\OutputFormatters\StructuredData\UnstructuredListData;
 use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
@@ -151,10 +150,10 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
      *   The update number to run.
      * @param array $dependency_map
      *   The update dependency map.
-     * @param DrushBatchContext $context
+     * @param array $context
      *   The batch context object.
      */
-    public static function updateDoOne(string $module, int $number, array $dependency_map, DrushBatchContext $context): void
+    public static function updateDoOne(string $module, int $number, array $dependency_map, array $context): void
     {
         $function = $module . '_update_' . $number;
 
@@ -229,9 +228,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         if (!empty($ret['#abort'])) {
             // Record this function in the list of updates that were aborted.
             $context['results']['#abort'][] = $function;
-            // Setting this value will output an error message.
-            // @see \DrushBatchContext::offsetSet()
-            $context['error_message'] = "Update failed: $function";
+            Drush::logger()->error("Update failed: $function");
         }
 
         // Record the schema update if it was completed successfully.
@@ -242,8 +239,6 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
             } else {
                 drupal_set_installed_schema_version($module, $number);
             }
-            // Setting this value will output a success message.
-            // @see \DrushBatchContext::offsetSet()
             $context['message'] = "Update completed: $function";
         }
     }
@@ -255,7 +250,7 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
      *   The post-update function to execute.
      *   The batch context object.
      */
-    public static function updateDoOnePostUpdate(string $function, DrushBatchContext $context): void
+    public static function updateDoOnePostUpdate(string $function, array $context): void
     {
         $ret = [];
 
@@ -331,12 +326,8 @@ class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInt
         if (!empty($ret['#abort'])) {
             // Record this function in the list of updates that were aborted.
             $context['results']['#abort'][] = $function;
-            // Setting this value will output an error message.
-            // @see \DrushBatchContext::offsetSet()
-            $context['error_message'] = "Update failed: $function";
+            Drush::logger()->error("Update failed: $function");
         } elseif ($context['finished'] == 1 && empty($ret['#abort'])) {
-            // Setting this value will output a success message.
-            // @see \DrushBatchContext::offsetSet()
             $context['message'] = "Update completed: $function";
         }
     }

--- a/src/Drupal/Commands/core/DeployHookCommands.php
+++ b/src/Drupal/Commands/core/DeployHookCommands.php
@@ -11,7 +11,6 @@ use Drupal\Core\Update\UpdateRegistry;
 use Drupal\Core\Utility\Error;
 use Drush\Commands\DrushCommands;
 use Drush\Drush;
-use DrushBatchContext;
 use Drush\Exceptions\UserAbortException;
 use Psr\Log\LogLevel;
 
@@ -161,7 +160,7 @@ class DeployHookCommands extends DrushCommands implements SiteAliasManagerAwareI
      *   The deploy-hook function to execute.
      *   The batch context object.
      */
-    public static function updateDoOneDeployHook(string $function, DrushBatchContext $context): void
+    public static function updateDoOneDeployHook(string $function, array $context): void
     {
         $ret = [];
 
@@ -239,12 +238,8 @@ class DeployHookCommands extends DrushCommands implements SiteAliasManagerAwareI
         if (!empty($ret['#abort'])) {
             // Record this function in the list of updates that were aborted.
             $context['results']['#abort'][] = $function;
-            // Setting this value will output an error message.
-            // @see \DrushBatchContext::offsetSet()
-            $context['error_message'] = "Deploy hook failed: $function";
+            Drush::logger()->error("Deploy hook failed: $function");
         } elseif ($context['finished'] == 1 && empty($ret['#abort'])) {
-            // Setting this value will output a success message.
-            // @see \DrushBatchContext::offsetSet()
             $context['message'] = "Performed: $function";
         }
     }


### PR DESCRIPTION
It should fix this issue #5009 

Tests are passing.

**Summary:**
The DrushBatchContext wrapper is causing issues to keep the batch $context values. It's mainly used for logging, but it can be done in the operations level instead of overriding the $context type.
The variable `$context['error_message']` is only being used by the drush batch processes and we can use `Drush::logger()->error();` as a replacement.
After this change, we can use the `$task_message` variable to retrieve the `$context['message']` value and log it to the user.

I tested the `updb` in one of my sites and this is the output:
```
 ----------------------- ------------------------------- --------------- ------------------------------------------------------------------------------ 
  Module                  Update ID                       Type            Description                                                                   
 ----------------------- ------------------------------- --------------- ------------------------------------------------------------------------------ 
  lightning_media_image   9001                            hook_update_n   9001 - Downloads the Cropper JavaScript library if needed.                    
  block_content           entity_changed_constraint       post-update     Clear the entity type cache.                                                  
  ctools                  remove_entitybundleconstraint   post-update     Invalidate the service container to force EntityBundleConstriant is Removed.  
  webform                 ckeditor                        post-update     Move from custom CKEditor to hidden 'webform_default' text format.            
 ----------------------- ------------------------------- --------------- ------------------------------------------------------------------------------ 


 Do you wish to run the specified pending updates? (yes/no) [yes]:
 > 

>  [notice] Update started: lightning_media_image_update_9001
>  [notice] Update completed: lightning_media_image_update_9001
>  [notice] Update started: block_content_post_update_entity_changed_constraint
>  [notice] Update completed: block_content_post_update_entity_changed_constraint
>  [notice] Update started: ctools_post_update_remove_entitybundleconstraint
>  [notice] Update completed: ctools_post_update_remove_entitybundleconstraint
>  [notice] Update started: webform_post_update_ckeditor
>  [notice] Update completed: webform_post_update_ckeditor
 [success] Finished performing updates.
```