### PR TITLE
Fix mysql default configuration files being ignored (#6187)

### DIFF
--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -70,7 +70,7 @@ password="{$dbSpec['password']}"
 EOT;
 
             $file = drush_save_data_to_temp_file($contents);
-            $parameters['defaults-file'] = $file;
+            $parameters['defaults-extra-file'] = $file;
         } else {
             // User is required. Drupal calls it 'username'. MySQL calls it 'user'.
             $parameters['user'] = $dbSpec['username'];


### PR DESCRIPTION
See #6187 for context.

Instead of using --defaults-file we will use --defaults-extra-file
This preserves the other configuration files that may be required for a connection.

See 
* https://mariadb.com/kb/en/mariadb-command-line-client/#option-files
* https://dev.mysql.com/doc/refman/8.4/en/option-file-options.html
![image](https://github.com/user-attachments/assets/28f996d5-66dc-48af-b3c2-e6917187bfce)
