### PR TITLE
Add Drush 13 / Drupal 11 to compatibility to help users plan

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -31,7 +31,7 @@ Drupal Compatibility
     <td> Drush 13 </td>
     <td> 8.3+ </td>
     <td> TBD </td>
-    <td></td> <td></td> <td></td> <td><b>✅</b></td> <td><b>✅</b></td>
+    <td></td> <td></td> <td></td> <td><b>✓</b></td> <td><b>✅</b></td>
   </tr>
   <tr>
     <td> Drush 12 </td>

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,65 +23,71 @@ Drupal Compatibility
     <th rowspan="2"> Drush Version </th> 
     <th rowspan="2"> PHP Version</th>
     <th rowspan="2"> End Of Life </th>
-    <th colspan="4"> Drupal versions </th>
+    <th colspan="5"> Drupal versions </th>
   </tr>
-    <th>7</th> <th>8</th> <th>9</th> <th>10</th>
+    <th>7</th> <th>8</th> <th>9</th> <th>10</th> <th>11</th>
+  </tr>
+  <tr>
+    <td> Drush 13 </td>
+    <td> 8.3+ </td>
+    <td> TBD </td>
+    <td></td> <td></td> <td></td> <td><b>✅</b></td> <td><b>✅</b></td>
   </tr>
   <tr>
     <td> Drush 12 </td>
     <td> 8.1+ </td>
     <!-- Released Jun 2023 -->
     <td> TBD </td>
-    <td></td> <td></td> <td></td> <td><b>✅</b></td>
+    <td></td> <td></td> <td></td> <td><b>✅</b></td> <td><b>✅</b></td>
   </tr>
   <tr>
     <td> Drush 11 </td>
     <td> 7.4+ </td>
     <!-- TBD -->
     <td> Nov 2023 </td>
-    <td></td> <td></td> <td><b>✓</b></td> <td><b>✓</b></td>
+    <td></td> <td></td> <td><b>✓</b></td> <td><b>✓</b></td> <td></td>
   </tr>
   <tr>
     <td> Drush 10 </td>
     <td> 7.1+ (not 8) </td>
     <!-- Released Oct 2019 -->
     <td> Jan 2022 </td>
-    <td></td> <td>✓</td> <td><b>✓</b></td> <td></td>
+    <td></td> <td>✓</td> <td><b>✓</b></td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 9 </td>
     <td> 5.6+ </td>
     <!-- Released Jan 2018 -->
     <td> May 2020 </td>
-    <td></td> <td>✓</td> <td></td> <td></td>
+    <td></td> <td>✓</td> <td></td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 8 </td>
     <td> 5.4.5+ </td>
     <!-- Released Nov 2015 -->
     <td> Jan 2025 </td>
-    <td>✅</td> <td><b>✓️</b></td> <td></td> <td></td>
+    <td>✅</td> <td><b>✓️</b></td> <td></td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 7 </td>
     <td> 5.3.0+ </td>
     <!-- Released May 2015 -->
     <td> Jul 2017 </td>
-    <td>✓</td> <td></td> <td></td> <td></td>
+    <td>✓</td> <td></td> <td></td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 6 </td>
     <td> 5.3.0+ </td>
     <!-- Released Aug 2013 -->
     <td> Dec 2015 </td>
-    <td>✓</td> <td></td> <td></td> <td></td>
+    <td>✓</td> <td></td> <td></td> <td></td> <td></td>
   </tr>
   <tr>
     <td> Drush 5 </td>
     <td> 5.2.0+ </td>
     <!-- Released March 2012 -->
     <td> May 2015 </td>
-    <td>✓</td> <td></td> <td></td> <td></td>
+    <td>✓</td> <td></td> <td></td> <td></td> <td></td>
   </tr>
 </table>
 


### PR DESCRIPTION
I was not sure which branch to submit this against but https://github.com/drush-ops/drush/blob/13.x/docs/install.md is the same content, so could be merged there too.