### PR TITLE
Work around legacy generators crashing drush

### DIFF
--- a/src/Runtime/ServiceManager.php
+++ b/src/Runtime/ServiceManager.php
@@ -201,15 +201,15 @@ class ServiceManager
             ->getClasses();
 
         return array_filter($classes, function (string $class): bool {
-                try {
-                    $reflectionClass = new \ReflectionClass($class);
-                } catch (\Throwable $e) {
-                    return false;
-                }
-                return $reflectionClass->isSubclassOf(BaseGenerator::class)
-                    && !$reflectionClass->isAbstract()
-                    && !$reflectionClass->isInterface()
-                    && !$reflectionClass->isTrait();
+            try {
+                $reflectionClass = new \ReflectionClass($class);
+            } catch (\Throwable $e) {
+                return false;
+            }
+            return $reflectionClass->isSubclassOf(BaseGenerator::class)
+                && !$reflectionClass->isAbstract()
+                && !$reflectionClass->isInterface()
+                && !$reflectionClass->isTrait();
         });
     }
 

--- a/src/Runtime/ServiceManager.php
+++ b/src/Runtime/ServiceManager.php
@@ -201,7 +201,11 @@ class ServiceManager
             ->getClasses();
 
         return array_filter($classes, function (string $class): bool {
-                $reflectionClass = new \ReflectionClass($class);
+                try {
+                    $reflectionClass = new \ReflectionClass($class);
+                } catch (\Throwable $e) {
+                    return false;
+                }
                 return $reflectionClass->isSubclassOf(BaseGenerator::class)
                     && !$reflectionClass->isAbstract()
                     && !$reflectionClass->isInterface()


### PR DESCRIPTION
Legacy generators are causing drush to crash during discovery because of this reflection runs but the classes extends a non-existant class.

