### PR TITLE
Fail Drush Deploy if Database Updates Produce a Diff Against Tracked Configuration (#5389)

### DIFF
--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -36,7 +36,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
         // Prepare custom options for checking configuration state.
         $configStatusOptions = $redispatchOptions;
-        $configStatusOptions['format'] = 'php';
+        $configStatusOptions['format'] = 'json';
         // Record the current state of configuration.
         $process = $manager->drush($self, 'config:status', [], $configStatusOptions);
         $process->mustRun();

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -52,7 +52,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
         // Record the current state of configuration.
         $process = $manager->drush($self, 'config:status', [], $configStatusOptions);
         $process->mustRun();
-        $newConfigDiff = unserialize($process->getOutput());
+        $newConfigDiff = $process->getOutputAsJson();
 
         // Check for new changes to active configuration that would be lost.
         if ($originalConfigDiff !== $newConfigDiff) {

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -40,7 +40,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
         // Record the current state of configuration.
         $process = $manager->drush($self, 'config:status', [], $configStatusOptions);
         $process->mustRun();
-        $originalConfigDiff = unserialize($process->getOutput());
+        $originalConfigDiff = $process->getOutputAsJson();
 
         $this->logger()->notice("Database updates start.");
         $options = ['no-cache-clear' => true];

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -56,8 +56,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
         // Check for new changes to active configuration that would be lost.
         if ($originalConfigDiff !== $newConfigDiff) {
-            $this->io()->error('Update hooks altered config that is about to be reverted during config import. Aborting.');
-            return;
+            throw new \RuntimeException('Update hooks altered config that is about to be reverted during config import. Aborting.');
         }
 
         $this->logger()->success("Config import start.");


### PR DESCRIPTION
## Motivation

- https://github.com/drush-ops/drush/issues/5712

## Known Issues

- I targeted this against 11.x as the site I'm working on daily won't let me get to 12.x due to issues I can't resolve at the moment. I'm happy to port this to 12.x once we agree on the general approach. This just helps me test it more easily.
- Adding some better logging/visibility into the differences it detected would be great. I'm happy to add that too once we have an agreement on the general approach/messaging we want.
- I'm unsure if the `return` is the preferred way to abort a process here, but figured someone with more knowledge could quickly point me in the right direction.

## Current State

I tested this locally and it does work though. I added an update hook that simply did this and it failed as expected. ✅ 
```
/**
 * Force a failure in the drush deploy command.
 */
function example_update_8004() {
  \Drupal::service('module_installer')->uninstall(['some_module']);
}
```

![Screenshot 2023-07-21 at 10 34 19 AM](https://github.com/drush-ops/drush/assets/1349906/b1c393c6-127d-43e6-ba30-c564ecc6e630)

