### PR TITLE
Add name of database to drush error message on "table not found" message. 

### DIFF
--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -167,7 +167,7 @@ class DrupalBoot8 extends DrupalBoot
             return false;
         }
         if (!$connection->schema()->tableExists('key_value')) {
-            $this->logger->info('key_value table not found. Database may be empty.');
+	    $this->logger->info('Can connecct to database ' . $connection_options['database'] .' but the table key_value was not found. Database ' . $connection_options['database'] . ' may be empty.');
             return false;
         }
         return true;

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -167,7 +167,7 @@ class DrupalBoot8 extends DrupalBoot
             return false;
         }
         if (!$connection->schema()->tableExists('key_value')) {
-	    $this->logger->info('Can connecct to database ' . $connection_options['database'] .' but the table key_value was not found. Database ' . $connection_options['database'] . ' may be empty.');
+            $this->logger->info('Can connecct to database ' . $connection_options['database'] . ' but the table key_value was not found. Database ' . $connection_options['database'] . ' may be empty.');
             return false;
         }
         return true;


### PR DESCRIPTION
I was doing a multi-site migration. The drush warning messages didn't identify which database drush was checking. This made the diagnosis take longer. This patch modifies reports to include the database name and clarify grammar to make it clearer that the check drush was doing is looking for a specific table named key_value in that database. 