### PR TITLE
fixes drush-ops/drush#5663 

### DIFF
--- a/commands/core/archive.drush.inc
+++ b/commands/core/archive.drush.inc
@@ -26,6 +26,7 @@ function archive_drush_command() {
       'preserve-symlinks' => 'Preserve symbolic links.',
       'no-core' => 'Exclude Drupal core, so the backup only contains the site specific stuff.',
       'tar-options' => 'Options passed thru to the tar command.',
+      'extra' => 'Options passed thru to the sql command.',
     ),
     'examples' => array(
       'drush archive-dump default,example.com,foo.com' => 'Write an archive containing 3 sites in it.',
@@ -55,6 +56,7 @@ function archive_drush_command() {
       'db-su-pw' => 'Password for the "db-su" account. Optional.',
       'overwrite' => 'Allow drush to overwrite any files in the destination. Default is --no-overwrite.',
       'tar-options' => 'Options passed thru to the tar command.',
+      'extra' => 'Options passed thru to the sql command.',
     ),
     'examples' => array(
       'drush archive-restore ./example.tar.gz' => 'Restore the files and databases for all sites in the archive.',


### PR DESCRIPTION
adds --extra parameter to archive-dump to pass flag arguments to sql-dump command (fixing the ability to use drush ard with a normal user that doesn't have the processlist permission and who cannot/won't use the --no-tablespaces flag as a default setting)