### PR TITLE
Fixes #5991: Adds Convert Symlinks Option #5992

### DIFF
--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -268,9 +268,9 @@ final class ArchiveDumpCommands extends DrushCommands
         foreach ($iterator as $file) {
             if (
                 $file->isLink() && ($convert_symlinks === true || strpos(
-                                                                      $file->getPathName(),
-                                                                      $archivePath
-                                                                  ) == 0)
+                    $file->getPathName(),
+                    $archivePath
+                ) == 0)
             ) {
                 $target = readlink($file->getPathname());
 
@@ -280,9 +280,9 @@ final class ArchiveDumpCommands extends DrushCommands
                     file_put_contents($file->getPathname(), $content);
                 } elseif (
                     is_dir($target) && ($convert_symlinks === true || strpos(
-                                                                          $file->getPathName(),
-                                                                          $archivePath
-                                                                      ) == 0)
+                        $file->getPathName(),
+                        $archivePath
+                    ) == 0)
                 ) {
                     $path = $file->getPathname();
                     unlink($path);

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -254,8 +254,8 @@ final class ArchiveDumpCommands extends DrushCommands
      * @return void
      */
     public function convertSymlinks(
-        $convert_symlinks,
-        $archivePath
+        bool $convert_symlinks,
+        string $archivePath
     ): void {
         // If symlinks are disabled, convert symlinks to full content.
         $this->logger()->info(dt('Converting symlinks...'));

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -123,24 +123,23 @@ class ArchiveTest extends CommandUnishTestCase
       // critical errors. To test for this, we manually create a symlink
       // and then run archive:dump. If it completes at all, the symlink fix
       // from Issue #5991 is working.
-      $linktarget      = Path::join($this->getSandbox(), '../symlinktest.txt');
-      $linkdestination = Path::join($this->getSandbox(), 'symlinkdest.txt');
+        $linktarget      = Path::join($this->getSandbox(), '../symlinktest.txt');
+        $linkdestination = Path::join($this->getSandbox(), 'symlinkdest.txt');
 
-      file_put_contents($linktarget, "This is a symlink target file.");
-      symlink($linktarget, $linkdestination);
+        file_put_contents($linktarget, "This is a symlink target file.");
+        symlink($linktarget, $linkdestination);
 
       // Overwrite the existing archive with "--destination" and "--overwrite".
-      $this->drush(
-        'archive:dump',
-        [],
-        array_merge($this->archiveDumpOptions, [
-          'destination' => $this->archivePath,
-          'overwrite' => null,
-        ])
-      );
+        $this->drush(
+            'archive:dump',
+            [],
+            array_merge($this->archiveDumpOptions, [
+            'destination' => $this->archivePath,
+            'overwrite' => null,
+            ])
+        );
 
-      unlink($linkdestination);
-      unlink($linktarget);
+        unlink($linkdestination);
+        unlink($linktarget);
     }
-
 }

--- a/tests/functional/ArchiveTest.php
+++ b/tests/functional/ArchiveTest.php
@@ -116,4 +116,31 @@ class ArchiveTest extends CommandUnishTestCase
             $this->getErrorOutput()
         );
     }
+
+    public function testArchiveDumpSymlinkSwapCommand(): void
+    {
+      // Sites that contain symlinks to files outside the project root cause
+      // critical errors. To test for this, we manually create a symlink
+      // and then run archive:dump. If it completes at all, the symlink fix
+      // from Issue #5991 is working.
+      $linktarget      = Path::join($this->getSandbox(), '../symlinktest.txt');
+      $linkdestination = Path::join($this->getSandbox(), 'symlinkdest.txt');
+
+      file_put_contents($linktarget, "This is a symlink target file.");
+      symlink($linktarget, $linkdestination);
+
+      // Overwrite the existing archive with "--destination" and "--overwrite".
+      $this->drush(
+        'archive:dump',
+        [],
+        array_merge($this->archiveDumpOptions, [
+          'destination' => $this->archivePath,
+          'overwrite' => null,
+        ])
+      );
+
+      unlink($linkdestination);
+      unlink($linktarget);
+    }
+
 }


### PR DESCRIPTION
Resolves: https://github.com/drush-ops/drush/issues/5991

This PR adds a convert-symlink option to the archive-dump command which will convert symlinks to standard/static files and directories in order to resolve a bug where symlinks external to the project would cause an error on dump.