### PR TITLE
Update deploy documentation to clarify that the Drupal API isn't completely unavailable

### DIFF
--- a/docs/deploycommand.md
+++ b/docs/deploycommand.md
@@ -13,15 +13,20 @@ drush deploy:hook
 ```
 
 ## Authoring update functions
-Below are the 3 types of update functions run by this command, in order. Choose the most appropriate for your need. 
+Below are the 3 types of update functions run by this command, in order. Choose the most appropriate for your
+need. **Exercise caution when implementing `HOOK_update_N()`** — the full API isn't available to you, see [the
+documentation][HOOK_update_N()] for more details.
 
-| Function | Drupal API | Purpose |
+
+| Function | Provided by | Purpose |
 | --- | --- | --- |
-| [HOOK_update_n()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_update_N) | Not allowed | Low level changes. |
-| [HOOK_post_update_NAME()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_post_update_NAME) | Allowed | Runs *before* config is imported. |
-| [HOOK_deploy_NAME()](https://github.com/drush-ops/drush/tree/HEAD/drush.api.php) | Allowed | Runs *after* config is imported. | 
+| [HOOK_update_N()] | Drupal | Low level changes. |
+| [HOOK_post_update_NAME()](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_post_update_NAME) | Drupal | Runs *before* config is imported. |
+| [HOOK_deploy_NAME()](https://github.com/drush-ops/drush/tree/HEAD/drush.api.php) | Drush | Runs *after* config is imported. | 
 
 ## Configuration
 
 If you need to customize this command, you should use Drush configuration for the 
 subcommands listed above (e.g. [updatedb](commands/updatedb.md), [config:import](commands/config_import.md), etc.).
+
+[HOOK_update_N()]: https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_update_N


### PR DESCRIPTION
This was triggered by [a Slack conversation](https://drupal.slack.com/archives/C62H9CWQM/p1730311183659209) where someone was uncertain exactly what it meant when the page said the Drupal API was not allowed. I think this could be particularly confusing if you aren't already primed on writing `hook_update_N()` implementations.

Just a suggestion, not entirely sure it's better...

Oh and I also muddied the waters by adding in whether it's implemented by Drupal or not. A contrib author might not realize they can't rely on the deploy hook, so I thought we could maybe add that.

Thanks!