### PR TITLE
WIP: Fix #6065: Add backtrace to watchdog:show-one

### DIFF
--- a/src/Commands/core/WatchdogCommands.php
+++ b/src/Commands/core/WatchdogCommands.php
@@ -373,7 +373,9 @@ final class WatchdogCommands extends DrushCommands
         if (is_string($variables)) {
             $variables = unserialize($variables);
         }
+        $has_hidden_backtrace = false;
         if (is_array($variables)) {
+            $has_hidden_backtrace = !empty($variables['@backtrace_string']) && !str_contains($result->message, '@backtrace_string');
             $result->message = strtr($result->message, $variables);
         }
         unset($result->variables);
@@ -389,6 +391,10 @@ final class WatchdogCommands extends DrushCommands
                 unset($result->referer);
             }
             $message_length = PHP_INT_MAX;
+
+            if ($has_hidden_backtrace) {
+                $result->backtrace = $variables['@backtrace_string'];
+            }
         }
         $result->message = Unicode::truncate(strip_tags(Html::decodeEntities($result->message)), $message_length);
 


### PR DESCRIPTION
This is a start on #6065, but the output isn't formatted neatly (I think because things are first converted to YAML):
```
wid: '38'
uid: '1'
type: php
message: 'Error: Class "Drupal\dblog\Controller\Foo" not found in Drupal\dblog\Controller\DbLogController->topLogMessages() (line 417 of /var/www/html/core/modules/dblog/src/Controller/DbLogController.php).'
severity: Error
location: 'https://drupal.ddev.site/admin/reports/access-denied'
referer: 'https://drupal.ddev.site/admin/reports'
hostname: 172.21.0.6
date: '16/Jul 10:36'
username: admin
backtrace: "#0 [internal function]: Drupal\\dblog\\Controller\\DbLogController->topLogMessages()\n#1 /var/www/html/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(123): call_user_func_array()\n#2 /var/www/html/core/lib/Drupal/Core/Render/Renderer.php(593): Drupal\\Core\\EventSubscriber\\EarlyRenderingControllerWrapperSubscriber->Drupal\\Core\\EventSubscriber\\{closure}()\n#3 /var/www/html/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(121): Drupal\\Core\\Render\\Renderer->executeInRenderContext()\n#4 /var/www/html/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php(97): Drupal\\Core\\EventSubscriber\\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext()\n#5 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(183): Drupal\\Core\\EventSubscriber\\EarlyRenderingControllerWrapperSubscriber->Drupal\\Core\\EventSubscriber\\{closure}()\n#6 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\\Component\\HttpKernel\\HttpKernel->handleRaw()\n#7 /var/www/html/core/lib/Drupal/Core/StackMiddleware/Session.php(53): Symfony\\Component\\HttpKernel\\HttpKernel->handle()\n#8 /var/www/html/core/lib/Drupal/Core/StackMiddleware/KernelPreHandle.php(48): Drupal\\Core\\StackMiddleware\\Session->handle()\n#9 /var/www/html/core/lib/Drupal/Core/StackMiddleware/ContentLength.php(28): Drupal\\Core\\StackMiddleware\\KernelPreHandle->handle()\n#10 /var/www/html/core/modules/big_pipe/src/StackMiddleware/ContentLength.php(32): Drupal\\Core\\StackMiddleware\\ContentLength->handle()\n#11 /var/www/html/core/modules/page_cache/src/StackMiddleware/PageCache.php(106): Drupal\\big_pipe\\StackMiddleware\\ContentLength->handle()\n#12 /var/www/html/core/modules/page_cache/src/StackMiddleware/PageCache.php(85): Drupal\\page_cache\\StackMiddleware\\PageCache->pass()\n#13 /var/www/html/core/lib/Drupal/Core/StackMiddleware/ReverseProxyMiddleware.php(48): Drupal\\page_cache\\StackMiddleware\\PageCache->handle()\n#14 /var/www/html/core/lib/Drupal/Core/StackMiddleware/NegotiationMiddleware.php(51): Drupal\\Core\\StackMiddleware\\ReverseProxyMiddleware->handle()\n#15 /var/www/html/core/lib/Drupal/Core/StackMiddleware/AjaxPageState.php(36): Drupal\\Core\\StackMiddleware\\NegotiationMiddleware->handle()\n#16 /var/www/html/core/lib/Drupal/Core/StackMiddleware/StackedHttpKernel.php(51): Drupal\\Core\\StackMiddleware\\AjaxPageState->handle()\n#17 /var/www/html/core/lib/Drupal/Core/DrupalKernel.php(709): Drupal\\Core\\StackMiddleware\\StackedHttpKernel->handle()\n#18 /var/www/html/index.php(19): Drupal\\Core\\DrupalKernel->handle()\n#19 {main}"
```

Would welcome help from someone who understands the drush output system a little better. I did quickly see if I could make `backtrace` an array of lines, which displays ok if you run `drush wd-one` but not when you do `drush wd-one --field=backtrace`.

Thanks!

Fixes #6065.