### PR TITLE
Fixes #5991: Adds Convert Symlinks Option 

### DIFF
--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -176,20 +176,20 @@ final class ArchiveDumpCommands extends DrushCommands
         $this->logger()->info(var_export($this->archiveDir, true));
 
         // If symlinks are disabled, convert symlinks to full content.
-        if ($options['convert-symlinks'] === true && is_dir($this->archiveDir)) {
+        if (is_dir($this->archiveDir)) {
             $this->logger()->info(dt('Converting symlinks...'));
 
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->archiveDir), RecursiveIteratorIterator::SELF_FIRST);
 
             foreach ($iterator as $file) {
-                if ($file->isLink()) {
+                if ($file->isLink() && ($options['convert-symlinks'] === true || strpos($file->getPathName(), $archivePath) == 0)) {
                     $target = readlink($file->getPathname());
 
                     if (is_file($target)) {
                         $content = file_get_contents($target);
                         unlink($file->getPathname());
                         file_put_contents($file->getPathname(), $content);
-                    } elseif (is_dir($target)) {
+                    } elseif (is_dir($target) && ($options['convert-symlinks'] === true || strpos($file->getPathName(), $archivePath) == 0)) {
                         $path = $file->getPathname();
                         unlink($path);
                         mkdir($path, 0755);

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -142,8 +142,7 @@ final class ArchiveDumpCommands extends DrushCommands
     protected function prepareArchiveDir(): void
     {
         $this->filesystem = new Filesystem();
-        // $this->archiveDir = FsUtils::tmpDir(self::ARCHIVES_DIR_NAME);
-        $this->archiveDir = "/tmp/findmetmp";
+        $this->archiveDir = FsUtils::tmpDir(self::ARCHIVES_DIR_NAME);
     }
 
     /**

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -169,15 +169,15 @@ final class ArchiveDumpCommands extends DrushCommands
         $archivePath = Path::join(dirname($this->archiveDir), self::ARCHIVE_FILE_NAME);
 
         stream_wrapper_restore('phar');
-        $this->logger()->info(var_export($archivePath, TRUE));
+        $this->logger()->info(var_export($archivePath, true));
         $archive = new PharData($archivePath);
 
         $this->createManifestFile($options);
 
-        $this->logger()->info(var_export($this->archiveDir, TRUE));
+        $this->logger()->info(var_export($this->archiveDir, true));
 
         // If symlinks are disabled, convert symlinks to full content.
-        if ($options['convert-symlinks'] === TRUE && is_dir($this->archiveDir)) {
+        if ($options['convert-symlinks'] === true && is_dir($this->archiveDir)) {
             $this->logger()->info(dt('Converting symlinks...'));
 
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->archiveDir), RecursiveIteratorIterator::SELF_FIRST);
@@ -197,8 +197,9 @@ final class ArchiveDumpCommands extends DrushCommands
                         foreach (
                             $iterator = new \RecursiveIteratorIterator(
                                 new \RecursiveDirectoryIterator($target, \RecursiveDirectoryIterator::SKIP_DOTS),
-                                \RecursiveIteratorIterator::SELF_FIRST) as $item
-                        ) {
+                            \RecursiveIteratorIterator::SELF_FIRST) as $item
+                        )
+                        {
                             if ($item->isDir()) {
                                 mkdir($path . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
                             } else {

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -596,11 +596,11 @@ final class ArchiveDumpCommands extends DrushCommands
     }
 
     /**
-     * Converts symlinks to full content for an archive.
+     * Converts symlinks to the linked files/folders for an archive.
      *
-     * @param $convert_symlinks
-     *  Whether to convert symlinks.
-     * @param $archivePath
+     * @param bool $convert_symlinks
+     *  Whether to convert all symlinks.
+     * @param string $archivePath
      *   The file path of the archive.
      *
      * @return void

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -612,37 +612,49 @@ final class ArchiveDumpCommands extends DrushCommands
         // If symlinks are disabled, convert symlinks to full content.
         $this->logger()->info(dt('Converting symlinks...'));
 
-        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->archiveDir),
-            RecursiveIteratorIterator::SELF_FIRST);
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->archiveDir),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
 
         foreach ($iterator as $file) {
-            if ($file->isLink() && ($convert_symlinks === true || strpos($file->getPathName(),
-                        $archivePath) == 0)) {
+            if (
+                $file->isLink() && ($convert_symlinks === true || strpos(
+                    $file->getPathName(),
+                    $archivePath
+                ) == 0)
+            ) {
                 $target = readlink($file->getPathname());
 
                 if (is_file($target)) {
                     $content = file_get_contents($target);
                     unlink($file->getPathname());
                     file_put_contents($file->getPathname(), $content);
-                }
-                elseif (is_dir($target) && ($convert_symlinks === true || strpos($file->getPathName(),
-                            $archivePath) == 0)) {
+                } elseif (
+                    is_dir($target) && ($convert_symlinks === true || strpos(
+                        $file->getPathName(),
+                        $archivePath
+                    ) == 0)
+                ) {
                     $path = $file->getPathname();
                     unlink($path);
                     mkdir($path, 0755);
                     foreach (
                         $iterator = new \RecursiveIteratorIterator(
-                            new \RecursiveDirectoryIterator($target,
-                                \RecursiveDirectoryIterator::SKIP_DOTS),
+                            new \RecursiveDirectoryIterator(
+                                $target,
+                                \RecursiveDirectoryIterator::SKIP_DOTS
+                            ),
                             \RecursiveIteratorIterator::SELF_FIRST
                         ) as $item
                     ) {
                         if ($item->isDir()) {
-                            mkdir($path.DIRECTORY_SEPARATOR.$iterator->getSubPathname());
-                        }
-                        else {
-                            copy($item->getPathname(),
-                                $path.DIRECTORY_SEPARATOR.$iterator->getSubPathname());
+                            mkdir($path . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
+                        } else {
+                            copy(
+                                $item->getPathname(),
+                                $path . DIRECTORY_SEPARATOR . $iterator->getSubPathname()
+                            );
                         }
                     }
                 }

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -172,7 +172,6 @@ final class ArchiveDumpCommands extends DrushCommands
 
         $this->createManifestFile($options);
 
-        $this->logger()->info(var_export($this->archiveDir, true));
         $this->convertSymlinks($options['convert-symlinks'], $archivePath);
 
         $archive->buildFromDirectory($this->archiveDir);

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -197,9 +197,9 @@ final class ArchiveDumpCommands extends DrushCommands
                         foreach (
                             $iterator = new \RecursiveIteratorIterator(
                                 new \RecursiveDirectoryIterator($target, \RecursiveDirectoryIterator::SKIP_DOTS),
-                            \RecursiveIteratorIterator::SELF_FIRST) as $item
-                        )
-                        {
+                                \RecursiveIteratorIterator::SELF_FIRST
+                            ) as $item
+                        ) {
                             if ($item->isDir()) {
                                 mkdir($path . DIRECTORY_SEPARATOR . $iterator->getSubPathname());
                             } else {

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -168,13 +168,12 @@ final class ArchiveDumpCommands extends DrushCommands
         $archivePath = Path::join(dirname($this->archiveDir), self::ARCHIVE_FILE_NAME);
 
         stream_wrapper_restore('phar');
-        $this->logger()->info(var_export($archivePath, true));
         $archive = new PharData($archivePath);
 
         $this->createManifestFile($options);
 
         $this->logger()->info(var_export($this->archiveDir, true));
-        $this->convertSymlinks($options, $archivePath);
+        $this->convertSymlinks($options['convert-symlinks'], $archivePath);
 
         $archive->buildFromDirectory($this->archiveDir);
 

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -129,7 +129,7 @@ class ArchiveTest extends CommandUnishTestCase
         // critical errors. To test for this, we manually create a symlink
         // and then run archive:dump. If it completes at all, the symlink fix
         // from Issue #5991 is working.
-        $linktarget      = Path::join("/tmp", 'symlinktest.txt');
+        $linktarget      = Path::join($this->getSandbox(), '../symlinktest.txt');
         $linkdestination = Path::join($this->getSandbox(), 'symlinkdest.txt');
 
         file_put_contents($linktarget, "This is a symlink target file.");
@@ -144,6 +144,9 @@ class ArchiveTest extends CommandUnishTestCase
                 'overwrite' => null,
             ])
         );
+
+      unlink($linkdestination);
+      unlink($linktarget);
     }
 
     public function SKIPtestArchiveRestoreCommand(): void

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -126,7 +126,7 @@ class ArchiveTest extends CommandUnishTestCase
     public function testArchiveDumpSymlinkSwapCommand(): void
     {
         $linktarget      = Path::join("/tmp", 'symlinktest.txt');
-        $linkdestination = Path::join($this->getSandbox(), 'web/symlinkdest.txt');
+        $linkdestination = Path::join($this->getSandbox(), 'symlinkdest.txt');
 
         file_put_contents($linktarget, "This is a symlink target file.");
         symlink($linktarget, $linkdestination);

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -123,20 +123,16 @@ class ArchiveTest extends CommandUnishTestCase
         );
     }
 
+    public function testArchiveDumpSymlinkSwapCommand(): void {
+        $linktarget      = Path::join($this->getSandbox(), 'symlinktest.txt');
+        $linkdestination = Path::join($this->archivePath, 'web/symlinkdest.txt');
 
-  public function testArchiveDumpSymlinkSwapCommand(): void
-  {
+        file_put_contents($linktarget, "This is a symlink target file.");
+        symlink($linktarget, $linkdestination);
 
-    $linktarget = Path::join($this->getSandbox(), 'symlinktest.txt');
-    $linkdestination = Path::join($this->archivePath, 'web/symlinkdest.txt');
-
-    file_put_contents($linktarget, "This is a symlink target file.");
-    symlink($linktarget, $linkdestination);
-
-    // Overwrite the existing archive with "--destination" and "--override".
-    $this->drush('archive:dump');
-
-  }
+        // Overwrite the existing archive with "--destination" and "--override".
+        $this->drush('archive:dump');
+    }
 
     public function SKIPtestArchiveRestoreCommand(): void
     {

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -145,8 +145,8 @@ class ArchiveTest extends CommandUnishTestCase
             ])
         );
 
-      unlink($linkdestination);
-      unlink($linktarget);
+        unlink($linkdestination);
+        unlink($linktarget);
     }
 
     public function SKIPtestArchiveRestoreCommand(): void

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -132,7 +132,14 @@ class ArchiveTest extends CommandUnishTestCase
         symlink($linktarget, $linkdestination);
 
         // Overwrite the existing archive with "--destination" and "--override".
-        $this->drush('archive:dump');
+        $this->drush(
+            'archive:dump',
+            [],
+            array_merge($this->archiveDumpOptions, [
+                'destination' => $this->archivePath,
+                'overwrite' => null,
+            ])
+        );
     }
 
     public function SKIPtestArchiveRestoreCommand(): void

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -125,13 +125,17 @@ class ArchiveTest extends CommandUnishTestCase
 
     public function testArchiveDumpSymlinkSwapCommand(): void
     {
+        // Sites that contain symlinks to files outside the project root cause
+        // critical errors. To test for this, we manually create a symlink
+        // and then run archive:dump. If it completes at all, the symlink fix
+        // from Issue #5991 is working.
         $linktarget      = Path::join("/tmp", 'symlinktest.txt');
         $linkdestination = Path::join($this->getSandbox(), 'symlinkdest.txt');
 
         file_put_contents($linktarget, "This is a symlink target file.");
         symlink($linktarget, $linkdestination);
 
-        // Overwrite the existing archive with "--destination" and "--override".
+        // Overwrite the existing archive with "--destination" and "--overwrite".
         $this->drush(
             'archive:dump',
             [],

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -123,7 +123,8 @@ class ArchiveTest extends CommandUnishTestCase
         );
     }
 
-    public function testArchiveDumpSymlinkSwapCommand(): void {
+    public function testArchiveDumpSymlinkSwapCommand(): void
+    {
         $linktarget      = Path::join($this->getSandbox(), 'symlinktest.txt');
         $linkdestination = Path::join($this->archivePath, 'web/symlinkdest.txt');
 

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -123,6 +123,21 @@ class ArchiveTest extends CommandUnishTestCase
         );
     }
 
+
+  public function testArchiveDumpSymlinkSwapCommand(): void
+  {
+
+    $linktarget = Path::join($this->getSandbox(), 'symlinktest.txt');
+    $linkdestination = Path::join($this->archivePath, 'web/symlinkdest.txt');
+
+    file_put_contents($linktarget, "This is a symlink target file.");
+    symlink($linktarget, $linkdestination);
+
+    // Overwrite the existing archive with "--destination" and "--override".
+    $this->drush('archive:dump');
+
+  }
+
     public function SKIPtestArchiveRestoreCommand(): void
     {
         // [info] Copying files from "C:/projects/work/sandbox/archive/code\" to "C:\projects\work\"...

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -125,8 +125,8 @@ class ArchiveTest extends CommandUnishTestCase
 
     public function testArchiveDumpSymlinkSwapCommand(): void
     {
-        $linktarget      = Path::join($this->getSandbox(), 'symlinktest.txt');
-        $linkdestination = Path::join($this->archivePath, 'web/symlinkdest.txt');
+        $linktarget      = Path::join("/tmp", 'symlinktest.txt');
+        $linkdestination = Path::join($this->getSandbox(), 'web/symlinkdest.txt');
 
         file_put_contents($linktarget, "This is a symlink target file.");
         symlink($linktarget, $linkdestination);


### PR DESCRIPTION
Resolves: https://github.com/drush-ops/drush/issues/5991

This PR adds a `convert-symlink` option to the `archive-dump` command which will convert symlinks to standard/static files and directories in order to resolve a bug where symlinks external to the project would cause an error on dump. 