### PR TITLE
More Drupal and Drush service dependency injection in CacheCommands

### DIFF
--- a/src/Commands/core/CacheCommands.php
+++ b/src/Commands/core/CacheCommands.php
@@ -6,14 +6,11 @@ namespace Drush\Commands\core;
 
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
-use Drupal\Core\Routing\RouteBuilderInterface;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareInterface;
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareTrait;
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Drush\Attributes as CLI;
-use Drush\Boot\AutoloaderAwareInterface;
-use Drush\Boot\AutoloaderAwareTrait;
 use Drush\Boot\BootstrapManager;
 use Drush\Boot\DrupalBootLevels;
 use Drush\Commands\DrushCommands;
@@ -29,10 +26,9 @@ use Symfony\Component\Filesystem\Exception\IOException;
 /*
  * Interact with Drupal's Cache API.
  */
-final class CacheCommands extends DrushCommands implements CustomEventAwareInterface, AutoloaderAwareInterface, StdinAwareInterface
+final class CacheCommands extends DrushCommands implements CustomEventAwareInterface, StdinAwareInterface
 {
     use CustomEventAwareTrait;
-    use AutoloaderAwareTrait;
     use StdinAwareTrait;
 
     const GET = 'cache:get';
@@ -238,10 +234,11 @@ final class CacheCommands extends DrushCommands implements CustomEventAwareInter
         DrupalKernel::bootEnvironment();
 
         $site_path = DrupalKernel::findSitePath($request);
-        Settings::initialize($root, $site_path, $this->autoloader());
+        $class_loader = $this->bootstrapManager->autoloader();
+        Settings::initialize($root, $site_path, $class_loader);
 
         // drupal_rebuild() calls drupal_flush_all_caches() itself, so we don't do it manually.
-        drupal_rebuild($this->autoloader(), $request);
+        drupal_rebuild($class_loader, $request);
         $this->logger()->success(dt('Cache rebuild complete.'));
     }
 

--- a/src/Commands/core/CacheCommands.php
+++ b/src/Commands/core/CacheCommands.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drush\Commands\core;
 
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Routing\RouteBuilderInterface;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\Events\CustomEventAwareInterface;
@@ -13,16 +14,16 @@ use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Drush\Attributes as CLI;
 use Drush\Boot\AutoloaderAwareInterface;
 use Drush\Boot\AutoloaderAwareTrait;
-use Drush\Boot\DrupalBoot;
+use Drush\Boot\BootstrapManager;
 use Drush\Boot\DrupalBootLevels;
 use Drush\Commands\DrushCommands;
 use Drupal\Core\DrupalKernel;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\Cache\Cache;
-use Drush\Drush;
 use Drush\Utils\StringUtils;
 use Consolidation\AnnotatedCommand\Input\StdinAwareInterface;
 use Consolidation\AnnotatedCommand\Input\StdinAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 
 /*
@@ -39,6 +40,35 @@ final class CacheCommands extends DrushCommands implements CustomEventAwareInter
     const CLEAR = 'cache:clear';
     const SET = 'cache:set';
     const REBUILD = 'cache:rebuild';
+
+    public function __construct(
+        private ContainerInterface $container,
+        private CacheTagsInvalidatorInterface $invalidator,
+        private $themeRegistry,
+        private $routerBuilder,
+        private $jsOptimizer,
+        private $cssOptimizer,
+        private $pluginCacheClearer,
+        private BootstrapManager $bootstrapManager
+    ) {
+    }
+
+    public static function create(ContainerInterface $container, $drush_container): self
+    {
+        $commandHandler = new static(
+            $container,
+            $container->get('cache_tags.invalidator'),
+            $container->get('theme.registry'),
+            $container->get('router.builder'),
+            $container->get('asset.js.collection_optimizer'),
+            $container->get('asset.css.collection_optimizer'),
+            $container->get('plugin.cache_clearer'),
+            // Note: pulling from Drush container, not Drupal.
+            $drush_container->get('bootstrap.manager')
+        );
+
+        return $commandHandler;
+    }
 
     /**
      * Fetch a cached object and display it.
@@ -78,7 +108,7 @@ final class CacheCommands extends DrushCommands implements CustomEventAwareInter
     public function tags(string $tags): void
     {
         $tags = StringUtils::csvToArray($tags);
-        Cache::invalidateTags($tags);
+        $this->invalidator->invalidateTags($tags);
         $this->logger()->success(dt("Invalidated tag(s): !list.", ['!list' => implode(' ', $tags)]));
     }
 
@@ -94,16 +124,12 @@ final class CacheCommands extends DrushCommands implements CustomEventAwareInter
     #[CLI\Usage(name: 'drush cc bin entity,bootstrap', description: 'Clear the entity and bootstrap cache bins.')]
     public function clear(string $type, array $args, $options = ['cache-clear' => true])
     {
-        $boot_manager = Drush::bootstrapManager();
-
         if (!$options['cache-clear']) {
             $this->logger()->info(dt("Skipping cache-clear operation due to --cache-clear=0 option."));
             return null;
         }
 
-        $types = $this->getTypes($boot_manager->hasBootstrapped((DrupalBootLevels::FULL)));
-
-        // Do it.
+        $types = $this->getTypes($this->bootstrapManager->hasBootstrapped((DrupalBootLevels::FULL)));
         drush_op($types[$type], $args);
         // Avoid double confirm.
         if ($type !== 'bin') {
@@ -114,9 +140,8 @@ final class CacheCommands extends DrushCommands implements CustomEventAwareInter
     #[CLI\Hook(type: HookManager::INTERACT, target: self::CLEAR)]
     public function interact($input, $output): void
     {
-        $boot_manager = Drush::bootstrapManager();
         if (empty($input->getArgument('type'))) {
-            $types = $this->getTypes($boot_manager->hasBootstrapped(DrupalBootLevels::FULL));
+            $types = $this->getTypes($this->bootstrapManager->hasBootstrapped(DrupalBootLevels::FULL));
             $choices = array_combine(array_keys($types), array_keys($types));
             $type = $this->io()->choice(dt("Choose a cache to clear"), $choices, 'all');
             $input->setArgument('type', $type);
@@ -206,10 +231,10 @@ final class CacheCommands extends DrushCommands implements CustomEventAwareInter
 
         // We no longer clear APC and similar caches as they are useless on CLI.
         // See https://github.com/drush-ops/drush/pull/2450
-        $root  = Drush::bootstrapManager()->getRoot();
+        $root  = $this->bootstrapManager->getRoot();
         require_once DRUSH_DRUPAL_CORE . '/includes/utility.inc';
 
-        $request = Drush::bootstrap()->getRequest();
+        $request = $this->bootstrapManager->bootstrap()->getRequest();
         DrupalKernel::bootEnvironment();
 
         $site_path = DrupalKernel::findSitePath($request);
@@ -223,15 +248,14 @@ final class CacheCommands extends DrushCommands implements CustomEventAwareInter
     #[CLI\Hook(type: HookManager::ARGUMENT_VALIDATOR, target: self::CLEAR)]
     public function validate(CommandData $commandData): void
     {
-        $boot_manager = Drush::bootstrapManager();
-        $types = $this->getTypes($boot_manager->hasBootstrapped(DrupalBootLevels::FULL));
+        $types = $this->getTypes($this->bootstrapManager->hasBootstrapped(DrupalBootLevels::FULL));
         $type = $commandData->input()->getArgument('type');
         // Check if the provided type ($type) is a valid cache type.
         if ($type && !array_key_exists($type, $types)) {
             // If we haven't done a full bootstrap, provide a more
             // specific message with instructions to the user on
             // bootstrapping a Drupal site for more options.
-            if (!$boot_manager->hasBootstrapped(DrupalBootLevels::FULL)) {
+            if (!$this->bootstrapManager->hasBootstrapped(DrupalBootLevels::FULL)) {
                 $all_types = $this->getTypes(true);
                 if (array_key_exists($type, $all_types)) {
                     throw new \Exception(dt("'!type' cache requires a working Drupal site to operate on. Use the --root and --uri options, or a site @alias, or cd to a directory containing a Drupal settings.php file.", ['!type' => $type]));
@@ -274,65 +298,62 @@ final class CacheCommands extends DrushCommands implements CustomEventAwareInter
     /**
      * Clear caches internal to Drush core.
      */
-    public static function clearDrush(): void
+    public function clearDrush(): void
     {
         try {
-            Drush::logger()->info(dt('Deprecation notice - Drush no longer caches anything.'));
+            $this->logger()->info(dt('Deprecation notice - Drush no longer caches anything.'));
         } catch (IOException $e) {
             // Sometimes another process writes files into a bin dir and \Drush\Cache\FileCache::clear fails.
             // That is not considered an error. https://github.com/drush-ops/drush/pull/4535.
-            Drush::logger()->info($e->getMessage());
+            $this->logger()->info($e->getMessage());
         }
     }
 
     /**
      * Clear one or more cache bins.
      */
-    public static function clearBins($args = ['default']): void
+    public function clearBins($args = ['default']): void
     {
         $bins = StringUtils::csvToArray($args);
         foreach ($bins as $bin) {
             \Drupal::service("cache.$bin")->deleteAll();
-            Drush::logger()->success("$bin cache bin cleared.");
+            $this->logger()->success("$bin cache bin cleared.");
         }
     }
 
-    public static function clearThemeRegistry(): void
+    public function clearThemeRegistry(): void
     {
-        \Drupal::service('theme.registry')->reset();
+        $this->themeRegistry->reset();
     }
 
-    public static function clearRouter(): void
+    public function clearRouter(): void
     {
-        /** @var RouteBuilderInterface $router_builder */
-        $router_builder = \Drupal::service('router.builder');
-        $router_builder->rebuild();
+        $this->routerBuilder->rebuild();
     }
 
-    public static function clearCssJs(): void
+    public function clearCssJs(): void
     {
         _drupal_flush_css_js();
-        \Drupal::service('asset.css.collection_optimizer')->deleteAll();
-        \Drupal::service('asset.js.collection_optimizer')->deleteAll();
+        $this->cssOptimizer->deleteAll();
+        $this->jsOptimizer->deleteAll();
     }
 
-    public static function clearContainer(): void
+    public function clearContainer(): void
     {
-        /** @var DrupalBoot $boot_object */
-        $boot_object = Drush::bootstrap();
+        $boot_object = $this->bootstrapManager->bootstrap();
         $boot_object->getKernel()->invalidateContainer();
     }
 
     /**
      * Clears the render cache entries.
      */
-    public static function clearRender(): void
+    public function clearRender(): void
     {
-        Cache::invalidateTags(['rendered']);
+        $this->invalidator->invalidateTags(['rendered']);
     }
 
-    public static function clearPlugin(): void
+    public function clearPlugin(): void
     {
-        \Drupal::getContainer()->get('plugin.cache_clearer')->clearCachedDefinitions();
+        $this->pluginCacheClearer->clearCachedDefinitions();
     }
 }

--- a/src/Commands/core/CacheCommands.php
+++ b/src/Commands/core/CacheCommands.php
@@ -38,7 +38,6 @@ final class CacheCommands extends DrushCommands implements CustomEventAwareInter
     const REBUILD = 'cache:rebuild';
 
     public function __construct(
-        private ContainerInterface $container,
         private CacheTagsInvalidatorInterface $invalidator,
         private $themeRegistry,
         private $routerBuilder,
@@ -52,7 +51,6 @@ final class CacheCommands extends DrushCommands implements CustomEventAwareInter
     public static function create(ContainerInterface $container, $drush_container): self
     {
         $commandHandler = new static(
-            $container,
             $container->get('cache_tags.invalidator'),
             $container->get('theme.registry'),
             $container->get('router.builder'),


### PR DESCRIPTION
@greg-1-anderson 

1. Does this look as expected?
2. Fixed by getting from Bootstrapmanager <strike>Does AutoloadAwareInterface still work? $this->autoloader() is not working (independent of this PR I think) - https://github.com/drush-ops/drush/blob/2afc8426c43cc51e515d1dd2838f3a489b7c940c/src/Commands/core/CacheCommands.php#L241</strike>

If this PR looks good, I will go through Commands looking for similar opportunities for DI. After all these years I'm still slightly hostile toward DI for all the indirection it adds to a codebase but I know that ship has sailed.