### PR TITLE
Improve logging when installing modules

### DIFF
--- a/src/Commands/pm/PmCommands.php
+++ b/src/Commands/pm/PmCommands.php
@@ -8,11 +8,14 @@ use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\Extension;
 use Drupal\Core\Extension\MissingDependencyException;
 use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Extension\ThemeHandlerInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
 use Drush\Attributes as CLI;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
@@ -93,7 +96,20 @@ final class PmCommands extends DrushCommands
         if (batch_get()) {
             drush_backend_batch_process();
         }
-        $this->logger()->success(dt('Successfully installed: !list', $todo_str));
+
+        $moduleData = $this->getExtensionListModule()->getList();
+        foreach ($todo as $moduleName) {
+            $links = $this->getModuleLinks($moduleData[$moduleName]);
+            $links = array_map(function ($link) {
+                return sprintf('<href=%s>%s</>', $link->getUrl()->setAbsolute()->toString(), $link->getText());
+            }, $links);
+
+            if ($links === []) {
+                $this->logger()->success(dt('Module %name has been enabled.', ['%name' => $moduleName]));
+            } else {
+                $this->logger()->success(dt('Module %name has been enabled. (%links)', ['%name' => $moduleName, '%links' => implode(' - ', $links)]));
+            }
+        }
     }
 
     /**
@@ -370,5 +386,30 @@ final class PmCommands extends DrushCommands
             }
         }
         return $module_list;
+    }
+
+    protected function getModuleLinks(Extension $module): array
+    {
+        $links = [];
+
+        // Generate link for module's help page. Assume that if a hook_help()
+        // implementation exists then the module provides an overview page, rather
+        // than checking to see if the page exists, which is costly.
+        if ($this->getModuleHandler()->moduleExists('help') && $module->status && $this->getModuleHandler()->hasImplementations('help', $module->getName())) {
+            $links[] = Link::fromTextAndUrl(dt('Help'), Url::fromRoute('help.page', ['name' => $module->getName()]));
+        }
+
+        // Generate link for module's permission, if the user has access to it.
+        if ($module->status && \Drupal::service('user.permissions')->moduleProvidesPermissions($module->getName())) {
+            $links[] = Link::fromTextAndUrl(dt('Permissions'), Url::fromRoute('user.admin_permissions.module', ['modules' => $module->getName()]));
+        }
+
+        // Generate link for module's configuration page, if it has one.
+        if ($module->status && isset($module->info['configure'])) {
+            $route_parameters = $module->info['configure_parameters'] ?? [];
+            $links[] = Link::fromTextAndUrl(dt('Configure'), Url::fromRoute($module->info['configure'], $route_parameters));
+        }
+
+        return $links;
     }
 }

--- a/src/Commands/pm/PmCommands.php
+++ b/src/Commands/pm/PmCommands.php
@@ -105,9 +105,9 @@ final class PmCommands extends DrushCommands
             }, $links);
 
             if ($links === []) {
-                $this->logger()->success(dt('Module %name has been enabled.', ['%name' => $moduleName]));
+                $this->logger()->success(dt('Module %name has been installed.', ['%name' => $moduleName]));
             } else {
-                $this->logger()->success(dt('Module %name has been enabled. (%links)', ['%name' => $moduleName, '%links' => implode(' - ', $links)]));
+                $this->logger()->success(dt('Module %name has been installed. (%links)', ['%name' => $moduleName, '%links' => implode(' - ', $links)]));
             }
         }
     }
@@ -399,7 +399,7 @@ final class PmCommands extends DrushCommands
             $links[] = Link::fromTextAndUrl(dt('Help'), Url::fromRoute('help.page', ['name' => $module->getName()]));
         }
 
-        // Generate link for module's permission, if the user has access to it.
+        // Generate link for module's permissions page.
         if ($module->status && \Drupal::service('user.permissions')->moduleProvidesPermissions($module->getName())) {
             $links[] = Link::fromTextAndUrl(dt('Permissions'), Url::fromRoute('user.admin_permissions.module', ['modules' => $module->getName()]));
         }

--- a/src/Commands/pm/PmCommands.php
+++ b/src/Commands/pm/PmCommands.php
@@ -16,6 +16,7 @@ use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Extension\ThemeHandlerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Drupal\user\PermissionHandlerInterface;
 use Drush\Attributes as CLI;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
@@ -36,7 +37,8 @@ final class PmCommands extends DrushCommands
         protected ModuleInstallerInterface $moduleInstaller,
         protected ModuleHandlerInterface $moduleHandler,
         protected ThemeHandlerInterface $themeHandler,
-        protected ModuleExtensionList $extensionListModule
+        protected ModuleExtensionList $extensionListModule,
+        protected PermissionHandlerInterface $permissionHandler
     ) {
         parent::__construct();
     }
@@ -64,6 +66,11 @@ final class PmCommands extends DrushCommands
     public function getExtensionListModule(): ModuleExtensionList
     {
         return $this->extensionListModule;
+    }
+
+    public function getPermissionHandler(): PermissionHandlerInterface
+    {
+        return $this->permissionHandler;
     }
 
     /**
@@ -400,7 +407,7 @@ final class PmCommands extends DrushCommands
         }
 
         // Generate link for module's permissions page.
-        if ($module->status && \Drupal::service('user.permissions')->moduleProvidesPermissions($module->getName())) {
+        if ($module->status && $this->getPermissionHandler()->moduleProvidesPermissions($module->getName())) {
             $links[] = Link::fromTextAndUrl(dt('Permissions'), Url::fromRoute('user.admin_permissions.module', ['modules' => $module->getName()]));
         }
 


### PR DESCRIPTION
I had an idea for improved logging when installing modules. I thought it would be useful to render help/permissions/configure links as done on the admin/modules page. This did require me to split up the success message into one module per line, instead of logging it as a comma separated list. I also changed the success message to be the same as the one when enabling through the UI.

![CleanShot 2024-09-10 at 12 04 31](https://github.com/user-attachments/assets/0295f387-5561-4666-96ea-d0560e5e0c83)

Let me know if you like the change, if so I'll further clean up the PR.