### PR TITLE
Add maint mode commands

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -1,14 +1,14 @@
 Running Drupal cron tasks from Drush
 ====================================
 
-Drupal cron tasks are often set up to be run via a wget call to cron.php; this same task can also be accomplished via the [cron command](commands/core_cron.md), which circumvents the need to provide a web server interface to cron.
+Drupal cron tasks are often set up to be run via a wget/curl call to cron.php; this same task can also be accomplished via the [cron command](commands/core_cron.md), which circumvents the need to provide a web server interface to cron.
 
 Quick start
 ----------
 
 If you just want to get started quickly, here is a crontab entry that will run cron once every hour at ten minutes after the hour:
 
-    10 * * * * cd [DOCROOT] && /usr/bin/env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin COLUMNS=72 ../vendor/bin/drush --uri=your.drupalsite.org --quiet cron
+    10 * * * * cd [DOCROOT] && /usr/bin/env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin COLUMNS=72 ../vendor/bin/drush --uri=your.drupalsite.org --quiet maint:status && /vendor/bin/drush --uri=your.drupalsite.org --quiet cron
 
 You should set up crontab to run your cron tasks as the same user that runs the web server; for example, if you run your web server as the user www-data:
 
@@ -47,3 +47,7 @@ Specifying the Drupal site to run
 
 There are many ways to tell Drush which Drupal site to select for the active command, and any may be used here. The example uses `cd [DOCROOT]`, but you could also use the --root and --uri flags.
 
+Avoiding Maintenance mode
+---------------------------------
+
+The call to maint:status checks to see if the site is in maintenance mode. If yes, cron will not run and the command returns a failure. It is not safe to run cron while the site is in maintenance. See https://drupal.slack.com/archives/C45SW3FLM/p1675287662331809.

--- a/src/Drupal/Commands/core/DrupalCommands.php
+++ b/src/Drupal/Commands/core/DrupalCommands.php
@@ -60,6 +60,8 @@ class DrupalCommands extends DrushCommands
      *
      * @command core:cron
      * @aliases cron,core-cron
+     * @usage drush maint:status && drush core:cron
+     *  Run cron unless maintenance mode is enabled
      * @topics docs:cron
      */
     public function cron(): void

--- a/src/Drupal/Commands/core/MaintCommands.php
+++ b/src/Drupal/Commands/core/MaintCommands.php
@@ -25,7 +25,9 @@ class MaintCommands extends DrushCommands
     }
 
     /**
-     * Get maintenance mode.
+     * Get maintenance mode. Returns 1 if enabled, 0 if not.
+     *
+     * Consider using maint:status instead when chaining commands.
      *
      * @command maint:get
      *
@@ -60,7 +62,7 @@ class MaintCommands extends DrushCommands
 
 
     /**
-     * Fails if maintenance mode is enabled.
+     * Fail if maintenance mode is enabled.
      *
      * This commands fails with exit code of 3 when maintenance mode is on. This special
      * exit code distinguishes from a failure to complete.
@@ -72,7 +74,7 @@ class MaintCommands extends DrushCommands
      * @aliases mstatus
      * @version 11.5
      */
-    public function status()
+    public function status(): int
     {
         $value = $this->getState()->get(self::KEY);
         return $value ? self::EXIT_FAILURE_WITH_CLARITY : self::EXIT_SUCCESS;

--- a/src/Drupal/Commands/core/MaintCommands.php
+++ b/src/Drupal/Commands/core/MaintCommands.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drush\Drupal\Commands\core;
+
+    use Consolidation\AnnotatedCommand\CommandResult;
+    use Consolidation\AnnotatedCommand\Input\StdinAwareInterface;
+    use Consolidation\AnnotatedCommand\Input\StdinAwareTrait;
+    use Drupal\Core\State\StateInterface;
+    use Drush\Commands\DrushCommands;
+
+class MaintCommands extends DrushCommands
+{
+    const KEY = 'system.maintenance_mode';
+
+    protected $state;
+
+    public function __construct(StateInterface $state)
+    {
+        $this->state = $state;
+    }
+
+    public function getState(): StateInterface
+    {
+        return $this->state;
+    }
+
+    /**
+     * Get maintenance mode.
+     *
+     * @command maint:get
+     *
+     * @usage drush maint:get
+     *   Print value of maintenance mode in Drupal
+     * @aliases mget
+     * @version 11.5
+     */
+    public function get(): string
+    {
+        $value = $this->getState()->get(self::KEY);
+        return $value ? '1' : '0';
+    }
+
+    /**
+     * Set maintenance mode.
+     *
+     * @command maint:set
+     *
+     * @param mixed $value The value to assign to the state key.
+     * @usage drush maint:set 1
+     *  Put site into Maintenance mode.
+     * @usage drush maint:set 0
+     *  Remove site from Maintenance mode.
+     * @aliases mset
+     * @version 11.5
+     */
+    public function set(string $value): void
+    {
+        $this->getState()->set(self::KEY, (bool) $value);
+    }
+
+
+    /**
+     * Fails if maintenance mode is enabled.
+     *
+     * This commands fails with exit code of 3 when maintenance mode is on. This special
+     * exit code distinguishes from a failure to complete.
+     *
+     * @command maint:status
+     *
+     * @usage drush maint:status && drush cron
+     *   Only run cron when Drupal is not in maintenance mode.
+     * @aliases mstatus
+     * @version 11.5
+     */
+    public function status()
+    {
+        $value = $this->getState()->get(self::KEY);
+        return $value ? self::EXIT_FAILURE_WITH_CLARITY : self::EXIT_SUCCESS;
+    }
+}

--- a/src/Drupal/Commands/core/drush.services.yml
+++ b/src/Drupal/Commands/core/drush.services.yml
@@ -45,6 +45,11 @@ services:
     arguments: ['@language_manager', '@config.factory', '@module_handler', '@state']
     tags:
       -  { name: drush.command }
+  maint.commands:
+    class: \Drush\Drupal\Commands\core\MaintCommands
+    arguments: [ '@state' ]
+    tags:
+      - { name: drush.command }
   messenger.commands:
       class: \Drush\Drupal\Commands\core\MessengerCommands
       arguments: ['@messenger']

--- a/tests/integration/MaintTest.php
+++ b/tests/integration/MaintTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Unish;
+
+/**
+ * Tests Maintenance commands
+ *
+ * @group commands
+ */
+class MaintenanceTest extends UnishIntegrationTestCase
+{
+    public function testMaint()
+    {
+        $this->drush('maint:set', [1]);
+        $this->drush('maint:get');
+        $this->assertOutputEquals('1');
+        $this->drush('maint:status', [], [], self::EXIT_ERROR_WITH_CLARITY);
+        $this->drush('maint:set', [0]);
+        $this->drush('maint:get');
+        $this->assertOutputEquals('0');
+        $this->drush('maint:status', [], [], self::EXIT_SUCCESS);
+    }
+}


### PR DESCRIPTION
Helps address https://github.com/drush-ops/drush/issues/3782 and https://drupal.slack.com/archives/C45SW3FLM/p1675287662331809 (Cron jobs that run while maint mode is on can break deployments, especially field add/edit during config import)

Example usages:
- `drush maint:status && drush purge`
- `drush maint:status && drush queue:run scheduled_transition_job`