### PR TITLE
Fix issue #5534. mysql password quoting

### DIFF
--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -111,7 +111,7 @@ EOT;
 
             // For MariaDB, ALTER USER was introduced in version 10.2. Support
             // for 10.1 ended in October 2020.
-            $sql[] = sprintf("ALTER USER %s IDENTIFIED BY '%s';", $user, $dbSpec['password']);
+            $sql[] = sprintf("ALTER USER %s IDENTIFIED BY '%s';", $user, str_replace(["\\", "'"], ["\\\\", "\\'"], $dbSpec['password']));
             $sql[] = sprintf('GRANT ALL PRIVILEGES ON %s.* TO %s;', $dbname, $user);
             $sql[] = 'FLUSH PRIVILEGES;';
         }


### PR DESCRIPTION
Although it was suggested enclosing the password in backticks would resolve this.  Further testing indicated that it didn't work when the password contains a backtick.  Also, the quoting mentioned in my previous attempt at a PR regarding the database name doesn't really have anything to do with this in my opinion.  I could put a check in to see if that was set but again in my opinion there is never a reason to not perform what the fix is doing since it is always a possibility that a user will use a backtick in their password.