### PR TITLE
Issue #6012: drush migrate:fields-source vs. strict_types

### DIFF
--- a/src/Commands/core/MigrateRunnerCommands.php
+++ b/src/Commands/core/MigrateRunnerCommands.php
@@ -661,7 +661,7 @@ class MigrateRunnerCommands extends DrushCommands implements ConfigAwareInterfac
         foreach ($source->fields() as $machineName => $description) {
             $table[] = [
                 'machine_name' => $machineName,
-                'description' => strip_tags($description),
+                'description' => strip_tags((string) $description),
             ];
         }
         return new RowsOfFields($table);


### PR DESCRIPTION
(cherry picked from commit 6577dd548ca0fb3c5fd1dad75c3be851ebbaea88)