### PR TITLE
In sql:sync command, catch exception for missing JSON and set $source_dump_path from original options.

### DIFF
--- a/src/Commands/sql/SqlSyncCommands.php
+++ b/src/Commands/sql/SqlSyncCommands.php
@@ -141,8 +141,13 @@ final class SqlSyncCommands extends DrushCommands implements SiteAliasManagerAwa
             if ($this->getConfig()->simulate()) {
                 $source_dump_path = '/simulated/path/to/dump.tgz';
             } else {
-                $json = $process->getOutputAsJson();
-                $source_dump_path = $json['path'];
+                try {
+                    $json = $process->getOutputAsJson();
+                    $source_dump_path = $json['path'];
+                } catch (\InvalidArgumentException $e) {
+                    $this->logger()->warning(dt('The Drush sql:dump command succeeded but the output was not JSON. Ensure drush/drush on the source site is version 9.6 or higher.'));
+                    $source_dump_path = $options['source-dump'];
+                }
             }
         } else {
             $source_dump_path = $options['source-dump'];


### PR DESCRIPTION
*This is a second attempt at fixing #5744.  A better approach than #5745.*

Drush `sql:sync` currently fails without an indication why when source drush is lower than v9.6.

This is because before drush v9.6, `sql-dump` could not return JSON data. The actual dumping works fine. It's the part in SQL Sync where it takes the next step that fails.

This PR catches the exception triggered during the `sql:sync` command when the output of `sql:dump` is not in JSON.

Note that at this point, the external drush process has succeeded because of `$process->mustRun()`. We know that the sql dump took place. In fact, the only thing the code uses in the JSON output is the result file, which we already have in the options.

I know maintainability is important here, which is why I thought this technique might be acceptable.  This adds a catch to an uncaught exception instead of keeping old code lying around.

Thoughts?


-----

Context: Without this patch, using `drush sql:sync` *from* a site with drush 9.5 or earlier fails with no explanation, meaning using `drush sql:sync` for syncing from drupal 7 or 8 to modern doesn't work.  

The other commands, `drush sql:dump` and `drush sql:client` work fine when the target is drupal 7 or 8.