### PR TITLE
Remove unused drupalLoggerAdapter code (12.x)

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -25,7 +25,6 @@ use Drush\Runtime\LegacyServiceFinder;
 
 class DrupalBoot8 extends DrupalBoot
 {
-    protected ?LoggrInterface $drupalLoggerAdapter = null;
     protected ?DrupalKernelInterface $kernel = null;
     protected Request $request;
 
@@ -47,23 +46,6 @@ class DrupalBoot8 extends DrupalBoot
     public function getKernel(): DrupalKernelInterface
     {
         return $this->kernel;
-    }
-
-    /**
-     * Sometimes (e.g. in the integration tests), the DrupalBoot
-     * object will be cached, and re-injected into a fresh set
-     * of preflight / bootstrap objects. When this happens, the
-     * new Drush logger will be injected into the boot object. If
-     * this happens after we have created the Drupal logger adapter
-     * (i.e., after bootstrapping Drupal), then we also need to
-     * update the logger reference in that adapter.
-     */
-    public function setLogger(LoggerInterface $logger): void
-    {
-        if ($this->drupalLoggerAdapter) {
-            $this->drupalLoggerAdapter->setLogger($logger);
-        }
-        parent::setLogger($logger);
     }
 
     public function validRoot(?string $path): bool


### PR DESCRIPTION
While trying to track down #6021 I found some dead code in DrupalBoot8.

`drupalLoggerAdapter` is not used anywhere and there is a typo in the type hint `LoggrInterface`. Was introduced in #5481 by mistake.

Phpstan would have caught this - could make sense to set it up?