### PR TITLE
Remove use of non-existing class Drush\Drupal\Commands\sql\Exit;

### DIFF
--- a/src/Commands/sql/sanitize/SanitizePluginInterface.php
+++ b/src/Commands/sql/sanitize/SanitizePluginInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drush\Commands\sql\sanitize;
 
 use Consolidation\AnnotatedCommand\CommandData;
-use Drush\Drupal\Commands\sql\Exit;
 use Symfony\Component\Console\Input\InputInterface;
 
 /**


### PR DESCRIPTION
Closes #6113