### PR TITLE
Use Composer Runtime API to determine Drush version

### DIFF
--- a/drush.info
+++ b/drush.info
@@ -1,1 +1,0 @@
-drush_version=12.0.0-dev

--- a/src/Drush.php
+++ b/src/Drush.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drush;
 
+use Composer\InstalledVersions;
 use Robo\Runner;
 use Robo\Robo;
 use Drush\Config\DrushConfig;
@@ -85,8 +86,7 @@ class Drush
     public static function getVersion()
     {
         if (!self::$version) {
-            $drush_info = self::drushReadDrushInfo();
-            self::$version = $drush_info['drush_version'];
+            self::$version = InstalledVersions::getVersion('drush/drush');
         }
         return self::$version;
     }


### PR DESCRIPTION
- [Composer says it is safe to get own version](https://getcomposer.org/doc/07-runtime.md#knowing-a-package-s-own-installed-version)
- When doing development on Drush itself, you might see see the version below which amuses me and seems "right enough" since the major version is correct.

```
Drush version : 12.9999999.9999999.9999999-dev
```