### PR TITLE
Add a progress bar to the queue:run command

### DIFF
--- a/src/Commands/core/QueueCommands.php
+++ b/src/Commands/core/QueueCommands.php
@@ -74,7 +74,10 @@ final class QueueCommands extends DrushCommands
             $queue->garbageCollection();
         }
 
-        $this->io()->progressStart($items_limit ?: $queue->numberOfItems());
+        $max = $items_limit ?: $queue->numberOfItems();
+        if ($max > 0) {
+            $this->io()->progressStart($max);
+        }
 
         while ((!$time_limit || $remaining > 0) && (!$items_limit || $count < $items_limit) && ($item = $queue->claimItem($lease_time))) {
             try {
@@ -112,7 +115,9 @@ final class QueueCommands extends DrushCommands
             $remaining = $end - time();
         }
         $elapsed = microtime(true) - $start;
-        $this->io()->progressFinish();
+        if ($max > 0) {
+            $this->io()->progressFinish();
+        }
         $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
     }
 

--- a/src/Commands/core/QueueCommands.php
+++ b/src/Commands/core/QueueCommands.php
@@ -112,6 +112,7 @@ final class QueueCommands extends DrushCommands
             $remaining = $end - time();
         }
         $elapsed = microtime(true) - $start;
+        $this->io()->progressFinish();
         $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
     }
 

--- a/src/Commands/core/QueueCommands.php
+++ b/src/Commands/core/QueueCommands.php
@@ -74,6 +74,8 @@ final class QueueCommands extends DrushCommands
             $queue->garbageCollection();
         }
 
+        $this->io()->progressStart($items_limit ?: $queue->numberOfItems());
+
         while ((!$time_limit || $remaining > 0) && (!$items_limit || $count < $items_limit) && ($item = $queue->claimItem($lease_time))) {
             try {
                 // @phpstan-ignore-next-line
@@ -82,6 +84,7 @@ final class QueueCommands extends DrushCommands
                 $worker->processItem($item->data);
                 $queue->deleteItem($item);
                 $count++;
+                $this->io()->progressAdvance();
             } catch (RequeueException) {
                 // The worker requested the task to be immediately requeued.
                 $queue->releaseItem($item);


### PR DESCRIPTION
Just an idea for a small improvement I had: the queue:run command could use a progress bar, especially in case of large queues.