### PR TITLE
Improve dumpProgram handling in mysql database driver, and fix for null param to ucfirst for 13.x

### DIFF
--- a/src/Sql/SqlBase.php
+++ b/src/Sql/SqlBase.php
@@ -119,8 +119,8 @@ abstract class SqlBase implements ConfigAwareInterface
     public static function getInstance($db_spec, $options): ?self
     {
         $driver = $db_spec['driver'];
-        $class_name = 'Drush\Sql\Sql' . ucfirst($driver);
-        if (class_exists($class_name)) {
+        $class_name = !empty($driver) ? 'Drush\Sql\Sql' . ucfirst($driver) : null;
+        if ($class_name && class_exists($class_name)) {
             $instance = method_exists($class_name, 'make') ? $class_name::make($db_spec, $options) : new $class_name($db_spec, $options);
             // Inject config
             $instance->setConfig(Drush::config());

--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -229,7 +229,7 @@ EOT;
 
             // Run mysqldump again and append output if we need some structure only tables.
             if (!empty($structure_tables)) {
-                $exec .= " && mysqldump " . $only_db_name . " --no-data $extra " . implode(' ', $structure_tables);
+                $exec .= " && " . $this->dumpProgram() . " " . $only_db_name . " --no-data $extra " . implode(' ', $structure_tables);
                 $parens = true;
             }
         }


### PR DESCRIPTION
* Use dumpProgram in an additional place in SqlMysql
* Fix null param to ucfirst() fatal error when DB information is missing

Forward ported from #6022 & #5918 (except fixed to not require #6022), as requested.