### PR TITLE
Stop using options hook in favor of Attribute

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -154,12 +154,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "15a8824cb2c3975b3f2decc671e9522c655806ea"
+                "reference": "ed8ae76206aade1ddf7f20e71bd9056d231cc68e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/15a8824cb2c3975b3f2decc671e9522c655806ea",
-                "reference": "15a8824cb2c3975b3f2decc671e9522c655806ea",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/ed8ae76206aade1ddf7f20e71bd9056d231cc68e",
+                "reference": "ed8ae76206aade1ddf7f20e71bd9056d231cc68e",
                 "shasum": ""
             },
             "require": {
@@ -203,7 +203,7 @@
                 "issues": "https://github.com/consolidation/annotated-command/issues",
                 "source": "https://github.com/consolidation/annotated-command/tree/4.x"
             },
-            "time": "2023-03-05T00:53:25+00:00"
+            "time": "2023-03-07T02:14:10+00:00"
         },
         {
             "name": "consolidation/config",

--- a/src/Attributes/OptionsetGetEditor.php
+++ b/src/Attributes/OptionsetGetEditor.php
@@ -10,7 +10,7 @@ class OptionsetGetEditor
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
-        $commandInfo->addOptionOrArgumentDescription($commandInfo->options(), 'editor' ,'A string of bash which launches user\'s preferred text editor. Defaults to <info>${VISUAL-${EDITOR-vi}}</info>.', [],'');
-        $commandInfo->addOptionOrArgumentDescription($commandInfo->options(), 'bg' ,'Launch editor in background process.', [], false);
+        $commandInfo->addOptionDescriptionDefaultValue('editor' ,'A string of bash which launches user\'s preferred text editor. Defaults to <info>${VISUAL-${EDITOR-vi}}</info>.', [],'');
+        $commandInfo->addOptionDescriptionDefaultValue('bg' ,'Launch editor in background process.', [], false);
     }
 }

--- a/src/Attributes/OptionsetGetEditor.php
+++ b/src/Attributes/OptionsetGetEditor.php
@@ -10,7 +10,7 @@ class OptionsetGetEditor
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
-        $commandInfo->addOption('editor' ,'A string of bash which launches user\'s preferred text editor. Defaults to <info>${VISUAL-${EDITOR-vi}}</info>.', [],'');
-        $commandInfo->addOption('bg' ,'Launch editor in background process.', [], false);
+        $commandInfo->addOption('editor', 'A string of bash which launches user\'s preferred text editor. Defaults to <info>${VISUAL-${EDITOR-vi}}</info>.', [], '');
+        $commandInfo->addOption('bg', 'Launch editor in background process.', [], false);
     }
 }

--- a/src/Attributes/OptionsetGetEditor.php
+++ b/src/Attributes/OptionsetGetEditor.php
@@ -3,9 +3,14 @@
 namespace Drush\Attributes;
 
 use Attribute;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 
 #[Attribute(Attribute::TARGET_METHOD)]
-class OptionsetGetEditor extends NoArgumentsBase
+class OptionsetGetEditor
 {
-    const NAME = 'optionset_get_editor';
+    public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
+    {
+        $commandInfo->addOptionOrArgumentDescription($commandInfo->options(), 'editor' ,'A string of bash which launches user\'s preferred text editor. Defaults to <info>${VISUAL-${EDITOR-vi}}</info>.', [],'');
+        $commandInfo->addOptionOrArgumentDescription($commandInfo->options(), 'bg' ,'Launch editor in background process.', [], false);
+    }
 }

--- a/src/Attributes/OptionsetGetEditor.php
+++ b/src/Attributes/OptionsetGetEditor.php
@@ -10,7 +10,7 @@ class OptionsetGetEditor
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
-        $commandInfo->addOptionDescriptionDefaultValue('editor' ,'A string of bash which launches user\'s preferred text editor. Defaults to <info>${VISUAL-${EDITOR-vi}}</info>.', [],'');
-        $commandInfo->addOptionDescriptionDefaultValue('bg' ,'Launch editor in background process.', [], false);
+        $commandInfo->addOption('editor' ,'A string of bash which launches user\'s preferred text editor. Defaults to <info>${VISUAL-${EDITOR-vi}}</info>.', [],'');
+        $commandInfo->addOption('bg' ,'Launch editor in background process.', [], false);
     }
 }

--- a/src/Attributes/OptionsetProcBuild.php
+++ b/src/Attributes/OptionsetProcBuild.php
@@ -7,7 +7,7 @@ use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Drush\Commands\DrushCommands;
 
 #[Attribute(Attribute::TARGET_METHOD)]
-class OptionsetProcBuild extends NoArgumentsBase
+class OptionsetProcBuild
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {

--- a/src/Attributes/OptionsetProcBuild.php
+++ b/src/Attributes/OptionsetProcBuild.php
@@ -3,9 +3,15 @@
 namespace Drush\Attributes;
 
 use Attribute;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Drush\Commands\DrushCommands;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 class OptionsetProcBuild extends NoArgumentsBase
 {
-    const NAME = 'optionset_proc_build';
+    public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
+    {
+        $commandInfo->addOption('ssh-options' ,'A string of extra options that will be passed to the ssh command (e.g. <info>-p 100</info>)', [],DrushCommands::REQ);
+        $commandInfo->addOption('tty' ,'Create a tty (e.g. to run an interactive program).', [], false);
+    }
 }

--- a/src/Attributes/OptionsetProcBuild.php
+++ b/src/Attributes/OptionsetProcBuild.php
@@ -11,7 +11,7 @@ class OptionsetProcBuild extends NoArgumentsBase
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
-        $commandInfo->addOption('ssh-options' ,'A string of extra options that will be passed to the ssh command (e.g. <info>-p 100</info>)', [],DrushCommands::REQ);
-        $commandInfo->addOption('tty' ,'Create a tty (e.g. to run an interactive program).', [], false);
+        $commandInfo->addOption('ssh-options', 'A string of extra options that will be passed to the ssh command (e.g. <info>-p 100</info>)', [], DrushCommands::REQ);
+        $commandInfo->addOption('tty', 'Create a tty (e.g. to run an interactive program).', [], false);
     }
 }

--- a/src/Attributes/OptionsetSql.php
+++ b/src/Attributes/OptionsetSql.php
@@ -3,9 +3,17 @@
 namespace Drush\Attributes;
 
 use Attribute;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Drush\Commands\DrushCommands;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 class OptionsetSql extends NoArgumentsBase
 {
-    const NAME = 'optionset_sql';
+    public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
+    {
+        $commandInfo->addOption('database','The DB connection key if using multiple connections in settings.php.', [],'default');
+        $commandInfo->addOption('db-url','A Drupal 6 style database URL. For example <info>mysql://root:pass@localhost:port/dbname</info>', [], 'default');
+        $commandInfo->addOption('target','The name of a target within the specified database connection.', [],DrushCommands::REQ);
+        $commandInfo->addOption('show-passwords','Show password on the CLI. Useful for debugging.', [], false);
+    }
 }

--- a/src/Attributes/OptionsetSql.php
+++ b/src/Attributes/OptionsetSql.php
@@ -11,9 +11,9 @@ class OptionsetSql extends NoArgumentsBase
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
-        $commandInfo->addOption('database','The DB connection key if using multiple connections in settings.php.', [],'default');
-        $commandInfo->addOption('db-url','A Drupal 6 style database URL. For example <info>mysql://root:pass@localhost:port/dbname</info>', [], 'default');
-        $commandInfo->addOption('target','The name of a target within the specified database connection.', [],DrushCommands::REQ);
-        $commandInfo->addOption('show-passwords','Show password on the CLI. Useful for debugging.', [], false);
+        $commandInfo->addOption('database', 'The DB connection key if using multiple connections in settings.php.', [], 'default');
+        $commandInfo->addOption('db-url', 'A Drupal 6 style database URL. For example <info>mysql://root:pass@localhost:port/dbname</info>', [], 'default');
+        $commandInfo->addOption('target', 'The name of a target within the specified database connection.', [], DrushCommands::REQ);
+        $commandInfo->addOption('show-passwords', 'Show password on the CLI. Useful for debugging.', [], false);
     }
 }

--- a/src/Attributes/OptionsetSql.php
+++ b/src/Attributes/OptionsetSql.php
@@ -7,7 +7,7 @@ use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Drush\Commands\DrushCommands;
 
 #[Attribute(Attribute::TARGET_METHOD)]
-class OptionsetSql extends NoArgumentsBase
+class OptionsetSql
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {

--- a/src/Attributes/OptionsetSql.php
+++ b/src/Attributes/OptionsetSql.php
@@ -12,8 +12,8 @@ class OptionsetSql
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
         $commandInfo->addOption('database', 'The DB connection key if using multiple connections in settings.php.', [], 'default');
-        $commandInfo->addOption('db-url', 'A Drupal 6 style database URL. For example <info>mysql://root:pass@localhost:port/dbname</info>', [], 'default');
-        $commandInfo->addOption('target', 'The name of a target within the specified database connection.', [], DrushCommands::REQ);
+        $commandInfo->addOption('db-url', 'A Drupal 6 style database URL. For example <info>mysql://root:pass@localhost:port/dbname</info>', [], DrushCommands::REQ);
+        $commandInfo->addOption('target', 'The name of a target within the specified database connection.', [], 'default');
         $commandInfo->addOption('show-passwords', 'Show password on the CLI. Useful for debugging.', [], false);
     }
 }

--- a/src/Attributes/OptionsetSsh.php
+++ b/src/Attributes/OptionsetSsh.php
@@ -11,6 +11,6 @@ class OptionsetSsh
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
-        $commandInfo->addOptionOrArgumentDescription($commandInfo->options(), 'ssh-options', 'A string appended to ssh command during rsync, sql-sync, etc.', [], DrushCommands::REQ);
+        $commandInfo->addOptionDescriptionDefaultValue('ssh-options', 'A string appended to ssh command during rsync, sql-sync, etc.', [], DrushCommands::REQ);
     }
 }

--- a/src/Attributes/OptionsetSsh.php
+++ b/src/Attributes/OptionsetSsh.php
@@ -3,9 +3,14 @@
 namespace Drush\Attributes;
 
 use Attribute;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Drush\Commands\DrushCommands;
 
 #[Attribute(Attribute::TARGET_METHOD)]
-class OptionsetSsh extends NoArgumentsBase
+class OptionsetSsh
 {
-    const NAME = 'optionset_ssh';
+    public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
+    {
+        $commandInfo->addOptionOrArgumentDescription($commandInfo->options(), 'ssh-options', 'A string appended to ssh command during rsync, sql-sync, etc.', [], DrushCommands::REQ);
+    }
 }

--- a/src/Attributes/OptionsetSsh.php
+++ b/src/Attributes/OptionsetSsh.php
@@ -11,6 +11,6 @@ class OptionsetSsh
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
-        $commandInfo->addOptionDescriptionDefaultValue('ssh-options', 'A string appended to ssh command during rsync, sql-sync, etc.', [], DrushCommands::REQ);
+        $commandInfo->addOption('ssh-options', 'A string appended to ssh command during rsync, sql-sync, etc.', [], DrushCommands::REQ);
     }
 }

--- a/src/Attributes/OptionsetTableSelection.php
+++ b/src/Attributes/OptionsetTableSelection.php
@@ -7,7 +7,7 @@ use Consolidation\AnnotatedCommand\Parser\CommandInfo;
 use Drush\Commands\DrushCommands;
 
 #[Attribute(Attribute::TARGET_METHOD)]
-class OptionsetTableSelection extends NoArgumentsBase
+class OptionsetTableSelection
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {

--- a/src/Attributes/OptionsetTableSelection.php
+++ b/src/Attributes/OptionsetTableSelection.php
@@ -11,12 +11,12 @@ class OptionsetTableSelection extends NoArgumentsBase
 {
     public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
     {
-        $commandInfo->addOption('skip-tables-key','A key in the $skip_tables array. @see [Site aliases](../site-aliases.md)', [],DrushCommands::REQ);
-        $commandInfo->addOption('structure-tables-key','A key in the $structure_tables array. @see [Site aliases](../site-aliases.md)', [], DrushCommands::REQ);
-        $commandInfo->addOption('tables-key','A key in the $tables array.', [], DrushCommands::REQ);
-        $commandInfo->addOption('skip-tables-list','A comma-separated list of tables to exclude completely.', [], DrushCommands::REQ);
-        $commandInfo->addOption('structure-tables-list','A comma-separated list of tables to include for structure, but not data.', [], DrushCommands::REQ);
-        $commandInfo->addOption('skip-tables-list','A comma-separated list of tables to exclude completely.', [], DrushCommands::REQ);
-        $commandInfo->addOption('tables-list','A comma-separated list of tables to transfer.', [], DrushCommands::REQ);
+        $commandInfo->addOption('skip-tables-key', 'A key in the $skip_tables array. @see [Site aliases](../site-aliases.md)', [], DrushCommands::REQ);
+        $commandInfo->addOption('structure-tables-key', 'A key in the $structure_tables array. @see [Site aliases](../site-aliases.md)', [], DrushCommands::REQ);
+        $commandInfo->addOption('tables-key', 'A key in the $tables array.', [], DrushCommands::REQ);
+        $commandInfo->addOption('skip-tables-list', 'A comma-separated list of tables to exclude completely.', [], DrushCommands::REQ);
+        $commandInfo->addOption('structure-tables-list', 'A comma-separated list of tables to include for structure, but not data.', [], DrushCommands::REQ);
+        $commandInfo->addOption('skip-tables-list', 'A comma-separated list of tables to exclude completely.', [], DrushCommands::REQ);
+        $commandInfo->addOption('tables-list', 'A comma-separated list of tables to transfer.', [], DrushCommands::REQ);
     }
 }

--- a/src/Attributes/OptionsetTableSelection.php
+++ b/src/Attributes/OptionsetTableSelection.php
@@ -3,9 +3,20 @@
 namespace Drush\Attributes;
 
 use Attribute;
+use Consolidation\AnnotatedCommand\Parser\CommandInfo;
+use Drush\Commands\DrushCommands;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 class OptionsetTableSelection extends NoArgumentsBase
 {
-    const NAME = 'optionset_table_selection';
+    public static function handle(\ReflectionAttribute $attribute, CommandInfo $commandInfo)
+    {
+        $commandInfo->addOption('skip-tables-key','A key in the $skip_tables array. @see [Site aliases](../site-aliases.md)', [],DrushCommands::REQ);
+        $commandInfo->addOption('structure-tables-key','A key in the $structure_tables array. @see [Site aliases](../site-aliases.md)', [], DrushCommands::REQ);
+        $commandInfo->addOption('tables-key','A key in the $tables array.', [], DrushCommands::REQ);
+        $commandInfo->addOption('skip-tables-list','A comma-separated list of tables to exclude completely.', [], DrushCommands::REQ);
+        $commandInfo->addOption('structure-tables-list','A comma-separated list of tables to include for structure, but not data.', [], DrushCommands::REQ);
+        $commandInfo->addOption('skip-tables-list','A comma-separated list of tables to exclude completely.', [], DrushCommands::REQ);
+        $commandInfo->addOption('tables-list','A comma-separated list of tables to transfer.', [], DrushCommands::REQ);
+    }
 }

--- a/src/Commands/OptionsCommands.php
+++ b/src/Commands/OptionsCommands.php
@@ -38,11 +38,13 @@ class OptionsCommands
      */
     #[CLI\Hook(type: HookManager::OPTION_HOOK, selector: 'optionset_ssh')]
     #[CLI\Option(name: 'ssh-options', description: 'A string appended to ssh command during rsync, sql-sync, etc.')]
-    #[Deprecated(reason: 'Use \Drush\Attributes\OptionsetSsh')]
     public function optionsetSsh($options = ['ssh-options' => self::REQ]): void
     {
     }
 
+    /**
+     * @deprecated Use \Drush\Attributes\OptionsetSql attribute instead.
+     */
     #[CLI\Hook(type: HookManager::OPTION_HOOK, selector: 'optionset_sql')]
     #[CLI\Option(name: 'database', description: 'The DB connection key if using multiple connections in settings.php.')]
     #[CLI\Option(name: 'db-url', description: 'A Drupal 6 style database URL. For example <info>mysql://root:pass@localhost:port/dbname</info>')]
@@ -52,6 +54,9 @@ class OptionsCommands
     {
     }
 
+    /**
+     * @deprecated Use \Drush\Attributes\OptionsetTableSelection attribute instead.
+     */
     #[CLI\Hook(type: HookManager::OPTION_HOOK, selector: 'optionset_table_selection')]
     #[CLI\Option(name: 'skip-tables-key', description: 'A key in the $skip_tables array. @see [Site aliases](../site-aliases.md)')]
     #[CLI\Option(name: 'structure-tables-key', description: 'A key in the $structure_tables array. @see [Site aliases](../site-aliases.md)')]

--- a/src/Commands/OptionsCommands.php
+++ b/src/Commands/OptionsCommands.php
@@ -13,8 +13,11 @@ class OptionsCommands
 {
     const REQ = InputOption::VALUE_REQUIRED;
 
+    /**
+     * @deprecated Use \Drush\Attributes\OptionsetGetEditor attribute instead.
+     */
     #[CLI\Hook(type: HookManager::OPTION_HOOK, selector: 'optionset_proc_build')]
-    #[CLI\Option(name: 'ssh-options', description: ' A string of extra options that will be passed to the ssh command (e.g. <info>-p 100</info>)')]
+    #[CLI\Option(name: 'ssh-options', description: 'A string of extra options that will be passed to the ssh command (e.g. <info>-p 100</info>)')]
     #[CLI\Option(name: 'tty', description: 'Create a tty (e.g. to run an interactive program).')]
     public function optionsetProcBuild($options = ['ssh-options' => self::REQ, 'tty' => false]): void
     {

--- a/src/Commands/OptionsCommands.php
+++ b/src/Commands/OptionsCommands.php
@@ -20,6 +20,9 @@ class OptionsCommands
     {
     }
 
+    /**
+     * @deprecated Use \Drush\Attributes\OptionsetGetEditor attribute instead.
+     */
     #[CLI\Hook(type: HookManager::OPTION_HOOK, selector: 'optionset_get_editor')]
     #[CLI\Option(name: 'editor', description: 'A string of bash which launches user\'s preferred text editor. Defaults to <info>${VISUAL-${EDITOR-vi}}</info>.')]
     #[CLI\Option(name: 'bg', description: 'Launch editor in background process.')]
@@ -27,8 +30,12 @@ class OptionsCommands
     {
     }
 
+    /**
+     * @deprecated Use \Drush\Attributes\OptionsetSsh attribute instead.
+     */
     #[CLI\Hook(type: HookManager::OPTION_HOOK, selector: 'optionset_ssh')]
     #[CLI\Option(name: 'ssh-options', description: 'A string appended to ssh command during rsync, sql-sync, etc.')]
+    #[Deprecated(reason: 'Use \Drush\Attributes\OptionsetSsh')]
     public function optionsetSsh($options = ['ssh-options' => self::REQ]): void
     {
     }

--- a/src/Drupal/Commands/sql/SanitizeUserFieldsCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserFieldsCommands.php
@@ -129,10 +129,6 @@ final class SanitizeUserFieldsCommands extends DrushCommands implements Sanitize
         $messages[] = dt('Sanitize text fields associated with users.');
     }
 
-    /**
-     * @hook option sql-sanitize
-     * @option allowlist-fields A comma delimited list of fields exempt from sanitization.
-     */
     #[CLI\Hook(type: HookManager::OPTION_HOOK, target: 'sql-sanitize')]
     #[CLI\Option(name: 'allowlist-fields', description: 'A comma delimited list of fields exempt from sanitization.')]
     public function options($options = ['whitelist-fields' => '', 'allowlist-fields' => '']): void


### PR DESCRIPTION
I realize that we could deprecate the options hook from annotated command and instead have Attributes directly add options to $commandinfo

Note: since we need to provide a default value for the option, I had to make `$commandInfo->addOptionOrArgumentDescription()` public