### PR TITLE
Fix mysql via mariadb warns about being deprecated (#6183)

### DIFF
--- a/src/Sql/SqlMariaDB.php
+++ b/src/Sql/SqlMariaDB.php
@@ -4,25 +4,15 @@ declare(strict_types=1);
 
 namespace Drush\Sql;
 
-use Drush\Exec\ExecTrait;
-
 class SqlMariaDB extends SqlMysql
 {
-    use ExecTrait;
-
     public function command(): string
     {
-        if (self::programExists('mariadb')) {
-            return 'mariadb';
-        }
-        return parent::command();
+        return 'mariadb';
     }
 
     public function dumpProgram(): string
     {
-        if (self::programExists('mariadb-dump')) {
-            return 'mariadb-dump';
-        }
-        return parent::dumpProgram();
+        return 'mariadb-dump';
     }
 }

--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Drush\Sql;
 
+use Drush\Drush;
+use Drush\Exec\ExecTrait;
 use PDO;
 
 class SqlMysql extends SqlBase
 {
+    use ExecTrait;
+
     protected string $version;
 
     public string $queryExtra = '-A';
@@ -17,15 +21,19 @@ class SqlMysql extends SqlBase
      */
     public static function make(array $dbSpec, array $options)
     {
-        // First get a MySQL instance
-        $instance = new self($dbSpec, $options);
+        // If the mysql version reports that it is MariaDB, use MariaDB as client.
+        $process = Drush::shell('mysql --version');
+        $process->setSimulated(false);
+        $process->run();
+        if ((!$process->isSuccessful() || str_contains($process->getOutput(), 'MariaDB')) && self::programExists('mariadb')) {
+            $instance = new SqlMariaDB($dbSpec, $options);
+        } else {
+            $instance = new self($dbSpec, $options);
+        }
+
         $sql = 'SELECT VERSION();"';
         $instance->alwaysQuery($sql);
         $out = trim($instance->getProcess()->getOutput());
-        if (str_contains($out, 'MariaDB')) {
-            // Replace with a MariaDB driver.
-            $instance = new SqlMariaDB($dbSpec, $options);
-        }
         $instance->setVersion($out);
         return $instance;
     }

--- a/tests/functional/SqlConnectTest.php
+++ b/tests/functional/SqlConnectTest.php
@@ -28,7 +28,7 @@ class SqlConnectTest extends CommandUnishTestCase
         $shell_options = "-e";
         $db_driver = $this->dbDriver();
         if ($db_driver == 'mysql') {
-            $this->assertMatchesRegularExpression('/^mysql --user=[^\s]+ --password=.* --database=[^\s]+ --host=[^\s]+/', $connectionString);
+            $this->assertMatchesRegularExpression('/^mysql|mariadb --user=[^\s]+ --password=.* --database=[^\s]+ --host=[^\s]+/', $connectionString);
         } elseif ($db_driver == 'sqlite') {
             $this->assertStringContainsString('sqlite3', $connectionString);
             $shell_options = '';


### PR DESCRIPTION
See #6183 for context

In short, this PR will prevent the following message while being fully compatible with mysql as a dropin replacement

"mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead"
When the mysql-binary is removed, this code-change will still be fully working with mariadb.