### PR TITLE
Issue #5643 - 11.x - Fix return value of the \Drush\Sql\SqlPgsql::dbExists()

### DIFF
--- a/src/Sql/SqlPgsql.php
+++ b/src/Sql/SqlPgsql.php
@@ -101,7 +101,9 @@ class SqlPgsql extends SqlBase
         $process = Drush::shell($sql_no_db->connect() . ' -t -c ' . $query, null, $this->getEnv());
         $process->setSimulated(false);
         $process->run();
-        return $process->isSuccessful();
+
+        return $process->isSuccessful()
+            && trim($process->getOutput()) === '1';
     }
 
     public function queryFormat($query)


### PR DESCRIPTION
Issue #5643 - Fix return value of the \Drush\Sql\SqlPgsql::dbExists()