### PR TITLE
drush.services.yml support will be removed in Drush 14 not 13

### DIFF
--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -5,7 +5,7 @@ Drush command files obtain references to the resources they need through a techn
 
 !!! tip
 
-    Drush 11 and prior required [dependency injection via a drush.services.yml file](https://www.drush.org/11.x/dependency-injection/#services-files). This approach is deprecated in Drush 12+ and removed in Drush 13.
+    Drush 11 and prior required [dependency injection via a drush.services.yml file](https://www.drush.org/11.x/dependency-injection/#services-files). This approach is deprecated in Drush 12+ and removed in Drush 14.
 
 Autowire
 ------------------


### PR DESCRIPTION
If I understand https://github.com/drush-ops/drush/issues/6096 correctly.