### PR TITLE
User name should be always a string

### DIFF
--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -49,7 +49,6 @@ class Environment
      */
     protected function getUsername(): string
     {
-        $name = null;
         if (!$name = getenv("username")) { // Windows
             if (!$name = getenv("USER")) {
                 // If USER not defined, use posix
@@ -60,7 +59,7 @@ class Environment
                 }
             }
         }
-        return $name;
+        return $name ?: '';
     }
 
     protected function getTmp(): string


### PR DESCRIPTION
Used to give a try to drush 12b1 I'm getting following fatal error (running in `skilldlabs/php:82-unit` docker image the `10.1.x` branch of core)

The fixed function using [`getenv()`](https://www.php.net/manual/en/function.getenv.php) which returns `FALSE` in case of absence a variable, so I added elvis'op to result 

Logs are the same for any command 
```
/var/www/html/web $ vendor/bin/drush cr
PHP Fatal error:  Uncaught TypeError: Drush\Config\Environment::getUsername(): Return value must be of type ?string, bool returned in /var/www/html/web/vendor/drush/drush/src/Config/Environment.php:98
Stack trace:
#0 /var/www/html/web/vendor/drush/drush/src/Config/Environment.php(164): Drush\Config\Environment->getUsername()
#1 /var/www/html/web/vendor/drush/drush/src/Config/ConfigLocator.php(200): Drush\Config\Environment->exportConfigData()
#2 /var/www/html/web/vendor/drush/drush/src/Preflight/Preflight.php(182): Drush\Config\ConfigLocator->addEnvironment()
#3 /var/www/html/web/vendor/drush/drush/src/Preflight/Preflight.php(257): Drush\Preflight\Preflight->prepareConfig()
#4 /var/www/html/web/vendor/drush/drush/src/Runtime/Runtime.php(71): Drush\Preflight\Preflight->preflight()
#5 /var/www/html/web/vendor/drush/drush/src/Runtime/Runtime.php(53): Drush\Runtime\Runtime->doRun()
#6 /var/www/html/web/vendor/drush/drush/drush.php(77): Drush\Runtime\Runtime->run()
#7 /var/www/html/web/vendor/drush/drush/drush(4): require('...')
#8 /var/www/html/web/vendor/bin/drush(120): include('...')
#9 {main}
  thrown in /var/www/html/web/vendor/drush/drush/src/Config/Environment.php on line 98

Fatal error: Uncaught TypeError: Drush\Config\Environment::getUsername(): Return value must be of type ?string, bool returned in /var/www/html/web/vendor/drush/drush/src/Config/Environment.php:98
Stack trace:
#0 /var/www/html/web/vendor/drush/drush/src/Config/Environment.php(164): Drush\Config\Environment->getUsername()
#1 /var/www/html/web/vendor/drush/drush/src/Config/ConfigLocator.php(200): Drush\Config\Environment->exportConfigData()
#2 /var/www/html/web/vendor/drush/drush/src/Preflight/Preflight.php(182): Drush\Config\ConfigLocator->addEnvironment()
#3 /var/www/html/web/vendor/drush/drush/src/Preflight/Preflight.php(257): Drush\Preflight\Preflight->prepareConfig()
#4 /var/www/html/web/vendor/drush/drush/src/Runtime/Runtime.php(71): Drush\Preflight\Preflight->preflight()
#5 /var/www/html/web/vendor/drush/drush/src/Runtime/Runtime.php(53): Drush\Runtime\Runtime->doRun()
#6 /var/www/html/web/vendor/drush/drush/drush.php(77): Drush\Runtime\Runtime->run()
#7 /var/www/html/web/vendor/drush/drush/drush(4): require('...')
#8 /var/www/html/web/vendor/bin/drush(120): include('...')
#9 {main}
  thrown in /var/www/html/web/vendor/drush/drush/src/Config/Environment.php on line 98
```