### PR TITLE
Update example command alterer example link.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,7 +69,7 @@ In the module that wants to alter a command info, add a class that:
 1. Implement the alteration logic in the `alterCommandInfo()` method.
 1. Along with the alter code, it's strongly recommended to log a debug message explaining what exactly was altered. This makes things easier on others who may need to debug the interaction of the alter code with other modules. Also it's a good practice to inject the the logger in the class constructor.
 
-For an example, see [WootCommandInfoAlterer](https://github.com/drush-ops/drush/blob/12.x/sut/modules/unish/woot/src/WootCommandInfoAlterer.php) provided by the testing 'woot' module.
+For an example, see [WootCommandInfoAlterer]([https://github.com/drush-ops/drush/blob/12.x/sut/modules/unish/woot/src/WootCommandInfoAlterer.php](https://github.com/drush-ops/drush/blob/b924aa6cfad1c0eb3ae853ccc373422c16184b8e/sut/modules/unish/woot/src/Drush/CommandInfoAlterers/WootCommandInfoAlterer.php#L13)) provided by the testing 'woot' module.
 
 ## Symfony Console Commands
 Drush lists and runs Symfony Console commands, in addition to more typical annotated commands. See [this test](https://github.com/drush-ops/drush/blob/eed106ae4510d5a2df89f8e7fd54b41ffb0aa5fa/tests/integration/AnnotatedCommandCase.php#L178-L180) and this [commandfile](https://github.com/drush-ops/drush/blob/12.x/sut/modules/unish/woot/src/Commands/GreetCommand.php).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,7 +69,7 @@ In the module that wants to alter a command info, add a class that:
 1. Implement the alteration logic in the `alterCommandInfo()` method.
 1. Along with the alter code, it's strongly recommended to log a debug message explaining what exactly was altered. This makes things easier on others who may need to debug the interaction of the alter code with other modules. Also it's a good practice to inject the the logger in the class constructor.
 
-For an example, see [WootCommandInfoAlterer]([https://github.com/drush-ops/drush/blob/12.x/sut/modules/unish/woot/src/WootCommandInfoAlterer.php](https://github.com/drush-ops/drush/blob/b924aa6cfad1c0eb3ae853ccc373422c16184b8e/sut/modules/unish/woot/src/Drush/CommandInfoAlterers/WootCommandInfoAlterer.php#L13)) provided by the testing 'woot' module.
+For an example, see [WootCommandInfoAlterer](https://github.com/search?q=repo%3Adrush-ops%2Fdrush%20CommandInfoAltererInterface&type=code) provided by the testing 'woot' module.
 
 ## Symfony Console Commands
 Drush lists and runs Symfony Console commands, in addition to more typical annotated commands. See [this test](https://github.com/drush-ops/drush/blob/eed106ae4510d5a2df89f8e7fd54b41ffb0aa5fa/tests/integration/AnnotatedCommandCase.php#L178-L180) and this [commandfile](https://github.com/drush-ops/drush/blob/12.x/sut/modules/unish/woot/src/Commands/GreetCommand.php).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,7 +69,7 @@ In the module that wants to alter a command info, add a class that:
 1. Implement the alteration logic in the `alterCommandInfo()` method.
 1. Along with the alter code, it's strongly recommended to log a debug message explaining what exactly was altered. This makes things easier on others who may need to debug the interaction of the alter code with other modules. Also it's a good practice to inject the the logger in the class constructor.
 
-For an example, see [WootCommandInfoAlterer](https://github.com/drush-ops/drush/blob/b924aa6cfad1c0eb3ae853ccc373422c16184b8e/sut/modules/unish/woot/src/Drush/CommandInfoAlterers/WootCommandInfoAlterer.php#L13) provided by the testing 'woot' module.
+For an example, see [WootCommandInfoAlterer](https://github.com/drush-ops/drush/blob/12.x/sut/modules/unish/woot/src/Drush/CommandInfoAlterers/WootCommandInfoAlterer.php) provided by the testing 'woot' module.
 
 ## Symfony Console Commands
 Drush lists and runs Symfony Console commands, in addition to more typical annotated commands. See [this test](https://github.com/drush-ops/drush/blob/eed106ae4510d5a2df89f8e7fd54b41ffb0aa5fa/tests/integration/AnnotatedCommandCase.php#L178-L180) and this [commandfile](https://github.com/drush-ops/drush/blob/12.x/sut/modules/unish/woot/src/Commands/GreetCommand.php).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,7 +69,7 @@ In the module that wants to alter a command info, add a class that:
 1. Implement the alteration logic in the `alterCommandInfo()` method.
 1. Along with the alter code, it's strongly recommended to log a debug message explaining what exactly was altered. This makes things easier on others who may need to debug the interaction of the alter code with other modules. Also it's a good practice to inject the the logger in the class constructor.
 
-For an example, see [WootCommandInfoAlterer](https://github.com/search?q=repo%3Adrush-ops%2Fdrush%20CommandInfoAltererInterface&type=code) provided by the testing 'woot' module.
+For an example, see [WootCommandInfoAlterer](https://github.com/drush-ops/drush/blob/b924aa6cfad1c0eb3ae853ccc373422c16184b8e/sut/modules/unish/woot/src/Drush/CommandInfoAlterers/WootCommandInfoAlterer.php#L13) provided by the testing 'woot' module.
 
 ## Symfony Console Commands
 Drush lists and runs Symfony Console commands, in addition to more typical annotated commands. See [this test](https://github.com/drush-ops/drush/blob/eed106ae4510d5a2df89f8e7fd54b41ffb0aa5fa/tests/integration/AnnotatedCommandCase.php#L178-L180) and this [commandfile](https://github.com/drush-ops/drush/blob/12.x/sut/modules/unish/woot/src/Commands/GreetCommand.php).


### PR DESCRIPTION
The previous link was broken. I'm not sure if this new link is what you want, but figured I would at least surface this issue with the potential fix.

FWIW I found the file by searching for the interface name.

https://github.com/search?q=repo%3Adrush-ops%2Fdrush%20CommandInfoAltererInterface&type=code


---

Possibly related, but likely outside the scope of this PR. I'm unable to get this working with Drush 11, which might just be an issue resolved by me updating to drush 12. I'm exploring that more now.