### PR TITLE
add loadRevision functionality

### DIFF
--- a/src/Commands/core/CliCommands.php
+++ b/src/Commands/core/CliCommands.php
@@ -308,7 +308,14 @@ final class CliCommands extends DrushCommands
         foreach ($this->entityTypeManager->getDefinitions() as $definition) {
             $class = $definition->getClass();
             $parts = explode('\\', $class);
-            class_alias($class, array_pop($parts));
+            eval(sprintf('class %s extends \%s {
+                public static function loadRevision($id) {
+                    $entity_type_repository = \Drupal::service("entity_type.repository");
+                    $entity_type_manager = \Drupal::entityTypeManager();
+                    $storage = $entity_type_manager->getStorage($entity_type_repository->getEntityTypeFromClass(static::class));
+                    return $storage->loadRevision($id);
+                }
+            }', end($parts), $class));
         }
     }
 }

--- a/src/Commands/core/CliCommands.php
+++ b/src/Commands/core/CliCommands.php
@@ -59,6 +59,7 @@ final class CliCommands extends DrushCommands
     #[CLI\Option(name: 'cwd', description: 'A directory to change to before launching the shell. Default is the project root directory')]
     #[CLI\Topics(topics: [self::DOCS_REPL])]
     #[CLI\Usage(name: '$node = Node::load(1)', description: 'Entity classes are available without their namespace. For example, Node::load(1) works instead of Drupal\Node\entity\Node::load(1).')]
+    #[CLI\Usage(name: '$paragraph = Paragraph::loadRevision(1)', description: 'Also, a loadRevision static method is made available for easier load of revisions.')]
     #[CLI\Bootstrap(level: DrupalBootLevels::FULL)]
     public function cli(array $options = ['version-history' => false, 'cwd' => self::REQ]): void
     {
@@ -308,6 +309,7 @@ final class CliCommands extends DrushCommands
         foreach ($this->entityTypeManager->getDefinitions() as $definition) {
             $class = $definition->getClass();
             $parts = explode('\\', $class);
+            // Make it possible to easily load revisions.
             eval(sprintf('class %s extends \%s {
                 public static function loadRevision($id) {
                     $entity_type_repository = \Drupal::service("entity_type.repository");


### PR DESCRIPTION
next step in the entity work is to add Paragraph::loadRevision. We can just steal the code from EntityBase::load(), wrap it in eval and boom.

![2023-07-24 16 51 31](https://github.com/drush-ops/drush/assets/193045/31765b87-55dd-4e5c-b194-d78107b83a61)
