### PR TITLE
Disable xdebug by default to improve performance

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -27,4 +27,4 @@ web_environment:
 #  - UNISH_DB_URL=pgsql://db:db@db:5432?module=pgsql
   - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL
   - EDITOR=nano
-  - DRUSH_ALLOW_XDEBUG=0
+  - DRUSH_ALLOW_XDEBUG=1

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -27,3 +27,4 @@ web_environment:
 #  - UNISH_DB_URL=pgsql://db:db@db:5432?module=pgsql
   - DRUSH_OPTIONS_URI=$DDEV_PRIMARY_URL
   - EDITOR=nano
+  - DRUSH_ALLOW_XDEBUG=0

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "security": "https://github.com/drush-ops/drush/security/advisories"
   },
   "bin": [
-    "drush"
+    "drush",
+    "drush.php"
   ],
   "repositories": {
     "drupal_org": {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -151,3 +151,11 @@ With this configuration in place, global commands may be placed as described in 
         1. The directory above `Commands` must be one of:
             1.  A Folder listed in the 'include' option. Include may be provided via [config](#global-drush-commands) or via CLI.
             1.  ../drush, /drush or /sites/all/drush. These paths are relative to Drupal root.
+
+Xdebug
+------------
+
+Drush disables Xdebug by default. This improves performance substantially, because developers are often debugging something other than Drush and they still need to clear caches, import config, etc. There are two equivalent ways to override Drush's disabling of Xdebug:
+
+- Pass the `--xdebug` global option.
+- Set an environment variable: `DRUSH_ALLOW_XDEBUG=1 drush [command]`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,11 +32,3 @@ $ drush sql:sync --structure-tables-key=custom @live @self
 ```
 
 See [Site aliases](site-aliases.md) for more information.
-
-Xdebug
-------------
-
-Drush disables Xdebug by default. This improves performance substantially, because developers are often debugging something other than Drush and they still need to clear caches, import config, etc. There are two equivalent ways to override Drush's disabling of Xdebug:
-
-- Set an environment variable: `DRUSH_ALLOW_XDEBUG=1 drush [command]`
-- Call `vendor/bin/drush.php` instead of `vendor/bin/drush`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,3 +32,12 @@ $ drush sql:sync --structure-tables-key=custom @live @self
 ```
 
 See [Site aliases](site-aliases.md) for more information.
+
+Xdebug
+------------
+
+Drush disables xdebug by default. This improves performance substantially. You may override this feature by setting an environment variable.
+
+```
+DRUSH_ALLOW_XDEBUG=1 drush [command]
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,8 +36,7 @@ See [Site aliases](site-aliases.md) for more information.
 Xdebug
 ------------
 
-Drush disables xdebug by default. This improves performance substantially. You may override this feature by setting an environment variable.
+Drush disables Xdebug by default. This improves performance substantially, because developers are often debugging something other than Drush and they still need to clear caches, import config, etc. There are two equivalent ways to override Drush's disabling of Xdebug:
 
-```
-DRUSH_ALLOW_XDEBUG=1 drush [command]
-```
+- Set an environment variable: `DRUSH_ALLOW_XDEBUG=1 drush [command]`
+- Call `vendor/bin/drush.php` instead of `vendor/bin/drush`.

--- a/drush
+++ b/drush
@@ -9,6 +9,23 @@ else
   DRUSH_PHP="$COMPOSER_RUNTIME_BIN_DIR/drush.php"
 fi
 
+parse_commandline()
+{
+	while test $# -gt 0
+	do
+		_key="$1"
+		case "$_key" in
+			--xdebug)
+				DRUSH_ALLOW_XDEBUG=1
+				return
+				;;
+		esac
+		shift
+	done
+}
+
+parse_commandline "$@"
+
 if [ "$DRUSH_ALLOW_XDEBUG" != 1 ]
 then
   export XDEBUG_MODE=off

--- a/drush
+++ b/drush
@@ -1,11 +1,16 @@
 #!/usr/bin/env sh
 
-# @see https://stackoverflow.com/questions/4774054
-SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+if [ -z "$COMPOSER_RUNTIME_BIN_DIR" ]; then
+  # @see https://stackoverflow.com/questions/4774054
+  SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+  DRUSH_PHP="$SCRIPTPATH/drush.php"
+else
+  DRUSH_PHP="$COMPOSER_RUNTIME_BIN_DIR/drush.php"
+fi
 
 if [ "$DRUSH_ALLOW_XDEBUG" != 1 ]
 then
   export XDEBUG_MODE=off
 fi
 
-php "${SCRIPTPATH}/drush.php" "$@"
+php "${DRUSH_PHP}" "$@"

--- a/drush
+++ b/drush
@@ -13,4 +13,4 @@ then
   export XDEBUG_MODE=off
 fi
 
-php "${DRUSH_PHP}" "$@"
+"$DRUSH_PHP" "$@"

--- a/drush
+++ b/drush
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
 if [ -z "$COMPOSER_RUNTIME_BIN_DIR" ]; then
+  # This branch is for the development of Drush itself.
   # @see https://stackoverflow.com/questions/4774054
   SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
   DRUSH_PHP="$SCRIPTPATH/drush.php"

--- a/drush
+++ b/drush
@@ -1,4 +1,11 @@
-#!/usr/bin/env php
-<?php
+#!/usr/bin/env sh
 
-require __DIR__ . '/drush.php';
+# @see https://stackoverflow.com/questions/4774054
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+if [ "$DRUSH_ALLOW_XDEBUG" != 1 ]
+then
+  export XDEBUG_MODE=off
+fi
+
+php "${SCRIPTPATH}/drush.php" "$@"

--- a/drush.bat
+++ b/drush.bat
@@ -1,5 +1,0 @@
-@ECHO OFF
-REM Running this file is equivalent to running `php drush`
-setlocal DISABLEDELAYEDEXPANSION
-SET BIN_TARGET=%~dp0drush
-php "%BIN_TARGET%" %*

--- a/drush.php
+++ b/drush.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 use Drush\Drush;

--- a/src/Application.php
+++ b/src/Application.php
@@ -88,6 +88,11 @@ class Application extends SymfonyApplication implements LoggerAwareInterface, Co
             ->addOption(
                 new InputOption('--define', '-D', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Define a configuration item value.', [])
             );
+
+        $this->getDefinition()
+            ->addOption(
+                new InputOption('--xdebug', null, InputOption::VALUE_NONE, 'Drush turns off Xdebug to achieve better performance. Pass this option to keep Xdebug enabled.')
+            );
     }
 
     public function bootstrapManager()

--- a/src/Config/ConfigLocator.php
+++ b/src/Config/ConfigLocator.php
@@ -263,7 +263,13 @@ class ConfigLocator
         // Remember that we've seen this location.
         $this->siteRoots[] = $siteRoot;
 
-        $this->addConfigPaths(self::DRUPAL_CONTEXT, [ dirname($siteRoot) . '/drush', "$siteRoot/drush", "$siteRoot/sites/all/drush" ]);
+        $paths = [
+            dirname($siteRoot) . '/drush',
+            "$siteRoot/drush",
+            "$siteRoot/sites/all/drush",
+        ];
+        $paths = array_filter($paths, is_dir(...));
+        $this->addConfigPaths(self::DRUPAL_CONTEXT, $paths);
         return $this;
     }
 

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -255,7 +255,7 @@ class Preflight
         // Now that we know the value, set debug flag.
         $this->logger()->setDebug($this->preflightArgs->get(PreflightArgs::DEBUG, false));
 
-        // Give hint if a developer might be trying to debug Drush
+        // Give hint if a developer might be trying to debug Drush.
         if (extension_loaded('xdebug')) {
             $this->logger()->log(strtr('If you are trying to perform step debugging of Drush, see !url', ['!url' => 'https://www.drush.org/latest/usage/#xdebug']));
         }

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -256,7 +256,7 @@ class Preflight
         $this->logger()->setDebug($this->preflightArgs->get(PreflightArgs::DEBUG, false));
 
         // Give hint if a developer might be trying to debug Drush
-        if (extension_loaded('xdebug') || empty(ini_get('xdebug.mode'))) {
+        if (extension_loaded('xdebug')) {
             $this->logger()->log(strtr('If you are trying to perform step debugging of Drush, see !url', ['!url' => 'https://www.drush.org/latest/usage/#xdebug']));
         }
 

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -257,7 +257,7 @@ class Preflight
 
         // Give hint if a developer might be trying to debug Drush.
         if (extension_loaded('xdebug')) {
-            $this->logger()->log(strtr('If you are trying to perform step debugging of Drush, see !url', ['!url' => 'https://www.drush.org/latest/usage/#xdebug']));
+            $this->logger()->log(strtr('Drush disables Xdebug by default. To override this, see !url', ['!url' => 'https://www.drush.org/latest/commands/#xdebug']));
         }
 
         // Do legacy initialization (load static includes, define old constants, etc.)

--- a/src/Preflight/Preflight.php
+++ b/src/Preflight/Preflight.php
@@ -255,6 +255,11 @@ class Preflight
         // Now that we know the value, set debug flag.
         $this->logger()->setDebug($this->preflightArgs->get(PreflightArgs::DEBUG, false));
 
+        // Give hint if a developer might be trying to debug Drush
+        if (extension_loaded('xdebug') || empty(ini_get('xdebug.mode'))) {
+            $this->logger()->log(strtr('If you are trying to perform step debugging of Drush, see !url', ['!url' => 'https://www.drush.org/latest/usage/#xdebug']));
+        }
+
         // Do legacy initialization (load static includes, define old constants, etc.)
         $this->init();
 

--- a/tests/functional/SqlSyncTest.php
+++ b/tests/functional/SqlSyncTest.php
@@ -53,14 +53,14 @@ class SqlSyncTest extends CommandUnishTestCase
         $this->drush(SqlSyncCommands::SYNC, ['@synctest.remote', '@synctest.local'], $options, '@synctest.local');
         $output = $this->getSimplifiedErrorOutput();
         $this->assertStringContainsString("[notice] Simulating: ssh -o PasswordAuthentication=whatever www-admin@server.isp.simulated '/path/to/drush sql:dump --no-interaction --strict=0 --gzip --result-file=auto --format=json --uri=remote", $output);
-        $this->assertStringContainsString("[notice] Simulating: __DIR__/drush core:rsync @synctest.remote:/simulated/path/to/dump.tgz @synctest.local:__SANDBOX__/tmp/dump.tgz --yes --uri=local -- --remove-source-files", $output);
-        $this->assertStringContainsString("[notice] Simulating: __DIR__/drush sql:query --no-interaction --strict=0 --file=__SANDBOX__/tmp/dump.tgz --file-delete --uri=local", $output);
+        $this->assertStringContainsString("[notice] Simulating: __DIR__/drush.php core:rsync @synctest.remote:/simulated/path/to/dump.tgz @synctest.local:__SANDBOX__/tmp/dump.tgz --yes --uri=local -- --remove-source-files", $output);
+        $this->assertStringContainsString("[notice] Simulating: __DIR__/drush.php sql:query --no-interaction --strict=0 --file=__SANDBOX__/tmp/dump.tgz --file-delete --uri=local", $output);
 
         // Test simulated simple sql:sync local-to-remote
         $this->drush(SqlSyncCommands::SYNC, ['@synctest.local', '@synctest.remote'], $options, '@synctest.local');
         $output = $this->getSimplifiedErrorOutput();
-        $this->assertStringContainsString("[notice] Simulating: __DIR__/drush sql:dump --no-interaction --strict=0 --gzip --result-file=auto --format=json --uri=local", $output);
-        $this->assertStringContainsString("[notice] Simulating: __DIR__/drush core:rsync @synctest.local:/simulated/path/to/dump.tgz @synctest.remote:/tmp/dump.tgz --yes --uri=local -- --remove-source-files", $output);
+        $this->assertStringContainsString("[notice] Simulating: __DIR__/drush.php sql:dump --no-interaction --strict=0 --gzip --result-file=auto --format=json --uri=local", $output);
+        $this->assertStringContainsString("[notice] Simulating: __DIR__/drush.php core:rsync @synctest.local:/simulated/path/to/dump.tgz @synctest.remote:/tmp/dump.tgz --yes --uri=local -- --remove-source-files", $output);
         $this->assertStringContainsString("[notice] Simulating: ssh -o PasswordAuthentication=whatever www-admin@server.isp.simulated '/path/to/drush sql:query --no-interaction --strict=0 --file=/tmp/dump.tgz --file-delete --uri=remote'", $output);
 
         // Test simulated remote invoke with a remote runner.


### PR DESCRIPTION
Xdebug maybe enabled in the dev environment, but most of the time its not the goal to debug drush commands. 

Speeds up drush cr, cex  tremendously.

This feature was in the old Drush Launcher. The implementationn in this PR is simpler, due to Xdebug 3.

PHPStan and Composer also disable by default.