### PR TITLE
field-create: Fix the field-create-field-storage event (11.x)

### DIFF
--- a/src/Drupal/Commands/field/FieldCreateCommands.php
+++ b/src/Drupal/Commands/field/FieldCreateCommands.php
@@ -509,7 +509,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         // Command files may customize $values as desired.
         $handlers = $this->getCustomEventHandlers('field-create-field-storage');
         foreach ($handlers as $handler) {
-            $handler($values);
+            $values = $handler($values, $this->input);
         }
 
         /** @var FieldStorageConfigInterface $fieldStorage */


### PR DESCRIPTION
I noticed the `field-create-field-storage` event doesn't actually work: the return value from the hook implementations is not used and the arguments are not consistent with the `field-create-field-config`.