### PR TITLE
Allow cache-rebuild to fix more things

### DIFF
--- a/src/Commands/core/CacheRebuildCommands.php
+++ b/src/Commands/core/CacheRebuildCommands.php
@@ -15,6 +15,7 @@ use Drush\Commands\DrushCommands;
 use Drush\Drupal\DrushLoggerServiceProvider;
 use Drush\Drupal\Migrate\MigrateRunnerServiceProvider;
 
+#[CLI\Bootstrap(DrupalBootLevels::NONE)]
 final class CacheRebuildCommands extends DrushCommands
 {
     use AutowireTrait;


### PR DESCRIPTION
If we add this annotation the cache rebuild command becomes even more useful and can recover from more terminal issues.

For example if you change the Drupal core service name cache.backend.database to cache.backend.databas and do a drush cr you'll get an error. On HEAD if you go back and fix this and then run drush cr again it'll still be broken. With this change drush cr is capable of fixing the site.