### PR TITLE
Separate using git from isDecorated.

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -580,8 +580,11 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
         self::copyConfig($source_storage, $temp_source_storage);
 
         $prefix = ['diff'];
-        if (self::programExists('git') && $output->isDecorated()) {
-            $prefix = ['git', 'diff', '--color=always'];
+        if (self::programExists('git')) {
+            $prefix = ['git', 'diff'];
+            if ($output->isDecorated()) {
+                $prefix[] = '--color=always';
+            }
         }
         $args = array_merge($prefix, ['-u', $temp_destination_dir, $temp_source_dir]);
         $process = Drush::process($args);


### PR DESCRIPTION
This will make the output consistent between interactive and non-interactive sessions.

On Acquia servers, `drush cex --diff --no` outputs a single-line `Only in [directory]` when a config file is fully added or deleted, where `drush cex --diff` will show the full diff, ie the contents, of the file.