### PR TITLE
Update cron documentation to reflect site-specifc Drush

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -14,7 +14,7 @@ You should set up crontab to run your cron tasks as the same user that runs the 
 
     sudo crontab -u www-data -e
 
-You might need to edit the crontab entry shown above slightly for your particular setup; for example, if you have installed Drush to some directory other than /usr/local/drush, then you will need to adjust the path to drush appropriately. We'll break down the meaning of each section of the crontab entry in the documentation that continues below.
+You might need to edit the crontab entry shown above slightly for your particular setup; we'll break down the meaning of each section of the crontab entry in the documentation that continues below.
 
 Setting the schedule
 --------------------


### PR DESCRIPTION
The original path reference makes no sense now that Drush is site-specific.