### PR TITLE
Update drush.api.php typo

### DIFF
--- a/drush.api.php
+++ b/drush.api.php
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * @file
+ * Drupal hooks provided by the Drush package.
+ */
+
+/**
  * Executes a deploy function which is intended to update data, like entities,
  * after config is imported during a deployment.
  *

--- a/drush.api.php
+++ b/drush.api.php
@@ -30,7 +30,7 @@
  * @ingroup update_api
  *
  * @see hook_update_N()
- * @see hook_post_update_N()
+ * @see hook_post_update_NAME()
  */
 function hook_deploy_NAME(array &$sandbox): string {
   $node = \Drupal\node\Entity\Node::load(123);


### PR DESCRIPTION
The `hook_post_update_N()` function doesn't exist, it should be `hook_post_update_NAME()`.