### PR TITLE
Skip abstract entity type classes from being exposed with their short…

### DIFF
--- a/src/Commands/core/CliCommands.php
+++ b/src/Commands/core/CliCommands.php
@@ -314,7 +314,7 @@ final class CliCommands extends DrushCommands
             $parts = explode('\\', $class);
             $end = end($parts);
             // https://github.com/drush-ops/drush/pull/5729 and https://github.com/drush-ops/drush/issues/5730.
-            if ($reflectionClass->isFinal() || class_exists($end)) {
+            if ($reflectionClass->isAbstract() || $reflectionClass->isFinal() || class_exists($end)) {
                 continue;
             }
             // Make it possible to easily load revisions.


### PR DESCRIPTION
It is possible the entity type class is abstract. For example the [quiz module](https://www.drupal.org/project/quiz) uses this for its QuizResultAnswer and QuizQuestion.

When executing `drush php` on a site with the quiz module enabled the following exception is triggered:

```
Fatal error: Class QuizResultAnswer contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (Drupal\quiz\QuizAnswerInterface::score, Drupal\quiz\QuizAnswerInterface::getResponse) in {...}/vendor/drush/drush/src/Commands/core/CliCommands.php(319) : eval()'d code on line 1
```