### PR TITLE
Deprecate IO trait

### DIFF
--- a/src/Commands/config/ConfigExportCommands.php
+++ b/src/Commands/config/ConfigExportCommands.php
@@ -16,6 +16,7 @@ use Drush\Exceptions\UserAbortException;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class ConfigExportCommands extends DrushCommands
 {
@@ -91,13 +92,13 @@ final class ConfigExportCommands extends DrushCommands
     #[CLI\Option(name: 'diff', description: 'Show preview as a diff, instead of a change list.')]
     #[CLI\Usage(name: 'drush config:export', description: 'Export configuration files to the site\'s config directory.')]
     #[CLI\Usage(name: 'drush config:export --destination', description: 'Export configuration; Save files in a backup directory named config-export.')]
-    public function export($options = ['add' => false, 'commit' => false, 'message' => self::REQ, 'destination' => self::OPT, 'diff' => false, 'format' => null]): array
+    public function export(SymfonyStyle $io, $options = ['add' => false, 'commit' => false, 'message' => self::REQ, 'destination' => self::OPT, 'diff' => false, 'format' => null]): array
     {
         // Get destination directory.
         $destination_dir = ConfigCommands::getDirectory($options['destination']);
 
         // Do the actual config export operation.
-        $preview = $this->doExport($options, $destination_dir);
+        $preview = $this->doExport($io, $options, $destination_dir);
 
         // Do the VCS operations.
         $this->doAddCommit($options, $destination_dir, $preview);
@@ -105,7 +106,7 @@ final class ConfigExportCommands extends DrushCommands
         return ['destination-dir' => $destination_dir];
     }
 
-    public function doExport($options, $destination_dir)
+    public function doExport(SymfonyStyle $io, $options, $destination_dir)
     {
         $sync_directory = Settings::get('config_sync_directory');
 
@@ -142,7 +143,7 @@ final class ConfigExportCommands extends DrushCommands
                 $this->logger()->notice($preamble . $preview);
             }
 
-            if (!$this->io()->confirm(dt('The .yml files in your export directory (!target) will be deleted and replaced with the active config.', ['!target' => $destination_dir]))) {
+            if (!$io->confirm(dt('The .yml files in your export directory (!target) will be deleted and replaced with the active config.', ['!target' => $destination_dir]))) {
                 throw new UserAbortException();
             }
 

--- a/src/Commands/config/ConfigImportCommands.php
+++ b/src/Commands/config/ConfigImportCommands.php
@@ -32,6 +32,7 @@ use Drush\Commands\DrushCommands;
 use Drush\Exceptions\UserAbortException;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ConfigImportCommands extends DrushCommands
 {
@@ -173,7 +174,7 @@ class ConfigImportCommands extends DrushCommands
     #[CLI\Usage(name: 'drush config:import --partial --source=/app/config', description: 'Import from the /app/config directory which typically contains one or a few yaml files.')]
     #[CLI\Usage(name: 'cat tmp.yml | drush config:set --input-format=yaml user.mail ? -', description: 'Update the <info>user.mail</info> config object in its entirety.')]
     #[CLI\Topics(topics: [DocsCommands::DEPLOY])]
-    public function import(array $options = ['source' => self::REQ, 'partial' => false, 'diff' => false])
+    public function import(SymfonyStyle $io, array $options = ['source' => self::REQ, 'partial' => false, 'diff' => false])
     {
         // Determine source directory.
         $source_storage_dir = ConfigCommands::getDirectory($options['source']);
@@ -224,7 +225,7 @@ class ConfigImportCommands extends DrushCommands
             $this->output()->writeln($output);
         }
 
-        if (!$this->io()->confirm(dt('Import the listed configuration changes?'))) {
+        if (!$io->confirm(dt('Import the listed configuration changes?'))) {
             throw new UserAbortException();
         }
         return drush_op([$this, 'doImport'], $storage_comparer);

--- a/src/Commands/core/DeployHookCommands.php
+++ b/src/Commands/core/DeployHookCommands.php
@@ -18,6 +18,7 @@ use Drush\Commands\DrushCommands;
 use Drush\Drush;
 use Drush\Exceptions\UserAbortException;
 use Psr\Log\LogLevel;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class DeployHookCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {
@@ -86,7 +87,7 @@ final class DeployHookCommands extends DrushCommands implements SiteAliasManager
     #[CLI\Topics(topics: [DocsCommands::DEPLOY])]
     #[CLI\Version(version: '10.3')]
     #[CLI\Bootstrap(level: DrupalBootLevels::FULL)]
-    public function run(): int
+    public function run(SymfonyStyle $io): int
     {
         $pending = self::getRegistry()->getPendingUpdateFunctions();
 
@@ -99,7 +100,7 @@ final class DeployHookCommands extends DrushCommands implements SiteAliasManager
         $process->mustRun();
         $this->output()->writeln($process->getOutput());
 
-        if (!$this->io()->confirm(dt('Do you wish to run the specified pending deploy hooks?'))) {
+        if (!$io->confirm(dt('Do you wish to run the specified pending deploy hooks?'))) {
             throw new UserAbortException();
         }
 

--- a/src/Commands/core/EditCommands.php
+++ b/src/Commands/core/EditCommands.php
@@ -12,6 +12,7 @@ use Drush\Drush;
 use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 use Drush\Exec\ExecTrait;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class EditCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {
@@ -33,7 +34,7 @@ final class EditCommands extends DrushCommands implements SiteAliasManagerAwareI
     #[CLI\Usage(name: 'drush core:edit --choice=2', description: 'Edit the second file in the choice list.')]
     #[CLI\Bootstrap(level: DrupalBootLevels::MAX)]
     #[CLI\HookSelector(name: 'optionset_get_editor')]
-    public function edit($filter = null, array $options = []): void
+    public function edit(SymfonyStyle $io, $filter = null, array $options = []): void
     {
         $all = $this->load();
 
@@ -50,7 +51,7 @@ final class EditCommands extends DrushCommands implements SiteAliasManagerAwareI
         if (count($all) == 1) {
             $filepath = current($all);
         } else {
-            $choice = $this->io()->choice(dt("Choose a file to edit"), $all);
+            $choice = $io->choice(dt("Choose a file to edit"), $all);
             $filepath = $choice;
             // We don't yet support launching editor at a start line.
             if ($pos = strpos($filepath, ':')) {

--- a/src/Commands/core/EntityCommands.php
+++ b/src/Commands/core/EntityCommands.php
@@ -13,6 +13,7 @@ use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
 use Drush\Utils\StringUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class EntityCommands extends DrushCommands
 {
@@ -49,7 +50,7 @@ final class EntityCommands extends DrushCommands
     #[CLI\Usage(name: 'drush entity:delete user', description: 'Delete all users except uid=1.')]
     #[CLI\Usage(name: 'drush entity:delete node --exclude=9,14,81', description: 'Delete all nodes except node 9, 14 and 81.')]
     #[CLI\Usage(name: 'drush entity:delete node --chunks=5', description: 'Delete all node entities in steps of 5.')]
-    public function delete(string $entity_type, $ids = null, array $options = ['bundle' => self::REQ, 'exclude' => self::REQ, 'chunks' => 50]): void
+    public function delete(SymfonyStyle $io, string $entity_type, $ids = null, array $options = ['bundle' => self::REQ, 'exclude' => self::REQ, 'chunks' => 50]): void
     {
         $query = $this->getQuery($entity_type, $ids, $options);
         $result = $query->execute();
@@ -62,12 +63,12 @@ final class EntityCommands extends DrushCommands
         if (empty($result)) {
             $this->logger()->success(dt('No matching entities found.'));
         } else {
-            $this->io()->progressStart(count($result));
+            $io->progressStart(count($result));
             foreach (array_chunk($result, $options['chunks'], true) as $chunk) {
                 drush_op([$this, 'doDelete'], $entity_type, $chunk);
-                $this->io()->progressAdvance(count($chunk));
+                $io->progressAdvance(count($chunk));
             }
-            $this->io()->progressFinish();
+            $io->progressFinish();
             $this->logger()->success(dt("Deleted !type entity Ids: !ids", ['!type' => $entity_type, '!ids' => implode(', ', array_values($result))]));
         }
     }
@@ -105,7 +106,7 @@ final class EntityCommands extends DrushCommands
     #[CLI\Usage(name: 'drush entity:save user', description: 'Re-save all users.')]
     #[CLI\Usage(name: 'drush entity:save node --chunks=5', description: 'Re-save all node entities in steps of 5.')]
     #[CLI\Version(version: '11.0')]
-    public function loadSave(string $entity_type, $ids = null, array $options = ['bundle' => self::REQ, 'exclude' => self::REQ, 'chunks' => 50]): void
+    public function loadSave(SymfonyStyle $io, string $entity_type, $ids = null, array $options = ['bundle' => self::REQ, 'exclude' => self::REQ, 'chunks' => 50]): void
     {
         $query = $this->getQuery($entity_type, $ids, $options);
         $result = $query->execute();
@@ -113,12 +114,12 @@ final class EntityCommands extends DrushCommands
         if (empty($result)) {
             $this->logger()->success(dt('No matching entities found.'));
         } else {
-            $this->io()->progressStart(count($result));
+            $io->progressStart(count($result));
             foreach (array_chunk($result, $options['chunks'], true) as $chunk) {
                 drush_op([$this, 'doSave'], $entity_type, $chunk);
-                $this->io()->progressAdvance(count($chunk));
+                $io->progressAdvance(count($chunk));
             }
-            $this->io()->progressFinish();
+            $io->progressFinish();
             $this->logger()->success(dt("Saved !type entity ids: !ids", ['!type' => $entity_type, '!ids' => implode(', ', array_values($result))]));
         }
     }

--- a/src/Commands/core/RsyncCommands.php
+++ b/src/Commands/core/RsyncCommands.php
@@ -18,6 +18,7 @@ use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 use Drush\Backend\BackendPathEvaluator;
 use Drush\Config\ConfigLocator;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class RsyncCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {
@@ -58,12 +59,12 @@ final class RsyncCommands extends DrushCommands implements SiteAliasManagerAware
     #[CLI\Usage(name: 'drush rsync @dev @stage -- --exclude=*.sql --delete', description: 'Rsync Drupal root from the Drush alias dev to the alias stage, excluding all .sql files and delete all files on the destination that are no longer on the source.')]
     #[CLI\Usage(name: 'drush rsync @dev @stage --ssh-options="-o StrictHostKeyChecking=no" -- --delete', description: 'Customize how rsync connects with remote host via SSH. rsync options like --delete are placed after a --.')]
     #[CLI\Topics(topics: [DocsCommands::ALIASES])]
-    public function rsync($source, $target, array $extra, $options = ['exclude-paths' => self::REQ, 'include-paths' => self::REQ, 'mode' => 'akz']): void
+    public function rsync(SymfonyStyle $io, $source, $target, array $extra, $options = ['exclude-paths' => self::REQ, 'include-paths' => self::REQ, 'mode' => 'akz']): void
     {
         // Prompt for confirmation. This is destructive.
         if (!$this->getConfig()->simulate()) {
             $replacements = ['!source' => $this->sourceEvaluatedPath->fullyQualifiedPathPreservingTrailingSlash(), '!target' => $this->targetEvaluatedPath->fullyQualifiedPath()];
-            if (!$this->io()->confirm(dt("Copy new and override existing files at !target. The source is !source?", $replacements))) {
+            if (!$io->confirm(dt("Copy new and override existing files at !target. The source is !source?", $replacements))) {
                 throw new UserAbortException();
             }
         }

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -17,6 +17,7 @@ use Drush\Commands\DrushCommands;
 use Drush\Drush;
 use Drush\Exceptions\UserAbortException;
 use Psr\Log\LogLevel;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAwareInterface
 {
@@ -34,7 +35,7 @@ final class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAw
     #[CLI\Bootstrap(level: DrupalBootLevels::FULL)]
     #[CLI\Topics(topics: [DocsCommands::DEPLOY])]
     #[CLI\Kernel(name: 'update')]
-    public function updatedb($options = ['cache-clear' => true]): int
+    public function updatedb(SymfonyStyle $io, $options = ['cache-clear' => true]): int
     {
         require_once DRUPAL_ROOT . '/core/includes/install.inc';
         require_once DRUPAL_ROOT . '/core/includes/update.inc';
@@ -46,7 +47,7 @@ final class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAw
 
         // Check requirements before updating.
         if (!$this->updateCheckRequirements()) {
-            if (!$this->io()->confirm(dt('Requirements check reports errors. Do you wish to continue?'))) {
+            if (!$io->confirm(dt('Requirements check reports errors. Do you wish to continue?'))) {
                 throw new UserAbortException();
             }
         }
@@ -59,7 +60,7 @@ final class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAw
         if ($output = $process->getOutput()) {
             // We have pending updates - let's run em.
             $this->output()->writeln($output);
-            if (!$this->io()->confirm(dt('Do you wish to run the specified pending updates?'))) {
+            if (!$io->confirm(dt('Do you wish to run the specified pending updates?'))) {
                 throw new UserAbortException();
             }
             if ($this->getConfig()->simulate()) {

--- a/src/Commands/core/UserCommands.php
+++ b/src/Commands/core/UserCommands.php
@@ -18,6 +18,7 @@ use Drush\Utils\StringUtils;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class UserCommands extends DrushCommands
 {
@@ -269,7 +270,7 @@ final class UserCommands extends DrushCommands
     #[CLI\Usage(name: 'drush user:cancel username', description: 'Block the user account with the name username.')]
     #[CLI\Usage(name: 'drush user:cancel --delete-content username', description: 'Delete the user account with the name <info>username<info> and delete all content created by that user.')]
     #[CLI\Usage(name: 'drush user:cancel --reassign-content username', description: 'Delete the user account with the name <info>username<info> and assign all her content to the anonymous user.')]
-    public function cancel(string $names, $options = ['delete-content' => false, 'reassign-content' => false, 'uid' => self::REQ, 'mail' => self::REQ]): void
+    public function cancel(SymfonyStyle $io, string $names, $options = ['delete-content' => false, 'reassign-content' => false, 'uid' => self::REQ, 'mail' => self::REQ]): void
     {
         $accounts = $this->getAccounts($names, $options);
         foreach ($accounts as $id => $account) {
@@ -278,7 +279,7 @@ final class UserCommands extends DrushCommands
             } elseif ($options['reassign-content']) {
                 $this->logger()->warning(dt('All content created by !name will be assigned to anonymous user.', ['!name' => $account->getAccountName()]));
             }
-            if ($this->io()->confirm('Cancel user account?: ')) {
+            if ($io->confirm('Cancel user account?: ')) {
                 $method = $options['delete-content'] ? 'user_cancel_delete' : ($options['reassign-content'] ? 'user_cancel_reassign' : 'user_cancel_block');
                 user_cancel([], $account->id(), $method);
                 drush_backend_batch_process();

--- a/src/Commands/core/ViewsCommands.php
+++ b/src/Commands/core/ViewsCommands.php
@@ -15,6 +15,7 @@ use Drush\Commands\DrushCommands;
 use Drupal\views\Views;
 use Drush\Utils\StringUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class ViewsCommands extends DrushCommands
 {
@@ -212,7 +213,7 @@ final class ViewsCommands extends DrushCommands
     #[CLI\Usage(name: 'drush views:execute my_view page_1 3,foo', description: "Show the rendered HTML of my_view:page_1 where the first two contextual filter values are 3 and 'foo' respectively.")]
     #[CLI\ValidateEntityLoad(entityType: 'view', argumentName: 'view_name')]
     #[CLI\ValidateModulesEnabled(modules: ['views'])]
-    public function execute(string $view_name, $display = null, $view_args = null, $options = ['count' => 0, 'show-admin-links' => false]): ?string
+    public function execute(SymfonyStyle $io, string $view_name, $display = null, $view_args = null, $options = ['count' => 0, 'show-admin-links' => false]): ?string
     {
 
         $view = Views::getView($view_name);
@@ -226,7 +227,7 @@ final class ViewsCommands extends DrushCommands
             $this->logger()->success(dt('No results returned for this View.'));
             return null;
         } elseif ($options['count']) {
-            $this->io()->writeln($view->result);
+            $io->writeln($view->result);
             return null;
         } else {
             // Don't show admin links in markup by default.

--- a/src/Commands/generate/GenerateCommands.php
+++ b/src/Commands/generate/GenerateCommands.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class GenerateCommands extends DrushCommands
 {
@@ -52,7 +53,7 @@ final class GenerateCommands extends DrushCommands
     #[CLI\Usage(name: 'drush generate controller -vvv --dry-run', description: 'Learn all the potential answers so you can re-run with several --answer options.')]
     #[CLI\Topics(topics: [DocsCommands::GENERATORS])]
     #[CLI\Complete(method_name_or_callable: 'generatorNameComplete')]
-    public function generate(string $generator = '', $options = ['replace' => false, 'working-dir' => self::REQ, 'answer' => [], 'destination' => self::REQ, 'dry-run' => false]): int
+    public function generate(SymfonyStyle $io, string $generator = '', $options = ['replace' => false, 'working-dir' => self::REQ, 'answer' => [], 'destination' => self::REQ, 'dry-run' => false]): int
     {
         $application = (new ApplicationFactory($this->container, $this->logger()))->create();
 
@@ -67,7 +68,7 @@ final class GenerateCommands extends DrushCommands
 
         // Symfony console app does not provide any way to remove registered commands.
         if ($generator === 'completion') {
-            $this->io()->getErrorStyle()->error('Command "completion" is not defined.');
+            $io->getErrorStyle()->error('Command "completion" is not defined.');
             return Command::FAILURE;
         }
 

--- a/src/Commands/help/ListCommands.php
+++ b/src/Commands/help/ListCommands.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Descriptor\XmlDescriptor;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Terminal;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ListCommands extends DrushCommands
 {
@@ -34,7 +35,7 @@ class ListCommands extends DrushCommands
     #[CLI\Usage(name: 'drush list', description: 'List all commands.')]
     #[CLI\Usage(name: 'drush list --filter=devel_generate', description: 'Show only commands starting with devel-')]
     #[CLI\Usage(name: 'drush list --format=xml', description: 'List all commands in Symfony compatible xml format.')]
-    public function helpList($options = ['format' => 'listcli', 'raw' => false, 'filter' => self::REQ]): ?string
+    public function helpList(SymfonyStyle $io, $options = ['format' => 'listcli', 'raw' => false, 'filter' => self::REQ]): ?string
     {
         $application = Drush::getApplication();
         $all = $application->all();
@@ -62,7 +63,7 @@ class ListCommands extends DrushCommands
             $preamble = dt('Run `drush help [command]` to view command-specific help.  Run `drush topic` to read even more documentation.');
             $this->renderListCLI($application, $namespaced, $this->output(), $preamble);
             if (!Drush::bootstrapManager()->hasBootstrapped((DrupalBootLevels::ROOT))) {
-                $this->io()->note(dt('Drupal root not found. Pass --root or a @siteAlias in order to see Drupal-specific commands.'));
+                $io->note(dt('Drupal root not found. Pass --root or a @siteAlias in order to see Drupal-specific commands.'));
             }
             return null;
         } elseif ($options['format'] == 'xml') {

--- a/src/Commands/pm/PmCommands.php
+++ b/src/Commands/pm/PmCommands.php
@@ -20,6 +20,7 @@ use Drush\Drush;
 use Drush\Exceptions\UserAbortException;
 use Drush\Utils\StringUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class PmCommands extends DrushCommands
 {
@@ -82,7 +83,7 @@ final class PmCommands extends DrushCommands
     #[CLI\Argument(name: 'modules', description: 'A comma delimited list of modules.')]
     #[CLI\Usage(name: 'drush pm:install --simulate content_moderation', description: "Display what modules would be installed but don't install them.")]
     #[CLI\Bootstrap(level: DrupalBootLevels::ROOT)]
-    public function install(array $modules): void
+    public function install(SymfonyStyle $io, array $modules): void
     {
         $modules = StringUtils::csvToArray($modules);
         $todo = $this->addInstallDependencies($modules);
@@ -95,7 +96,7 @@ final class PmCommands extends DrushCommands
             return;
         } elseif (array_values($todo) !== $modules) {
             $this->output()->writeln(dt('The following module(s) will be enabled: !list', $todo_str));
-            if (!$this->io()->confirm(dt('Do you want to continue?'))) {
+            if (!$io->confirm(dt('Do you want to continue?'))) {
                 throw new UserAbortException();
             }
         }
@@ -153,8 +154,9 @@ final class PmCommands extends DrushCommands
         }
 
         if ($error) {
+            $io = new DrushStyle($commandData->input(), $commandData->output());
             // Allow the user to bypass the install requirements.
-            if (!$this->io()->confirm(dt('The module install requirements failed. Do you wish to continue?'), false)) {
+            if (!$io->confirm(dt('The module install requirements failed. Do you wish to continue?'), false)) {
                 throw new UserAbortException();
             }
         }
@@ -166,7 +168,7 @@ final class PmCommands extends DrushCommands
     #[CLI\Command(name: self::UNINSTALL, aliases: ['un', 'pmu', 'pm-uninstall'])]
     #[CLI\Argument(name: 'modules', description: 'A comma delimited list of modules.')]
     #[CLI\Usage(name: 'drush pm:uninstall --simulate field_ui', description: "Display what modules would be uninstalled but don't uninstall them.")]
-    public function uninstall(array $modules): void
+    public function uninstall(SymfonyStyle $io, array $modules): void
     {
         $modules = StringUtils::csvToArray($modules);
 
@@ -188,7 +190,7 @@ final class PmCommands extends DrushCommands
 
         if (array_values($list) !== $modules) {
             $this->output()->writeln(dt('The following extensions will be uninstalled: !list', ['!list' => implode(', ', $list)]));
-            if (!$this->io()->confirm(dt('Do you want to continue?'))) {
+            if (!$io->confirm(dt('Do you want to continue?'))) {
                 throw new UserAbortException();
             }
         }

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -20,6 +20,7 @@ use Drush\Exec\ExecTrait;
 use Drush\Sql\SqlBase;
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class SqlCommands extends DrushCommands implements StdinAwareInterface
 {
@@ -86,13 +87,13 @@ final class SqlCommands extends DrushCommands implements StdinAwareInterface
     #[CLI\Usage(name: 'drush sql:create --db-su=root --db-su-pw=rootpassword --db-url="mysql://drupal_db_user:drupal_db_password@127.0.0.1/drupal_db"', description: 'Create the database as specified in the db-url option.')]
     #[CLI\Bootstrap(level: DrupalBootLevels::MAX, max_level: DrupalBootLevels::CONFIGURATION)]
     #[CLI\OptionsetSql]
-    public function create($options = ['db-su' => self::REQ, 'db-su-pw' => self::REQ]): void
+    public function create(SymfonyStyle $io, $options = ['db-su' => self::REQ, 'db-su-pw' => self::REQ]): void
     {
         $sql = SqlBase::create($options);
         $db_spec = $sql->getDbSpec();
 
         $this->output()->writeln(dt("Creating database !target. Any existing database will be dropped!", ['!target' => $db_spec['database']]));
-        if (!$this->getConfig()->simulate() && !$this->io()->confirm(dt('Do you really want to continue?'))) {
+        if (!$this->getConfig()->simulate() && !$io->confirm(dt('Do you really want to continue?'))) {
             throw new UserAbortException();
         }
 
@@ -108,11 +109,11 @@ final class SqlCommands extends DrushCommands implements StdinAwareInterface
     #[CLI\Bootstrap(level: DrupalBootLevels::MAX, max_level: DrupalBootLevels::CONFIGURATION)]
     #[CLI\OptionsetSql]
     #[CLI\Topics(topics: [DocsCommands::POLICY])]
-    public function drop($options = []): void
+    public function drop(SymfonyStyle $io, $options = []): void
     {
         $sql = SqlBase::create($options);
         $db_spec = $sql->getDbSpec();
-        if (!$this->io()->confirm(dt('Do you really want to drop all tables in the database !db?', ['!db' => $db_spec['database']]))) {
+        if (!$io->confirm(dt('Do you really want to drop all tables in the database !db?', ['!db' => $db_spec['database']]))) {
             throw new UserAbortException();
         }
         $tables = $sql->listTablesQuoted();

--- a/src/Drupal/Commands/sql/SanitizeCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeCommands.php
@@ -10,6 +10,7 @@ use Drush\Attributes as CLI;
 use Drush\Commands\core\DocsCommands;
 use Drush\Commands\DrushCommands;
 use Drush\Exceptions\UserAbortException;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class SanitizeCommands extends DrushCommands implements CustomEventAwareInterface
 {
@@ -31,7 +32,7 @@ final class SanitizeCommands extends DrushCommands implements CustomEventAwareIn
     #[CLI\Usage(name: 'drush sql:sanitize --sanitize-password=no', description: 'Sanitize database without modifying any passwords.')]
     #[CLI\Usage(name: 'drush sql:sanitize --allowlist-fields=field_biography,field_phone_number', description: 'Sanitizes database but exempts two user fields from modification.')]
     #[CLI\Topics(topics: [DocsCommands::HOOKS])]
-    public function sanitize(): void
+    public function sanitize(SymfonyStyle $io): void
     {
      /**
      * In order to present only one prompt, collect all confirmations from
@@ -46,9 +47,9 @@ final class SanitizeCommands extends DrushCommands implements CustomEventAwareIn
         }
         if (!empty($messages)) {
             $this->output()->writeln(dt('The following operations will be performed:'));
-            $this->io()->listing($messages);
+            $io->listing($messages);
         }
-        if (!$this->io()->confirm(dt('Do you want to sanitize the current database?'))) {
+        if (!$io->confirm(dt('Do you want to sanitize the current database?'))) {
             throw new UserAbortException();
         }
 

--- a/sut/modules/unish/woot/src/Drush/Commands/WootStaticFactoryCommands.php
+++ b/sut/modules/unish/woot/src/Drush/Commands/WootStaticFactoryCommands.php
@@ -8,6 +8,7 @@ use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drush\Commands\DrushCommands;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Psr\Container\ContainerInterface as DrushContainer;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Module commandfiles discovered by virtue of being located in the
@@ -37,16 +38,16 @@ class WootStaticFactoryCommands extends DrushCommands
      *
      * @command woot-factory
      */
-    public function wootFactory($count = 10)
+    public function wootFactory(SymfonyStyle $io, $count = 10)
     {
         $a = 1;
         $b = 1;
 
         $siteName = $this->configFactory->get('system.site')->get('name');
-        $this->io()->writeln('Woot factorial command with a static factory method in site ' . $siteName);
+        $io->writeln('Woot factorial command with a static factory method in site ' . $siteName);
 
         foreach (range(1,$count) as $i) {
-            $this->io()->writeln("Woot " . $a);
+            $io->writeln("Woot " . $a);
             $t = $a + $b;
             $a = $b;
             $b = $t;

--- a/tests/fixtures/drush-extensions/DrushExtensionsCommands.php
+++ b/tests/fixtures/drush-extensions/DrushExtensionsCommands.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drush\Commands\drush_extensions;
 
 use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class DrushExtensionsCommands extends DrushCommands
 {
@@ -15,8 +16,8 @@ class DrushExtensionsCommands extends DrushCommands
      * @bootstrap none
      * @hidden
      */
-    public function customCommand(): void
+    public function customCommand(SymfonyStyle $io): void
     {
-        $this->io()->text('Hello world!');
+        $io->text('Hello world!');
     }
 }

--- a/tests/fixtures/lib/Drush/Commands/CustomDrushCommands.php
+++ b/tests/fixtures/lib/Drush/Commands/CustomDrushCommands.php
@@ -3,6 +3,7 @@
 namespace Custom\Library\Drush\Commands;
 
 use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class CustomDrushCommands extends DrushCommands
 {
@@ -12,8 +13,8 @@ class CustomDrushCommands extends DrushCommands
      * @command custom_cmd
      * @hidden
      */
-    public function customCommand(): void
+    public function customCommand(SymfonyStyle $io): void
     {
-        $this->io()->text('Hello world!');
+        $io->text('Hello world!');
     }
 }

--- a/tests/fixtures/lib/Drush/Commands/StaticFactoryDrushCommands.php
+++ b/tests/fixtures/lib/Drush/Commands/StaticFactoryDrushCommands.php
@@ -6,6 +6,7 @@ use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\DrupalKernel;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Composer library commandfiles discovered by virtue of being located
@@ -32,8 +33,8 @@ class StaticFactoryDrushCommands extends DrushCommands
 
     #[CLI\Command(name: 'site:path')]
     #[CLI\Help(description: "This command asks the Kernel for the site path.", hidden: true)]
-    public function mySitePath()
+    public function mySitePath(SymfonyStyle $io)
     {
-        $this->io()->text('The site path is: ' . $this->kernel->getSitePath());
+        $io->text('The site path is: ' . $this->kernel->getSitePath());
     }
 }


### PR DESCRIPTION
Favor passing $io via parameter injection rather than inflecting it via the IO trait.

I originally thought that I would get rid of `$this->io()` everywhere, but there are a lot of places where this is cross-referenced e.g. via traits that are used in multiple commands, so it would be a bit lengthy / tedious to unwind it all.

We'll see how this MVP work to partially remove such access holds up in testing.