### PR TITLE
Fix return type of Drush\Commands\DrushCommands::logger()

### DIFF
--- a/src/Commands/DrushCommands.php
+++ b/src/Commands/DrushCommands.php
@@ -13,7 +13,6 @@ use Drush\Attributes as CLI;
 use Drush\Config\ConfigAwareTrait;
 use Drush\Drush;
 use Drush\Exec\ExecTrait;
-use Drush\Log\DrushLoggerManager;
 use Drush\SiteAlias\ProcessManager;
 use Drush\Style\DrushStyle;
 use GuzzleHttp\HandlerStack;
@@ -21,6 +20,7 @@ use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Middleware;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Robo\Common\IO;
 use Robo\Contract\ConfigAwareInterface;
 use Robo\Contract\IOAwareInterface;
@@ -71,9 +71,9 @@ abstract class DrushCommands implements IOAwareInterface, LoggerAwareInterface, 
     /**
      * Returns a logger object.
      */
-    public function logger(): ?DrushLoggerManager
+    public function logger(): ?LoggerInterface
     {
-        assert(is_null($this->logger) || $this->logger instanceof DrushLoggerManager);
+        assert(is_null($this->logger) || $this->logger instanceof LoggerInterface);
         return $this->logger;
     }
 


### PR DESCRIPTION
Since Drush 13, I get the following error when running any Drush command:
```
AssertionError: assert(is_null($this->logger) || $this->logger instanceof DrushLoggerManager) in assert() (line 76 of /Users/dieterholvoet/Projects/sites-personal/whathappens/vendor/drush/drush/src/Commands/DrushCommands.php)
```

It's caused by `Drupal\ultimate_cron\Commands\UltimateCronCommands` of the Ultimate Cron module assigning a Drupal logger to `$this->logger`. Is there any reason the return type is `Drush\Log\DrushLoggerManager` and not `Psr\Log\LoggerInterface`?