### PR TITLE
Remove the use of `mt_rand`

### DIFF
--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -120,7 +120,7 @@ class StringUtils
         for ($i = 0; $i < $length; $i++) {
             // Each iteration, pick a random character from the
             // allowable string and append it to the password:
-            $pass .= $allowable_characters[mt_rand(0, $len)];
+            $pass .= $allowable_characters[random_int(0, $len)];
         }
 
         return $pass;


### PR DESCRIPTION
`mt_rand` does not generate cryptographically secure values (https://www.php.net/manual/en/function.mt-rand.php). This logic should be updated to follow best practices because this key should be random. Although the outcome is the same, because of the limited character set, it sets precedence to follow good security practices.