### PR TITLE
Fixes #5761 Get the relative path to the project root as the descript…

### DIFF
--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -96,9 +96,9 @@ class ProcessManager extends ConsolidationProcessManager
     protected function relativePathToVendorBinDrush()
     {
         $absoluteVendorBin = $_composer_bin_dir ?? Path::join($this->getConfig()->get('drush.vendor-dir'), 'bin');
-        $basePath = $this->getConfig()->get('drush.base-dir');
+        $projectRoot = $this->getConfig()->get('runtime.project');
 
-        $relativeVendorBin = Path::makeRelative($absoluteVendorBin, $basePath);
+        $relativeVendorBin = Path::makeRelative($absoluteVendorBin, $projectRoot);
 
         return Path::join($relativeVendorBin, 'drush');
     }


### PR DESCRIPTION
Get the relative path to the project root as the docblock says not the drush base path.

This works for me but I'm not sure if the runtime.project is the correct config to use or if there is a better way?  It seems like the drush.base-dir is not the correct config though and it's broken for my remote alias commands.