### PR TITLE
Fix WootCommandInfoAlterer

### DIFF
--- a/src/Runtime/DependencyInjection.php
+++ b/src/Runtime/DependencyInjection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drush\Runtime;
 
 use Composer\Autoload\ClassLoader;
+use Consolidation\AnnotatedCommand\CommandFileDiscovery;
 use Consolidation\Config\ConfigInterface;
 use Consolidation\Config\Util\ConfigOverlay;
 use Consolidation\SiteAlias\SiteAliasManager;
@@ -31,6 +32,7 @@ use League\Container\ContainerInterface;
 use Robo\Robo;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Prepare our Dependency Injection Container
@@ -143,7 +145,7 @@ class DependencyInjection
         // but we will register and configure one for our use.
         // TODO: Some old adapter code uses this, but the Symfony dispatcher does not.
         // See Application::commandDiscovery().
-        Robo::addShared($container, 'commandDiscovery', 'Consolidation\AnnotatedCommand\CommandFileDiscovery')
+        Robo::addShared($container, 'commandDiscovery', CommandFileDiscovery::class)
             ->addMethodCall('addSearchLocation', ['CommandFiles'])
             ->addMethodCall('setSearchPattern', ['#.*(Commands|CommandFile).php$#']);
 
@@ -161,7 +163,7 @@ class DependencyInjection
     protected function alterServicesForDrush($container, Application $application): void
     {
         $paramInjection = $container->get('parameterInjection');
-        $paramInjection->register('Symfony\Component\Console\Style\SymfonyStyle', new DrushStyleInjector());
+        $paramInjection->register(SymfonyStyle::class, new DrushStyleInjector());
 
         // Add our own callback to the hook manager
         $hookManager = $container->get('hookManager');

--- a/src/Runtime/DependencyInjection.php
+++ b/src/Runtime/DependencyInjection.php
@@ -12,7 +12,9 @@ use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteAlias\SiteAliasManagerInterface;
 use Consolidation\SiteProcess\ProcessManagerAwareInterface;
 use Drush\Application;
+use Drush\Boot\BootstrapHook;
 use Drush\Boot\BootstrapManager;
+use Drush\Boot\DrupalBoot8;
 use Drush\Cache\CommandCache;
 use Drush\Command\DrushCommandInfoAlterer;
 use Drush\Command\GlobalOptionsEventListener;
@@ -116,25 +118,25 @@ class DependencyInjection
             ->addMethodCall('addSimplifier', [new EntityToArraySimplifier()]);
 
         // Add some of our own objects to the container
-        Robo::addShared($container, 'service.manager', 'Drush\Runtime\ServiceManager')
+        Robo::addShared($container, 'service.manager', ServiceManager::class)
             ->addArgument(self::LOADER)
             ->addArgument('config')
             ->addArgument('logger');
-        Robo::addShared($container, 'bootstrap.drupal8', 'Drush\Boot\DrupalBoot8')
+        Robo::addShared($container, 'bootstrap.drupal8', DrupalBoot8::class)
             ->addArgument('service.manager')
             ->addArgument(self::LOADER);
-        Robo::addShared($container, self::BOOTSTRAP_MANAGER, 'Drush\Boot\BootstrapManager')
+        Robo::addShared($container, self::BOOTSTRAP_MANAGER, BootstrapManager::class)
             ->addMethodCall('setDrupalFinder', [$drupalFinder])
             ->addMethodCall('add', ['bootstrap.drupal8']);
         Robo::addShared($container, BootstrapManager::class, self::BOOTSTRAP_MANAGER); // For autowiring
-        Robo::addShared($container, 'bootstrap.hook', 'Drush\Boot\BootstrapHook')
+        Robo::addShared($container, 'bootstrap.hook', BootstrapHook::class)
           ->addArgument(self::BOOTSTRAP_MANAGER);
-        Robo::addShared($container, 'tildeExpansion.hook', 'Drush\Runtime\TildeExpansionHook');
+        Robo::addShared($container, 'tildeExpansion.hook', TildeExpansionHook::class);
         Robo::addShared($container, 'process.manager', ProcessManager::class)
             ->addMethodCall('setConfig', ['config'])
             ->addMethodCall('setConfigRuntime', ['config.runtime'])
             ->addMethodCall('setDrupalFinder', [$drupalFinder]);
-        Robo::addShared($container, 'redispatch.hook', 'Drush\Runtime\RedispatchHook')
+        Robo::addShared($container, 'redispatch.hook', RedispatchHook::class)
             ->addArgument('process.manager');
 
         // Robo does not manage the command discovery object in the container,
@@ -146,8 +148,8 @@ class DependencyInjection
             ->addMethodCall('setSearchPattern', ['#.*(Commands|CommandFile).php$#']);
 
         // Error and Shutdown handlers
-        Robo::addShared($container, 'errorHandler', 'Drush\Runtime\ErrorHandler');
-        Robo::addShared($container, 'shutdownHandler', 'Drush\Runtime\ShutdownHandler');
+        Robo::addShared($container, 'errorHandler', ErrorHandler::class);
+        Robo::addShared($container, 'shutdownHandler', ShutdownHandler::class);
 
         // Add inflectors. @see \Drush\Boot\BaseBoot::inflect
         $container->inflector(SiteAliasManagerAwareInterface::class)

--- a/sut/modules/unish/woot/src/Drush/CommandInfoAlterers/WootCommandInfoAlterer.php
+++ b/sut/modules/unish/woot/src/Drush/CommandInfoAlterers/WootCommandInfoAlterer.php
@@ -6,20 +6,12 @@ namespace Drupal\woot\Drush\CommandInfoAlterers;
 
 use Consolidation\AnnotatedCommand\CommandInfoAltererInterface;
 use Consolidation\AnnotatedCommand\Parser\CommandInfo;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
-use Drush\Commands\AutowireTrait;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 
-class WootCommandInfoAlterer implements CommandInfoAltererInterface
+class WootCommandInfoAlterer implements CommandInfoAltererInterface, LoggerAwareInterface
 {
-    use AutowireTrait;
-
-    protected LoggerChannelInterface $logger;
-
-    public function __construct(LoggerChannelFactoryInterface $loggerFactory)
-    {
-        $this->logger = $loggerFactory->get('drush');
-    }
+    use LoggerAwareTrait;
 
     public function alterCommandInfo(CommandInfo $commandInfo, $commandFileInstance)
     {


### PR DESCRIPTION
Command Info Altering will change anyway in Drush 14 (#6135) so just use old approach until then. Fixes #6231

Also a few unrelated class reference improvements.
