### PR TITLE
Fix `config-pull` source notice

### DIFF
--- a/src/Commands/config/ConfigPullCommands.php
+++ b/src/Commands/config/ConfigPullCommands.php
@@ -53,7 +53,7 @@ final class ConfigPullCommands extends DrushCommands
             'yes' => null,
             'format' => 'string',
         ];
-        $this->logger()->notice(dt('Starting to export configuration on :destination.', [':destination' => $destination]));
+        $this->logger()->notice(dt('Starting to export configuration on :source.', [':source' => $source]));
         $process = $this->processManager()->drush($sourceRecord, ConfigExportCommands::EXPORT, [], $export_options + $global_options);
         $process->mustRun();
 


### PR DESCRIPTION
Currently when using `config:pull` it will show a notice, that it is exporting the config on the destination when in fact it is exporting the config on the source. So for example when pulling config from a remote site with the alias `prod`, e.g. `drush config-pull @prod @self` (so pulling config from a source named `prod` to a destination named `self`) a notice appears saying `Starting to export configuration on @self.` when it is actually exporting on `prod`.

I replaced the `destination` in the notice with the `source` so it reflects the actual source the command executes on the next line. I did not resolve the alias to an actual remote host name, like it is done in some cases in other commands like `drush sql:sync`.