### PR TITLE
Various build errors in Drush 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,21 +78,13 @@ workflows:
     jobs:
       - lint
       - test:
-          name: test-drupal-9.3-php-8.1
-          drupal: "9.3.0"
+          name: test-drupal-8-php-8.1
+          drupal: "8.9.20"
           os: linux81
       - test:
-          name: test-drupal-9.3-php-8.0
-          drupal: "9.3.0"
-          os: linux80
-      - test:
-          name: test-drupal-9.3-php-7.4
-          drupal: "9.3.0"
-          os: linux74
-      - test:
-          name: test-drupal-9.1-php-7.4
-          drupal: "9.1.15"
-          os: linux74
+          name: test-drupal-7-php-8.1
+          drupal: "7"
+          os: linux81
       - test:
           name: test-drupal-7-php-7.4
           drupal: "7"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,9 @@ workflows:
     jobs:
       - lint
       - test:
-          name: test-drupal-8-php-8.1
+          name: test-drupal-8-php-7.4
           drupal: "8.9.20"
-          os: linux81
+          os: linux74
       - test:
           name: test-drupal-7-php-8.1
           drupal: "7"

--- a/tests/makeTest.php
+++ b/tests/makeTest.php
@@ -463,11 +463,13 @@ class makeMakefileCase extends CommandUnishTestCase {
   }
 
   function testMakeInclude() {
+    $this->markTestSkipped('Make test must be updated; Drupal 6 is EOL, fixture projects are not available. PRs welcome.');
     $this->runMakefileTest('include');
   }
 
   /** @group make.yml */
   function testMakeIncludeYaml() {
+    $this->markTestSkipped('Make test must be updated; Drupal 6 is EOL, fixture projects are not available. PRs welcome.');
     $this->runMakefileTest('include-yaml');
   }
 


### PR DESCRIPTION
Skip some Drush Make tests that depend on Drupal 6 fixtures that no longer work correctly. Throw in a hack of a fix to the pm-releases code to account for changing drupal.org markup.