### PR TITLE
Add lost configuration checking to deploy command.

### DIFF
--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -26,11 +26,12 @@ final class DeployCommands extends DrushCommands implements SiteAliasManagerAwar
      * Run several commands after performing a code deployment.
      */
     #[CLI\Command(name: self::DEPLOY)]
+    #[CLI\Option(name: 'ignore-mismatched-config', description: 'Proceed with config:import even if changes made by update hooks will be reverted.')]
     #[CLI\Usage(name: 'drush deploy -v -y', description: 'Run updates with verbose logging and accept all prompts.')]
     #[CLI\Version(version: '10.3')]
     #[CLI\Topics(topics: [DocsCommands::DEPLOY])]
     #[CLI\Bootstrap(level: DrupalBootLevels::FULL)]
-    public function deploy(): void
+    public function deploy(array $options = ['ignore-mismatched-config' => false]): void
     {
         $self = $this->siteAliasManager()->getSelf();
         $redispatchOptions = Drush::redispatchOptions();
@@ -63,7 +64,9 @@ final class DeployCommands extends DrushCommands implements SiteAliasManagerAwar
             $this->logger()->warning(dt('The following config changes will be lost during config import: :config', [
                 ':config' => implode(', ', $configDiff),
             ]));
-            throw new \RuntimeException('Update hooks altered config that is about to be reverted during config import. Aborting.');
+            if (!$options['ignore-mismatched-config']) {
+                throw new \RuntimeException('Update hooks altered config that is about to be reverted during config import. Aborting.');
+            }
         }
 
         $this->logger()->success("Config import start.");

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -65,7 +65,7 @@ final class DeployCommands extends DrushCommands implements SiteAliasManagerAwar
                 ':config' => implode(', ', $configDiff),
             ]));
             if (!$options['ignore-mismatched-config']) {
-                throw new \RuntimeException('Update hooks altered config that is about to be reverted during config import. Aborting.');
+                throw new \RuntimeException('Update hooks altered config that is about to be reverted during config import. Use --ignore-mismatched-config to bypass this error. Aborting.');
             }
         }
 


### PR DESCRIPTION
_This replaces https://github.com/drush-ops/drush/pull/5713_

---

## Motivation

- https://github.com/drush-ops/drush/issues/5712

## Current State

I added an update hook that simply did this and it failed as expected. ✅ 
```
/**
 * Force a failure in the drush deploy command.
 */
function example_update_8004() {
  \Drupal::service('module_installer')->uninstall(['some_module']);
}
```

<img width="763" alt="Screenshot 2023-07-24 at 8 07 18 PM" src="https://github.com/drush-ops/drush/assets/1349906/c478f9de-bfab-44d7-8c21-16f5591a855b">

I tested this code on the 11.x branch and then ported it to 12.x without being able to 100% test it as I don't have time to scaffold up an environment that is 12.x friendly, but it looks like it will work. 

If someone else could test this and help 100% validate it that would be great.

I also added logging to help add visibility to the config items affected. Hopefully we are all on board with that and find that valuable. Happy to adjust as needed though.
