### PR TITLE
Fix #6225. Remove dupe non working keys from core:status

### DIFF
--- a/src/Commands/core/StatusCommands.php
+++ b/src/Commands/core/StatusCommands.php
@@ -78,19 +78,18 @@ final class StatusCommands extends DrushCommands
         'install-profile' => 'Install profile',
         'root' => 'Drupal root',
         'drupal-settings-file' => 'Drupal Settings',
-        'site-path' => 'Site path',
         'site' => 'Site path',
         'themes' => 'Themes path',
         'modules' => 'Modules path',
         'files' => 'Files, Public',
         'private' => 'Files, Private',
         'temp' => 'Files, Temp',
+        // config-sync is deprecated. Use 'config' instead.
         'config-sync' => 'Drupal config',
-        'files-path' => 'Files, Public',
-        'temp-path' => 'Files, Temp',
+        'config' => 'Drupal config',
         '%paths' => 'Other paths'
     ])]
-    #[CLI\DefaultTableFields(fields: ['drupal-version', 'uri', 'db-driver', 'db-hostname', 'db-port', 'db-username', 'db-name', 'db-status', 'bootstrap', 'theme', 'admin-theme', 'php-bin', 'php-conf', 'php-os', 'php-version', 'drush-script', 'drush-version', 'drush-temp', 'drush-conf', 'install-profile', 'root', 'site', 'files', 'private', 'temp'])]
+    #[CLI\DefaultTableFields(fields: ['drupal-version', 'uri', 'db-driver', 'db-hostname', 'db-port', 'db-username', 'db-name', 'db-status', 'bootstrap', 'theme', 'admin-theme', 'php-bin', 'php-conf', 'php-os', 'php-version', 'drush-script', 'drush-version', 'drush-temp', 'drush-conf', 'install-profile', 'root', 'site', 'files', 'private', 'temp', 'config'])]
     #[CLI\Bootstrap(level: DrupalBootLevels::MAX)]
     #[CLI\Topics(topics: [DocsCommands::README])]
     public function status($options = ['project' => self::REQ, 'format' => 'table']): PropertyList
@@ -224,6 +223,7 @@ final class StatusCommands extends DrushCommands
                 if ($boot_manager->hasBootstrapped(DrupalBootLevels::CONFIGURATION)) {
                     try {
                         $paths["%config-sync"] = Settings::get('config_sync_directory');
+                        $paths["%config"] = Settings::get('config_sync_directory');
                     } catch (\Exception $e) {
                         // Nothing to do.
                     }


### PR DESCRIPTION
Also show 'config' dir by default in core:status
