### PR TITLE
Directly add recipe command from Drupal 11

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -229,6 +229,10 @@ class DrupalBoot8 extends DrupalBoot
         $this->logger->debug(dt('Finished bootstrap of the Drupal Kernel.'));
 
         parent::bootstrapDrupalFull($manager);
+
+        // Directly add the Drupal core bootstrapped commands.
+        Drush::getApplication()->addCommands($this->serviceManager->instantiateDrupalCoreBootstrappedCommands());
+        
         $this->addDrupalModuleDrushCommands($manager);
 
         // Set a default account to make sure the correct timezone is set

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -232,7 +232,7 @@ class DrupalBoot8 extends DrupalBoot
 
         // Directly add the Drupal core bootstrapped commands.
         Drush::getApplication()->addCommands($this->serviceManager->instantiateDrupalCoreBootstrappedCommands());
-        
+
         $this->addDrupalModuleDrushCommands($manager);
 
         // Set a default account to make sure the correct timezone is set

--- a/src/Runtime/ServiceManager.php
+++ b/src/Runtime/ServiceManager.php
@@ -12,6 +12,7 @@ use Consolidation\Filter\Hooks\FilterHooks;
 use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteProcess\ProcessManagerAwareInterface;
 use Drupal\Component\DependencyInjection\ContainerInterface as DrupalContainer;
+use Drupal\Core\Recipe\RecipeCommand;
 use DrupalCodeGenerator\Command\BaseGenerator;
 use Drush\Attributes\Bootstrap;
 use Drush\Boot\DrupalBootLevels;
@@ -287,6 +288,27 @@ class ServiceManager
             $instance->setHelp('See https://github.com/grasmash/yaml-cli for a README and bug reports.');
             $instances[] = $instance;
         }
+        return $instances;
+    }
+
+    /**
+     * Instantiate commands from Drupal Core that we want to expose
+     * as Drush commands.
+     *
+     * These require a bootstrapped Drupal.
+     *
+     * @return Command[]
+     *   List of Symfony Command objects
+     */
+    public function instantiateDrupalCoreBootstrappedCommands(): array
+    {
+        $instances = [];
+        if (class_exists(RecipeCommand::class)) {
+            $instance = new RecipeCommand($this->autoloader);
+            $instance->setHelp('See https://drupal.org/project/issues/drupal for bug reports and feature requests for this command.');
+            $instances[] = $instance;
+        }
+
         return $instances;
     }
 


### PR DESCRIPTION
This direct addition of recipe command has pluses and minuses. 

The upside is that it will automatically gain powers as Drupal core builds out the command. The downside is users will incorrectly file issues in Drush for it, and the command help is weaker than an Annotated command.

A recipe path should be absolute or relative to Drupal root. Hopefully Drupal will update its command help to note that.