### PR TITLE
Replace Assets class alias

### DIFF
--- a/src/Drupal/Commands/generate/Generators/Drush/DrushCommandFile.php
+++ b/src/Drupal/Commands/generate/Generators/Drush/DrushCommandFile.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Drush\Drupal\Commands\generate\Generators\Drush;
 
-use DrupalCodeGenerator\Asset\Assets;
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
 use DrupalCodeGenerator\Attribute\Generator;
 use DrupalCodeGenerator\Command\BaseGenerator;
 use DrupalCodeGenerator\GeneratorType;

--- a/tests/fixtures/modules/woot/src/Generators/ExampleGenerator.php
+++ b/tests/fixtures/modules/woot/src/Generators/ExampleGenerator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Drupal\woot\Generators;
 
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use DrupalCodeGenerator\Asset\Assets;
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
 use DrupalCodeGenerator\Attribute\Generator;
 use DrupalCodeGenerator\Command\BaseGenerator;
 use DrupalCodeGenerator\GeneratorType;


### PR DESCRIPTION
Assets class alias is a relic that needs to be removed before DCG 3 release.