### PR TITLE
field-create: Don't list field types with no_ui set to true

### DIFF
--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -321,6 +321,10 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         $choices = [];
 
         foreach ($definitions as $definition) {
+            if (isset($definition['no_ui']) && $definition['no_ui'] === true) {
+                continue;
+            }
+
             $label = $this->input->getOption('show-machine-names') ? $definition['id'] : $definition['label']->render();
             $choices[$definition['id']] = $label;
         }


### PR DESCRIPTION
As reported in Slack: https://drupal.slack.com/archives/C62H9CWQM/p1697130264708009