### PR TITLE
adding diff command for remote exporting

### DIFF
--- a/src/Commands/config/ConfigExportCommands.php
+++ b/src/Commands/config/ConfigExportCommands.php
@@ -215,4 +215,29 @@ final class ConfigExportCommands extends DrushCommands
             }
         }
     }
+
+    /**
+     * Display a diff of the active configuration set versus what's on disk.
+     *
+     * @command config:diff
+     *
+     * @usage drush config:diff
+     *   Display a diff of the active configuration set versus what's on disk.
+     */
+    public function diff(): string
+    {
+        $diff = '';
+        $destination_dir = ConfigCommands::getDirectory();
+        $sync_directory = Settings::get('config_sync_directory');
+        // Prepare the configuration storage for the export.
+        if ($sync_directory !== null && $destination_dir == Path::canonicalize($sync_directory)) {
+            $target_storage = $this->getConfigStorageSync();
+            $config_comparer = new StorageComparer($this->getConfigStorageExport(), $target_storage, $this->getConfigManager());
+            if ($config_comparer->createChangelist()->hasChanges()) {
+                $diff = ConfigCommands::getDiff($target_storage, $this->getConfigStorageExport(), $this->output());
+                $diff = preg_replace("/\033\[[^m]*m/", '', $diff);
+            }
+        }
+        return $diff;
+    }
 }


### PR DESCRIPTION
Now I know there are several ways of exporting configuration now, but at the moment, I find it difficult on Pantheon and Acquia to. I've been eyeing that `--diff` option on `drush config:export` for a while thinking about how nice it would be if I could grab that diff and apply it it locally to my configuration directory and not have to worry about ssh access, setting up site aliases, or having to download the database backup.

for the quick one off I've been using `drush config:get` and pushing the output to the appropriate file... with something like this:

```
DRUSH="acli drush acme.prod --";
#DRUSH="terminus drush acme.live --";
#DRUSH="drush @live"
SYNC_DIR="./config/default"
$DRUSH config:status --format=list | xargs -I{} bash -c '$2 config:get "$1" > "$3/$1.yml"' -- {} "$DRUSH" "$SYNC_DIR"
$DRUSH config:status --format=list --state='Only in sync dir' | xargs -I{} bash -c 'rm "$3/$1.yml"' -- {} "$DRUSH" "$SYNC_DIR"
```

However if we get the diff into a clean text format I can do the following:
```
terminus drush acme.live -- config:diff | patch -p3 --directory config/default/
```
and it's super fast and much less text transfer.

Here is my attempt at that.

For what it's worth, I'm perfectly fine with people telling me of a better way or how they do it, but I do see a performance value in this change.