### PR TITLE
Fix xdebug handling for sub processes

### DIFF
--- a/drush
+++ b/drush
@@ -16,7 +16,7 @@ parse_commandline()
 		_key="$1"
 		case "$_key" in
 			--xdebug)
-				DRUSH_ALLOW_XDEBUG=1
+				export DRUSH_ALLOW_XDEBUG=1
 				return
 				;;
 		esac


### PR DESCRIPTION
The xdebug session is dropped for drush subprocesses. Use export to make it persistent.