### PR TITLE
Add queue:run-all command

### DIFF
--- a/src/Commands/core/QueueCommands.php
+++ b/src/Commands/core/QueueCommands.php
@@ -61,28 +61,30 @@ final class QueueCommands extends DrushCommands
     #[CLI\Complete(method_name_or_callable: 'queueComplete')]
     public function run(string $name, $options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'lease-time' => self::REQ]): void
     {
-        $time_limit = (int) $options['time-limit'];
-        $items_limit = (int) $options['items-limit'];
-        $start = microtime(true);
         $worker = $this->getWorkerManager()->createInstance($name);
         $info = $this->getWorkerManager()->getDefinition($name);
-        $end = time() + $time_limit;
         $queue = $this->getQueue($name);
-        $count = 0;
-        $remaining = $time_limit;
+
+        $time_limit = (int) $options['time-limit'];
+        $start = microtime(true);
+        $end = time() + $time_limit;
+        $time_remaining = $time_limit;
         $lease_time = $options['lease-time'] ?? $info['cron']['time'] ?? 30;
+        $items_count = 0;
 
         if ($queue instanceof QueueGarbageCollectionInterface) {
             $queue->garbageCollection();
         }
 
-        while ((!$time_limit || $remaining > 0) && (!$items_limit || $count < $items_limit) && ($item = $queue->claimItem($lease_time))) {
-            $this->doRun($queue, $worker, $name, $item, $count);
-            $remaining = $end - time();
+        while (!$this->hasReachedLimit($options, $items_count, $time_remaining) && ($item = $queue->claimItem($lease_time))) {
+            if ($this->processItem($queue, $worker, $name, $item)) {
+                $items_count++;
+            }
+            $time_remaining = $end - time();
         }
 
         $elapsed = microtime(true) - $start;
-        $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
+        $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $items_count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
     }
 
     /**
@@ -95,33 +97,63 @@ final class QueueCommands extends DrushCommands
     public function runAll($options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'lease-time' => self::REQ]): void
     {
         $time_limit = (int) $options['time-limit'];
-        $items_limit = (int) $options['items-limit'];
         $start = microtime(true);
         $end = time() + $time_limit;
-        $count = 0;
-        $remaining = $time_limit;
-
+        $time_remaining = $time_limit;
+        $items_count = 0;
         $queues = $this->getQueues();
-        foreach ($queues as $name => $info) {
-            $queue = $this->getQueue($name);
-            $worker = $this->getWorkerManager()->createInstance($name);
-            $lease_time = $options['lease-time'] ?? $info['cron']['time'] ?? 30;
 
-            if ($queue instanceof QueueGarbageCollectionInterface) {
-                $queue->garbageCollection();
-            }
+        while (!$this->hasReachedLimit($options, $items_count, $time_remaining)) {
+            foreach ($queues as $name => $info) {
+                $queue = $this->getQueue($name);
+                $worker = $this->getWorkerManager()->createInstance($name);
+                $lease_time = $options['lease-time'] ?? $info['cron']['time'] ?? 30;
+                $queue_starting = true;
+                $queue_count = 0;
 
-            while ((!$time_limit || $remaining > 0) && (!$items_limit || $count < $items_limit) && ($item = $queue->claimItem($lease_time))) {
-                $this->doRun($queue, $worker, $name, $item, $count);
-                $remaining = $end - time();
+                if ($queue instanceof QueueGarbageCollectionInterface) {
+                    $queue->garbageCollection();
+                }
+
+                while ($item = $queue->claimItem($lease_time)) {
+                    if ($queue_starting) {
+                        $this->logger()->notice('Processing queue ' . $name);
+                    }
+                    if ($this->processItem($queue, $worker, $name, $item)) {
+                        $queue_count++;
+                    }
+                    $time_remaining = $end - time();
+                    $queue_starting = false;
+                }
+
+                if ($queue_count > 0) {
+                    $items_count += $queue_count;
+                    $elapsed = microtime(true) - $start;
+                    $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $queue_count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
+                }
             }
         }
 
         $elapsed = microtime(true) - $start;
-        $this->logger()->success(dt('Processed @count items in @elapsed sec.', ['@count' => $count, '@elapsed' => round($elapsed, 2)]));
+        $this->logger()->success(dt('Processed @count items in @elapsed sec.', ['@count' => $items_count, '@elapsed' => round($elapsed, 2)]));
     }
 
-    protected function doRun(QueueInterface $queue, QueueWorkerInterface $worker, string $name, $item, int &$count): void
+    protected function hasReachedLimit(array $options, int $items_count, int $time_remaining): bool
+    {
+        $time_limit = (int) $options['time-limit'];
+        $items_limit = (int) $options['items-limit'];
+
+        return ($time_limit && $time_remaining <= 0)
+            || ($items_limit && $items_count >= $items_limit);
+    }
+
+    /**
+     * Process an item from the queue.
+     *
+     * @return bool
+     *   TRUE if the item was processed, FALSE otherwise.
+     */
+    protected function processItem(QueueInterface $queue, QueueWorkerInterface $worker, string $name, object $item): bool
     {
         try {
             // @phpstan-ignore-next-line
@@ -129,7 +161,7 @@ final class QueueCommands extends DrushCommands
             // @phpstan-ignore-next-line
             $worker->processItem($item->data);
             $queue->deleteItem($item);
-            $count++;
+            return true;
         } catch (RequeueException) {
             // The worker requested the task to be immediately requeued.
             $queue->releaseItem($item);
@@ -154,6 +186,8 @@ final class QueueCommands extends DrushCommands
             // item in the queue to be processed again later.
             $this->logger()->error($e->getMessage());
         }
+
+        return false;
     }
 
     /**

--- a/src/Commands/core/QueueCommands.php
+++ b/src/Commands/core/QueueCommands.php
@@ -10,6 +10,7 @@ use Drupal\Core\Queue\DelayedRequeueException;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueGarbageCollectionInterface;
 use Drupal\Core\Queue\QueueInterface;
+use Drupal\Core\Queue\QueueWorkerInterface;
 use Drupal\Core\Queue\QueueWorkerManagerInterface;
 use Drupal\Core\Queue\RequeueException;
 use Drupal\Core\Queue\SuspendQueueException;
@@ -24,6 +25,7 @@ final class QueueCommands extends DrushCommands
     use AutowireTrait;
 
     const RUN = 'queue:run';
+    const RUN_ALL = 'queue:run-all';
     const LIST = 'queue:list';
     const DELETE = 'queue:delete';
 
@@ -75,41 +77,83 @@ final class QueueCommands extends DrushCommands
         }
 
         while ((!$time_limit || $remaining > 0) && (!$items_limit || $count < $items_limit) && ($item = $queue->claimItem($lease_time))) {
-            try {
-                // @phpstan-ignore-next-line
-                $this->logger()->info(dt('Processing item @id from @name queue.', ['@name' => $name, '@id' => $item->item_id ?? $item->qid]));
-                // @phpstan-ignore-next-line
-                $worker->processItem($item->data);
-                $queue->deleteItem($item);
-                $count++;
-            } catch (RequeueException) {
-                // The worker requested the task to be immediately requeued.
-                $queue->releaseItem($item);
-            } catch (SuspendQueueException $e) {
-                // If the worker indicates there is a problem with the whole queue,
-                // release the item.
-                $queue->releaseItem($item);
-                throw new \Exception($e->getMessage(), $e->getCode(), $e);
-            } catch (DelayedRequeueException $e) {
-                // The worker requested the task not be immediately re-queued.
-                // - If the queue doesn't support ::delayItem(), we should leave the
-                // item's current expiry time alone.
-                // - If the queue does support ::delayItem(), we should allow the
-                // queue to update the item's expiry using the requested delay.
-                if ($queue instanceof DelayableQueueInterface) {
-                    // This queue can handle a custom delay; use the duration provided
-                    // by the exception.
-                    $queue->delayItem($item, $e->getDelay());
-                }
-            } catch (\Exception $e) {
-                // In case of any other kind of exception, log it and leave the
-                // item in the queue to be processed again later.
-                $this->logger()->error($e->getMessage());
-            }
+            $this->doRun($queue, $worker, $name, $item, $count);
             $remaining = $end - time();
         }
+
         $elapsed = microtime(true) - $start;
         $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
+    }
+
+    /**
+     * Run all available queues.
+     */
+    #[CLI\Command(name: self::RUN_ALL, aliases: ['queue-run-all'])]
+    #[CLI\Option(name: 'time-limit', description: 'The maximum number of seconds allowed to run the queue.')]
+    #[CLI\Option(name: 'items-limit', description: 'The maximum number of items allowed to run the queue.')]
+    #[CLI\Option(name: 'lease-time', description: 'The maximum number of seconds that an item remains claimed.')]
+    public function runAll($options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'lease-time' => self::REQ]): void
+    {
+        $time_limit = (int) $options['time-limit'];
+        $items_limit = (int) $options['items-limit'];
+        $start = microtime(true);
+        $end = time() + $time_limit;
+        $count = 0;
+        $remaining = $time_limit;
+
+        $queues = $this->getQueues();
+        foreach ($queues as $name => $info) {
+            $queue = $this->getQueue($name);
+            $worker = $this->getWorkerManager()->createInstance($name);
+            $lease_time = $options['lease-time'] ?? $info['cron']['time'] ?? 30;
+
+            if ($queue instanceof QueueGarbageCollectionInterface) {
+                $queue->garbageCollection();
+            }
+
+            while ((!$time_limit || $remaining > 0) && (!$items_limit || $count < $items_limit) && ($item = $queue->claimItem($lease_time))) {
+                $this->doRun($queue, $worker, $name, $item, $count);
+                $remaining = $end - time();
+            }
+        }
+
+        $elapsed = microtime(true) - $start;
+        $this->logger()->success(dt('Processed @count items in @elapsed sec.', ['@count' => $count, '@elapsed' => round($elapsed, 2)]));
+    }
+
+    protected function doRun(QueueInterface $queue, QueueWorkerInterface $worker, string $name, $item, int &$count): void
+    {
+        try {
+            // @phpstan-ignore-next-line
+            $this->logger()->info(dt('Processing item @id from @name queue.', ['@name' => $name, '@id' => $item->item_id ?? $item->qid]));
+            // @phpstan-ignore-next-line
+            $worker->processItem($item->data);
+            $queue->deleteItem($item);
+            $count++;
+        } catch (RequeueException) {
+            // The worker requested the task to be immediately requeued.
+            $queue->releaseItem($item);
+        } catch (SuspendQueueException $e) {
+            // If the worker indicates there is a problem with the whole queue,
+            // release the item.
+            $queue->releaseItem($item);
+            throw new \Exception($e->getMessage(), $e->getCode(), $e);
+        } catch (DelayedRequeueException $e) {
+            // The worker requested the task not be immediately re-queued.
+            // - If the queue doesn't support ::delayItem(), we should leave the
+            // item's current expiry time alone.
+            // - If the queue does support ::delayItem(), we should allow the
+            // queue to update the item's expiry using the requested delay.
+            if ($queue instanceof DelayableQueueInterface) {
+                // This queue can handle a custom delay; use the duration provided
+                // by the exception.
+                $queue->delayItem($item, $e->getDelay());
+            }
+        } catch (\Exception $e) {
+            // In case of any other kind of exception, log it and leave the
+            // item in the queue to be processed again later.
+            $this->logger()->error($e->getMessage());
+        }
     }
 
     /**

--- a/src/Commands/core/QueueCommands.php
+++ b/src/Commands/core/QueueCommands.php
@@ -116,7 +116,8 @@ final class QueueCommands extends DrushCommands
                 $worker = $this->getWorkerManager()->createInstance($name);
                 $lease_time = $options['lease-time'] ?? $info['cron']['time'] ?? 30;
                 $queue_starting = true;
-                $queue_count = 0;
+                $queue_start = microtime(true);
+                $queue_items_count = 0;
 
                 if ($queue instanceof QueueGarbageCollectionInterface) {
                     $queue->garbageCollection();
@@ -127,16 +128,16 @@ final class QueueCommands extends DrushCommands
                         $this->logger()->notice('Processing queue ' . $name);
                     }
                     if ($this->processItem($queue, $worker, $name, $item)) {
-                        $queue_count++;
+                        $queue_items_count++;
                     }
                     $time_remaining = $end - time();
                     $queue_starting = false;
                 }
 
-                if ($queue_count > 0) {
-                    $items_count += $queue_count;
-                    $elapsed = microtime(true) - $start;
-                    $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $queue_count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
+                if ($queue_items_count > 0) {
+                    $items_count += $queue_items_count;
+                    $elapsed = microtime(true) - $queue_start;
+                    $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $queue_items_count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
                 }
             }
             if ($options['daemon']) {

--- a/src/Commands/core/QueueCommands.php
+++ b/src/Commands/core/QueueCommands.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drush\Commands\core;
 
+use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Core\Queue\DelayableQueueInterface;
 use Drupal\Core\Queue\DelayedRequeueException;
@@ -19,6 +20,7 @@ use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Input\InputInterface;
 
 final class QueueCommands extends DrushCommands
 {
@@ -56,21 +58,19 @@ final class QueueCommands extends DrushCommands
     #[CLI\Argument(name: 'name', description: 'The name of the queue to run.')]
     #[CLI\Option(name: 'time-limit', description: 'The maximum number of seconds allowed to run the queue.')]
     #[CLI\Option(name: 'items-limit', description: 'The maximum number of items allowed to run the queue.')]
+    #[CLI\Option(name: 'memory-limit', description: 'The maximum amount of memory the script can consume before exiting. Can be a value supported by the memory_limit PHP setting or a percentage.')]
     #[CLI\Option(name: 'lease-time', description: 'The maximum number of seconds that an item remains claimed.')]
     #[CLI\Option(name: 'daemon', description: 'Keep the command running indefinitely, or until one of the chosen limits has been reached.')]
     #[CLI\ValidateQueueName(argumentName: 'name')]
     #[CLI\Complete(method_name_or_callable: 'queueComplete')]
-    public function run(string $name, $options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'lease-time' => self::REQ, 'daemon' => false]): void
+    public function run(string $name, $options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'memory-limit' => self::REQ, 'lease-time' => self::REQ, 'daemon' => false]): void
     {
         $worker = $this->getWorkerManager()->createInstance($name);
-        $info = $this->getWorkerManager()->getDefinition($name);
         $queue = $this->getQueue($name);
 
-        $time_limit = (int) $options['time-limit'];
         $start = microtime(true);
-        $end = time() + $time_limit;
-        $time_remaining = $time_limit;
-        $lease_time = $options['lease-time'] ?? $info['cron']['time'] ?? 30;
+        $end = time() + $options['time-limit'];
+        $time_remaining = $options['time-limit'];
         $items_count = 0;
 
         if ($queue instanceof QueueGarbageCollectionInterface) {
@@ -78,7 +78,7 @@ final class QueueCommands extends DrushCommands
         }
 
         do {
-            while (!$this->hasReachedLimit($options, $items_count, $time_remaining) && ($item = $queue->claimItem($lease_time))) {
+            while (!$this->hasReachedLimit($options, $items_count, $time_remaining) && ($item = $queue->claimItem($options['lease-time']))) {
                 if ($this->processItem($queue, $worker, $name, $item)) {
                     $items_count++;
                 }
@@ -93,20 +93,32 @@ final class QueueCommands extends DrushCommands
         $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $items_count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
     }
 
+    #[CLI\Hook(type: HookManager::POST_INITIALIZE, target: self::RUN)]
+    public function postInitRun(InputInterface $input): void
+    {
+        $name = $input->getArgument('name');
+        $info = $this->getWorkerManager()->getDefinition($name);
+
+        $input->setOption('time-limit', (int) $input->getOption('time-limit'));
+        $input->setOption('items-limit', (int) $input->getOption('items-limit'));
+        $input->setOption('memory-limit', $this->parseMemoryLimit($input->getOption('memory-limit')));
+        $input->setOption('lease-time', $input->getOption('lease-time') ?? $info['cron']['time'] ?? 30);
+    }
+
     /**
      * Run all available queues.
      */
     #[CLI\Command(name: self::RUN_ALL, aliases: ['queue-run-all'])]
     #[CLI\Option(name: 'time-limit', description: 'The maximum number of seconds allowed to run the queue.')]
     #[CLI\Option(name: 'items-limit', description: 'The maximum number of items allowed to run the queue.')]
+    #[CLI\Option(name: 'memory-limit', description: 'The maximum amount of memory the script can consume before exiting. Can be a value supported by the memory_limit PHP setting or a percentage.')]
     #[CLI\Option(name: 'lease-time', description: 'The maximum number of seconds that an item remains claimed.')]
     #[CLI\Option(name: 'daemon', description: 'Keep the command running indefinitely, or until one of the chosen limits has been reached.')]
-    public function runAll($options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'lease-time' => self::REQ, 'daemon' => false]): void
+    public function runAll($options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'memory-limit' => self::REQ, 'lease-time' => self::REQ, 'daemon' => false]): void
     {
-        $time_limit = (int) $options['time-limit'];
         $start = microtime(true);
-        $end = time() + $time_limit;
-        $time_remaining = $time_limit;
+        $end = time() + $options['time-limit'];
+        $time_remaining = $options['time-limit'];
         $items_count = 0;
         $queues = $this->getQueues();
 
@@ -149,13 +161,42 @@ final class QueueCommands extends DrushCommands
         $this->logger()->success(dt('Processed @count items in @elapsed sec.', ['@count' => $items_count, '@elapsed' => round($elapsed, 2)]));
     }
 
+    #[CLI\Hook(type: HookManager::POST_INITIALIZE, target: self::RUN_ALL)]
+    public function postInitRunAll(InputInterface $input): void
+    {
+        $input->setOption('time-limit', (int) $input->getOption('time-limit'));
+        $input->setOption('items-limit', (int) $input->getOption('items-limit'));
+        $input->setOption('memory-limit', $this->parseMemoryLimit($input->getOption('memory-limit')));
+    }
+
     protected function hasReachedLimit(array $options, int $items_count, int $time_remaining): bool
     {
-        $time_limit = (int) $options['time-limit'];
-        $items_limit = (int) $options['items-limit'];
+        return ($options['time-limit'] && $time_remaining <= 0)
+            || ($options['items-limit'] && $items_count >= $options['items-limit'])
+            || ($options['memory-limit'] && memory_get_usage() >= $options['memory-limit']);
+    }
 
-        return ($time_limit && $time_remaining <= 0)
-            || ($items_limit && $items_count >= $items_limit);
+    protected function parseMemoryLimit(?string $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $last = strtolower($value[strlen($value)-1]);
+        $size = (int) rtrim($value, 'GgMmKk%');
+
+        switch ($last) {
+            case 'g':
+                $size *= DRUSH_KILOBYTE;
+            case 'm':
+                $size *= DRUSH_KILOBYTE;
+            case 'k':
+                $size *= DRUSH_KILOBYTE;
+            case '%':
+                $size = (int) ($size * (drush_memory_limit() / 100));
+        }
+
+        return $size;
     }
 
     /**

--- a/src/Commands/core/QueueCommands.php
+++ b/src/Commands/core/QueueCommands.php
@@ -57,9 +57,10 @@ final class QueueCommands extends DrushCommands
     #[CLI\Option(name: 'time-limit', description: 'The maximum number of seconds allowed to run the queue.')]
     #[CLI\Option(name: 'items-limit', description: 'The maximum number of items allowed to run the queue.')]
     #[CLI\Option(name: 'lease-time', description: 'The maximum number of seconds that an item remains claimed.')]
+    #[CLI\Option(name: 'daemon', description: 'Keep the command running indefinitely, or until one of the chosen limits has been reached.')]
     #[CLI\ValidateQueueName(argumentName: 'name')]
     #[CLI\Complete(method_name_or_callable: 'queueComplete')]
-    public function run(string $name, $options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'lease-time' => self::REQ]): void
+    public function run(string $name, $options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'lease-time' => self::REQ, 'daemon' => false]): void
     {
         $worker = $this->getWorkerManager()->createInstance($name);
         $info = $this->getWorkerManager()->getDefinition($name);
@@ -76,12 +77,17 @@ final class QueueCommands extends DrushCommands
             $queue->garbageCollection();
         }
 
-        while (!$this->hasReachedLimit($options, $items_count, $time_remaining) && ($item = $queue->claimItem($lease_time))) {
-            if ($this->processItem($queue, $worker, $name, $item)) {
-                $items_count++;
+        do {
+            while (!$this->hasReachedLimit($options, $items_count, $time_remaining) && ($item = $queue->claimItem($lease_time))) {
+                if ($this->processItem($queue, $worker, $name, $item)) {
+                    $items_count++;
+                }
+                $time_remaining = $end - time();
             }
-            $time_remaining = $end - time();
-        }
+            if ($options['daemon']) {
+                sleep(1);
+            }
+        } while ($options['daemon'] && !$this->hasReachedLimit($options, $items_count, $time_remaining));
 
         $elapsed = microtime(true) - $start;
         $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $items_count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
@@ -94,7 +100,8 @@ final class QueueCommands extends DrushCommands
     #[CLI\Option(name: 'time-limit', description: 'The maximum number of seconds allowed to run the queue.')]
     #[CLI\Option(name: 'items-limit', description: 'The maximum number of items allowed to run the queue.')]
     #[CLI\Option(name: 'lease-time', description: 'The maximum number of seconds that an item remains claimed.')]
-    public function runAll($options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'lease-time' => self::REQ]): void
+    #[CLI\Option(name: 'daemon', description: 'Keep the command running indefinitely, or until one of the chosen limits has been reached.')]
+    public function runAll($options = ['time-limit' => self::REQ, 'items-limit' => self::REQ, 'lease-time' => self::REQ, 'daemon' => false]): void
     {
         $time_limit = (int) $options['time-limit'];
         $start = microtime(true);
@@ -103,7 +110,7 @@ final class QueueCommands extends DrushCommands
         $items_count = 0;
         $queues = $this->getQueues();
 
-        while (!$this->hasReachedLimit($options, $items_count, $time_remaining)) {
+        do {
             foreach ($queues as $name => $info) {
                 $queue = $this->getQueue($name);
                 $worker = $this->getWorkerManager()->createInstance($name);
@@ -115,7 +122,7 @@ final class QueueCommands extends DrushCommands
                     $queue->garbageCollection();
                 }
 
-                while ($item = $queue->claimItem($lease_time)) {
+                while (!$this->hasReachedLimit($options, $items_count, $time_remaining) && $item = $queue->claimItem($lease_time)) {
                     if ($queue_starting) {
                         $this->logger()->notice('Processing queue ' . $name);
                     }
@@ -132,7 +139,10 @@ final class QueueCommands extends DrushCommands
                     $this->logger()->success(dt('Processed @count items from the @name queue in @elapsed sec.', ['@count' => $queue_count, '@name' => $name, '@elapsed' => round($elapsed, 2)]));
                 }
             }
-        }
+            if ($options['daemon']) {
+                sleep(1);
+            }
+        } while ($options['daemon'] && !$this->hasReachedLimit($options, $items_count, $time_remaining));
 
         $elapsed = microtime(true) - $start;
         $this->logger()->success(dt('Processed @count items in @elapsed sec.', ['@count' => $items_count, '@elapsed' => round($elapsed, 2)]));


### PR DESCRIPTION
Adds a `queue:run-all` command that does the same as `queue:run`, but for all available queues instead of a specific one. It takes the same options, but without the argument. The limit options count across all queues instead of a specific queue.

Also adds a `--memory-limit` option that takes either a number that ends with g/m/k (the format of the `memory_limit` ini setting) or a percentage. The command will run until that amount of memory is consumed. This option is added to both `queue:run` and `queue:run-all`.

Also adds a `--daemon` option that keeps the command running until `items-limit`, `lease-limit` or `memory-limit` is reached - if defined. Else, it keeps going indefinitely. This option is added to both `queue:run` and `queue:run-all`.

Fixes #6062.