### PR TITLE
Use the mariadb executable for SQL commands where possible

### DIFF
--- a/src/Sql/SqlMariaDB.php
+++ b/src/Sql/SqlMariaDB.php
@@ -10,6 +10,14 @@ class SqlMariaDB extends SqlMysql
 {
     use ExecTrait;
 
+    public function command(): string
+    {
+        if (self::programExists('mariadb')) {
+            return 'mariadb';
+        }
+        return parent::command();
+    }
+
     public function dumpProgram(): string
     {
         if (self::programExists('mariadb-dump')) {


### PR DESCRIPTION
On newer versions of MariaDB e.g. 11.4.3, the following warning is shown:
```
mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
```