### PR TITLE
Fix update notes from prior Drush versions to include missing /src

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,7 +3,7 @@
 !!! tip
 
       1. Drush 12 expects commandfiles to use a [create() method](dependency-injection.md#create-method) to inject Drupal and Drush dependencies. Prior versions used a [drush.services.yml file](https://www.drush.org/11.x/dependency-injection/#services-files) which is now deprecated and will be removed in Drush 13.
-      1. Drush 12 expects all commandfiles in the `<module-name>/Drush/<Commands|Generators>` directory. The `Drush` subdirectory is a new requirement.
+      1. Drush 12 expects all commandfiles in the `<module-name>/src/Drush/<Commands|Generators>` directory. The `Drush` subdirectory is a new requirement.
 
 Creating a new Drush command is easy. Follow the steps below.
 


### PR DESCRIPTION
An /src was missing AFAIS.