### PR TITLE
Remove drush.services.yml warning message

### DIFF
--- a/src/Runtime/LegacyServiceFinder.php
+++ b/src/Runtime/LegacyServiceFinder.php
@@ -111,7 +111,6 @@ class LegacyServiceFinder
         if (!file_exists($result)) {
             return;
         }
-        Drush::logger()->info(dt("!module should have an extra.drush.services section in its composer.json. See https://www.drush.org/latest/commands/#specifying-the-services-file.", ['!module' => $module]));
         return $result;
     }
 


### PR DESCRIPTION
Remove warning when drush.services.yml file exists without a services section in the module's composer.json file. This feature is now deprecated, so there is no reason to encourage users to be pedantic in its selection.