### PR TITLE
Relax auto-discoverable command file/class naming convention

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -90,7 +90,7 @@ Such commands are auto-discovered by their class PSR4 namespace and class/file n
   }
   ```
   then the Drush global commands class namespace should be `My\Custom\Library\Drush\Commands` and the class file should be located under the `src/Drush/Commands` directory.
-* The class and file name ends with `*DrushCommands`, e.g. `FooDrushCommands`.
+* The class and file name ends with `*Commands`, e.g. `FooCommands`.
 
 Auto-discovered commandfiles should declare their Drush version compatibility via a `conflict` directive. For example, a Composer-managed site-wide command that works with both Drush 11 and Drush 12 might contain something similar to the following in its composer.json file:
 ```json

--- a/src/Runtime/ServiceManager.php
+++ b/src/Runtime/ServiceManager.php
@@ -179,7 +179,7 @@ class ServiceManager
     {
         $classes = (new RelativeNamespaceDiscovery($this->autoloader))
             ->setRelativeNamespace('Drush\Commands')
-            ->setSearchPattern('/.*DrushCommands\.php$/')
+            ->setSearchPattern('/.*Commands\.php$/')
             ->getClasses();
 
         return array_filter($classes, function (string $class): bool {

--- a/tests/fixtures/lib/Drush/Commands/CustomCommands.php
+++ b/tests/fixtures/lib/Drush/Commands/CustomCommands.php
@@ -3,15 +3,15 @@
 namespace Custom\Library\Drush\Commands;
 
 use Drush\Commands\DrushCommands;
+use Drush\Attributes as CLI;
 
-class CustomDrushCommands extends DrushCommands
+class CustomCommands extends DrushCommands
 {
     /**
      * Auto-discoverable custom command. Used for Drush testing.
-     *
-     * @command custom_cmd
-     * @hidden
      */
+    #[CLI\Command(name: 'custom_cmd')]
+    #[CLI\Help(hidden: true)]
     public function customCommand(): void
     {
         $this->io()->note('Hello world!');

--- a/tests/fixtures/lib/Drush/Commands/ExampleAttributesCommands.php
+++ b/tests/fixtures/lib/Drush/Commands/ExampleAttributesCommands.php
@@ -12,7 +12,7 @@ use Drush\Commands\DrushCommands;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 
-class ExampleAttributesDrushCommands extends DrushCommands
+class ExampleAttributesCommands extends DrushCommands
 {
     const ARITHMATIC = 'test:arithmatic';
     const ECHO = 'my:echo';

--- a/tests/fixtures/lib/Drush/Commands/StaticFactoryCommands.php
+++ b/tests/fixtures/lib/Drush/Commands/StaticFactoryCommands.php
@@ -12,7 +12,7 @@ use Drush\Commands\DrushCommands;
  * in Drush/Commands directory + namespace, relative to some entry in
  * the library's `autoload` section in its composer.json file.
  */
-class StaticFactoryDrushCommands extends DrushCommands
+class StaticFactoryCommands extends DrushCommands
 {
     use AutowireTrait;
 

--- a/tests/integration/AttributesTest.php
+++ b/tests/integration/AttributesTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Unish;
 
 use Consolidation\AnnotatedCommand\AnnotatedCommandFactory;
-use Custom\Library\Drush\Commands\ExampleAttributesDrushCommands;
+use Custom\Library\Drush\Commands\ExampleAttributesCommands;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Filesystem\Path;
 
@@ -16,7 +16,7 @@ use Symfony\Component\Filesystem\Path;
  */
 class AttributesTest extends UnishIntegrationTestCase
 {
-    private ExampleAttributesDrushCommands $commandFileInstance;
+    private ExampleAttributesCommands $commandFileInstance;
     private AnnotatedCommandFactory $commandFactory;
 
     public function testAttributes()
@@ -52,7 +52,7 @@ class AttributesTest extends UnishIntegrationTestCase
             $this->markTestSkipped('Symfony Console 6.2+ needed for rest this test.');
         }
 
-        $this->commandFileInstance = new ExampleAttributesDrushCommands();
+        $this->commandFileInstance = new ExampleAttributesCommands();
         $this->commandFactory = new AnnotatedCommandFactory();
         $commandInfo = $this->commandFactory->createCommandInfo($this->commandFileInstance, 'testArithmatic');
         $command = $this->commandFactory->createCommand($commandInfo, $this->commandFileInstance);


### PR DESCRIPTION
From https://mglaman.dev/blog/auto-discovery-global-commands-drush

> Personal note: I find the file naming requirement a bit redundant since we already have a specific namespace, and the class is inspected to ensure it isn't abstract, an interface, and is a subclass of Drush\Commands\DrushCommands.

Agree, lets relax the file/class naming convention `*DrushCommands` -> `*Commands`