### PR TITLE
field-create: Fix the field-create-field-storage event (12.x)

### DIFF
--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -490,7 +490,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         // Command files may customize $values as desired.
         $handlers = $this->getCustomEventHandlers('field-create-field-storage');
         foreach ($handlers as $handler) {
-            $handler($values);
+            $values = $handler($values, $this->input);
         }
 
         /** @var FieldStorageConfigInterface $fieldStorage */


### PR DESCRIPTION
Same as https://github.com/drush-ops/drush/pull/5555, but for 12.x. Needed for https://github.com/drush-ops/drush/pull/5609.