### PR TITLE
Add tip that `--destination` starting point is Drupal root 

### DIFF
--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -64,7 +64,7 @@ final class ArchiveDumpCommands extends DrushCommands
      */
     #[CLI\Command(name: self::DUMP, aliases: ['ard'])]
     #[CLI\ValidatePhpExtensions(extensions: ['Phar'])]
-    #[CLI\Option(name: 'destination', description: 'The full path and filename in which the archive should be stored, relative to Drupal root, normally "web" for drupal/recommended-project projects. If omitted, it will be saved to the drush-backups directory.')]
+    #[CLI\Option(name: 'destination', description: 'The full path and filename in which the archive should be stored, relative to Drupal root, normally "web" for drupal/recommended-project projects. If omitted, it will be saved to the /tmp directory.')]
     #[CLI\Option(name: 'overwrite', description: 'Overwrite destination file if exists.')]
     #[CLI\Option(name: 'code', description: 'Archive codebase.')]
     #[CLI\Option(name: 'exclude-code-paths', description: 'Comma-separated list of paths (or regular expressions matching paths) to exclude from the code archive.')]

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -64,7 +64,7 @@ final class ArchiveDumpCommands extends DrushCommands
      */
     #[CLI\Command(name: self::DUMP, aliases: ['ard'])]
     #[CLI\ValidatePhpExtensions(extensions: ['Phar'])]
-    #[CLI\Option(name: 'destination', description: 'The full path and filename in which the archive should be stored, relative to Drupal root, normally "web" for drupal/recommended-project projects. If omitted, it will be saved to the /tmp directory.')]
+    #[CLI\Option(name: 'destination', description: 'The full path and filename in which the archive should be stored. Any relative path will be calculated from Drupal root (usually <info>web</web> for drupal/recommended-project projects). If omitted, it will be saved to the configured temp directory.')]
     #[CLI\Option(name: 'overwrite', description: 'Overwrite destination file if exists.')]
     #[CLI\Option(name: 'code', description: 'Archive codebase.')]
     #[CLI\Option(name: 'exclude-code-paths', description: 'Comma-separated list of paths (or regular expressions matching paths) to exclude from the code archive.')]

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -47,7 +47,7 @@ final class ArchiveDumpCommands extends DrushCommands
     /**
      * Backup your code, files, and database into a single file.
      *
-     * --destination starting point is Drupal root, normally web for drupal/recommended-project projects.
+     * --destination starting point is Drupal root, normally "web" for drupal/recommended-project projects.
      *
      * The following paths would be excluded from a code archive:
      *

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -47,8 +47,6 @@ final class ArchiveDumpCommands extends DrushCommands
     /**
      * Backup your code, files, and database into a single file.
      *
-     * --destination starting point is Drupal root, normally "web" for drupal/recommended-project projects.
-     *
      * The following paths would be excluded from a code archive:
      *
      *  - .git
@@ -66,7 +64,7 @@ final class ArchiveDumpCommands extends DrushCommands
      */
     #[CLI\Command(name: self::DUMP, aliases: ['ard'])]
     #[CLI\ValidatePhpExtensions(extensions: ['Phar'])]
-    #[CLI\Option(name: 'destination', description: 'The full path and filename in which the archive should be stored. If omitted, it will be saved to the drush-backups directory.')]
+    #[CLI\Option(name: 'destination', description: 'The full path and filename in which the archive should be stored, relative to Drupal root, normally "web" for drupal/recommended-project projects. If omitted, it will be saved to the drush-backups directory.')]
     #[CLI\Option(name: 'overwrite', description: 'Overwrite destination file if exists.')]
     #[CLI\Option(name: 'code', description: 'Archive codebase.')]
     #[CLI\Option(name: 'exclude-code-paths', description: 'Comma-separated list of paths (or regular expressions matching paths) to exclude from the code archive.')]

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -47,6 +47,8 @@ final class ArchiveDumpCommands extends DrushCommands
     /**
      * Backup your code, files, and database into a single file.
      *
+     * --destination starting point is Drupal root, normally web for drupal/recommended-project projects.
+     *
      * The following paths would be excluded from a code archive:
      *
      *  - .git


### PR DESCRIPTION
It would be nice if the `drush archive:dump` starting point was from where the command was run ... which is normally here, for most projects using `drupal/recommended-project projects`:

```
$ tree -L 1
.
├── composer.json
├── composer.lock
├── vendor
└── web
```

I guess it's not possible? So perhaps adding the tip that `--destination` starting point is Drupal root would help people in this situation?

1. Run `drush archive:dump --destination=archive.tar.gz`
1. Don't see the file in the folder from where it was run
1. Look in "web" folder by chance and realize they need to run `drush archive:dump --destination=../archive.tar.gz`