### PR TITLE
Prevent batch-process hidden commands to throw a fatal error if the g…

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -152,7 +152,10 @@ function _drush_backend_batch_process($command = 'batch-process', $args = [], $o
       $process->setTimeout(null);
       // Suppress printing stdout since a JSON array is returned to us here.
       $process->run($process->showRealtime()->hideStdout());
-      $result = $process->getOutputAsJson();
+      try {
+        $result = $process->getOutputAsJson();
+      }
+      catch (\InvalidArgumentException) {}
       $finished = !$process->isSuccessful() || (isset($result['drush_batch_process_finished']) && $result['drush_batch_process_finished'] === TRUE);
     }
   }

--- a/src/Commands/core/BatchCommands.php
+++ b/src/Commands/core/BatchCommands.php
@@ -20,9 +20,9 @@ class BatchCommands extends DrushCommands
     #[CLI\Argument(name: 'batch_id', description: 'The batch id that will be processed.')]
     #[CLI\Help(hidden: true)]
     #[CLI\Bootstrap(level: DrupalBootLevels::FULL)]
-    public function process($batch_id, $options = ['format' => 'json']): UnstructuredListData
+    public function process($batch_id, $options = ['format' => 'json']): ?UnstructuredListData
     {
         $return = drush_batch_command($batch_id);
-        return new UnstructuredListData($return);
+        return $return ? new UnstructuredListData($return) : null;
     }
 }

--- a/src/Commands/core/DeployHookCommands.php
+++ b/src/Commands/core/DeployHookCommands.php
@@ -147,10 +147,10 @@ final class DeployHookCommands extends DrushCommands implements SiteAliasManager
     #[CLI\Argument(name: 'batch_id', description: 'The batch id that will be processed.')]
     #[CLI\Bootstrap(level: DrupalBootLevels::FULL)]
     #[CLI\Help(hidden: true)]
-    public function process(string $batch_id, $options = ['format' => 'json']): UnstructuredListData
+    public function process(string $batch_id, $options = ['format' => 'json']): ?UnstructuredListData
     {
         $result = drush_batch_command($batch_id);
-        return new UnstructuredListData($result);
+        return $result ? new UnstructuredListData($result) : null;
     }
 
     /**

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -131,10 +131,10 @@ final class UpdateDBCommands extends DrushCommands implements SiteAliasManagerAw
     #[CLI\Argument(name: 'batch_id', description: 'The batch id that will be processed.')]
     #[CLI\Bootstrap(level: DrupalBootLevels::FULL)]
     #[CLI\Kernel(name: 'update')]
-    public function process(string $batch_id, $options = ['format' => 'json']): UnstructuredListData
+    public function process(string $batch_id, $options = ['format' => 'json']): ?UnstructuredListData
     {
         $result = drush_batch_command($batch_id);
-        return new UnstructuredListData($result);
+        return $result ? new UnstructuredListData($result) : null;
     }
 
     /**


### PR DESCRIPTION
…iven batch does not exist anymore.

`UnstructuredListData` has been introduced in #3750 and #3758 to display the return of `drush_batch_command()`.
As this function can return `FALSE`, we need to check the value before creating the return object to prevent a fatal error due to the mistyped argument (ArrayObject only allow the value to be an array or an object, not a boolean).