### PR TITLE
Information dense entity dumper

### DIFF
--- a/src/Psysh/Caster.php
+++ b/src/Psysh/Caster.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Drush\Psysh;
 
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\dynamic_entity_reference\Plugin\Field\FieldType\DynamicEntityReferenceFieldItemList;
+use Drupal\entity_reference_revisions\EntityReferenceRevisionsFieldItemList;
 use Symfony\Component\VarDumper\Caster\Caster as BaseCaster;
 
 /**
@@ -14,11 +20,32 @@ class Caster
     /**
      * Casts \Drupal\Core\Entity\ContentEntityInterface classes.
      */
-    public static function castContentEntity($entity, $array, $stub, $isNested)
+    public static function castContentEntity(ContentEntityInterface $entity, $array, $stub, $isNested)
     {
         if (!$isNested) {
-            foreach ($entity as $property => $item) {
-                $array[BaseCaster::PREFIX_PROTECTED . $property] = $item;
+            $array[BaseCaster::PREFIX_VIRTUAL . 'translationLanguages'] = implode(', ', array_keys($entity->getTranslationLanguages()));
+            foreach ($entity->getFields() as $fieldName => $fieldItemList) {
+                $fieldStorageDefinition = $fieldItemList->getFieldDefinition()
+                    ->getFieldStorageDefinition();
+                $value = $fieldItemList->getValue();
+                $key = sprintf('%s (%s)', BaseCaster::PREFIX_VIRTUAL . $fieldName, $fieldStorageDefinition->getType());
+                if (count($value) > 1) {
+                    $key .= ' x' . count($value);
+                }
+                if ($fieldItemList instanceof EntityReferenceFieldItemListInterface) {
+                    $value = self::handleReferences($value, $fieldItemList, $fieldStorageDefinition);
+                }
+                // Truncate long values.
+                array_walk_recursive($value, function (&$x) {
+                    if (is_string($x) && strlen($x) > 200) {
+                        $x = Unicode::truncate($x, 80, false, true);
+                    }
+                });
+                // Collapse single value'd field values.
+                if (count($value[0] ?? []) === 1) {
+                    $value = implode(', ', array_column($value, array_keys($value[0])[0]));
+                }
+                $array[$key] = $value;
             }
         }
 
@@ -106,5 +133,29 @@ class Caster
         }
 
         return $array;
+    }
+
+    protected static function handleReferences(array $value, EntityReferenceFieldItemListInterface $fieldItemList, FieldStorageDefinitionInterface $fieldStorageDefinition): array
+    {
+        if ($target_type = $fieldStorageDefinition->getSetting('target_type')) {
+            $shortClass = self::getShortClass($target_type);
+        }
+        if ($fieldItemList instanceof EntityReferenceRevisionsFieldItemList) {
+            $callback = fn ($item) => ['!ref' => sprintf('%s::loadRevision(%d) (id: %d)', $shortClass, $item['target_revision_id'], $item['target_id'])];
+        } elseif ($fieldItemList instanceof DynamicEntityReferenceFieldItemList) {
+            $callback = fn ($item) => ['!ref' => sprintf('%s::load(%s)', self::getShortClass($item['target_type']), $item['target_id'])];
+        } elseif ($fieldStorageDefinition->getColumns()['target_id']['type'] === 'int') {
+            $callback = fn ($item) => ['!ref' => sprintf('%s::load(%d)', $shortClass, $item['target_id'])];
+        }
+        return isset($callback) ? array_map($callback, $value) : $value;
+    }
+
+    protected static function getShortClass(string $entity_type_id): string
+    {
+        $class = \Drupal::entityTypeManager()
+            ->getDefinition($entity_type_id)
+            ->getClass();
+        $parts = explode('\\', $class);
+        return end($parts);
     }
 }


### PR DESCRIPTION
Now that we can load entities fast, we should have useful information after loading them.

This PR

1. Shows the field types
2. Shows how many values currently there are if more than one
3. Shows as much information as possible on a single line. See the `hide_translation` field below for a demo of the first three.
4. Shows entity references with an executable snippet: `User::load(123)` shows a reference to user 123. It's very easy to load it, this way. Yes, `Paragraph::loadRevision()` is not a thing yet but just wait. It still tells the story in a very compact way. It doesn't do this for config entities to avoid `NodeType::load()` for node types. Perhaps it could for config entities which do not have a `bundleOf` annotation. Alas, this PR is written with one particular consumer in mind (me) and I didn't need this one. There's always the next PR.

![2023-07-19 09 47 31 (1)](https://github.com/drush-ops/drush/assets/193045/af1d87c9-cc7b-4468-8544-e682ed92af94)

![2023-07-19 10 19 54 (1)](https://github.com/drush-ops/drush/assets/193045/5f48622b-e381-4f0a-bee0-e3a00e273f36)
