### PR TITLE
Update SiteInstallCommands.php

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -98,7 +98,7 @@ final class SiteInstallCommands extends DrushCommands
         // Was giving error during validate() so its here for now.
         if ($options['existing-config']) {
             $existing_config_dir = Settings::get('config_sync_directory');
-            if (!is_dir($existing_config_dir)) {
+            if ($existing_config_dir === null || !is_dir($existing_config_dir)) {
                 throw new \Exception(dt('Existing config directory @dir not found', ['@dir' => $existing_config_dir]));
             }
             $this->logger()->info(dt('Installing from existing config at @dir', ['@dir' => $existing_config_dir]));


### PR DESCRIPTION
Just a quick win to save the bummer of a fatal error, cause ::get can return `null`, which `is_dir` doesn't like at all.