### PR TITLE
Fixes #5655: Ensure that Drush 11 is tested on PHP 7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,18 @@ jobs:
       - image: cimg/mysql:5.7.38
     <<: *test80steps
 
+  # PHP 7.4 test:
+  #   Checks the most common configuration.
+  test_74_drupal9_mysql:
+    <<: *defaults
+    docker:
+      - image: wodby/php:7.4
+        environment:
+          - MYSQL_HOST=127.0.0.1
+          - UNISH_DB_URL=mysql://root:@127.0.0.1
+      - image: cimg/mysql:5.7.38
+    <<: *test80steps
+
   test_80_drupal9_sqlite:
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,8 @@ workflows:
     jobs:
       - code_style
       - check_mergable
+      - test_74_drupal9_mysql:
+          <<: *requires
       - test_80_drupal92_security:
           <<: *requires
       - test_80_drupal9_mysql:

--- a/src/Drupal/Commands/config/ConfigCommands.php
+++ b/src/Drupal/Commands/config/ConfigCommands.php
@@ -390,7 +390,7 @@ class ConfigCommands extends DrushCommands implements StdinAwareInterface, SiteA
      * @param mixed $directory
      *   A configuration directory. Note; can be boolean.
      */
-    public static function getDirectory(mixed $directory = null): string
+    public static function getDirectory($directory = null): string
     {
         $return = null;
         // If the user provided a directory, use it.


### PR DESCRIPTION
It appears that the PHP 7.4 tests were dropped from the Drush 11 branch, leaving us open to regressions when backporting from the Drush 12 branch.