### PR TITLE
Handle missing URI in Drush alias file generator

### DIFF
--- a/src/Drupal/Commands/generate/Generators/Drush/DrushAliasFile.php
+++ b/src/Drupal/Commands/generate/Generators/Drush/DrushAliasFile.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Drush\Drupal\Commands\generate\Generators\Drush;
 
 use DrupalCodeGenerator\Asset\AssetCollection as Assets;
+use DrupalCodeGenerator\Attribute\Generator;
 use DrupalCodeGenerator\Command\BaseGenerator;
 use DrupalCodeGenerator\GeneratorType;
 use Drush\Drush;
 
-#[\DrupalCodeGenerator\Attribute\Generator(
+#[Generator(
     name: 'drush:alias-file',
     description: 'Generates a Drush site alias file.',
     aliases: ['daf'],

--- a/src/Drupal/Commands/generate/Generators/Drush/DrushAliasFile.php
+++ b/src/Drupal/Commands/generate/Generators/Drush/DrushAliasFile.php
@@ -27,7 +27,7 @@ class DrushAliasFile extends BaseGenerator
 
         $vars['prefix'] = $ir->ask('File prefix (one word)', 'self');
         $vars['root'] = $ir->ask('Path to Drupal root', Drush::bootstrapManager()->getRoot());
-        $vars['uri'] = $ir->ask('Drupal uri', Drush::bootstrapManager()->getUri());
+        $vars['uri'] = $ir->ask('Drupal uri', Drush::bootstrapManager()->getUri() ?: NULL);
         $vars['host'] = $ir->ask('Remote host');
 
         if ($vars['host']) {

--- a/src/Drupal/Commands/generate/Generators/Drush/DrushAliasFile.php
+++ b/src/Drupal/Commands/generate/Generators/Drush/DrushAliasFile.php
@@ -27,7 +27,7 @@ class DrushAliasFile extends BaseGenerator
 
         $vars['prefix'] = $ir->ask('File prefix (one word)', 'self');
         $vars['root'] = $ir->ask('Path to Drupal root', Drush::bootstrapManager()->getRoot());
-        $vars['uri'] = $ir->ask('Drupal uri', Drush::bootstrapManager()->getUri() ?: NULL);
+        $vars['uri'] = $ir->ask('Drupal uri', Drush::bootstrapManager()->getUri() ?: null);
         $vars['host'] = $ir->ask('Remote host');
 
         if ($vars['host']) {


### PR DESCRIPTION
`Drush::bootstrapManager()->getUri()` can return boolean value under some conditions. That potentially can cause a fatal PHP error.