### PR TITLE
 Add YAML edit commands from YAML-CLI project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "consolidation/robo": "^4.0.3",
     "consolidation/site-alias": "^4",
     "consolidation/site-process": "^5.2.0",
+    "grasmash/yaml-cli": "^3.1",
     "guzzlehttp/guzzle": "^7.0",
     "league/container": "^4",
     "psy/psysh": "~0.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d70f09596a744bd1235f1a3115826d3",
+    "content-hash": "32688a947361350028b4c536f3e7f673",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",
@@ -791,6 +791,62 @@
                 "source": "https://github.com/grasmash/expander/tree/3.0.0"
             },
             "time": "2022-05-10T13:14:49+00:00"
+        },
+        {
+            "name": "grasmash/yaml-cli",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grasmash/yaml-cli.git",
+                "reference": "00f3fd775f6abbfacd44432f1999c3c3b02791f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grasmash/yaml-cli/zipball/00f3fd775f6abbfacd44432f1999c3c3b02791f0",
+                "reference": "00f3fd775f6abbfacd44432f1999c3c3b02791f0",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^3",
+                "php": ">=8.0",
+                "symfony/console": "^6",
+                "symfony/filesystem": "^6",
+                "symfony/yaml": "^6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2",
+                "phpunit/phpunit": "^9",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "bin": [
+                "bin/yaml-cli"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Grasmash\\YamlCli\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Grasmick"
+                }
+            ],
+            "description": "A command line tool for reading and manipulating yaml files.",
+            "support": {
+                "issues": "https://github.com/grasmash/yaml-cli/issues",
+                "source": "https://github.com/grasmash/yaml-cli/tree/3.1.0"
+            },
+            "time": "2022-05-09T20:22:34+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/src/Commands/core/MkCommands.php
+++ b/src/Commands/core/MkCommands.php
@@ -222,6 +222,8 @@ EOT;
         $body .= "# {$command->getName()}\n\n";
         if ($command instanceof AnnotatedCommand && $version = $command->getAnnotationData()->get('version')) {
             $body .= ":octicons-tag-24: $version+\n\n";
+        } elseif (str_starts_with($command->getName(), 'yaml:')) {
+            $body .= ":octicons-tag-24: 12.0+\n\n";
         }
         if ($command->getDescription()) {
             $body .= self::cliTextToMarkdown($command->getDescription()) . "\n\n";

--- a/src/Commands/help/HelpCLIFormatter.php
+++ b/src/Commands/help/HelpCLIFormatter.php
@@ -32,12 +32,31 @@ class HelpCLIFormatter implements FormatterInterface
             $output->writeln($data['help']);
         }
 
+        $rows = [];
         if (array_key_exists('examples', $data)) {
+            // Examples come from Annotated commands.
             $output->writeln('');
             $output->writeln('<comment>Examples:</comment>');
             foreach ($data['examples'] as $example) {
                 $rows[] = [' ' . $example['usage'], $example['description']];
             }
+        } elseif (array_key_exists('usages', $data)) {
+            // Usages come from Console commands.
+            // Don't show the last two Usages which come from synopsis and alias. See \Symfony\Component\Console\Descriptor\XmlDescriptor::getCommandDocument.
+            array_pop($data['usages']);
+            array_pop($data['usages']);
+            if ($data['usages']) {
+                $output->writeln('');
+                $output->writeln('<comment>Examples:</comment>');
+                foreach ($data['usages'] as $usage) {
+                    if (!str_starts_with($usage, 'drush')) {
+                        $usage = sprintf('%s %s', 'drush', $usage);
+                    }
+                    $rows[] = [$usage, ''];
+                }
+            }
+        }
+        if ($rows) {
             $formatterManager->write($output, 'table', new RowsOfFields($rows), $options);
         }
 

--- a/src/Drupal/Commands/generate/GenerateCommands.php
+++ b/src/Drupal/Commands/generate/GenerateCommands.php
@@ -30,6 +30,8 @@ final class GenerateCommands extends DrushCommands
      *
      * Drush asks questions so that the generated code is as polished as possible. After
      * generating, Drush lists the files that were created.
+     *
+     * See https://github.com/grasmash/yaml-cli for a README and bug reports.
      */
     #[CLI\Command(name: self::GENERATE, aliases: ['gen'])]
     #[CLI\Argument(name: 'generator', description: 'A generator name. Omit to pick from available Generators.')]

--- a/src/Drupal/Commands/generate/GenerateCommands.php
+++ b/src/Drupal/Commands/generate/GenerateCommands.php
@@ -31,7 +31,7 @@ final class GenerateCommands extends DrushCommands
      * Drush asks questions so that the generated code is as polished as possible. After
      * generating, Drush lists the files that were created.
      *
-     * See https://github.com/grasmash/yaml-cli for a README and bug reports.
+     * See https://github.com/Chi-teck/drupal-code-generator for a README and bug reports.
      */
     #[CLI\Command(name: self::GENERATE, aliases: ['gen'])]
     #[CLI\Argument(name: 'generator', description: 'A generator name. Omit to pick from available Generators.')]

--- a/sut/modules/unish/woot/src/Commands/GreetCommand.php
+++ b/sut/modules/unish/woot/src/Commands/GreetCommand.php
@@ -37,7 +37,7 @@ class GreetCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $name = $input->getArgument('name');
         if ($name) {
@@ -51,5 +51,6 @@ class GreetCommand extends Command
         }
 
         $output->writeln($text);
+        return 0;
     }
 }


### PR DESCRIPTION
A redo of #5179

- Adds [grasmash/yaml-cli](https://github.com/grasmash/yaml-cli) as a dependency
- Adds all the commands from that project. These are directly added as Symfony Console commands (not Annotated Commands)
- Doesn't add any tests. We rely on the tests in the yaml-cli package.

Fixes https://github.com/drush-ops/drush/issues/5026