### PR TITLE
Provide example configuration on how to enable MySQL autocomplete

### DIFF
--- a/docs/using-drush-configuration.md
+++ b/docs/using-drush-configuration.md
@@ -101,10 +101,14 @@ options:
 ```yml
 command:
   sql:
+    cli:
+      options:
+        # Enable auto-complete in MySQL.
+        extra: "--auto-rehash"
     dump:
       options:
         # Omit cache and similar tables (including during a sql:sync).
-          structure-tables-key: common
+        structure-tables-key: common
   php:
     script:
       options:


### PR DESCRIPTION
It would be nice if we provide an example on how to enable shell autocompletion in `drush sql:cli`. When googling for this an old issue from 10+ years ago always pops up, but this is irrelevant: https://www.drupal.org/project/drush/issues/570890