### PR TITLE
Use own DrupalFinder which pulls path from Composer API

### DIFF
--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -14,7 +14,7 @@ use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteProcess\ProcessManagerAwareInterface;
 use Consolidation\AnnotatedCommand\Input\StdinAwareInterface;
 use Consolidation\AnnotatedCommand\AnnotationData;
-use Drush\DrupalFinder\DrupalFinder;
+use Drush\DrupalFinder\DrushDrupalFinder;
 use Drush\Config\ConfigAwareTrait;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;
@@ -30,7 +30,7 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
     use ContainerAwareTrait;
 
     /**
-     * @var DrupalFinder
+     * @var DrushDrupalFinder
      */
     protected $drupalFinder;
 
@@ -80,15 +80,15 @@ class BootstrapManager implements LoggerAwareInterface, AutoloaderAwareInterface
         }
     }
 
-    public function drupalFinder(): DrupalFinder
+    public function drupalFinder(): DrushDrupalFinder
     {
         if (!isset($this->drupalFinder)) {
-            $this->drupalFinder = new DrupalFinder();
+            $this->drupalFinder = new DrushDrupalFinder();
         }
         return $this->drupalFinder;
     }
 
-    public function setDrupalFinder(DrupalFinder $drupalFinder): void
+    public function setDrupalFinder(DrushDrupalFinder $drupalFinder): void
     {
         $this->drupalFinder = $drupalFinder;
     }

--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -14,7 +14,7 @@ use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteProcess\ProcessManagerAwareInterface;
 use Consolidation\AnnotatedCommand\Input\StdinAwareInterface;
 use Consolidation\AnnotatedCommand\AnnotationData;
-use DrupalFinder\DrupalFinder;
+use Drush\DrupalFinder\DrupalFinder;
 use Drush\Config\ConfigAwareTrait;
 use League\Container\ContainerAwareInterface;
 use League\Container\ContainerAwareTrait;

--- a/src/DrupalFinder/DrupalFinder.php
+++ b/src/DrupalFinder/DrupalFinder.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drush\DrupalFinder;
+
+use Composer\InstalledVersions;
+use Drush\Config\Environment;
+
+/**
+ * A replacement for DrupalFinder. We may go back to that once it uses InstalledVersions from Composer.
+ */
+class DrupalFinder
+{
+
+    public function __construct(private Environment $environment)
+    {
+    }
+
+    /**
+     * Get the Drupal root.
+     *
+     * @return string|bool
+     *   The path to the Drupal root, if it was discovered. False otherwise.
+     */
+    public function getDrupalRoot()
+    {
+        $core = InstalledVersions::getInstallPath('drupal/core');
+        return $core ? dirname($core) : false;
+    }
+
+    /**
+     * Get the Composer root.
+     *
+     * @return string|bool
+     *   The path to the Composer root, if it was discovered. False otherwise.
+     */
+    public function getComposerRoot()
+    {
+        return dirname($this->getVendorDir());
+    }
+
+    /**
+     * Get the vendor path.
+     *
+     * @return string|bool
+     *   The path to the vendor directory, if it was found. False otherwise.
+     */
+    public function getVendorDir()
+    {
+        return $this->environment->vendorPath();
+    }
+}

--- a/src/DrupalFinder/DrupalFinder.php
+++ b/src/DrupalFinder/DrupalFinder.php
@@ -10,7 +10,6 @@ use Drush\Config\Environment;
  */
 class DrupalFinder
 {
-
     public function __construct(private Environment $environment)
     {
     }

--- a/src/DrupalFinder/DrushDrupalFinder.php
+++ b/src/DrupalFinder/DrushDrupalFinder.php
@@ -8,7 +8,7 @@ use Drush\Config\Environment;
 /**
  * A replacement for DrupalFinder. We may go back to that once it uses InstalledVersions from Composer.
  */
-class DrupalFinder
+class DrushDrupalFinder
 {
     public function __construct(private Environment $environment)
     {
@@ -45,6 +45,6 @@ class DrupalFinder
      */
     public function getVendorDir()
     {
-        return $this->environment->vendorPath();
+        return realpath($this->environment->vendorPath());
     }
 }

--- a/src/DrupalFinder/DrushDrupalFinder.php
+++ b/src/DrupalFinder/DrushDrupalFinder.php
@@ -23,7 +23,7 @@ class DrushDrupalFinder
     public function getDrupalRoot()
     {
         $core = InstalledVersions::getInstallPath('drupal/core');
-        return $core ? dirname($core) : false;
+        return $core ? realpath(dirname($core)) : false;
     }
 
     /**

--- a/src/DrupalFinder/DrushDrupalFinder.php
+++ b/src/DrupalFinder/DrushDrupalFinder.php
@@ -4,6 +4,7 @@ namespace Drush\DrupalFinder;
 
 use Composer\InstalledVersions;
 use Drush\Config\Environment;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * A replacement for DrupalFinder. We may go back to that once it uses InstalledVersions from Composer.
@@ -23,7 +24,7 @@ class DrushDrupalFinder
     public function getDrupalRoot()
     {
         $core = InstalledVersions::getInstallPath('drupal/core');
-        return $core ? realpath(dirname($core)) : false;
+        return $core ? Path::canonicalize(realpath(dirname($core))) : false;
     }
 
     /**
@@ -45,6 +46,6 @@ class DrushDrupalFinder
      */
     public function getVendorDir()
     {
-        return realpath($this->environment->vendorPath());
+        return Path::canonicalize(realpath($this->environment->vendorPath()));
     }
 }

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -6,7 +6,7 @@ namespace Drush\Preflight;
 
 use Composer\Autoload\ClassLoader;
 use Consolidation\SiteAlias\SiteAliasManager;
-use DrupalFinder\DrupalFinder;
+use Drush\DrupalFinder\DrupalFinder;
 use Drush\Config\ConfigLocator;
 use Drush\Config\DrushConfig;
 use Drush\Config\Environment;
@@ -69,7 +69,7 @@ class Preflight
         $this->environment = $environment;
         $this->verify = $verify ?: new PreflightVerify();
         $this->configLocator = $configLocator ?: new ConfigLocator('DRUSH_', $environment->getConfigFileVariant());
-        $this->drupalFinder = new DrupalFinder();
+        $this->drupalFinder = new DrupalFinder($environment);
         $this->logger = $preflightLog ?: new PreflightLog();
     }
 
@@ -302,8 +302,9 @@ class Preflight
 
         // Check to see if the alias on the command line points at
         // a local Drupal site that is not the site at $root
-        $localAliasDrupalFinder = new DrupalFinder();
-        $foundAlternateRoot = $localAliasDrupalFinder->locateRoot($selfSiteAlias->localRoot());
+        $localAliasDrupalFinder = new DrupalFinder($this->environment());
+        // @todo deal with this.
+        $foundAlternateRoot = false; //$localAliasDrupalFinder->locateRoot($selfSiteAlias->localRoot());
         if ($foundAlternateRoot) {
             $alteredRoot = $localAliasDrupalFinder->getDrupalRoot();
 
@@ -345,7 +346,7 @@ class Preflight
     protected function preferredSite()
     {
         $projectRoot = dirname($this->environment->vendorPath());
-        $this->drupalFinder->locateRoot($projectRoot);
+        // $this->drupalFinder->locateRoot($projectRoot);
         $root = $this->drupalFinder()->getDrupalRoot();
 
         // We prohibit global installs of Drush (without a Drupal site).

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -6,7 +6,8 @@ namespace Drush\Preflight;
 
 use Composer\Autoload\ClassLoader;
 use Consolidation\SiteAlias\SiteAliasManager;
-use Drush\DrupalFinder\DrupalFinder;
+use DrupalFinder\DrupalFinder;
+use Drush\DrupalFinder\DrushDrupalFinder;
 use Drush\Config\ConfigLocator;
 use Drush\Config\DrushConfig;
 use Drush\Config\Environment;
@@ -42,7 +43,7 @@ class Preflight
     protected $configLocator;
 
     /**
-     * @var DrupalFinder
+     * @var DrushDrupalFinder
      */
     protected $drupalFinder;
 
@@ -69,7 +70,7 @@ class Preflight
         $this->environment = $environment;
         $this->verify = $verify ?: new PreflightVerify();
         $this->configLocator = $configLocator ?: new ConfigLocator('DRUSH_', $environment->getConfigFileVariant());
-        $this->drupalFinder = new DrupalFinder($environment);
+        $this->drupalFinder = new DrushDrupalFinder($environment);
         $this->logger = $preflightLog ?: new PreflightLog();
     }
 
@@ -304,7 +305,7 @@ class Preflight
         // a local Drupal site that is not the site at $root
         $localAliasDrupalFinder = new DrupalFinder($this->environment());
         // @todo deal with this.
-        $foundAlternateRoot = false; //$localAliasDrupalFinder->locateRoot($selfSiteAlias->localRoot());
+        $foundAlternateRoot = $localAliasDrupalFinder->locateRoot($selfSiteAlias->localRoot());
         if ($foundAlternateRoot) {
             $alteredRoot = $localAliasDrupalFinder->getDrupalRoot();
 
@@ -360,7 +361,7 @@ class Preflight
     /**
      * Return the Drupal Finder
      */
-    public function drupalFinder(): DrupalFinder
+    public function drupalFinder(): DrushDrupalFinder
     {
         return $this->drupalFinder;
     }

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -322,7 +322,7 @@ class Preflight
             // contain its own copy of Drush, then we cannot continue.
             if ($alteredRoot != $root) {
                 $aliasName = $this->preflightArgs->alias();
-                throw new \Exception("AR=$alteredRoot, ROOT=$root The alias $aliasName references a Drupal site that does not contain its own copy of Drush. Please add Drush to this site to use it.");
+                throw new \Exception("The alias $aliasName references a Drupal site that does not contain its own copy of Drush. Please add Drush to this site to use it.");
             }
         }
 

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -304,7 +304,6 @@ class Preflight
         // Check to see if the alias on the command line points at
         // a local Drupal site that is not the site at $root
         $localAliasDrupalFinder = new DrupalFinder($this->environment());
-        // @todo deal with this.
         $foundAlternateRoot = $localAliasDrupalFinder->locateRoot($selfSiteAlias->localRoot());
         if ($foundAlternateRoot) {
             $alteredRoot = $localAliasDrupalFinder->getDrupalRoot();

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -14,6 +14,7 @@ use Drush\Config\Environment;
 use Drush\SiteAlias\SiteAliasFileLoader;
 use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
@@ -306,7 +307,7 @@ class Preflight
         $localAliasDrupalFinder = new DrupalFinder($this->environment());
         $foundAlternateRoot = $localAliasDrupalFinder->locateRoot($selfSiteAlias->localRoot());
         if ($foundAlternateRoot) {
-            $alteredRoot = $localAliasDrupalFinder->getDrupalRoot();
+            $alteredRoot = Path::canonicalize($localAliasDrupalFinder->getDrupalRoot());
 
             // Now that we have our final Drupal root, check to see if there is
             // a site-local Drush. If there is, we will redispatch to it.

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -321,7 +321,7 @@ class Preflight
             // contain its own copy of Drush, then we cannot continue.
             if ($alteredRoot != $root) {
                 $aliasName = $this->preflightArgs->alias();
-                throw new \Exception("The alias $aliasName references a Drupal site that does not contain its own copy of Drush. Please add Drush to this site to use it.");
+                throw new \Exception("AR=$alteredRoot, ROOT=$root The alias $aliasName references a Drupal site that does not contain its own copy of Drush. Please add Drush to this site to use it.");
             }
         }
 

--- a/src/Runtime/DependencyInjection.php
+++ b/src/Runtime/DependencyInjection.php
@@ -17,7 +17,7 @@ use Drush\Command\GlobalOptionsEventListener;
 use Drush\Drush;
 use Drush\Symfony\DrushStyleInjector;
 use Drush\Cache\CommandCache;
-use Drush\DrupalFinder\DrupalFinder;
+use Drush\DrupalFinder\DrushDrupalFinder;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Application;
@@ -51,7 +51,7 @@ class DependencyInjection
         InputInterface $input,
         OutputInterface $output,
         ClassLoader $loader,
-        DrupalFinder $drupalFinder,
+        DrushDrupalFinder $drupalFinder,
         SiteAliasManager $aliasManager
     ): Container {
 
@@ -96,7 +96,7 @@ class DependencyInjection
     }
 
     // Add Drush Services to league/container 3.x
-    protected function addDrushServices($container, ClassLoader $loader, DrupalFinder $drupalFinder, SiteAliasManager $aliasManager, DrushConfig $config, OutputInterface $output): void
+    protected function addDrushServices($container, ClassLoader $loader, DrushDrupalFinder $drupalFinder, SiteAliasManager $aliasManager, DrushConfig $config, OutputInterface $output): void
     {
         // Override Robo's logger with a LoggerManager that delegates to the Drush logger.
         Robo::addShared($container, 'logger', '\Drush\Log\DrushLoggerManager')

--- a/src/Runtime/DependencyInjection.php
+++ b/src/Runtime/DependencyInjection.php
@@ -17,7 +17,7 @@ use Drush\Command\GlobalOptionsEventListener;
 use Drush\Drush;
 use Drush\Symfony\DrushStyleInjector;
 use Drush\Cache\CommandCache;
-use DrupalFinder\DrupalFinder;
+use Drush\DrupalFinder\DrupalFinder;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Application;


### PR DESCRIPTION
- Implements our own DrupalFinder
- Keeps using webflo/drupal-finder when we want to discover roots that are different from the bootstrapped site. That happens in ArchiveDump and in Preflight (when you use a site alias with a local drupal root)