### PR TITLE
#5952: Database update step for `drush deploy` behaves differently than `drush updb --no-cache-clear`

### DIFF
--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -34,6 +34,7 @@ final class DeployCommands extends DrushCommands
     #[CLI\Version(version: '10.3')]
     #[CLI\Topics(topics: [DocsCommands::DEPLOY])]
     #[CLI\Bootstrap(level: DrupalBootLevels::FULL)]
+    #[CLI\Kernel(name: 'update')]
     public function deploy(): void
     {
         $self = $this->siteAliasManager->getSelf();

--- a/src/Commands/core/DeployCommands.php
+++ b/src/Commands/core/DeployCommands.php
@@ -14,6 +14,7 @@ use Drush\Commands\config\ConfigImportCommands;
 use Drush\Commands\DrushCommands;
 use Drush\Drush;
 
+#[CLI\Bootstrap(DrupalBootLevels::NONE)]
 final class DeployCommands extends DrushCommands
 {
     use AutowireTrait;
@@ -33,8 +34,6 @@ final class DeployCommands extends DrushCommands
     #[CLI\Usage(name: 'drush deploy -v -y', description: 'Run updates with verbose logging and accept all prompts.')]
     #[CLI\Version(version: '10.3')]
     #[CLI\Topics(topics: [DocsCommands::DEPLOY])]
-    #[CLI\Bootstrap(level: DrupalBootLevels::FULL)]
-    #[CLI\Kernel(name: 'update')]
     public function deploy(): void
     {
         $self = $this->siteAliasManager->getSelf();


### PR DESCRIPTION
Fixes the issue #5952

As a reminder, Drush's usage of UpdateKernel started in https://github.com/drush-ops/drush/pull/5953. This PR would again use it in the main request of _deploy_ command, in addition to deploy's subrequest to _updatedb_.