### PR TITLE
Refs #5785. Fix path to remote drush

### DIFF
--- a/src/Runtime/DependencyInjection.php
+++ b/src/Runtime/DependencyInjection.php
@@ -133,7 +133,8 @@ class DependencyInjection
         Robo::addShared($container, 'tildeExpansion.hook', 'Drush\Runtime\TildeExpansionHook');
         Robo::addShared($container, 'process.manager', ProcessManager::class)
             ->addMethodCall('setConfig', ['config'])
-            ->addMethodCall('setConfigRuntime', ['config.runtime']);
+            ->addMethodCall('setConfigRuntime', ['config.runtime'])
+            ->addMethodCall('setDrupalFinder', [$drupalFinder]);
         Robo::addShared($container, 'redispatch.hook', 'Drush\Runtime\RedispatchHook')
             ->addArgument('process.manager');
 

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -108,9 +108,8 @@ class ProcessManager extends ConsolidationProcessManager
     protected function relativePathToVendorBinDrush()
     {
         // https://getcomposer.org/doc/articles/vendor-binaries.md#finding-the-composer-bin-dir-from-a-binary
-        $drupalFinder = $this->getDrupalFinder();
-        $vendorBin = $GLOBALS['_composer_bin_dir'] ?? Path::join($drupalFinder->getVendorDir(), 'bin');
-        $drupalRoot = $drupalFinder->getDrupalRoot();
+        $vendorBin = $GLOBALS['_composer_bin_dir'] ?? Path::join($this->getDrupalFinder()->getVendorDir(), 'bin');
+        $drupalRoot = $this->getDrupalFinder()->getDrupalRoot();
         $relativeVendorBin = Path::makeRelative($vendorBin, $drupalRoot);
         return Path::join($relativeVendorBin, 'drush');
     }

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -18,6 +18,18 @@ use Symfony\Component\Process\Process;
  */
 class ProcessManager extends ConsolidationProcessManager
 {
+    protected $drupalFinder;
+
+    public function setDrupalFinder($drupalFinder): void
+    {
+        $this->drupalFinder = $drupalFinder;
+    }
+
+    public function getDrupalFinder()
+    {
+        return $this->drupalFinder;
+    }
+
     /**
      * Run a Drush command on a site alias (or @self).
      */
@@ -66,13 +78,13 @@ class ProcessManager extends ConsolidationProcessManager
             return $siteAlias->get('paths.drush-script');
         }
 
-        // If the provided site alias is for a remote site / container et. al.,
-        // then use the 'drush' in the $PATH.
+        // A remote site / container et. al.,
         if ($this->hasTransport($siteAlias)) {
             if ($siteAlias->hasRoot()) {
                 return Path::join($siteAlias->root(), $this->relativePathToVendorBinDrush());
             }
 
+            // Fallback to the 'drush' in the $PATH.
             return $defaultDrushScript;
         }
 
@@ -91,15 +103,15 @@ class ProcessManager extends ConsolidationProcessManager
     }
 
     /**
-     * Return the relative path to 'vendor/bin/drush' from the project root.
+     * Return the relative path to 'vendor/bin/drush' from the Drupal root.
      */
     protected function relativePathToVendorBinDrush()
     {
-        $absoluteVendorBin = $_composer_bin_dir ?? Path::join($this->getConfig()->get('drush.vendor-dir'), 'bin');
-        $projectRoot = $this->getConfig()->get('runtime.project');
-
-        $relativeVendorBin = Path::makeRelative($absoluteVendorBin, $projectRoot);
-
+        // https://getcomposer.org/doc/articles/vendor-binaries.md#finding-the-composer-bin-dir-from-a-binary
+        $drupalFinder = $this->getDrupalFinder();
+        $vendorBin = $GLOBALS['_composer_bin_dir'] ?? Path::join($drupalFinder->getVendorDir(), 'bin');
+        $drupalRoot = $drupalFinder->getDrupalRoot();
+        $relativeVendorBin = Path::makeRelative($vendorBin, $drupalRoot);
         return Path::join($relativeVendorBin, 'drush');
     }
 

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -108,7 +108,7 @@ class ProcessManager extends ConsolidationProcessManager
     protected function relativePathToVendorBinDrush()
     {
         // https://getcomposer.org/doc/articles/vendor-binaries.md#finding-the-composer-bin-dir-from-a-binary
-        $vendorBin = $GLOBALS['_composer_bin_dir'] ?? Path::join($this->getConfig()->get('drush.vendor-dir'), 'bin');
+        $vendorBin = $GLOBALS['_composer_bin_dir'] ?? Path::join($this->getDrupalFinder()->getVendorDir(), 'bin');
         $drupalRoot = $this->getDrupalFinder()->getDrupalRoot();
         $relativeVendorBin = Path::makeRelative($vendorBin, $drupalRoot);
         return Path::join($relativeVendorBin, 'drush');

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -108,7 +108,7 @@ class ProcessManager extends ConsolidationProcessManager
     protected function relativePathToVendorBinDrush()
     {
         // https://getcomposer.org/doc/articles/vendor-binaries.md#finding-the-composer-bin-dir-from-a-binary
-        $vendorBin = $GLOBALS['_composer_bin_dir'] ?? Path::join($this->getDrupalFinder()->getVendorDir(), 'bin');
+        $vendorBin = $GLOBALS['_composer_bin_dir'] ?? Path::join($this->getConfig()->get('drush.vendor-dir'), 'bin');
         $drupalRoot = $this->getDrupalFinder()->getDrupalRoot();
         $relativeVendorBin = Path::makeRelative($vendorBin, $drupalRoot);
         return Path::join($relativeVendorBin, 'drush');

--- a/tests/functional/RsyncTest.php
+++ b/tests/functional/RsyncTest.php
@@ -41,7 +41,7 @@ class RsyncTest extends CommandUnishTestCase
         // the remote side, at which point they will be evaluated & any needed
         // injection will be done.
         $this->drush('rsync', ['@example.dev', '@example.stage'], $options, 'user@server/path/to/drupal#sitename');
-        $expected = "[notice] Simulating: ssh -o PasswordAuthentication=no user@server '/path/to/drupal/vendor/bin/drush --no-interaction rsync @example.dev @example.stage --uri=sitename";
+        $expected = "[notice] Simulating: ssh -o PasswordAuthentication=no user@server '/path/to/vendor/bin/drush --no-interaction rsync @example.dev @example.stage --uri=sitename";
         $this->assertStringContainsString($expected, $this->getSimplifiedErrorOutput());
     }
 

--- a/tests/functional/SqlSyncTest.php
+++ b/tests/functional/SqlSyncTest.php
@@ -66,7 +66,7 @@ class SqlSyncTest extends CommandUnishTestCase
         // Test simulated remote invoke with a remote runner.
         $this->drush(SqlSyncCommands::SYNC, ['@synctest.remote', '@synctest.local'], $options, 'user@server/path/to/drupal#sitename');
         $output = $this->getSimplifiedErrorOutput();
-        $this->assertStringContainsString("[notice] Simulating: ssh -o PasswordAuthentication=no user@server '/path/to/drupal/vendor/bin/drush --no-interaction sql:sync @synctest.remote @synctest.local --uri=sitename'", $output);
+        $this->assertStringContainsString("[notice] Simulating: ssh -o PasswordAuthentication=no user@server '/path/to/vendor/bin/drush --no-interaction sql:sync @synctest.remote @synctest.local --uri=sitename'", $output);
     }
 
     /**

--- a/tests/unish/CommandUnishTestCase.php
+++ b/tests/unish/CommandUnishTestCase.php
@@ -189,7 +189,7 @@ abstract class CommandUnishTestCase extends UnishTestCase
             $cmd[] = '2>' . $this->bitBucket();
         }
         // Remove NULLs
-        $exec = @array_filter($cmd, 'strlen');
+        $exec = array_filter($cmd, fn ($value) => !is_null($value));
         $cmd = implode(' ', $exec);
         return [$cmd, $coverage_file];
     }


### PR DESCRIPTION
The Doxygen misled us in #5785. We want Drupal root and not project root as base path. Use DrupalFinder to get that.
