### PR TITLE
For sql:sync command, add --backend option for sources using older drush.

### DIFF
--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -157,7 +157,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
                     $source_dump_path = $json['path'];
                 } else {
                     // Next, try 9.5- format.
-                    $return = c($process->getOutput());
+                    $return = drush_backend_parse_output($process->getOutput());
                     if (!$return['error_status'] || !empty($return['object'])) {
                         $source_dump_path = $return['object'];
                     }

--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -139,6 +139,9 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
         $dump_options = $global_options + [
             'gzip' => true,
             'result-file' => $options['source-dump'] ?: 'auto',
+
+            // Old drush commands need --backend to produce output consumable by drush_backend_parse_output()
+            'backend' => 'true'
         ];
         if (!$options['no-dump']) {
             $this->logger()->notice(dt('Starting to dump database on source.'));
@@ -154,7 +157,7 @@ class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwareInte
                     $source_dump_path = $json['path'];
                 } else {
                     // Next, try 9.5- format.
-                    $return = drush_backend_parse_output($process->getOutput());
+                    $return = c($process->getOutput());
                     if (!$return['error_status'] || !empty($return['object'])) {
                         $source_dump_path = $return['object'];
                     }


### PR DESCRIPTION
Addresses https://github.com/drush-ops/drush/issues/5744 but not sure it solves the problem.

This change makes it possible to sql:sync from old Drupal sites with drush 8.

It's not possible in 11.x or 12.x because the command removed support for non-json sql-dump output here: https://github.com/drush-ops/drush/commit/14d55983120db638889de0ed56f8f386cdddc5ce

I'm not sure what to do here exactly. Not sure if this is ok.  It's my finding that if you are using sql:sync with a source that's drush8, you have to use drush10 on the destination with this patch or it will fail.

