### PR TITLE
Fix parameter name in ConfigCommands::__constructor()

### DIFF
--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -84,7 +84,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
         if (isset($this->configStorageExport)) {
             return $this->configStorageExport;
         }
-        return $this->configStorage;
+        return $this->configStorageExport;
     }
 
     public function setImportTransformer(ImportStorageTransformer $importStorageTransformer): void
@@ -412,7 +412,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
             $target_storage = $this->getImportTransformer()->transform($target_storage);
         }
 
-        $config_comparer = new StorageComparer($this->configStorage, $target_storage);
+        $config_comparer = new StorageComparer($this->configStorageExport, $target_storage);
 
         $change_list = [];
         if ($config_comparer->createChangelist()->hasChanges()) {

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -59,13 +59,13 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
     /**
      * ConfigCommands constructor.
      * @param ConfigFactoryInterface $configFactory
-     * @param StorageInterface $configStorageExport
+     * @param StorageInterface $configStorage
      */
-    public function __construct($configFactory, StorageInterface $configStorageExport)
+    public function __construct($configFactory, StorageInterface $configStorage)
     {
         parent::__construct();
         $this->configFactory = $configFactory;
-        $this->configStorageExport = $configStorageExport;
+        $this->configStorage = $configStorage;
     }
 
     /**

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -46,6 +46,11 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
     protected $configStorageExport;
 
     /**
+     * @var StorageInterface
+     */
+    protected $configStorage;
+
+    /**
      * @var ImportStorageTransformer
      */
     protected $importStorageTransformer;

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -59,13 +59,13 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
     /**
      * ConfigCommands constructor.
      * @param ConfigFactoryInterface $configFactory
-     * @param StorageInterface $configStorage
+     * @param StorageInterface $configStorageExport
      */
-    public function __construct($configFactory, StorageInterface $configStorage)
+    public function __construct($configFactory, StorageInterface $configStorageExport)
     {
         parent::__construct();
         $this->configFactory = $configFactory;
-        $this->configStorage = $configStorage;
+        $this->configStorageExport = $configStorageExport;
     }
 
     /**

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -84,7 +84,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
         if (isset($this->configStorageExport)) {
             return $this->configStorageExport;
         }
-        return $this->configStorageExport;
+        return $this->configStorage;
     }
 
     public function setImportTransformer(ImportStorageTransformer $importStorageTransformer): void
@@ -412,7 +412,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
             $target_storage = $this->getImportTransformer()->transform($target_storage);
         }
 
-        $config_comparer = new StorageComparer($this->configStorageExport, $target_storage);
+        $config_comparer = new StorageComparer($this->configStorage, $target_storage);
 
         $change_list = [];
         if ($config_comparer->createChangelist()->hasChanges()) {


### PR DESCRIPTION
This currently triggers the following notice on PHP 8.2.
> Deprecated function: Creation of dynamic property Drush\Drupal\Commands\config\ConfigCommands::$configStorage is deprecated in Drush\Drupal\Commands\config\ConfigCommands->__construct()