### PR TITLE
Anticipate method deprecation

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,5 +1,6 @@
 parameters:
 	ignoreErrors:
+		# Remove once MigrationInterface::setRequirements() is added in https://www.drupal.org/i/2796755
 		-
 			message: "#^Call to an undefined method Drupal\\\\migrate\\\\Plugin\\\\MigrationInterface\\:\\:set\\(\\)\\.$#"
 			count: 1

--- a/src/Commands/core/MigrateRunnerCommands.php
+++ b/src/Commands/core/MigrateRunnerCommands.php
@@ -388,6 +388,10 @@ class MigrateRunnerCommands extends DrushCommands
             }
         }
         if (!empty($userData['options']['force'])) {
+            // @todo Use the new MigrationInterface::setRequirements() method,
+            //   instead of Migration::set() and remove the PHPStan exception
+            //   from phpstan-baseline.neon when #2796755 lands in Drupal core.
+            // @see https://www.drupal.org/i/2796755
             $migration->set('requirements', []);
         }
         if (!empty($userData['options']['update'])) {


### PR DESCRIPTION
PHPStan complains about inexistent `MigrationInterface::set()` method. Indeed, the method exists on the class but not on its interface and the variable is strict-typed using the interface:

```
Call to an undefined method Drupal\migrate\Plugin\MigrationInterface::set().
         ✏️  Commands/core/MigrateRunnerCommands.php
```

This is a Drupal core's migrate module issue, see https://www.drupal.org/i/2796755, and there's nothing we can do about it in Drush.


- We should keep the PHPStan exception from `phpstan-baseline.neon`
- When `MigrationInterface::set()` will be deprecated ,in  https://www.drupal.org/i/2796755, will start to emit `E_USER_DEPRECATED` muted errors. Our PHPUnit tests will (hopefully) start to fail and we can do the refactoring and remove the PHPStan exception.

I've documented this exception in Drush