### PR TITLE
SqlBase: Fix PHP 8.1 compatibility with `drush sql:create --simulate`

### DIFF
--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -296,6 +296,7 @@ abstract class SqlBase implements ConfigAwareInterface
             return $this->alwaysQuery($query, $input_file, $result_file);
         }
         $this->logQueryInDebugMode($query, $input_file);
+        return true;
     }
 
     /**


### PR DESCRIPTION
An exception is thrown because the return type doesn't match a boolean value or null.

This issue also affects Drush 11 and will probably need backporting, but the following exception is thrown when running `drush sql:create --simulate`:

```
TypeError: Drush\Sql\SqlBase::query(): Return value must be of type ?bool, none returned in /app/application/vendor/drush/drush/src/Sql/SqlBase.php on line 305 
#0 /app/application/vendor/drush/drush/src/Sql/SqlBase.php(457): Drush\Sql\SqlBase->query('DROP DATABASE I...')
#1 /app/application/vendor/drush/drush/src/Commands/sql/SqlCommands.php(99): Drush\Sql\SqlBase->createdb(true)
#2 [internal function]: Drush\Commands\sql\SqlCommands->create(Array)
```