### PR TITLE
Sanity check service data in legacy service instantiator

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -257,7 +257,7 @@ class DrupalBoot8 extends DrupalBoot
         // Legacy service adapters for drush.services.yml files.
         $serviceFinder = new LegacyServiceFinder($moduleHandler, Drush::config());
         $drushServiceFiles = $serviceFinder->getDrushServiceFiles();
-        $legacyServiceInstantiator = new LegacyServiceInstantiator($container);
+        $legacyServiceInstantiator = new LegacyServiceInstantiator($container, $this->logger);
         $legacyServiceInstantiator->loadServiceFiles($drushServiceFiles);
 
         // Find the containerless commands, and command info alterers

--- a/src/Runtime/LegacyServiceInstantiator.php
+++ b/src/Runtime/LegacyServiceInstantiator.php
@@ -99,8 +99,7 @@ class LegacyServiceInstantiator
      */
     protected function allServicesHaveClassElement(string $serviceFile, array $services)
     {
-        foreach ($services as $service => $data)
-        {
+        foreach ($services as $service => $data) {
             if (!isset($data['class'])) {
                 $this->logger->warning(dt('Service @service does not have a class element; skipping @file', ['@service' => $service, '@file' => $serviceFile]));
                 return false;

--- a/src/Runtime/LegacyServiceInstantiator.php
+++ b/src/Runtime/LegacyServiceInstantiator.php
@@ -63,6 +63,12 @@ class LegacyServiceInstantiator
         }
     }
 
+    /**
+     * Validate service data before using it.
+     *
+     * @param string $serviceFile Path to service file being checked
+     * @param array $serviceFileData Parsed data from drush.services.yml
+     */
     protected function isValidServiceData(string $serviceFile, array $serviceFileData)
     {
         // If there are no services, then silently skip this service file.
@@ -85,6 +91,12 @@ class LegacyServiceInstantiator
         return true;
     }
 
+    /**
+     * Check all elements for required "class" elements.
+     *
+     * @param string $serviceFile Path to service file being checked
+     * @param array $services List of data from 'services' element from drush.services.yml
+     */
     protected function allServicesHaveClassElement(string $serviceFile, array $services)
     {
         foreach ($services as $service => $data)

--- a/src/Runtime/LegacyServiceInstantiator.php
+++ b/src/Runtime/LegacyServiceInstantiator.php
@@ -69,7 +69,7 @@ class LegacyServiceInstantiator
      * @param string $serviceFile Path to service file being checked
      * @param array $serviceFileData Parsed data from drush.services.yml
      */
-    protected function isValidServiceData(string $serviceFile, array $serviceFileData)
+    protected function isValidServiceData(string $serviceFile, array $serviceFileData): bool
     {
         // If there are no services, then silently skip this service file.
         if (!isset($serviceFileData['services'])) {
@@ -78,7 +78,7 @@ class LegacyServiceInstantiator
 
         // We don't support auto-wiring
         if (!empty($serviceFileData['services']['_defaults']['autowire'])) {
-            $this->logger->warning(dt('Autoloading not supported; skipping @file', ['@file' => $serviceFile]));
+            $this->logger->warning(dt('Autowire not supported; skipping @file', ['@file' => $serviceFile]));
             return false;
         }
 
@@ -97,7 +97,7 @@ class LegacyServiceInstantiator
      * @param string $serviceFile Path to service file being checked
      * @param array $services List of data from 'services' element from drush.services.yml
      */
-    protected function allServicesHaveClassElement(string $serviceFile, array $services)
+    protected function allServicesHaveClassElement(string $serviceFile, array $services): bool
     {
         foreach ($services as $service => $data) {
             if (!isset($data['class'])) {

--- a/src/Runtime/LegacyServiceInstantiator.php
+++ b/src/Runtime/LegacyServiceInstantiator.php
@@ -78,7 +78,7 @@ class LegacyServiceInstantiator
 
         // We don't support auto-wiring
         if (!empty($serviceFileData['services']['_defaults']['autowire'])) {
-            $this->logger->warning(dt('Autowire not supported; skipping @file', ['@file' => $serviceFile]));
+            $this->logger->info(dt('Autowire not supported; skipping @file', ['@file' => $serviceFile]));
             return false;
         }
 
@@ -101,7 +101,7 @@ class LegacyServiceInstantiator
     {
         foreach ($services as $service => $data) {
             if (!isset($data['class'])) {
-                $this->logger->warning(dt('Service @service does not have a class element; skipping @file', ['@service' => $service, '@file' => $serviceFile]));
+                $this->logger->info(dt('Service @service does not have a class element; skipping @file', ['@service' => $service, '@file' => $serviceFile]));
                 return false;
             }
         }


### PR DESCRIPTION
Validate that service data looks reasonable before instantiating any services. Skip any service file that we do not have confidence in.