### PR TITLE
Make the url logged in field:create a clickable link

### DIFF
--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -527,11 +527,9 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
 
         if ($this->moduleHandler->moduleExists('field_ui')) {
             $this->logger()->success(
-                'Further customisation can be done at the following url:'
-                . PHP_EOL
-                . Url::fromRoute($routeName, $routeParams)
-                    ->setAbsolute(true)
-                    ->toString()
+                dt('Further customisation can be done through the <href=%editForm>edit form</>.', [
+                    '%editForm' => Url::fromRoute($routeName, $routeParams)->setAbsolute(true)->toString(),
+                ]),
             );
         }
     }

--- a/tests/functional/FieldTest.php
+++ b/tests/functional/FieldTest.php
@@ -51,7 +51,7 @@ class FieldTest extends CommandUnishTestCase
         $this->assertStringContainsString("Bundle 'NO-EXIST' does not exist on entity type with id 'unish_article'.", $this->getErrorOutputRaw());
         $this->drush(FieldCreateCommands::CREATE, ['unish_article', 'alpha'], ['field-label' => 'Test', 'field-name' => 'field_test3', 'field-type' => 'entity_reference', 'field-widget' => 'entity_reference_autocomplete', 'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, 'target-type' => 'unish_article', 'target-bundle' => 'beta']);
         $this->assertStringContainsString("Successfully created field 'field_test3' on unish_article type with bundle 'alpha'", $this->getErrorOutputRaw());
-        $this->assertStringContainsString("http://dev/admin/structure/unish_article_types/manage/alpha/fields/unish_article.alpha.field_test3", $this->getErrorOutputRaw());
+        $this->assertStringContainsString("http://dev/admin/structure/unish_article_types/manage/alpha/fields/unish_article.alpha.field_test3", $this->getSimplifiedErrorOutput());
         $php = "return Drupal::entityTypeManager()->getStorage('field_config')->load('unish_article.alpha.field_test3')->getSettings()";
         $this->drush(PhpCommands::EVAL, [$php], ['format' => 'json']);
         $settings = $this->getOutputFromJSON();

--- a/tests/functional/FieldTest.php
+++ b/tests/functional/FieldTest.php
@@ -51,7 +51,6 @@ class FieldTest extends CommandUnishTestCase
         $this->assertStringContainsString("Bundle 'NO-EXIST' does not exist on entity type with id 'unish_article'.", $this->getErrorOutputRaw());
         $this->drush(FieldCreateCommands::CREATE, ['unish_article', 'alpha'], ['field-label' => 'Test', 'field-name' => 'field_test3', 'field-type' => 'entity_reference', 'field-widget' => 'entity_reference_autocomplete', 'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, 'target-type' => 'unish_article', 'target-bundle' => 'beta']);
         $this->assertStringContainsString("Successfully created field 'field_test3' on unish_article type with bundle 'alpha'", $this->getErrorOutputRaw());
-        $this->assertStringContainsString("http://dev/admin/structure/unish_article_types/manage/alpha/fields/unish_article.alpha.field_test3", $this->getSimplifiedErrorOutput());
         $php = "return Drupal::entityTypeManager()->getStorage('field_config')->load('unish_article.alpha.field_test3')->getSettings()";
         $this->drush(PhpCommands::EVAL, [$php], ['format' => 'json']);
         $settings = $this->getOutputFromJSON();

--- a/tests/functional/FieldTest.php
+++ b/tests/functional/FieldTest.php
@@ -51,7 +51,7 @@ class FieldTest extends CommandUnishTestCase
         $this->assertStringContainsString("Bundle 'NO-EXIST' does not exist on entity type with id 'unish_article'.", $this->getErrorOutputRaw());
         $this->drush(FieldCreateCommands::CREATE, ['unish_article', 'alpha'], ['field-label' => 'Test', 'field-name' => 'field_test3', 'field-type' => 'entity_reference', 'field-widget' => 'entity_reference_autocomplete', 'cardinality' => FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED, 'target-type' => 'unish_article', 'target-bundle' => 'beta']);
         $this->assertStringContainsString("Successfully created field 'field_test3' on unish_article type with bundle 'alpha'", $this->getErrorOutputRaw());
-        $this->assertStringContainsString("http://dev/admin/structure/unish_article_types/manage/alpha/fields/unish_article.alpha.field_test3", $this->getSimplifiedErrorOutput());
+        $this->assertStringContainsString("http://dev/admin/structure/unish_article_types/manage/alpha/fields/unish_article.alpha.field_test3", $this->getErrorOutputRaw());
         $php = "return Drupal::entityTypeManager()->getStorage('field_config')->load('unish_article.alpha.field_test3')->getSettings()";
         $this->drush(PhpCommands::EVAL, [$php], ['format' => 'json']);
         $settings = $this->getOutputFromJSON();


### PR DESCRIPTION
Since we started using clickable links in the `drush en` command, I thought we could use it in `drush field:create` too.