### PR TITLE
Correcting user:role:remove role description

### DIFF
--- a/src/Commands/core/UserCommands.php
+++ b/src/Commands/core/UserCommands.php
@@ -184,7 +184,7 @@ final class UserCommands extends DrushCommands
      * Remove a role from the specified user accounts.
      */
     #[CLI\Command(name: self::ROLE_REMOVE, aliases: ['urrol', 'user-remove-role'])]
-    #[CLI\Argument(name: 'role', description: 'The machine name of the role to add.')]
+    #[CLI\Argument(name: 'role', description: 'The machine name of the role to remove.')]
     #[CLI\Argument(name: 'names', description: 'A comma delimited list of user names.')]
     #[CLI\Option(name: 'uid', description: 'A comma delimited list of user ids to lookup (an alternative to names).')]
     #[CLI\Option(name: 'mail', description: 'A comma delimited list of emails to lookup (an alternative to names).')]


### PR DESCRIPTION
role description says add when it should say remove. Changing this will make the description accurately describe the action being taken. In this case the machine name of the role to remove.