### PR TITLE
Fixes #5999: Allow drush site:install to work with recipes.

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -50,7 +50,7 @@ final class SiteInstallCommands extends DrushCommands
      * Install Drupal along with modules/themes/configuration/profile.
      */
     #[CLI\Command(name: self::INSTALL, aliases: ['si', 'sin', 'site-install'])]
-    #[CLI\Argument(name: 'recipeOrProfile', description: 'An install profile name, or a path to a directory containing a recipe. Defaults to <info>standard</info> unless an install profile is marked as a distribution. Use <info>minimal</info> for a bare minimum installation. Additional info for the install profile may also be provided with additional arguments. The key is in the form <info>[form name].[parameter name]</info>')]
+    #[CLI\Argument(name: 'recipeOrProfile', description: 'An install profile name, or a path to a directory containing a recipe. Defaults to <info>standard</info> unless an install profile is marked as a distribution. Use <info>minimal</info> for a bare minimum installation. Additional info for the install profile may also be provided with additional arguments. Use the format <info>[form name].[parameter name]</info>')]
     #[CLI\Option(name: 'db-url', description: 'A Drupal 10 style database URL. Required for initial install, not re-install. If omitted and required, Drush prompts for this item.')]
     #[CLI\Option(name: 'db-prefix', description: 'An optional table prefix to use for initial install.')]
     #[CLI\Option(name: 'db-su', description: 'Account to use when creating a new database. Must have Grant permission (mysql only). Optional.')]

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -132,7 +132,7 @@ final class SiteInstallCommands extends DrushCommands
         ];
 
         if ($recipe) {
-          $settings['parameters']['recipe'] = $recipe;
+            $settings['parameters']['recipe'] = $recipe;
         }
 
         $sql = SqlBase::create($options);
@@ -204,13 +204,14 @@ final class SiteInstallCommands extends DrushCommands
      * @return bool
      *   TRUE if the recipe exists, FALSE if not.
      */
-    protected function validateRecipe(string $recipe): bool {
+    protected function validateRecipe(string $recipe): bool
+    {
         // It is impossible to validate a recipe fully at this point because that
         // requires a container.
         if (!is_dir($recipe) || !is_file($recipe . '/recipe.yml')) {
-            return FALSE;
+            return false;
         }
-        return TRUE;
+        return true;
     }
 
     protected function determineProfile($profile, $options): string|bool

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -204,7 +204,7 @@ final class SiteInstallCommands extends DrushCommands
         // not, we'll assume the user was trying to select a recipe that could
         // not be found.
         if (!empty($recipeOrProfile) && !$this->isValidProfileName($recipeOrProfile)) {
-            throw new \Exception(dt('Could not find a recipe.yml file for @recipe', ['@recipe' => $recipeOrProfile]));           
+            throw new \Exception(dt('Could not find a recipe.yml file for @recipe', ['@recipe' => $recipeOrProfile]));
         }
 
         return [null, $this->determineProfile($recipeOrProfile, $options)];
@@ -217,7 +217,8 @@ final class SiteInstallCommands extends DrushCommands
      * valid, we will pass it through to Drupal and let the system tell us
      * if it is not allowed.
      */
-    protected function isValidProfileName(string $profile) {
+    protected function isValidProfileName(string $profile)
+    {
         return preg_match('/^[a-z][a-z0-9_]*$/', $profile);
     }
 

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -70,7 +70,7 @@ final class SiteInstallCommands extends DrushCommands
     #[CLI\Usage(name: 'drush si --account-pass=mom', description: 'Re-install with specified uid1 password.')]
     #[CLI\Usage(name: 'drush si --existing-config', description: 'Install based on the yml files stored in the config export/import directory.')]
     #[CLI\Usage(name: 'drush si standard install_configure_form.enable_update_status_emails=NULL', description: 'Disable email notification during install and later. If your server has no mail transfer agent, this gets rid of an error during install.')]
-    #[CLI\Usage(name: 'drush si core/recipes/standard', description: 'Install from a core recipe.')]
+    #[CLI\Usage(name: 'drush si core/recipes/standard', description: 'Install from the core Standard recipe.')]
     #[CLI\Bootstrap(level: DrupalBootLevels::ROOT)]
     #[CLI\Kernel(name: Kernels::INSTALLER)]
     public function install(array $profile, $options = ['db-url' => self::REQ, 'db-prefix' => self::REQ, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'account-name' => 'admin', 'account-mail' => 'admin@example.com', 'site-mail' => 'admin@example.com', 'account-pass' => self::REQ, 'locale' => 'en', 'site-name' => 'Drush Site-Install', 'site-pass' => self::REQ, 'sites-subdir' => self::REQ, 'config-dir' => self::REQ, 'existing-config' => false]): void
@@ -186,6 +186,9 @@ final class SiteInstallCommands extends DrushCommands
         $this->logger()->notice('Performed install task: {task}', ['task' => $install_state['active_task']]);
     }
 
+    /**
+     * Determine if the passed parameter is a recipe directory, or a profile name.
+     */
     protected function determineRecipeOrProfile($recipeOrProfile, $options): array
     {
         if ($this->validateRecipe($recipeOrProfile)) {

--- a/tests/fixtures/recipes/test_recipe/config/user.role.administrator.yml
+++ b/tests/fixtures/recipes/test_recipe/config/user.role.administrator.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: administrator
+label: 'Site Administrator'
+weight: 3
+is_admin: true
+permissions: {  }

--- a/tests/fixtures/recipes/test_recipe/config/user.role.content_editor.yml
+++ b/tests/fixtures/recipes/test_recipe/config/user.role.content_editor.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies: {  }
+id: content_editor
+label: 'Site editor'
+weight: 2
+is_admin: false
+permissions:
+  - 'access administration pages'
+  - 'access content overview'
+  - 'access contextual links'
+  - 'access files overview'
+  - 'access toolbar'
+  - 'delete own files'
+  - 'revert all revisions'
+  - 'view all revisions'
+  - 'view own unpublished content'
+  - 'view the administration theme'

--- a/tests/fixtures/recipes/test_recipe/recipe.yml
+++ b/tests/fixtures/recipes/test_recipe/recipe.yml
@@ -1,0 +1,42 @@
+name: 'Test Recipe'
+description: 'A small subset of the Standard core recipe; contains just enough configuration to allow us to prove that the recipe was installed.'
+type: 'Site'
+install:
+  - image
+  - help
+  - history
+  - config
+  - contextual
+  - menu_link_content
+  - datetime
+  - menu_ui
+  - options
+  - toolbar
+  - field_ui
+  - views_ui
+  - shortcut
+config:
+  import:
+    user:
+      - core.entity_view_mode.user.compact
+      - search.page.user_search
+      - views.view.user_admin_people
+      - views.view.who_s_new
+      - views.view.who_s_online
+  actions:
+    user.role.authenticated:
+      grantPermission: 'delete own files'
+    user.role.content_editor:
+      grantPermissionsForEachNodeType:
+        - 'create %bundle content'
+        - 'delete %bundle revisions'
+        - 'delete own %bundle content'
+        - 'edit own %bundle content'
+    user.role.anonymous:
+      # This recipe assumes all published content should be publicly accessible.
+      grantPermission: 'access content'
+    user.settings:
+      simple_config_update:
+        verify_mail: true
+        register: visitors_admin_approval
+        cancel_method: user_cancel_block

--- a/tests/functional/SiteInstallTest.php
+++ b/tests/functional/SiteInstallTest.php
@@ -41,10 +41,14 @@ class SiteInstallTest extends CommandUnishTestCase
     }
 
     /**
-     * Test functionality of installing a site with a core recipe.
+     * Test functionality of installing a site with a recipe.
      */
     public function testSiteInstallRecipe()
     {
+        if (version_compare(\Drupal::VERSION, '10.3.0') < 0) {
+            $this->markTestSkipped('Recipes require Drupal 10.3.0 or later.');
+        }
+
         // Install Drupal with our test recipe.
         $recipeDir = $this->fixturesDir() . '/recipes/test_recipe';
         $this->installDrupal('dev', true, ['profile' => $recipeDir]);

--- a/tests/functional/SiteInstallTest.php
+++ b/tests/functional/SiteInstallTest.php
@@ -62,5 +62,4 @@ class SiteInstallTest extends CommandUnishTestCase
         $roles = $this->getOutputFromJSON();
         $this->assertEquals('Site editor', $roles['content_editor']['label']);
     }
-
 }

--- a/tests/functional/SiteInstallTest.php
+++ b/tests/functional/SiteInstallTest.php
@@ -70,6 +70,10 @@ class SiteInstallTest extends CommandUnishTestCase
             $this->markTestSkipped('We can only test the recipes requirement check on versions prior to Drupal 10.3.0.');
         }
 
+        if ($this->dbDriver() === 'sqlite') {
+            $this->markTestSkipped('This test runs afoul of profile-selection code that does not work right with SQLite, since we have not set up the db-url for this test.');
+        }
+
         $recipeDir = $this->fixturesDir() . '/recipes/test_recipe';
         $this->drush(SiteInstallCommands::INSTALL, [$recipeDir], ['no-interaction' => null], null, null, self::EXIT_ERROR);
         $error_output = $this->getErrorOutput();

--- a/tests/functional/SiteInstallTest.php
+++ b/tests/functional/SiteInstallTest.php
@@ -70,7 +70,8 @@ class SiteInstallTest extends CommandUnishTestCase
             $this->markTestSkipped('We can only test the recipes requirement check on versions prior to Drupal 10.3.0.');
         }
 
-        $this->drush(SiteInstallCommands::INSTALL, ['core/recipes/standard'], ['no-interaction' => null], null, null, self::EXIT_ERROR);
+        $recipeDir = $this->fixturesDir() . '/recipes/test_recipe';
+        $this->drush(SiteInstallCommands::INSTALL, [$recipeDir], ['no-interaction' => null], null, null, self::EXIT_ERROR);
         $error_output = $this->getErrorOutput();
         $this->assertStringContainsString('Recipes are only supported on Drupal 10.3.0 and later.', $error_output);
     }

--- a/tests/functional/SiteInstallTest.php
+++ b/tests/functional/SiteInstallTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Unish;
 
+use Drush\Commands\core\RoleCommands;
 use Drush\Commands\core\StatusCommands;
 use Drush\Commands\sql\SqlCommands;
+use Unish\Utils\Fixtures;
 
 /**
  * @group base
@@ -13,8 +15,10 @@ use Drush\Commands\sql\SqlCommands;
  */
 class SiteInstallTest extends CommandUnishTestCase
 {
+    use Fixtures;
+
     /**
-     * Test functionality of site set.
+     * Test functionality of installing a site with a database prefix.
      */
     public function testSiteInstallPrefix()
     {
@@ -35,4 +39,28 @@ class SiteInstallTest extends CommandUnishTestCase
             $this->assertStringContainsString('1', $output);
         }
     }
+
+    /**
+     * Test functionality of installing a site with a core recipe.
+     */
+    public function testSiteInstallRecipe()
+    {
+        // Install Drupal with our test recipe.
+        $recipeDir = $this->fixturesDir() . '/recipes/test_recipe';
+        $this->installDrupal('dev', true, ['profile' => $recipeDir]);
+
+        // Run 'core-status' and insure that we can bootstrap Drupal.
+        $this->drush(StatusCommands::STATUS, [], ['fields' => 'bootstrap']);
+        $output = $this->getOutput();
+        $this->assertStringContainsString('Successful', $output);
+
+        // Fetch the Content Editor role and see if its label is 'Site Editor'.
+        // The label of Content Editor in the Standard profile & recipe is
+        // 'Content Editor', so if our expectation is satisfied, we know that
+        // we must have installed from our recipe, and not from anywhere else.
+        $this->drush(RoleCommands::LIST, [], ['format' => 'json']);
+        $roles = $this->getOutputFromJSON();
+        $this->assertEquals('Site editor', $roles['content_editor']['label']);
+    }
+
 }

--- a/tests/functional/SiteInstallTest.php
+++ b/tests/functional/SiteInstallTest.php
@@ -66,7 +66,7 @@ class SiteInstallTest extends CommandUnishTestCase
      */
     public function testSiteInstallRecipesNotSupported()
     {
-        if (version_compare(\Drupal::VERSION, '10.3.0') >= 0) {
+        if ($this->isDrupalGreaterThanOrEqualTo('10.3.0')) {
             $this->markTestSkipped('We can only test the recipes requirement check on versions prior to Drupal 10.3.0.');
         }
 
@@ -85,7 +85,7 @@ class SiteInstallTest extends CommandUnishTestCase
      */
     public function testSiteInstallRecipe()
     {
-        if (version_compare(\Drupal::VERSION, '10.3.0') < 0) {
+        if (!$this->isDrupalGreaterThanOrEqualTo('10.3.0')) {
             $this->markTestSkipped('Recipes require Drupal 10.3.0 or later.');
         }
 

--- a/tests/unish/UnishTestCase.php
+++ b/tests/unish/UnishTestCase.php
@@ -678,13 +678,16 @@ EOT;
             'db-url' => $this->dbUrl($uri),
             'sites-subdir' => $uri,
             'yes' => true,
+            'profile' => 'testing', // or path to recipe directory
             // quiet suppresses error reporting as well.
             // 'quiet' => true,
         ];
         if ($level = $this->logLevel()) {
             $options[$level] = true;
         }
-        $process = $this->processManager()->siteProcess($sutAlias, [self::getDrush(), SiteInstallCommands::INSTALL, 'testing', 'install_configure_form.enable_update_status_emails=NULL'], $options);
+        $recipeOrProfile = $options['profile'];
+        unset($options['profile']);
+        $process = $this->processManager()->siteProcess($sutAlias, [self::getDrush(), SiteInstallCommands::INSTALL, $recipeOrProfile, 'install_configure_form.enable_update_status_emails=NULL'], $options);
         // Set long timeout because Xdebug slows everything.
         $process->setTimeout(0);
         $this->process = $process;

--- a/tests/unish/UnishTestCase.php
+++ b/tests/unish/UnishTestCase.php
@@ -678,15 +678,15 @@ EOT;
             'db-url' => $this->dbUrl($uri),
             'sites-subdir' => $uri,
             'yes' => true,
-            'profile' => 'testing', // or path to recipe directory
+            'recipeOrProfile' => 'testing', // or path to recipe directory
             // quiet suppresses error reporting as well.
             // 'quiet' => true,
         ];
         if ($level = $this->logLevel()) {
             $options[$level] = true;
         }
-        $recipeOrProfile = $options['profile'];
-        unset($options['profile']);
+        $recipeOrProfile = $options['recipeOrProfile'];
+        unset($options['recipeOrProfile']);
         $process = $this->processManager()->siteProcess($sutAlias, [self::getDrush(), SiteInstallCommands::INSTALL, $recipeOrProfile, 'install_configure_form.enable_update_status_emails=NULL'], $options);
         // Set long timeout because Xdebug slows everything.
         $process->setTimeout(0);


### PR DESCRIPTION
POC was pretty straightforward. Lightly tested. Seems to work with core standard recipe. Have not tried with Starshot. Additional work may be needed. Needs tests.