### PR TITLE
Correct quick start crontab entry

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -8,7 +8,7 @@ Quick start
 
 If you just want to get started quickly, here is a crontab entry that will run cron once every hour at ten minutes after the hour:
 
-    10 * * * * cd [DOCROOT] && /usr/bin/env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin COLUMNS=72 ../vendor/bin/drush --uri=your.drupalsite.org --quiet maint:status && /vendor/bin/drush --uri=your.drupalsite.org --quiet cron
+    10 * * * * cd [DOCROOT] && /usr/bin/env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin COLUMNS=72 ../vendor/bin/drush --uri=your.drupalsite.org --quiet maint:status && /usr/bin/env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin COLUMNS=72 ../vendor/bin/drush --uri=your.drupalsite.org --quiet cron
 
 You should set up crontab to run your cron tasks as the same user that runs the web server; for example, if you run your web server as the user www-data:
 


### PR DESCRIPTION
In the documentation a quick start example is provided, but if I'm not mistaken:
- the use of `/usr/bin/env` should also be applied when executing `drush cron` (similar to `drush maint:status`), and
- `../vendor/bin/drush` should be used to run `drush cron` (similar to `drush maint:status`).