### PR TITLE
fix(php): Fix PHP 8.4 deprecations for nullable types

### DIFF
--- a/src-symfony-compatibility/v6/Symfony/BufferedConsoleOutput.php
+++ b/src-symfony-compatibility/v6/Symfony/BufferedConsoleOutput.php
@@ -21,7 +21,7 @@ class BufferedConsoleOutput extends BufferedOutput implements ConsoleOutputInter
      * @param bool|null                     $decorated Whether to decorate messages (null for auto-guessing)
      * @param OutputFormatterInterface|null $formatter Output formatter instance (null to use default OutputFormatter)
      */
-    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = false, OutputFormatterInterface $formatter = null)
+    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = false, ?OutputFormatterInterface $formatter = null)
     {
         parent::__construct($verbosity, $decorated, $formatter);
 

--- a/src-symfony-compatibility/v6/Symfony/LessStrictArgvInput.php
+++ b/src-symfony-compatibility/v6/Symfony/LessStrictArgvInput.php
@@ -29,7 +29,7 @@ class LessStrictArgvInput extends ArgvInput
      * @param array|null           $argv       An array of parameters from the CLI (in the argv format)
      * @param InputDefinition|null $definition A InputDefinition instance
      */
-    public function __construct(array $argv = null, InputDefinition $definition = null)
+    public function __construct(?array $argv = null, ?InputDefinition $definition = null)
     {
         // We have to duplicate the implementation of ArgvInput
         // because of liberal use of `private`

--- a/src/Boot/BootstrapManager.php
+++ b/src/Boot/BootstrapManager.php
@@ -211,7 +211,7 @@ class BootstrapManager implements LoggerAwareInterface, ConfigAwareInterface
      *   TRUE if the specified bootstrap phase has completed.
      * @see \Drush\Boot\Boot::bootstrapPhases()
      */
-    public function doBootstrap(int $phase, $phase_max = false, AnnotationData $annotationData = null): bool
+    public function doBootstrap(int $phase, $phase_max = false, ?AnnotationData $annotationData = null): bool
     {
         $bootstrap = $this->bootstrap();
         $phases = $this->bootstrapPhases(true);
@@ -314,7 +314,7 @@ class BootstrapManager implements LoggerAwareInterface, ConfigAwareInterface
      *   Thrown when an unknown bootstrap phase is passed in the annotation
      *   data.
      */
-    public function bootstrapToPhase(string $bootstrapPhase, AnnotationData $annotationData = null): bool
+    public function bootstrapToPhase(string $bootstrapPhase, ?AnnotationData $annotationData = null): bool
     {
         $this->logger->info('Starting bootstrap to {phase}', ['phase' => $bootstrapPhase]);
         $phase = $this->bootstrap()->lookUpPhaseIndex($bootstrapPhase);
@@ -348,7 +348,7 @@ class BootstrapManager implements LoggerAwareInterface, ConfigAwareInterface
      *   Optional annotation data from the command.
      *   TRUE if the specified bootstrap phase has completed.
      */
-    public function bootstrapToPhaseIndex(int $max_phase_index, AnnotationData $annotationData = null): bool
+    public function bootstrapToPhaseIndex(int $max_phase_index, ?AnnotationData $annotationData = null): bool
     {
         if ($max_phase_index == DRUSH_BOOTSTRAP_MAX) {
             // Try get a max phase.
@@ -396,7 +396,7 @@ class BootstrapManager implements LoggerAwareInterface, ConfigAwareInterface
      *
      *   The maximum phase to which we bootstrapped.
      */
-    public function bootstrapMax($max_phase_index = false, AnnotationData $annotationData = null): int
+    public function bootstrapMax($max_phase_index = false, ?AnnotationData $annotationData = null): int
     {
         // Bootstrap as far as we can without throwing an error, but log for
         // debugging purposes.

--- a/src/Boot/DrupalBoot8.php
+++ b/src/Boot/DrupalBoot8.php
@@ -179,7 +179,7 @@ class DrupalBoot8 extends DrupalBoot
         parent::bootstrapDrupalDatabase($manager);
     }
 
-    public function bootstrapDrupalConfiguration(BootstrapManager $manager, AnnotationData $annotationData = null): void
+    public function bootstrapDrupalConfiguration(BootstrapManager $manager, ?AnnotationData $annotationData = null): void
     {
         // Coax \Drupal\Core\DrupalKernel::discoverServiceProviders to add our logger.
         $GLOBALS['conf']['container_service_providers'][] = DrushLoggerServiceProvider::class;

--- a/src/Commands/core/ArchiveRestoreCommands.php
+++ b/src/Commands/core/ArchiveRestoreCommands.php
@@ -88,7 +88,7 @@ final class ArchiveRestoreCommands extends DrushCommands implements SiteAliasMan
     #[CLI\Bootstrap(level: DrupalBootLevels::NONE)]
     #[CLI\ValidatePhpExtensions(extensions: ['Phar'])]
     public function restore(
-        string $path = null,
+        ?string $path = null,
         ?string $site = null,
         array $options = [
             'destination-path' => null,

--- a/src/Commands/core/LocaleCommands.php
+++ b/src/Commands/core/LocaleCommands.php
@@ -487,7 +487,7 @@ final class LocaleCommands extends DrushCommands
      * @param array $options The export options for PoDatabaseReader.
      * @return bool True if successful.
      */
-    private function writePoFile(string $file_uri, LanguageInterface $language = null, array $options = []): bool
+    private function writePoFile(string $file_uri, ?LanguageInterface $language = null, array $options = []): bool
     {
         $reader = new PoDatabaseReader();
 

--- a/src/Commands/core/WatchdogCommands.php
+++ b/src/Commands/core/WatchdogCommands.php
@@ -295,7 +295,7 @@ final class WatchdogCommands extends DrushCommands
      * @param $severity_min
      *   Int or String for the minimum severity to return.
      */
-    protected function where(?string $type = null, $severity = null, ?string $filter = null, string $criteria = 'AND', int|string $severity_min = null): array
+    protected function where(?string $type = null, $severity = null, ?string $filter = null, string $criteria = 'AND', int|string|null $severity_min = null): array
     {
         $args = [];
         $conditions = [];

--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -73,7 +73,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         return $commandHandler;
     }
 
-    public function setContentTranslationManager(ContentTranslationManagerInterface $manager = null): void
+    public function setContentTranslationManager(?ContentTranslationManagerInterface $manager = null): void
     {
         if ($manager) {
             $this->contentTranslationManager = $manager;

--- a/src/Drush.php
+++ b/src/Drush.php
@@ -364,7 +364,7 @@ class Drush
      * @return
      *   A wrapper around Symfony Process.
      */
-    public static function shell(string $command, $cwd = null, array $env = null, $input = null, $timeout = 60): ProcessBase
+    public static function shell(string $command, $cwd = null, ?array $env = null, $input = null, $timeout = 60): ProcessBase
     {
         return self::processManager()->shell($command, $cwd, $env, $input, $timeout);
     }

--- a/src/Exceptions/CommandFailedException.php
+++ b/src/Exceptions/CommandFailedException.php
@@ -9,7 +9,7 @@ namespace Drush\Exceptions;
  */
 class CommandFailedException extends \Exception
 {
-    public function __construct($message = "Failed.", $code = 1, \Throwable $previous = null)
+    public function __construct($message = "Failed.", $code = 1, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exceptions/UserAbortException.php
+++ b/src/Exceptions/UserAbortException.php
@@ -9,7 +9,7 @@ namespace Drush\Exceptions;
  */
 class UserAbortException extends \Exception
 {
-    public function __construct($message = "Cancelled.", $code = 0, \Exception $previous = null)
+    public function __construct($message = "Cancelled.", $code = 0, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/SiteAlias/ProcessManager.php
+++ b/src/SiteAlias/ProcessManager.php
@@ -140,7 +140,7 @@ class ProcessManager extends ConsolidationProcessManager
      *
      *   A wrapper around Symfony Process.
      */
-    public function process($commandline, $cwd = null, array $env = null, $input = null, $timeout = 60): ProcessBase
+    public function process($commandline, $cwd = null, ?array $env = null, $input = null, $timeout = 60): ProcessBase
     {
         $process = parent::process($commandline, $cwd, $env, $input, $timeout);
         return $this->configureProcess($process);
@@ -154,7 +154,7 @@ class ProcessManager extends ConsolidationProcessManager
      * @param mixed|null $input   The input as stream resource, scalar or \Traversable, or null for no input
      * @param int|float|null $timeout The timeout in seconds or null to disable
      */
-    public function shell($command, $cwd = null, array $env = null, $input = null, $timeout = 60): ProcessBase
+    public function shell($command, $cwd = null, ?array $env = null, $input = null, $timeout = 60): ProcessBase
     {
         $process = parent::shell($command, $cwd, $env, $input, $timeout);
         return $this->configureProcess($process);

--- a/src/TestTraits/OutputUtilsTrait.php
+++ b/src/TestTraits/OutputUtilsTrait.php
@@ -113,7 +113,7 @@ trait OutputUtilsTrait
      * @param $key
      *   Optionally return only a top level element from the json object.
      */
-    public function getOutputFromJSON(string|int $key = null): mixed
+    public function getOutputFromJSON(string|int|null $key = null): mixed
     {
         $output = $this->getOutput();
         $json = json_decode($output, true);


### PR DESCRIPTION
I'm working on upgrading from PHP 8.1 to 8.4. I cannot use Drush 13 yet because that requires PHP 8.2. I want to upgrade as many dependencies as possible before jumping to PHP 8.4, so I need Drush 12 to run on both PHP 8.1 and 8.4.

The changes were created automatically with
```
~/workspace/php-cs-fixer/vendor/bin/php-cs-fixer fix . --rules=nullable_type_declaration_for_default_null_value
```