### PR TITLE
Add argument/option autocompletion to field commands

### DIFF
--- a/src/Commands/field/EntityTypeBundleAskTrait.php
+++ b/src/Commands/field/EntityTypeBundleAskTrait.php
@@ -19,14 +19,19 @@ use function t;
  */
 trait EntityTypeBundleAskTrait
 {
-    protected function askEntityType(): ?string
+    protected function getFieldableEntityTypes(): array
     {
-        $entityTypeDefinitions = array_filter(
+        return array_filter(
             $this->entityTypeManager->getDefinitions(),
             function (EntityTypeInterface $entityType) {
                 return $entityType->entityClassImplements(FieldableEntityInterface::class);
             }
         );
+    }
+
+    protected function askEntityType(): ?string
+    {
+        $entityTypeDefinitions = $this->getFieldableEntityTypes();
         $choices = [];
 
         foreach ($entityTypeDefinitions as $entityTypeDefinition) {

--- a/src/Commands/field/FieldBaseInfoCommands.php
+++ b/src/Commands/field/FieldBaseInfoCommands.php
@@ -10,6 +10,8 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class FieldBaseInfoCommands extends DrushCommands
@@ -66,6 +68,7 @@ class FieldBaseInfoCommands extends DrushCommands
     #[CLI\FilterDefaultField(field: 'field_name')]
     #[CLI\Usage(name: 'field:base-info taxonomy_term', description: 'List all base fields.')]
     #[CLI\Usage(name: 'field:base-info', description: 'List all base fields and fill in the remaining information through prompts.')]
+    #[CLI\Complete(method_name_or_callable: 'complete')]
     #[CLI\Version(version: '11.0')]
     public function info(?string $entityType = null, array $options = [
         'format' => 'table',
@@ -77,5 +80,12 @@ class FieldBaseInfoCommands extends DrushCommands
         $fieldDefinitions = $this->entityFieldManager->getBaseFieldDefinitions($entityType);
 
         return $this->getRowsOfFieldsByFieldDefinitions($fieldDefinitions);
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->getCompletionName() === 'entityType') {
+            $suggestions->suggestValues(array_keys($this->getFieldableEntityTypes()));
+        }
     }
 }

--- a/src/Commands/field/FieldBaseOverrideCreateCommands.php
+++ b/src/Commands/field/FieldBaseOverrideCreateCommands.php
@@ -11,6 +11,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\Entity\BaseFieldOverride;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -58,6 +60,7 @@ class FieldBaseOverrideCreateCommands extends DrushCommands
     #[CLI\Usage(name: 'field:base-field-override-create', description: 'Create a base field override by answering the prompts.')]
     #[CLI\Usage(name: 'field:base-field-override-create taxonomy_term tag', description: 'Create a base field override and fill in the remaining information through prompts.')]
     #[CLI\Usage(name: 'field:base-field-override-create taxonomy_term tag --field-name=name --field-label=Label --is-required=1', description: 'Create a base field override in a completely non-interactive way.')]
+    #[CLI\Complete(method_name_or_callable: 'complete')]
     #[CLI\Version(version: '11.0')]
     public function baseOverrideCreateField(?string $entityType = null, ?string $bundle = null, array $options = [
         'field-name' => InputOption::VALUE_REQUIRED,
@@ -116,6 +119,20 @@ class FieldBaseOverrideCreateCommands extends DrushCommands
         $baseFieldOverride = $this->createBaseFieldOverride($entityType, $bundle, $fieldName, $fieldLabel, $fieldDescription, $isRequired);
 
         $this->logResult($baseFieldOverride);
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->getCompletionName() === 'entityType') {
+            $suggestions->suggestValues(array_keys($this->getFieldableEntityTypes()));
+        }
+
+        if ($input->getCompletionName() === 'bundle') {
+            $entityTypeId = $input->getArgument('entityType');
+            $bundleInfo = $this->entityTypeBundleInfo->getBundleInfo($entityTypeId);
+
+            $suggestions->suggestValues(array_keys($bundleInfo));
+        }
     }
 
     protected function askFieldName(string $entityType): ?string

--- a/src/Commands/field/FieldBaseOverrideCreateCommands.php
+++ b/src/Commands/field/FieldBaseOverrideCreateCommands.php
@@ -123,15 +123,25 @@ class FieldBaseOverrideCreateCommands extends DrushCommands
 
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
     {
-        if ($input->getCompletionName() === 'entityType') {
-            $suggestions->suggestValues(array_keys($this->getFieldableEntityTypes()));
+        if ($input->getCompletionType() === CompletionInput::TYPE_ARGUMENT_VALUE) {
+            if ($input->getCompletionName() === 'entityType') {
+                $suggestions->suggestValues(array_keys($this->getFieldableEntityTypes()));
+            }
+
+            if ($input->getCompletionName() === 'bundle') {
+                $entityTypeId = $input->getArgument('entityType');
+                $bundleInfo = $this->entityTypeBundleInfo->getBundleInfo($entityTypeId);
+
+                $suggestions->suggestValues(array_keys($bundleInfo));
+            }
         }
 
-        if ($input->getCompletionName() === 'bundle') {
-            $entityTypeId = $input->getArgument('entityType');
-            $bundleInfo = $this->entityTypeBundleInfo->getBundleInfo($entityTypeId);
-
-            $suggestions->suggestValues(array_keys($bundleInfo));
+        if ($input->getCompletionType() === CompletionInput::TYPE_OPTION_VALUE) {
+            if ($input->getCompletionName() === 'field-name') {
+                $entityTypeId = $input->getArgument('entityType');
+                $definitions = $this->entityFieldManager->getBaseFieldDefinitions($entityTypeId);
+                $suggestions->suggestValues(array_keys($definitions));
+            }
         }
     }
 

--- a/src/Commands/field/FieldDefinitionCommands.php
+++ b/src/Commands/field/FieldDefinitionCommands.php
@@ -12,6 +12,8 @@ use Drupal\Core\Field\FormatterPluginManager;
 use Drupal\Core\Field\WidgetPluginManager;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 final class FieldDefinitionCommands extends DrushCommands
@@ -90,6 +92,7 @@ final class FieldDefinitionCommands extends DrushCommands
     ),
     ]
     #[CLI\FilterDefaultField(field: 'id')]
+    #[CLI\Complete(method_name_or_callable: 'complete')]
     public function widgets(array $options = ['format' => 'yaml', 'field-type' => self::REQ]): UnstructuredListData
     {
         $processor = static fn(array $definition): array => [
@@ -126,6 +129,7 @@ final class FieldDefinitionCommands extends DrushCommands
     ),
     ]
     #[CLI\FilterDefaultField(field: 'id')]
+    #[CLI\Complete(method_name_or_callable: 'complete')]
     public function formatters(array $options = ['format' => 'yaml', 'field-type' => self::REQ]): UnstructuredListData
     {
         $processor = static fn(array $definition): array => [
@@ -141,6 +145,16 @@ final class FieldDefinitionCommands extends DrushCommands
             $definitions = self::filterByFieldType($definitions, $options['field-type']);
         }
         return new UnstructuredListData($definitions);
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->getCompletionType() === CompletionInput::TYPE_OPTION_VALUE) {
+            if ($input->getCompletionName() === 'field-type') {
+                $fieldTypes = $this->typePluginManager->getDefinitions();
+                $suggestions->suggestValues(array_keys($fieldTypes));
+            }
+        }
     }
 
     /**

--- a/src/Commands/field/FieldInfoCommands.php
+++ b/src/Commands/field/FieldInfoCommands.php
@@ -9,6 +9,8 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class FieldInfoCommands extends DrushCommands
@@ -64,6 +66,7 @@ class FieldInfoCommands extends DrushCommands
     #[CLI\FilterDefaultField(field: 'field_name')]
     #[CLI\Usage(name: 'field:info taxonomy_term tag', description: 'List all fields.')]
     #[CLI\Usage(name: 'field:info', description: 'List all fields and fill in the remaining information through prompts.')]
+    #[CLI\Complete(method_name_or_callable: 'complete')]
     #[CLI\Version(version: '11.0')]
     public function info(?string $entityType = null, ?string $bundle = null, array $options = [
         'format' => 'table',
@@ -83,5 +86,19 @@ class FieldInfoCommands extends DrushCommands
             ]);
 
         return $this->getRowsOfFieldsByFieldDefinitions($fieldDefinitions);
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->getCompletionName() === 'entityType') {
+            $suggestions->suggestValues(array_keys($this->getFieldableEntityTypes()));
+        }
+
+        if ($input->getCompletionName() === 'bundle') {
+            $entityTypeId = $input->getArgument('entityType');
+            $bundleInfo = $this->entityTypeBundleInfo->getBundleInfo($entityTypeId);
+
+            $suggestions->suggestValues(array_keys($bundleInfo));
+        }
     }
 }


### PR DESCRIPTION
I added autocompletion to the `entityType`/`bundle` arguments of the field commands. Not sure if we have a way to test these kind of things yet.