### PR TITLE
--ignore-roles for sql:sanitize 12.x, based on PR #4725

### DIFF
--- a/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
+++ b/src/Drupal/Commands/sql/SanitizeUserTableCommands.php
@@ -74,6 +74,22 @@ final class SanitizeUserTableCommands extends DrushCommands implements SanitizeP
             $messages[] = dt('User emails sanitized.');
         }
 
+        if (!empty($options['ignored-roles'])) {
+            $roles = explode(',', $options['ignored-roles']);
+            /** @var \Drupal\Core\Database\Query\SelectInterface $roles_query */
+            $roles_query = $this->database->select('user__roles', 'ur');
+            $roles_query
+                ->condition('roles_target_id', $roles, 'IN')
+                ->fields('ur', ['entity_id']);
+            $roles_query_results = $roles_query->execute();
+            $ignored_users = $roles_query_results->fetchCol();
+
+            if (!empty($ignored_users)) {
+                $query->condition('uid', $ignored_users, 'NOT IN');
+                $messages[] = dt('User emails and passwords for the specified roles preserved.');
+            }
+        }
+
         if ($messages) {
             $query->execute();
             $this->entityTypeManager->getStorage('user')->resetCache();
@@ -86,7 +102,8 @@ final class SanitizeUserTableCommands extends DrushCommands implements SanitizeP
     #[CLI\Hook(type: HookManager::OPTION_HOOK, target: SanitizeCommands::SANITIZE)]
     #[CLI\Option(name: 'sanitize-email', description: 'The pattern for test email addresses in the sanitization operation, or <info>no</info> to keep email addresses unchanged. May contain replacement patterns <info>%uid</info>, <info>%mail</info> or <info>%name</info>.')]
     #[CLI\Option(name: 'sanitize-password', description: 'By default, passwords are randomized. Specify <info>no</info> to disable that. Specify any other value to set all passwords to that value.')]
-    public function options($options = ['sanitize-email' => 'user+%uid@localhost.localdomain', 'sanitize-password' => null]): void
+    #[CLI\Option(name: 'ignored-roles', description: 'A comma delimited list of roles. Users with at least one of the roles will be exempt from sanitization.')]
+    public function options($options = ['sanitize-email' => 'user+%uid@localhost.localdomain', 'sanitize-password' => null, 'ignored-roles' => null]): void
     {
     }
 
@@ -99,6 +116,9 @@ final class SanitizeUserTableCommands extends DrushCommands implements SanitizeP
         }
         if ($this->isEnabled($options['sanitize-email'])) {
             $messages[] = dt('Sanitize user emails.');
+        }
+        if (in_array('ignored-roles', $options)) {
+            $messages[] = dt('Preserve user emails and passwords for the specified roles.');
         }
     }
 


### PR DESCRIPTION
See existing discussion in PR #4725.

This is just a rebase, wanted to make this available when I did the work anyway.