### PR TITLE
Trust existing config to have a profile set correctly

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -182,7 +182,7 @@ final class SiteInstallCommands extends DrushCommands
     }
 
 
-    protected function determineProfile($profile, $options)
+    protected function determineProfile($profile, $options): string|bool
     {
         // Try to get profile from existing config if not provided as an argument.
         // @todo Arguably Drupal core [$boot->getKernel()->getInstallProfile()] could do this - https://github.com/drupal/drupal/blob/8.6.x/core/lib/Drupal/Core/DrupalKernel.php#L1606 reads from DB storage but not file storage.

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -194,7 +194,8 @@ final class SiteInstallCommands extends DrushCommands
                 throw new \Exception(dt('Existing configuration directory @config does not contain a core.extension.yml file.', ['@config' => $config_directory]));
             }
             $config = $source_storage->read('core.extension');
-            $profile = $config['profile'];
+            $profile = $config['profile'] ?? FALSE;
+            return $profile;
         }
 
         if (empty($profile)) {

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -194,7 +194,7 @@ final class SiteInstallCommands extends DrushCommands
                 throw new \Exception(dt('Existing configuration directory @config does not contain a core.extension.yml file.', ['@config' => $config_directory]));
             }
             $config = $source_storage->read('core.extension');
-            $profile = $config['profile'] ?? FALSE;
+            $profile = $config['profile'] ?? false;
             return $profile;
         }
 


### PR DESCRIPTION
This also and more importantly allow sites with no profile to be installed from config. This is now a reality after https://www.drupal.org/project/drupal/issues/1170362 has landed.

Note that for this to actually work we need to land https://www.drupal.org/project/drupal/issues/3432602 too.