### PR TITLE
Fix #6232. Make sure redispatchOptions() are used in deploy:hook

### DIFF
--- a/src/Commands/core/DeployHookCommands.php
+++ b/src/Commands/core/DeployHookCommands.php
@@ -111,7 +111,7 @@ final class DeployHookCommands extends DrushCommands
             return self::EXIT_SUCCESS;
         }
 
-        $process = $this->processManager()->drush($this->siteAliasManager->getSelf(), self::HOOK_STATUS);
+        $process = $this->processManager()->drush($this->siteAliasManager->getSelf(), self::HOOK_STATUS, [], Drush::redispatchOptions());
         $process->mustRun();
         $this->output()->writeln($process->getOutput());
 


### PR DESCRIPTION
This makes sure that --xdebug gets passed to subprocesses. I'm going to audit the codebase to see if there are more similar omissions. In the meanwhile, folks can enable xdebug via env variable instead of --xdebug