### PR TITLE
Fix #5667: Use CREATE USER IF NOT EXISTS, preserve existing GRANTS

### DIFF
--- a/lib/Drush/Sql/Sqlmysql.php
+++ b/lib/Drush/Sql/Sqlmysql.php
@@ -94,8 +94,7 @@ EOT;
       //   We can't easily know what IP adderss or hostname would represent our server.
       $domain = ($this->db_spec['host'] == 'localhost') ? 'localhost' : '%';
       $user = sprintf("'%s'@'%s'", $this->db_spec['username'], $domain);
-      $sql[] = sprintf("DROP USER IF EXISTS %s;", $user);
-      $sql[] = sprintf("CREATE USER %s IDENTIFIED WITH mysql_native_password;", $user);
+      $sql[] = sprintf("CREATE USER IF NOT EXISTS %s IDENTIFIED WITH mysql_native_password;", $user);
       $sql[] = sprintf("SET PASSWORD FOR %s = PASSWORD('%s');", $user, $this->db_spec['password']);
       $sql[] = sprintf('GRANT ALL PRIVILEGES ON %s.* TO %s;', $dbname, $user);
       $sql[] = 'FLUSH PRIVILEGES;';


### PR DESCRIPTION
This fixes #5667 by not deleting the DB  user on each site-install.