### PR TITLE
Error with asciinema install on `ddev start`

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -15,6 +15,7 @@ composer_version: ""
 disable_settings_management: true
 webimage_extra_packages:
   - bash-completion
+  - asciinema
 # https://ddev.readthedocs.io/en/latest/users/extend/database-types/
 # When switching DBs, use ddev delete --omit-snapshot
 #database:

--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -1,9 +1,6 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
-# https://asciinema.org/docs/installation
-RUN pip3 install asciinema
-
 # Install Autocast https://github.com/k9withabone/autocast/tree/main#installation
 # https://stackoverflow.com/questions/67092242/how-can-i-add-to-the-path-in-the-ddev-web-container-for-drush-for-example
 RUN echo 'export PATH="$PATH:$HOME/.cargo/bin"' >/etc/bashrc/commandline-addons.bashrc


### PR DESCRIPTION
Fixes #5987

Why not installing `asciinema` via `webimage_extra_packages` DDEV config?