### PR TITLE
Fix 'TypeError: FieldBaseOverrideCreateCommands::askFieldDescription(): Argument #1 ($default) must be of type ?string, TranslatableMarkup given'

### DIFF
--- a/src/Commands/field/FieldBaseOverrideCreateCommands.php
+++ b/src/Commands/field/FieldBaseOverrideCreateCommands.php
@@ -101,7 +101,7 @@ class FieldBaseOverrideCreateCommands extends DrushCommands
         );
         $this->input->setOption(
             'field-description',
-            $this->input->getOption('field-description') ?? $this->askFieldDescription($definition->getDescription())
+            $this->input->getOption('field-description') ?? $this->askFieldDescription((string) $definition->getDescription())
         );
         $this->input->setOption(
             'is-required',


### PR DESCRIPTION
The default option argument of `SymfonyStyle::ask()` got a string typehint. For the _Description_ option in the `field:create` command we were passing an instance of `TranslatableMarkup`, which causes a `TypeError`.
