### PR TITLE
Add --extra-dump option to archive:dump

### DIFF
--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -97,7 +97,7 @@ final class ArchiveDumpCommands extends DrushCommands
         'generator' => InputOption::VALUE_REQUIRED,
         'generatorversion' => InputOption::VALUE_REQUIRED,
         'exclude-code-paths' => InputOption::VALUE_REQUIRED,
-        'extra-dump' => false,
+        'extra-dump' => self::REQ,
     ]): string
     {
         $this->prepareArchiveDir();

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -68,6 +68,7 @@ final class ArchiveDumpCommands extends DrushCommands
     #[CLI\Option(name: 'overwrite', description: 'Overwrite destination file if exists.')]
     #[CLI\Option(name: 'code', description: 'Archive codebase.')]
     #[CLI\Option(name: 'exclude-code-paths', description: 'Comma-separated list of paths (or regular expressions matching paths) to exclude from the code archive.')]
+    #[CLI\Option(name: 'extra-dump', description: 'Add custom arguments/options to the dumping of the database (e.g. <info>mysqldump</info> command).')]
     #[CLI\Option(name: 'files', description: 'Archive Drupal files.')]
     #[CLI\Option(name: 'db', description: 'Archive database SQL dump.')]
     #[CLI\Option(name: 'description', description: 'Describe the archive contents.')]
@@ -79,6 +80,7 @@ final class ArchiveDumpCommands extends DrushCommands
     #[CLI\Usage(name: 'drush archive:dump --destination=/path/to/archive.tar.gz --overwrite', description: 'Create (or overwrite if exists) /path/to/archive.tar.gz file containing code, database and Drupal files.')]
     #[CLI\Usage(name: 'drush archive:dump --code --destination=/path/to/archive.tar.gz', description: 'Create /path/to/archive.tar.gz file containing the code only.')]
     #[CLI\Usage(name: 'drush archive:dump --exclude-code-paths=foo_bar.txt,web/sites/.+/settings.php --destination=/path/to/archive.tar.gz', description: 'Create /path/to/archive.tar.gz file containing code, database and Drupal files but excluding foo_bar.txt file and settings.php files if found in web/sites/* subdirectories.')]
+    #[CLI\Usage(name: 'drush archive:dump --extra-dump=--no-data --destination=/path/to/archive.tar.gz', description: 'Create /path/to/archive.tar.gz file and pass extra option to <info>mysqldump</info> command.')]
     #[CLI\Usage(name: 'drush archive:dump --files --destination=/path/to/archive.tar.gz', description: 'Create /path/to/archive.tar.gz file containing the Drupal files only.')]
     #[CLI\Usage(name: 'drush archive:dump --database --destination=/path/to/archive.tar.gz', description: 'Create /path/to/archive.tar.gz archive file containing the database dump only.')]
     #[CLI\OptionsetTableSelection]
@@ -95,6 +97,7 @@ final class ArchiveDumpCommands extends DrushCommands
         'generator' => InputOption::VALUE_REQUIRED,
         'generatorversion' => InputOption::VALUE_REQUIRED,
         'exclude-code-paths' => InputOption::VALUE_REQUIRED,
+        'extra-dump' => InputOption::VALUE_REQUIRED,
     ]): string
     {
         $this->prepareArchiveDir();

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -97,7 +97,7 @@ final class ArchiveDumpCommands extends DrushCommands
         'generator' => InputOption::VALUE_REQUIRED,
         'generatorversion' => InputOption::VALUE_REQUIRED,
         'exclude-code-paths' => InputOption::VALUE_REQUIRED,
-        'extra-dump' => InputOption::VALUE_REQUIRED,
+        'extra-dump' => false,
     ]): string
     {
         $this->prepareArchiveDir();


### PR DESCRIPTION
The --extra-dump flag works fine with sql:dump. This adds the same option to archive:dump, which passes the option on to the sql command in turn.