### PR TITLE
Fix #5688. sql:query fails when given a Gzip file with path starting …

### DIFF
--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -323,7 +323,7 @@ abstract class SqlBase implements ConfigAwareInterface
             $process->run();
             $this->setProcess($process);
             if ($process->isSuccessful()) {
-                $input_file = trim($input_file, '.gz');
+                $input_file = preg_replace('/\.gz$/i', '', $input_file);
             } else {
                 Drush::logger()->error(dt('Failed to decompress input file.'));
                 return false;


### PR DESCRIPTION
Fixes #5688.

Use `preg_replace` instead of `trim` to remove `.gz` suffix