### PR TITLE
TypeError when running core:requirements with certain modules (e.g. o365)

### DIFF
--- a/src/Commands/core/DrupalCommands.php
+++ b/src/Commands/core/DrupalCommands.php
@@ -95,7 +95,7 @@ final class DrupalCommands extends DrushCommands
         foreach ($requirements as $key => $info) {
             if (is_numeric($key)) {
                 unset($requirements[$key]);
-                $new_key = strtolower(str_replace(' ', '_', $info['title']));
+                $new_key = strtolower(str_replace(' ', '_', (string) $info['title']));
                 $requirements[$new_key] = $info;
             }
         }


### PR DESCRIPTION
**Describe the bug**

Related to #6052

Following the addition of `strict_type` checking on commandfiles in #5450, running:

```bash
drush core:requirements
```

With certain modules, currently throws an exception:

```
TypeError: str_replace(): Argument #3 ($subject) must be of type array|string, Drupal\Core\StringTranslation\TranslatableMarkup given in /app/application/vendor/drush/drush/src/Commands/core/DrupalCommands.php on line 104 #0 /app/application/vendor/drush/drush/src/Commands/core/DrupalCommands.php(104): str_replace(' ', '_', Object(Drupal\Core\StringTranslation\TranslatableMarkup))
#1 [internal function]: Drush\Commands\core\DrupalCommands->requirements(Array)
#2 /app/application/vendor/consolidation/annotated-command/src/CommandProcessor.php(276): call_user_func_array(Array, Array)
#3 /app/application/vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback(Array, Object(Consolidation\AnnotatedCommand\CommandData))
#4 /app/application/vendor/consolidation/annotated-command/src/CommandProcessor.php(176): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter(Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#5 /app/application/vendor/consolidation/annotated-command/src/AnnotatedCommand.php(391): Consolidation\AnnotatedCommand\CommandProcessor->process(Object(Symfony\Component\Console\Output\ConsoleOutput), Array, Array, Object(Consolidation\AnnotatedCommand\CommandData))
#6 /app/application/vendor/symfony/console/Command/Command.php(326): Consolidation\AnnotatedCommand\AnnotatedCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /app/application/vendor/symfony/console/Application.php(1096): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /app/application/vendor/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand(Object(Consolidation\AnnotatedCommand\AnnotatedCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /app/application/vendor/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /app/application/vendor/drush/drush/src/Runtime/Runtime.php(110): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /app/application/vendor/drush/drush/src/Runtime/Runtime.php(40): Drush\Runtime\Runtime->doRun(Array, Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /app/application/vendor/drush/drush/drush.php(139): Drush\Runtime\Runtime->run(Array)
#13 /app/application/vendor/drush/drush/drush(4): require('/app/applicatio...')
#14 /app/application/vendor/bin/drush(120): include('/app/applicatio...')
#15 {main}
```

**To Reproduce**
Install the `o365` module, or any module which has a [numeric requirement key](https://git.drupalcode.org/project/o365/-/blob/3e43739f/o365.install#L54-59), then running `drush core:requirements` will cause the fatal TypeError to occur.

**Expected behavior**
It should show the requirement status as expected.

**Actual behavior**
A fatal type error is shown.

**Workaround**
N/A. Except patching the module itself to use a non-numeric requirement key.

### System Configuration
| Q               | A
| --------------- | ---
| Drush version?  | 12.5.2.0
| Drupal version? | 10.2.7
| PHP version     | 8.1.28
| OS?             | Linux

**Additional information**
N/A
