### PR TITLE
Fix 'TypeError: FieldCreateCommands::getExistingFieldStorageOptions(): Argument #3 ($showMachineNames) must be of type bool, string given'

### DIFF
--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -259,7 +259,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
     {
         $entityType = $this->input->getArgument('entityType');
         $bundle = $this->input->getArgument('bundle');
-        $showMachineNames = $this->input->getOption('show-machine-names');
+        $showMachineNames = (bool) $this->input->getOption('show-machine-names');
         $choices = $this->getExistingFieldStorageOptions($entityType, $bundle, $showMachineNames);
 
         if (empty($choices)) {


### PR DESCRIPTION
The following error is triggered when running `drush field:create` with the `--existing` option:
```
TypeError: Drush\Commands\field\FieldCreateCommands::getExistingFieldStorageOptions(): Argument #3 ($showMachineNames) must be of type bool, string given, called in /[..]/vendor/drush/drush/src/Commands/field/FieldCreateCommands.php on line 263
```