### PR TITLE
Log CLI errors using Drupal error handler

### DIFF
--- a/src/Runtime/ErrorHandler.php
+++ b/src/Runtime/ErrorHandler.php
@@ -24,6 +24,7 @@ class ErrorHandler implements LoggerAwareInterface, HandlerInterface
 
     public function errorHandler($errno, $message, $filename, $line)
     {
+        _drupal_error_handler($errno, $message, $filename, $line);
         // "error_reporting" is usually set in php.ini, but may be changed by
         // drush_errors_on() and drush_errors_off().
         if ($errno & error_reporting()) {


### PR DESCRIPTION
Currently PHP errors that happen in Drush commands are not logged to Drupal. When Drush commands are running in background through Cron or Supervisor there is no way to notice these errors. For that reason I have to prepend each custom Drush command with the following line.
```php
\set_error_handler('_drupal_error_handler');
```
The downside of this is that it'll not display a error when the command is running in foreground.

The simplest solution is to call the Drupal error handler manually.