### PR TITLE
field-create: Make it easier for field types extending entity reference to add target type/bundles options (12.x)

### DIFF
--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -183,10 +183,6 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
             $this->ensureOption('is-translatable', [$this, 'askTranslatable'], false);
             $this->ensureOption('cardinality', [$this, 'askCardinality'], true);
 
-            if ($this->input->getOption('field-type') === 'entity_reference') {
-                $this->ensureOption('target-type', [$this, 'askReferencedEntityType'], true);
-            }
-
             $this->createFieldStorage();
         }
 
@@ -345,80 +341,6 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         return $limit;
     }
 
-    protected function askReferencedEntityType(): string
-    {
-        $definitions = $this->entityTypeManager->getDefinitions();
-        $choices = [];
-
-        foreach ($definitions as $name => $definition) {
-            $label = $this->input->getOption('show-machine-names')
-                ? $name
-                : sprintf('%s: %s', $definition->getGroupLabel()->render(), $definition->getLabel());
-            $choices[$name] = $label;
-        }
-
-        return $this->io()->choice('Referenced entity type', $choices);
-    }
-
-    protected function askReferencedBundles(FieldDefinitionInterface $fieldDefinition): array
-    {
-        $choices = [];
-        $bundleInfo = $this->entityTypeBundleInfo->getBundleInfo(
-            $fieldDefinition->getFieldStorageDefinition()->getSetting('target_type')
-        );
-
-        if (empty($bundleInfo)) {
-            return [];
-        }
-
-        foreach ($bundleInfo as $bundle => $info) {
-            $label = $this->input->getOption('show-machine-names') ? $bundle : $info['label'];
-            $choices[$bundle] = $label;
-        }
-
-        $question = (new ChoiceQuestion('Referenced bundles', $choices))
-            ->setMultiselect(true);
-
-        return $this->io()->askQuestion($question) ?: [];
-    }
-
-    protected function askBundle(): ?string
-    {
-        $entityTypeId = $this->input->getArgument('entityType');
-        $entityTypeDefinition = $this->entityTypeManager->getDefinition($entityTypeId);
-        $bundleEntityType = $entityTypeDefinition->getBundleEntityType();
-        $bundleInfo = $this->entityTypeBundleInfo->getBundleInfo($entityTypeId);
-        $choices = [];
-
-        if ($bundleEntityType && $bundleInfo === []) {
-            throw new \InvalidArgumentException(
-                dt("Entity type with id '!entityType' does not have any bundles.", ['!entityType' => $entityTypeId])
-            );
-        }
-
-        if ($fieldName = $this->input->getOption('existing-field-name')) {
-            $bundleInfo = array_filter($bundleInfo, function (string $bundle) use ($entityTypeId, $fieldName) {
-                return !$this->entityTypeManager->getStorage('field_config')->load("$entityTypeId.$bundle.$fieldName");
-            }, ARRAY_FILTER_USE_KEY);
-        }
-
-        if (!$bundleEntityType && count($bundleInfo) === 1) {
-            // eg. User
-            return $entityTypeId;
-        }
-
-        foreach ($bundleInfo as $bundle => $data) {
-            $label = $this->input->getOption('show-machine-names') ? $bundle : $data['label'];
-            $choices[$bundle] = $label;
-        }
-
-        if (!$answer = $this->io()->choice('Bundle', $choices)) {
-            throw new \InvalidArgumentException(dt('The bundle argument is required.'));
-        }
-
-        return $answer;
-    }
-
     protected function createField(): FieldConfigInterface
     {
         $values = [
@@ -442,32 +364,6 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
             ->getStorage('field_config')
             ->create($values);
 
-        if ($this->input->getOption('field-type') === 'entity_reference') {
-            $targetType = $this->input->getOption('target-type');
-            $targetTypeDefinition = $this->entityTypeManager->getDefinition($targetType);
-            // For the 'target_bundles' setting, a NULL value is equivalent to "allow
-            // entities from any bundle to be referenced" and an empty array value is
-            // equivalent to "no entities from any bundle can be referenced".
-            $targetBundles = null;
-
-            if ($targetTypeDefinition->hasKey('bundle')) {
-                if ($referencedBundle = $this->input->getOption('target-bundle')) {
-                    $this->validateBundle($targetType, $referencedBundle);
-                    $referencedBundles = [$referencedBundle];
-                } else {
-                    $referencedBundles = $this->askReferencedBundles($field);
-                }
-
-                if (!empty($referencedBundles)) {
-                    $targetBundles = array_combine($referencedBundles, $referencedBundles);
-                }
-            }
-
-            $settings = $field->getSetting('handler_settings') ?? [];
-            $settings['target_bundles'] = $targetBundles;
-            $field->setSetting('handler_settings', $settings);
-        }
-
         $field->save();
 
         return $field;
@@ -482,10 +378,6 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
             'cardinality' => $this->input->getOption('cardinality'),
             'translatable' => true,
         ];
-
-        if ($targetType = $this->input->getOption('target-type')) {
-            $values['settings']['target_type'] = $targetType;
-        }
 
         // Command files may customize $values as desired.
         $handlers = $this->getCustomEventHandlers('field-create-field-storage');

--- a/src/Commands/field/FieldEntityReferenceHooks.php
+++ b/src/Commands/field/FieldEntityReferenceHooks.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Drush\Commands\field;
+
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class FieldEntityReferenceHooks extends DrushCommands
+{
+    use EntityTypeBundleValidationTrait;
+
+    public function __construct(
+        protected EntityTypeManagerInterface $entityTypeManager,
+        protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,
+    ) {
+    }
+
+    public static function create(ContainerInterface $container): static
+    {
+        return new static(
+            $container->get('entity_type.manager'),
+            $container->get('entity_type.bundle.info'),
+        );
+    }
+
+    /**
+     * @hook on-event field-create-field-storage
+     */
+    public function hookFieldStorage(array $values, InputInterface $input): array
+    {
+        if ($input->getOption('field-type') === 'entity_reference') {
+            $values['settings']['target_type'] = $this->getTargetType($input);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @hook on-event field-create-field-config
+     */
+    public function hookFieldConfig(array $values, InputInterface $input): array
+    {
+        if ($input->getOption('field-type') === 'entity_reference') {
+            $values['settings']['handler_settings']['target_bundles'] = $this->getTargetBundles($input);
+        }
+
+        return $values;
+    }
+
+    protected function getTargetType(InputInterface $input): string
+    {
+        $value = $input->getOption('target-type');
+
+        if ($value === null && $input->isInteractive()) {
+            $value = $this->askReferencedEntityType();
+        }
+
+        if ($value === null) {
+            throw new \InvalidArgumentException(dt('The %optionName option is required.', [
+                '%optionName' => 'target-type',
+            ]));
+        }
+
+        $input->setOption('target-type', $value);
+
+        return $value;
+    }
+
+    protected function getTargetBundles(InputInterface $input): ?array
+    {
+        $targetType = $input->getOption('target-type');
+        $targetTypeDefinition = $this->entityTypeManager->getDefinition($targetType);
+        // For the 'target_bundles' setting, a NULL value is equivalent to "allow
+        // entities from any bundle to be referenced" and an empty array value is
+        // equivalent to "no entities from any bundle can be referenced".
+        $targetBundles = null;
+
+        if ($targetTypeDefinition->hasKey('bundle')) {
+            if ($referencedBundle = $input->getOption('target-bundle')) {
+                $this->validateBundle($targetType, $referencedBundle);
+                $referencedBundles = [$referencedBundle];
+            } else {
+                $referencedBundles = $this->askReferencedBundles($targetType);
+            }
+
+            if (!empty($referencedBundles)) {
+                $targetBundles = array_combine($referencedBundles, $referencedBundles);
+            }
+        }
+
+        return $targetBundles;
+    }
+
+    protected function askReferencedEntityType(): string
+    {
+        $definitions = $this->entityTypeManager->getDefinitions();
+        $choices = [];
+
+        foreach ($definitions as $name => $definition) {
+            $label = $this->input->getOption('show-machine-names')
+                ? $name
+                : sprintf('%s: %s', $definition->getGroupLabel()->render(), $definition->getLabel());
+            $choices[$name] = $label;
+        }
+
+        return $this->io()->choice('Referenced entity type', $choices);
+    }
+
+    protected function askReferencedBundles(string $targetType): ?array
+    {
+        $choices = [];
+        $bundleInfo = $this->entityTypeBundleInfo->getBundleInfo($targetType);
+
+        if (empty($bundleInfo)) {
+            return [];
+        }
+
+        foreach ($bundleInfo as $bundle => $info) {
+            $label = $this->input->getOption('show-machine-names') ? $bundle : $info['label'];
+            $choices[$bundle] = $label;
+        }
+
+        $question = (new ChoiceQuestion('Referenced bundles', $choices))
+            ->setMultiselect(true);
+
+        return $this->io()->askQuestion($question) ?: null;
+    }
+}

--- a/src/Commands/field/FieldEntityReferenceHooks.php
+++ b/src/Commands/field/FieldEntityReferenceHooks.php
@@ -2,8 +2,10 @@
 
 namespace Drush\Commands\field;
 
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
@@ -27,9 +29,7 @@ class FieldEntityReferenceHooks extends DrushCommands
         );
     }
 
-    /**
-     * @hook on-event field-create-field-storage
-     */
+    #[CLI\Hook(type: HookManager::ON_EVENT, target: 'field-create-field-storage')]
     public function hookFieldStorage(array $values, InputInterface $input): array
     {
         if ($input->getOption('field-type') === 'entity_reference') {
@@ -39,9 +39,7 @@ class FieldEntityReferenceHooks extends DrushCommands
         return $values;
     }
 
-    /**
-     * @hook on-event field-create-field-config
-     */
+    #[CLI\Hook(type: HookManager::ON_EVENT, target: 'field-create-field-config')]
     public function hookFieldConfig(array $values, InputInterface $input): array
     {
         if ($input->getOption('field-type') === 'entity_reference') {


### PR DESCRIPTION
Same as https://github.com/drush-ops/drush/pull/5556, but for 12.x.