### PR TITLE
Add Drush 13 and Drupal 11 in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-or-support-request.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-or-support-request.md
@@ -22,8 +22,8 @@ Is there another way to do the desired action?
 ### System Configuration
 | Q               | A
 | --------------- | ---
-| Drush version?  | 12.x/11.x/10.x/8.x (please be specific, and try latest release)
-| Drupal version? | 10.x/9.x/8.x/7.x
+| Drush version?  | 13.x/12.x/11.x/10.x/8.x (please be specific, and try latest release)
+| Drupal version? | 11.x/10.x/9.x/8.x/7.x
 | PHP version     | 8.x/7.x
 | OS?             | Mac/Linux/Windows
 


### PR DESCRIPTION
Drupal 11 is close to be officially released, and Drush 13 is supported and recommended.

Perhaps going forward, the Drush and Drupal versions in the issue template should be added as soon as dev-versions are created? This task could be added to a checklist, when creating a new Drush version.