### PR TITLE
Fix 'TypeError: SymfonyStyle::ask(): Argument #2 ($default) must be of type ?string, int given'

### DIFF
--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -335,7 +335,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
 
         $limit = FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED;
         while ($cardinality === 'Limited' && $limit < 1) {
-            $limit = (int) $this->io()->ask('Allowed number of values', 1);
+            $limit = (int) $this->io()->ask('Allowed number of values', '1');
         }
 
         return $limit;


### PR DESCRIPTION
The default option argument of `SymfonyStyle::ask()` got a string typehint. For the _Allowed number of values_ option in the field:create command we were passing an integer, which causes a TypeError.