### PR TITLE
Allow for a custom release XML base URL in pm-updatecode

### DIFF
--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -361,6 +361,8 @@ function pm_drush_command() {
       'projects' => 'Optional. A list of installed projects to update.',
     ),
     'options' => array(
+      // source is passed along to pm-updatestatus command.
+      'source' => 'The base URL which provides project release history in XML. Defaults to http://updates.drupal.org/release-history.',
       'notes' => 'Show release notes for each project to be updated.',
       'no-core' => 'Only update modules and skip the core update.',
       'check-updatedb' => 'Check to see if an updatedb is needed after updating the code. Default is on; use --check-updatedb=0 to disable.',

--- a/commands/pm/pm.drush.inc
+++ b/commands/pm/pm.drush.inc
@@ -336,6 +336,7 @@ function pm_drush_command() {
     ),
     'options' => array(
       'pipe' => 'Return a list of the projects with any extensions enabled that need updating, one project per line.',
+      'source' => 'The base URL which provides project release history in XML. Defaults to http://updates.drupal.org/release-history.',
     ) + $update_options,
     'sub-options' => $update_suboptions,
     'engines' => array(

--- a/commands/pm/updatecode.pm.inc
+++ b/commands/pm/updatecode.pm.inc
@@ -31,7 +31,7 @@ function drush_pm_updatecode() {
   // Print report of modules to update, and record
   // result of that function in $update_info.
   $updatestatus_options = array();
-  foreach (array('lock', 'unlock', 'lock-message', 'update-backend', 'check-disabled', 'security-only') as $option) {
+  foreach (array('lock', 'unlock', 'lock-message', 'update-backend', 'check-disabled', 'security-only', 'source') as $option) {
     $value = drush_get_option($option, FALSE);
     if ($value) {
       $updatestatus_options[$option] = $value;
@@ -406,4 +406,3 @@ function drush_pm_updatecode_rollback() {
     drush_delete_dir($drupal_core['full_project_path']);
   }
 }
-

--- a/lib/Drush/UpdateService/Project.php
+++ b/lib/Drush/UpdateService/Project.php
@@ -114,7 +114,7 @@ class Project {
    * @see \Drupal\update\UpdateFetcher::buildFetchUrl()
    */
   public static function buildFetchUrl(array $request) {
-    $status_url = isset($request['status url']) ? $request['status url'] : ReleaseInfo::DEFAULT_URL;
+    $status_url = isset($request['status url']) ? $request['status url'] : drush_get_option('source', ReleaseInfo::DEFAULT_URL);
     $drupal_version = $request['drupal_version'];
     if (drush_drupal_major_version() >= 8) {
       $drupal_version = 'current';


### PR DESCRIPTION
To test: `./drush pm-updatestatus -r ~/reps/tag1/d7  --debug --source=https://cnn.com`. Then look in the logs for something like `Executing: wget -q --timeout=30 -O /Users/weitzman/tmp/download_fileQoaHoo https://cnn.com/drupal/7.x`