### PR TITLE
Sanitize version before displaying it in human-readable formats. 

### DIFF
--- a/src/Commands/core/CoreCommands.php
+++ b/src/Commands/core/CoreCommands.php
@@ -11,6 +11,7 @@ use Drush\Drush;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
 
 final class CoreCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {
@@ -72,6 +73,16 @@ final class CoreCommands extends DrushCommands implements SiteAliasManagerAwareI
     #[CLI\FieldLabels(labels: ['drush-version' => 'Drush version'])]
     public function version($options = ['format' => 'table']): PropertyList
     {
-        return new PropertyList(['drush-version' => Drush::getVersion()]);
+        $versionPropertyList = new PropertyList(['drush-version' => Drush::getVersion()]);
+        $versionPropertyList->addRendererFunction(
+            function ($key, $cellData, FormatterOptions $options) {
+                if ($key == 'drush-version') {
+                    return Drush::sanitizeVersionString($cellData);
+                }
+                return $cellData;
+            }
+        );
+
+        return $versionPropertyList;
     }
 }

--- a/src/Commands/core/StatusCommands.php
+++ b/src/Commands/core/StatusCommands.php
@@ -172,6 +172,9 @@ final class StatusCommands extends DrushCommands implements SiteAliasManagerAwar
 
     public function renderStatusCell($key, $cellData, FormatterOptions $options)
     {
+        if ($key == 'drush-version') {
+            return Drush::sanitizeVersionString($cellData);
+        }
         if (is_array($cellData)) {
             return implode("\n", $cellData);
         }

--- a/src/Drush.php
+++ b/src/Drush.php
@@ -90,6 +90,14 @@ class Drush
         return self::$version;
     }
 
+    /**
+     * Convert internal Composer dev version to ".x"
+     */
+    public static function sanitizeVersionString($version)
+    {
+        return preg_replace('#\.9+\.9+\.9+#', '.x', $version);
+    }
+
     public static function getMajorVersion(): string
     {
         if (!self::$majorVersion) {

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -71,7 +71,7 @@ class Runtime
 
         // Create the Symfony Application et. al.
         $input = $this->preflight->createInput();
-        $application = new Application('Drush Commandline Tool', Drush::getVersion());
+        $application = new Application('Drush Commandline Tool', Drush::sanitizeVersionString(Drush::getVersion()));
 
         // Set up the DI container.
         $container = $this->di->initContainer(


### PR DESCRIPTION
Still displays the Composer version in machine formats (json, yaml, etc.)

Example usage:

```
$ drush --version
Drush Commandline Tool 12.x-dev
$ drush version
Drush version : 12.x-dev 
$ drush version --format=json
{
    "drush-version": "12.9999999.9999999.9999999-dev"
}
```