### PR TITLE
Restore SqlMariaDB override

### DIFF
--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -121,7 +121,7 @@ abstract class SqlBase implements ConfigAwareInterface
         $driver = $db_spec['driver'];
         $class_name = !empty($driver) ? 'Drush\Sql\Sql' . ucfirst($driver) : null;
         if ($class_name && class_exists($class_name)) {
-            $instance = new $class_name($db_spec, $options);
+            $instance = method_exists($class_name, 'make') ? $class_name::make($db_spec, $options) : new $class_name($db_spec, $options);
             // Inject config
             $instance->setConfig(Drush::config());
             return $instance;

--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -229,7 +229,7 @@ EOT;
 
             // Run mysqldump again and append output if we need some structure only tables.
             if (!empty($structure_tables)) {
-                $exec .= " && mysqldump " . $only_db_name . " --no-data $extra " . implode(' ', $structure_tables);
+                $exec .= " && " . $this->dumpProgram() . " " . $only_db_name . " --no-data $extra " . implode(' ', $structure_tables);
                 $parens = true;
             }
         }


### PR DESCRIPTION
#5918 removed the call to `SqlMysql::make`. Not sure why.

Refixes #5777.

Additionally uses `dumpProgram()` in an additional place.

I'm not quite sure of how things get backported/forward ported or whatever. But it seems that #5918 was only applied to 12.x, not 13.x. Shout if I need to do something different.