### PR TITLE
Remove unused drupalLoggerAdapter code

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -25,7 +25,6 @@ use Symfony\Component\HttpKernel\TerminableInterface;
 
 class DrupalBoot8 extends DrupalBoot
 {
-    protected ?LoggerInterface $drupalLoggerAdapter = null;
     protected ?DrupalKernelInterface $kernel = null;
     protected Request $request;
 
@@ -47,23 +46,6 @@ class DrupalBoot8 extends DrupalBoot
     public function getKernel(): DrupalKernelInterface
     {
         return $this->kernel;
-    }
-
-    /**
-     * Sometimes (e.g. in the integration tests), the DrupalBoot
-     * object will be cached, and re-injected into a fresh set
-     * of preflight / bootstrap objects. When this happens, the
-     * new Drush logger will be injected into the boot object. If
-     * this happens after we have created the Drupal logger adapter
-     * (i.e., after bootstrapping Drupal), then we also need to
-     * update the logger reference in that adapter.
-     */
-    public function setLogger(LoggerInterface $logger): void
-    {
-        if ($this->drupalLoggerAdapter && $this->drupalLoggerAdapter instanceof LoggerAwareInterface) {
-            $this->drupalLoggerAdapter->setLogger($logger);
-        }
-        parent::setLogger($logger);
     }
 
     public function validRoot(?string $path): bool


### PR DESCRIPTION
Same as #6028, but for 13.x.

This is unused code not called from anywhere, so can be removed.