### PR TITLE
Autowire Drupal container params and plain values

### DIFF
--- a/src/Commands/AutowireTrait.php
+++ b/src/Commands/AutowireTrait.php
@@ -2,6 +2,9 @@
 
 namespace Drush\Commands;
 
+use Drupal\Component\DependencyInjection\ContainerInterface as DrupalContainer;
+use Drush\Drush;
+use League\Container\Container as DrushContainer;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Exception\AutowiringFailedException;
@@ -16,7 +19,18 @@ use Symfony\Component\DependencyInjection\Exception\AutowiringFailedException;
  */
 trait AutowireTrait
 {
-  /**
+    /**
+     * Limit to service and param or plain value.
+     *
+     * @see \Symfony\Component\DependencyInjection\Attribute\Autowire::__construct
+     */
+    private const ACCEPTED_AUTOWIRE_ARGUMENTS = [
+        0 => 'value',
+        1 => 'service',
+        4 => 'param',
+    ];
+
+    /**
      * Instantiates a new instance of the implementing class using autowiring.
      *
      * @param ContainerInterface $container
@@ -24,23 +38,56 @@ trait AutowireTrait
      *
      * @return static
      */
-    public static function create(ContainerInterface $container)
+    public static function create(ContainerInterface $container, ?ContainerInterface $drushContainer = null): self
     {
         $args = [];
 
         if (method_exists(static::class, '__construct')) {
+            $drushContainer = $container instanceof DrushContainer ? $container : ($drushContainer instanceof DrushContainer ? $drushContainer : Drush::getContainer());
+            $drupalContainer = $container instanceof DrupalContainer ? $container : null;
+
             $constructor = new \ReflectionMethod(static::class, '__construct');
             foreach ($constructor->getParameters() as $parameter) {
-                $service = ltrim((string) $parameter->getType(), '?');
-                foreach ($parameter->getAttributes(Autowire::class) as $attribute) {
-                    $service = (string) $attribute->newInstance()->value;
+                if (!$attributes = $parameter->getAttributes(Autowire::class)) {
+                    // No #[Autowire()] attribute.
+                    $service = ltrim((string) $parameter->getType(), '?');
+                    if (!$drushContainer->has($service)) {
+                        throw new AutowiringFailedException($service, sprintf('Cannot autowire service "%s": argument "$%s" of method "%s::_construct()", you should configure its value explicitly.', $service, $parameter->getName(), static::class));
+                    }
+                    $args[] = $drushContainer->get($service);
+                    continue;
                 }
 
-                if (!$container->has($service)) {
-                    throw new AutowiringFailedException($service, sprintf('Cannot autowire service "%s": argument "$%s" of method "%s::_construct()", you should configure its value explicitly.', $service, $parameter->getName(), static::class));
-                }
+                // This parameter has an #[Autowire()] attribute.
+                [$attribute] = $attributes;
+                $value = null;
+                foreach ($attribute->getArguments() as $key => $argument) {
+                    // Resolve argument name when arguments are passed as list.
+                    if (is_int($key)) {
+                        if ($argument === null || !isset(self::ACCEPTED_AUTOWIRE_ARGUMENTS[$key])) {
+                            continue;
+                        }
+                        $key = self::ACCEPTED_AUTOWIRE_ARGUMENTS[$key];
+                    }
 
-                $args[] = $container->get($service);
+                    if (!in_array($key, self::ACCEPTED_AUTOWIRE_ARGUMENTS, true)) {
+                        continue;
+                    }
+
+                    $value = $attribute->newInstance()->value;
+                    $valueAsString = (string) $value;
+                    $value = match ($key) {
+                        'service' => $drushContainer->has($valueAsString) ? $drushContainer->get($valueAsString) : throw new AutowiringFailedException($valueAsString, sprintf('Cannot autowire service "%s": argument "$%s" of method "%s::_construct()", you should configure its value explicitly.', $valueAsString, $parameter->getName(), static::class)),
+                        // Container param comes as %foo.bar.param%.
+                        'param' => $drupalContainer ? $drupalContainer->getParameter(trim($valueAsString, '%')) : $valueAsString,
+                        default => $value,
+                    };
+                    // Done as Autowire::__construct() only needs one argument.
+                    break;
+                }
+                if ($value !== null) {
+                    $args[] = $value;
+                }
             }
         }
 

--- a/src/Commands/generate/GenerateCommands.php
+++ b/src/Commands/generate/GenerateCommands.php
@@ -8,7 +8,7 @@ use Drush\Attributes as CLI;
 use Drush\Commands\core\DocsCommands;
 use Drush\Commands\DrushCommands;
 use Drush\Commands\help\ListCommands;
-use Psr\Container\ContainerInterface as DrushContainer;
+use League\Container\DefinitionContainerInterface as DrushContainer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
@@ -21,6 +21,7 @@ final class GenerateCommands extends DrushCommands
     protected function __construct(
         private readonly DrushContainer $drush_container,
     ) {
+        parent::__construct();
     }
 
     public static function create(DrushContainer $container): self

--- a/sut/modules/unish/woot/src/AutowireTestService.php
+++ b/sut/modules/unish/woot/src/AutowireTestService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\woot;
+
+final class AutowireTestService implements AutowireTestServiceInterface
+{
+    public function __toString(): string
+    {
+        return 'Hello World!';
+    }
+}

--- a/sut/modules/unish/woot/src/AutowireTestServiceInterface.php
+++ b/sut/modules/unish/woot/src/AutowireTestServiceInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\woot;
+
+interface AutowireTestServiceInterface extends \Stringable {}

--- a/sut/modules/unish/woot/woot.services.yml
+++ b/sut/modules/unish/woot/woot.services.yml
@@ -11,3 +11,9 @@ services:
     class: Drupal\woot\EventSubscriber\PreRowDeleteTestSubscriber
     tags:
       - { name: event_subscriber }
+  woot.autowire_test:
+    class: Drupal\woot\AutowireTestService
+  Drupal\woot\AutowireTestServiceInterface: '@woot.autowire_test'
+
+parameters:
+  foo: bar

--- a/tests/fixtures/lib/CreateExpectsDrupalContainer.php
+++ b/tests/fixtures/lib/CreateExpectsDrupalContainer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Custom\Library;
+
+use Drupal\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Routing\RedirectDestinationInterface;
+use Drush\Commands\DrushCommands;
+use Psr\Log\LoggerInterface;
+
+final class CreateFactoryExpectsDrupalContainer extends DrushCommands
+{
+    public function __construct(
+        public readonly string $string,
+        public readonly RedirectDestinationInterface $redirectDestination,
+    ) {
+        parent::__construct();
+    }
+
+    public static function create(ContainerInterface $container): self
+    {
+        return new self('a string as it is', $container->get('redirect.destination'));
+    }
+}

--- a/tests/fixtures/lib/CreateExpectsDrushContainer.php
+++ b/tests/fixtures/lib/CreateExpectsDrushContainer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Custom\Library;
+
+use Drush\Commands\DrushCommands;
+use League\Container\DefinitionContainerInterface;
+use Psr\Log\LoggerInterface;
+
+final class CreateExpectsDrushContainer extends DrushCommands
+{
+    public function __construct(
+        public readonly string $string,
+        public readonly LoggerInterface $log,
+    ) {
+        parent::__construct();
+    }
+
+    public static function create(DefinitionContainerInterface $container): self
+    {
+        return new self('a string as it is', $container->get('logger'));
+    }
+}

--- a/tests/fixtures/lib/Drush/Commands/AutowireTestCommands.php
+++ b/tests/fixtures/lib/Drush/Commands/AutowireTestCommands.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Custom\Library\Drush\Commands;
+
+use Drupal\woot\AutowireTestService;
+use Drupal\woot\AutowireTestServiceInterface;
+use Drush\Attributes as CLI;
+use Drush\Boot\DrupalBootLevels;
+use Drush\Commands\AutowireTrait;
+use Drush\Commands\DrushCommands;
+use League\Container\ContainerAwareInterface;
+use League\Container\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class AutowireTestCommands extends DrushCommands
+{
+    use AutowireTrait;
+
+    public function __construct(
+        #[Autowire('a string as it is')]
+        private readonly string $argListStringValue,
+        #[Autowire(null, 'woot.autowire_test')]
+        private readonly AutowireTestService $argListContainerService,
+        #[Autowire(null, null, null, null, 'foo')]
+        private readonly string $argListContainerParam,
+        #[Autowire(value: 'a string as it is')]
+        private readonly string $namedArgStringValue,
+        #[Autowire(service: 'woot.autowire_test')]
+        private readonly AutowireTestService $namedArgContainerService,
+        #[Autowire(param: 'foo')]
+        private readonly string $namedArgContainerParam,
+        private readonly AutowireTestServiceInterface $noAutowireAttributeContainerService,
+    ) {
+        parent::__construct();
+    }
+
+    #[CLI\Command(name: 'test_autowire:drupal-container')]
+    #[CLI\Bootstrap(level: DrupalBootLevels::FULL)]
+    #[CLI\Help(hidden: true)]
+    public function drupal(): string
+    {
+        $values = [];
+        $constructor = new \ReflectionMethod($this, '__construct');
+        foreach ($constructor->getParameters() as $param) {
+            $values[] = (string) $this->{$param->getName()};
+        }
+        return implode("\n", $values);
+    }
+
+    #[CLI\Command(name: 'test_autowire:drush-container')]
+    #[CLI\Bootstrap(level: DrupalBootLevels::NONE)]
+    #[CLI\Help(hidden: true)]
+    public function drush(): string
+    {
+        $values = [];
+        $constructor = new \ReflectionMethod($this, '__construct');
+        foreach ($constructor->getParameters() as $param) {
+            $values[] = (string) $this->{$param->getName()};
+        }
+        return implode("\n", $values);
+    }
+}

--- a/tests/integration/AutowireArgumentsTest.php
+++ b/tests/integration/AutowireArgumentsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unish;
+
+use Drupal\woot\AutowireTestService;
+use Drupal\woot\AutowireTestServiceInterface;
+use Drush\Commands\pm\PmCommands;
+use Drush\Drush;
+
+/**
+ * @covers \Drush\Commands\AutowireTrait::create
+ * @group base
+ */
+class AutowireArgumentsTest extends UnishIntegrationTestCase
+{
+    public function testWithDrupalContainer(): void
+    {
+        $this->drush(PmCommands::INSTALL, ['woot']);
+
+        $expected = [
+            // Autowire('a string as it is')
+            'a string as it is',
+            // Autowire(null, 'woot.autowire_test')
+            'Hello World!',
+            // Autowire(null, null, null, null, 'foo')
+            'bar',
+            // Autowire(value: 'a string as it is')
+            'a string as it is',
+            // Autowire(service: 'woot.autowire_test')
+            'Hello World!',
+            // Autowire(param: 'foo')
+            'bar',
+            // Autowire by service full qualified interface name
+            // @see \Drupal\woot\AutowireTestServiceInterface
+            'Hello World!',
+        ];
+
+        $this->drush('test_autowire:drupal-container');
+        $this->assertSame(implode("\n", $expected), $this->getOutput());
+
+        $this->drush(PmCommands::UNINSTALL, ['woot']);
+    }
+
+    // @todo This test will fail because I coudn't find a way to add a new
+    //   service to Drush container.
+    public function testWithDrushContainer(): void
+    {
+        $drushContainer = Drush::getContainer();
+        $drushContainer->add('woot.autowire_test', AutowireTestService::class);
+        $drushContainer->add(AutowireTestServiceInterface::class, AutowireTestService::class);
+        Drush::setContainer($drushContainer);
+
+        $expected = [
+            // Autowire('a string as it is')
+          'a string as it is',
+            // Autowire(null, 'woot.autowire_test')
+          'Hello World!',
+            // Autowire(null, null, null, null, 'foo')
+          'bar',
+            // Autowire(value: 'a string as it is')
+          'a string as it is',
+            // Autowire(service: 'woot.autowire_test')
+          'Hello World!',
+            // Autowire(param: 'foo')
+          'bar',
+            // Autowire by service full qualified interface name
+            // @see \Drupal\woot\AutowireTestServiceInterface
+          'Hello World!',
+        ];
+
+        $this->drush('test_autowire:drush-container');
+        $this->assertSame(implode("\n", $expected), $output);
+    }
+}


### PR DESCRIPTION
Autowiring works now for services but not for Drupal container parameters or even plain values.

It should be possible to autowire Drupal container params and plain values in his way:

```php
public function __construct(
    #[Autowire(param: 'container.modules')]
    protected array $installedModules,
    #[Autowire(value: 'a plain string')]
    protected string $string,
)
{
    parent:: __construct();
}