### PR TITLE
Fix path to files directory when it is a symlink

### DIFF
--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -382,6 +382,10 @@ final class ArchiveDumpCommands extends DrushCommands
         $process->mustRun();
         $composerInfoRaw = $process->getOutput();
         $installedPackages = json_decode($composerInfoRaw, true)['installed'] ?? [];
+        // Remove path projects ('source' is empty for path projects)
+        $installedPackages = array_filter($installedPackages, function ($dependency) {
+            return !empty($dependency['source']);
+        });
         $installedPackagesPaths = array_filter(array_column($installedPackages, 'path'));
         $installedPackagesRelativePaths = array_map(
             fn($path) => ltrim(str_replace([$this->getComposerRoot()], '', $path), '/'),

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -469,7 +469,11 @@ final class ArchiveDumpCommands extends DrushCommands
      */
     private function getDrupalFilesDir(): string
     {
-        return realpath(Path::join($this->getRoot(), $this->getRelativeDrupalFilesDir()));
+        $filesDir = Path::join($this->getRoot(), $this->getRelativeDrupalFilesDir());
+        if (!file_exists($filesDir)) {
+            throw new \Exception(dt('Drupal files directory does not exist.'));
+        }
+        return realpath($filesDir);
     }
 
     /**
@@ -484,7 +488,7 @@ final class ArchiveDumpCommands extends DrushCommands
         }
 
         Drush::bootstrapManager()->doBootstrap(DrupalBootLevels::FULL);
-        $drupalFilesPath = Path::join($this->getRelativeRoot(), PublicStream::basePath());
+        $drupalFilesPath = PublicStream::basePath();
         if (!$drupalFilesPath) {
             throw new Exception(dt('Path to Drupal files is empty.'));
         }

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -347,17 +347,6 @@ final class ArchiveDumpCommands extends DrushCommands
     }
 
     /**
-     * Return the relative path to the site's docroot.
-     */
-    private function getRelativeRoot(): string
-    {
-        if (!$this->isWebRootSite()) {
-            return '';
-        }
-        return Path::makeRelative($this->getRoot(), $this->getComposerRoot());
-    }
-
-    /**
      * Creates "code" archive component and returns the absolute path.
      *
      * @param array $options

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -462,26 +462,12 @@ final class ArchiveDumpCommands extends DrushCommands
      */
     private function getDrupalFilesDir(): string
     {
-        $filesDir = Path::join($this->getRoot(), $this->getRelativeDrupalFilesDir());
-        if (!file_exists($filesDir)) {
-            throw new \Exception(dt('Drupal files directory does not exist.'));
-        }
-        return realpath($filesDir);
-    }
-
-    /**
-     * Returns the relative path to Drupal files directory.
-     *
-     * @throws \Exception
-     */
-    private function getRelativeDrupalFilesDir(): string
-    {
         if (isset($this->drupalFilesDir)) {
             return $this->drupalFilesDir;
         }
 
         Drush::bootstrapManager()->doBootstrap(DrupalBootLevels::FULL);
-        $drupalFilesPath = PublicStream::basePath();
+        $drupalFilesPath = Path::join($this->getRoot(), PublicStream::basePath());
         if (!$drupalFilesPath) {
             throw new Exception(dt('Path to Drupal files is empty.'));
         }
@@ -597,7 +583,7 @@ final class ArchiveDumpCommands extends DrushCommands
             '#^' . $this->getDocrootRegexpPrefix() . 'sites/.+/settings\..+\.php$#',
         ];
 
-        $drupalFilesPath = $this->getRelativeDrupalFilesDir();
+        $drupalFilesPath = $this->getDrupalFilesDir();
         $drupalFilesPathRelative = Path::makeRelative($drupalFilesPath, $this->getComposerRoot());
         $excludes[] = '#^' . $drupalFilesPathRelative . '$#';
 

--- a/src/Commands/core/ArchiveDumpCommands.php
+++ b/src/Commands/core/ArchiveDumpCommands.php
@@ -469,7 +469,7 @@ final class ArchiveDumpCommands extends DrushCommands
      */
     private function getDrupalFilesDir(): string
     {
-        return realpath($this->getRelativeDrupalFilesDir());
+        return realpath(Path::join($this->getRoot(), $this->getRelativeDrupalFilesDir()));
     }
 
     /**


### PR DESCRIPTION
archive:dump does not do the right thing when sites/default/files is a symlink to a different directory.