### PR TITLE
Typehint variable in batch query to integer

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -183,7 +183,7 @@ function _drush_batch_command($id) {
 
   $data = Database::getConnection()->select('batch', 'b')
     ->fields('b', ['batch'])
-    ->condition('bid', $id)
+    ->condition('bid', (int) $id)
     ->execute()
     ->fetchField();
 


### PR DESCRIPTION
Updated the query on the batch table to typehint the variable $id to an integer value. This is necessary for working with MongoDB. For MongoDB a condition variable needs to the right type.