### PR TITLE
Replace subshell with exec

### DIFF
--- a/drush
+++ b/drush
@@ -31,4 +31,4 @@ then
   export XDEBUG_MODE=off
 fi
 
-"$DRUSH_PHP" "$@"
+exec "$DRUSH_PHP" "$@"


### PR DESCRIPTION
Related to https://github.com/drush-ops/drush/issues/6137

---

This replaces the sub-process with exec, so the signals are treated correctly. But it won't fix the issue if drush is invoked from ```./vendor/bin/drush``` (the composer wrapper script, creates a sub-process too).