### PR TITLE
Remove dual autoloader feature from global Drush installs

### DIFF
--- a/drush.php
+++ b/drush.php
@@ -75,7 +75,7 @@ use Symfony\Component\Filesystem\Path;
  *                 └── drush
  *                     └── drush.php
  *
- * Drush project: (Only used when developing Drush; `composer install --dev`)
+ * Drush project: (Only used when developing Drush)
  *
  *   [*3]    drush
  *           ├── drush.php

--- a/drush.php
+++ b/drush.php
@@ -43,14 +43,8 @@ use Symfony\Component\Filesystem\Path;
  *
  * ## Viable Drush configurations ##
  *
- * As of Drush 12, only a site-local Drush will bootstrap Drupal. Any
- * other installation configuration may only be used as a launcher. A
- * site-local Drush may also be used as a launcher. The built-in launcher
- * may be used to run certain Drush commands that do not require an
- * existing site to bootstrap, such as the `archive:restore` command.
- * Beyond that, the built-in launcher may only be used to run commands
- * in a remote Drupal site, or in another local site with a site-local
- * Drush.
+ * As of Drush 12, only a site-local Drush will bootstrap Drupal.
+ * A globally installed Drush is no longer supported.
  *
  * The following directory layouts are supported:
  *
@@ -88,13 +82,6 @@ use Symfony\Component\Filesystem\Path;
  *           ├── sut
  *           │   ├── core
  *           │   └── index.php
- *           └── vendor
- *               └── autoload.php
- *
- * Global Drush: (Only usable as a launcher; `composer install --no-dev`)
- *
- *   [*3]    drush
- *           ├── drush.php
  *           └── vendor
  *               └── autoload.php
  *

--- a/drush.php
+++ b/drush.php
@@ -10,7 +10,8 @@ use Symfony\Component\Filesystem\Path;
 /**
  * This script runs Drush.
  *
- * Responsibilities of this script:
+ * ## Responsibilities of this script ##
+ *
  *   - Locate and include the Composer autoload file for Drush.
  *   - Set up the environment (record user home directory, cwd, etc.).
  *   - Call the Preflight object to do all necessary setup and execution.
@@ -21,6 +22,7 @@ use Symfony\Component\Filesystem\Path;
  * This script will only be tested via the functional tests.
  *
  * The Drush bootstrap goes through the following steps:
+ *
  *   - (ArgsPreprocessor) Preprocess the commandline arguments, considering only:
  *     - The named alias `@sitealias` (removed from arguments if present)
  *     - The --root option (read and retained)
@@ -38,6 +40,74 @@ use Symfony\Component\Filesystem\Path;
  *     - Run commands and command hooks via annotated commands library
  *     - Catch 'command not found' exception, bootstrap Drupal and run again
  *   - Return status code
+ *
+ * ## Viable Drush configurations ##
+ *
+ * As of Drush 12, only a site-local Drush will bootstrap Drupal. Any
+ * other installation configuration may only be used as a launcher. A
+ * site-local Drush may also be used as a launcher. The built-in launcher
+ * may be used to run certain Drush commands that do not require an
+ * existing site to bootstrap, such as the `archive:restore` command.
+ * Beyond that, the built-in launcher may only be used to run commands
+ * in a remote Drupal site, or in another local site with a site-local
+ * Drush.
+ *
+ * The following directory layouts are supported:
+ *
+ * Drush binary in site-local configuration in recommended Drupal site: (typical)
+ *
+ *         drupal
+ *         ├── web
+ *         │   ├── core
+ *         │   └── index.php
+ *         └── vendor
+ *             ├── autoload.php
+ *   [*1]      ├── bin
+ *             │   └── drush.php -> ../drush/drush/drush.php
+ *   [*2]      └── drush
+ *                 └── drush
+ *                     └── drush.php
+ *
+ * Drush binary in site-local configuration in a legacy Drupal site: (unusual)
+ *
+ *         drupal
+ *         ├── core
+ *         ├── index.php
+ *         └── vendor
+ *             ├── autoload.php
+ *   [*1]      ├── bin
+ *             │   └── drush.php -> ../drush/drush/drush.php
+ *   [*2]      └── drush
+ *                 └── drush
+ *                     └── drush.php
+ *
+ * Drush project: (Only used when developing Drush; `composer install --dev`)
+ *
+ *   [*3]    drush
+ *           ├── drush.php
+ *           ├── sut
+ *           │   ├── core
+ *           │   └── index.php
+ *           └── vendor
+ *               └── autoload.php
+ *
+ * Global Drush: (Only usable as a launcher; `composer install --no-dev`)
+ *
+ *   [*3]    drush
+ *           ├── drush.php
+ *           └── vendor
+ *               └── autoload.php
+ *
+ * The possible locations that __DIR__ may point to in the supported
+ * configurations are indicated by [*1], [*2] and [*3] in the diagrams
+ * above.
+ *
+ * Note that in the case of the Drush project, the Drupal site used for
+ * testing during development, called the "System Under Test", or "sut",
+ * counts as a site-local configuration, since the `vendor` directory is
+ * common between Drush and Drupal. Drush uses information from the
+ * project root to find the Drupal root, so it does not matter what the
+ * 'web' directory is called.
  */
 
 // We use PWD if available because getcwd() resolves symlinks, which  could take

--- a/drush.php
+++ b/drush.php
@@ -12,7 +12,7 @@ use Symfony\Component\Filesystem\Path;
  *
  * ## Responsibilities of this script ##
  *
- *   - Locate and include the Composer autoload file for Drush.
+ *   - Include the Composer autoload file.
  *   - Set up the environment (record user home directory, cwd, etc.).
  *   - Call the Preflight object to do all necessary setup and execution.
  *   - Exit with status code returned

--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -113,6 +113,8 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
     {
         // TODO: Throw if we already bootstrapped a framework?
 
+        // TODO: We shouldn't get here unless there is a root;
+        // Drush 12.x is not allowed to exist without a Drupal site.
         if (!isset($root)) {
             $root = $this->getConfig()->cwd();
         }

--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -109,18 +109,6 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
         return $this->drupalFinder()->getComposerRoot();
     }
 
-    public function locateRoot($root, $start_path = null): void
-    {
-        // TODO: Throw if we already bootstrapped a framework?
-
-        // TODO: We shouldn't get here unless there is a root;
-        // Drush 12.x is not allowed to exist without a Drupal site.
-        if (!isset($root)) {
-            $root = $this->getConfig()->cwd();
-        }
-        $this->drupalFinder()->locateRoot($root);
-    }
-
     /**
      * Return the framework uri selected by the user.
      */

--- a/src/Config/ConfigLocator.php
+++ b/src/Config/ConfigLocator.php
@@ -401,7 +401,7 @@ class ConfigLocator
      * @param $commandPaths
      * @param $root
      */
-    public function getCommandFilePaths(array $commandPaths, string $root): array
+    public function getCommandFilePaths(array $commandPaths, string|bool $root): array
     {
         $builtin = $this->getBuiltinCommandFilePaths();
         $included = $this->getIncludedCommandFilePaths($commandPaths);
@@ -463,6 +463,9 @@ class ConfigLocator
      */
     protected function getSiteCommandFilePaths($root): array
     {
+        if (empty($root)) {
+            return [];
+        }
         $directories = ["$root/drush", dirname($root) . '/drush', "$root/sites/all/drush"];
 
         return array_filter($directories, 'is_dir');

--- a/src/Config/ConfigLocator.php
+++ b/src/Config/ConfigLocator.php
@@ -401,7 +401,7 @@ class ConfigLocator
      * @param $commandPaths
      * @param $root
      */
-    public function getCommandFilePaths(array $commandPaths, string|bool $root): array
+    public function getCommandFilePaths(array $commandPaths, string $root): array
     {
         $builtin = $this->getBuiltinCommandFilePaths();
         $included = $this->getIncludedCommandFilePaths($commandPaths);
@@ -463,9 +463,6 @@ class ConfigLocator
      */
     protected function getSiteCommandFilePaths($root): array
     {
-        if (empty($root)) {
-            return [];
-        }
         $directories = ["$root/drush", dirname($root) . '/drush', "$root/sites/all/drush"];
 
         return array_filter($directories, 'is_dir');

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -45,41 +45,6 @@ class Environment
     }
 
     /**
-     * Load the autoloader for the selected Drupal site.
-     */
-    public function loadSiteAutoloader(string $root): ClassLoader
-    {
-        $autloadFilePath = "$root/autoload.php";
-        if (!file_exists($autloadFilePath)) {
-            return $this->loader;
-        }
-
-        if ($this->siteLoader) {
-            return $this->siteLoader;
-        }
-
-        $this->siteLoader = require $autloadFilePath;
-        if ($this->siteLoader === false) {
-            // Nothing more to do. See https://github.com/drush-ops/drush/issues/3741.
-            return $this->loader;
-        }
-        if ($this->siteLoader === true) {
-            // The autoloader was already required. Assume that Drush and Drupal share an autoloader per
-            // "Point autoload.php to the proper vendor directory" - https://www.drupal.org/node/2404989
-            $this->siteLoader = $this->loader;
-        }
-
-        // Ensure that the site's autoloader has highest priority. Usually,
-        // the first classloader registered gets the first shot at loading classes.
-        // We want Drupal's classloader to be used first when a class is loaded,
-        // and have Drush's classloader only be called as a fallback measure.
-        $this->siteLoader->unregister();
-        $this->siteLoader->register(true);
-
-        return $this->siteLoader;
-    }
-
-    /**
      * Return the name of the user running drush.
      */
     protected function getUsername(): string

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -268,9 +268,10 @@ class Preflight
         // a site alias, then a redispatch will happen.
         $root = $this->preferredSite();
 
-        // TODO: We might redispatch to some other site later, but THROW
-        // now if there is no root. Drush 12.x won't run if it is in a vendor
-        // directory with a Drupal site.
+        // We also prohibit global installs of Drush (without a Drupal site).
+        if (empty($root)) {
+            throw new \Exception("Globally installed Drush no longer supported.");
+        }
 
         // Extend configuration and alias files to include files in
         // target site.

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -79,9 +79,6 @@ class Runtime
         $this->preflight->logger()->log('Commandfile search paths: ' . implode(',', $commandfileSearchpath));
         $this->preflight->config()->set('runtime.commandfile.paths', $commandfileSearchpath);
 
-        // Require the Composer autoloader for Drupal (if different)
-        $loader = $this->preflight->loadSiteAutoloader();
-
         // Load the Symfony compatability layer autoloader
         $this->preflight->loadSymfonyCompatabilityAutoloader();
 
@@ -95,7 +92,7 @@ class Runtime
             $this->preflight->config(),
             $input,
             $output,
-            $loader,
+            $this->preflight->environment()->loader(),
             $this->preflight->drupalFinder(),
             $this->preflight->aliasManager()
         );
@@ -118,7 +115,7 @@ class Runtime
         // Configure the application object and register all of the commandfiles
         // from the search paths we found above.  After this point, the input
         // and output objects are ready & we can start using the logger, etc.
-        $application->configureAndRegisterCommands($input, $output, $commandfileSearchpath, $loader);
+        $application->configureAndRegisterCommands($input, $output, $commandfileSearchpath, $this->preflight->environment()->loader());
 
         // Run the Symfony Application
         // Predispatch: call a remote Drush command if applicable (via a 'pre-init' hook)

--- a/tests/functional/FunctionalCoreTest.php
+++ b/tests/functional/FunctionalCoreTest.php
@@ -25,6 +25,8 @@ class FunctionalCoreTest extends CommandUnishTestCase
 
     public function testSiteSelectionViaCwd()
     {
+        $this->markTestSkipped("Drush 12.x no longer supports site selection via cwd");
+
         // $cwd = getcwd();
         foreach (['dev', 'stage'] as $uri) {
             $conf_dir = $this->webroot() . '/sites/' . $uri;

--- a/tests/unish/CommandUnishTestCase.php
+++ b/tests/unish/CommandUnishTestCase.php
@@ -84,7 +84,8 @@ abstract class CommandUnishTestCase extends UnishTestCase
       */
     public function drush($command, array $args = [], array $options = [], $site_specification = null, $cd = null, $expected_return = self::EXIT_SUCCESS, $suffix = null, $env = [])
     {
-        list($cmd, $coverage_file) = $this->prepareDrushCommand($command, $args, $options, $site_specification, $suffix);
+        list($cmd, $coverage_file) = $this->prepareDrushCommand($command, $args, $options, $site_specification, $suffix, $cd);
+        $env['COLUMNS'] = '9999';
         $this->execute($cmd, $expected_return, $cd, $env);
 
         // Save code coverage information.
@@ -98,13 +99,20 @@ abstract class CommandUnishTestCase extends UnishTestCase
         // return $return;
     }
 
-    protected function prepareDrushCommand($command, array $args = [], array $options = [], $site_specification = null, $suffix = null): array
+    protected function prepareDrushCommand($command, array $args = [], array $options = [], $site_specification = null, $suffix = null, $cd = null): array
     {
         // cd is added for the benefit of siteSshTest which tests a strict command.
         $global_option_list = ['simulate', 'root', 'uri', 'include', 'config', 'alias-path', 'ssh-options', 'cd'];
         $options += ['uri' => 'dev']; // Default value.
         $hide_stderr = false;
-        $cmd[] = self::getDrush();
+        $drushExecutable = self::getDrush();
+        if ($cd) {
+            $project = dirname($cd);
+            if (file_exists("$project/vendor/bin/drush")) {
+                $drushExecutable = "$project/vendor/bin/drush";
+            }
+        }
+        $cmd[] = $drushExecutable;
 
         // Insert global options.
         foreach ($options as $key => $values) {

--- a/tests/unish/Controllers/RuntimeController.php
+++ b/tests/unish/Controllers/RuntimeController.php
@@ -121,9 +121,6 @@ class RuntimeController
         $commandfileSearchpath = $this->preflight->getCommandFilePaths();
         $this->preflight->config()->set('runtime.commandfile.paths', $commandfileSearchpath);
 
-        // Require the Composer autoloader for Drupal (if different)
-        $loader = $this->preflight->loadSiteAutoloader();
-
         // Load the Symfony compatability layer autoloader
         $this->preflight->loadSymfonyCompatabilityAutoloader();
 


### PR DESCRIPTION
Do not allow Drush to combine autoload files from a non-site-local Drupal; only bootstrap Drupal sites with a shared vendor.

Continuation of #5138. No changes yet, just rebased on 12.x branch.

c.f. https://github.com/drush-ops/drush/pull/5138#issuecomment-1126702688