### PR TITLE
Update path to /path/to/vendor/bin under Install > Execution

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,7 @@
     See the [Drush 8](http://docs.drush.org/en/8.x) or [Drush 9](https://docs.drush.org/en/9.x) docs for installing prior versions of Drush.
 
 1. **Composer**. It is required that Drupal sites be built using Composer, with Drush listed as a dependency. See [recommended-project](https://www.drupal.org/docs/develop/using-composer/using-composer-to-install-drupal-and-manage-dependencies) (Drush must be added). If your Composer project doesn't yet depend on Drush, run `composer require drush/drush` to add it.
-1. **Execution**. Change your working directory to your project root, and call Drush via `vendor/bin/drush`. To make this easier, append `./vendor/bin` to the end of your `$PATH`; this allows you to call Drush via `drush` once your working directory is set. If you only have only one Drupal codebase on your system, you may put `/path/to/vendor/bin/drush` in your `$PATH`; if you do this, then it is not necessary to set your working directory before calling Drush.
+1. **Execution**. Change to the project root, and call Drush via `vendor/bin/drush`. To simplify things, add `./vendor/bin` to your `$PATH`, allowing you to call Drush via `drush` from the project root. If you have only one Drupal codebase on your system, you may put `/path/to/vendor/bin` in your `$PATH`; now you can call Drush from everywhere, without having to change to project root.
 1. **Completion**. Optional. Append to .bashrc or equivalent for ZSH or [Fish shell](https://fishshell.com/). Run `drush completion --help` for more details.  
 1. **Multiple Codebases**. Optional. If using the bash shell, consider installing the [fd](https://github.com/g1a/fd) project, a small set of scripts that make it easier to switch between different project directories quickly, with type completion.
 


### PR DESCRIPTION
**Describe the bug**

The current documentation is using a wrong path for the single Drupal codebase tip.

2. **Execution**. Change your working directory to your project root, and call Drush via `vendor/bin/drush`. To make this easier, append `./vendor/bin` to the end of your `$PATH`; this allows you to call Drush via `drush` once your working directory is set. If you only have only one Drupal codebase on your system, you may put `/path/to/vendor/bin/drush` in your `$PATH`; if you do this, then it is not necessary to set your working directory before calling Drush.

From https://www.drush.org/latest/install/

**To Reproduce**

1. Add `/path/to/vendor/bin/drush` to `$PATH`
1. Run `drush` from any folder and fail
 
**Expected behavior**

Allow running `drush` from any folder.

**Workaround**

Add `/path/to/vendor/bin` to `$PATH`.

### System Configuration
| Q               | A
| --------------- | ---
| Drush version?  | 12.x
| Drupal version? | 10.x
| PHP version     | 8.x
| OS?             | Linux
