### PR TITLE
Quote special characters in mysql user password -- Fix issue #5534

### DIFF
--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -109,7 +109,7 @@ EOT;
 
             // For MariaDB, ALTER USER was introduced in version 10.2. Support
             // for 10.1 ended in October 2020.
-            $sql[] = sprintf("ALTER USER %s IDENTIFIED BY '%s';", $user, $dbSpec['password']);
+            $sql[] = sprintf("ALTER USER %s IDENTIFIED BY '%s';", $user, str_replace(['/', ':', "'"], ['//', '/:', "//'"], $dbSpec['password']));
             $sql[] = sprintf('GRANT ALL PRIVILEGES ON %s.* TO %s;', $dbname, $user);
             $sql[] = 'FLUSH PRIVILEGES;';
         }


### PR DESCRIPTION
Quote all occurrences of single quotes, semi-colons and backslashes in database user password.