### PR TITLE
Add `--extra` option to `sql:create`, `sql:drop`, and `site:install`

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -55,6 +55,7 @@ final class SiteInstallCommands extends DrushCommands
     #[CLI\Option(name: 'db-prefix', description: 'An optional table prefix to use for initial install.')]
     #[CLI\Option(name: 'db-su', description: 'Account to use when creating a new database. Must have Grant permission (mysql only). Optional.')]
     #[CLI\Option(name: 'db-su-pw', description: 'Password for the <info>db-su</info> account. Optional.')]
+    #[CLI\Option(name: 'extra', description: 'Add custom options to the SQL connect string (e.g. --extra=--skip-column-names)')]
     #[CLI\Option(name: 'account-name', description: 'uid1 name.')]
     #[CLI\Option(name: 'account-pass', description: 'uid1 pass. Defaults to a randomly generated password. If desired, set a fixed password in drush.yml.')]
     #[CLI\Option(name: 'account-mail', description: 'uid1 email.')]
@@ -73,7 +74,7 @@ final class SiteInstallCommands extends DrushCommands
     #[CLI\Usage(name: 'drush si core/recipes/standard', description: 'Install from the core Standard recipe.')]
     #[CLI\Bootstrap(level: DrupalBootLevels::ROOT)]
     #[CLI\Kernel(name: Kernels::INSTALLER)]
-    public function install(array $recipeOrProfile, $options = ['db-url' => self::REQ, 'db-prefix' => self::REQ, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'account-name' => 'admin', 'account-mail' => 'admin@example.com', 'site-mail' => 'admin@example.com', 'account-pass' => self::REQ, 'locale' => 'en', 'site-name' => 'Drush Site-Install', 'site-pass' => self::REQ, 'sites-subdir' => self::REQ, 'config-dir' => self::REQ, 'existing-config' => false]): void
+    public function install(array $recipeOrProfile, $options = ['db-url' => self::REQ, 'db-prefix' => self::REQ, 'db-su' => self::REQ, 'db-su-pw' => self::REQ, 'extra' => self::REQ, 'account-name' => 'admin', 'account-mail' => 'admin@example.com', 'site-mail' => 'admin@example.com', 'account-pass' => self::REQ, 'locale' => 'en', 'site-name' => 'Drush Site-Install', 'site-pass' => self::REQ, 'sites-subdir' => self::REQ, 'config-dir' => self::REQ, 'existing-config' => false]): void
     {
         $additional = $recipeOrProfile;
         $recipeOrProfile = array_shift($additional) ?: '';

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -81,12 +81,13 @@ final class SqlCommands extends DrushCommands implements StdinAwareInterface
     #[CLI\Command(name: self::CREATE, aliases: ['sql-create'])]
     #[CLI\Option(name: 'db-su', description: 'Account to use when creating a new database.')]
     #[CLI\Option(name: 'db-su-pw', description: 'Password for the db-su account.')]
+    #[CLI\Option(name: 'extra', description: 'Add custom options to the connect string (e.g. --extra=--skip-column-names)')]
     #[CLI\Usage(name: 'drush sql:create', description: 'Create the database for the current site.')]
     #[CLI\Usage(name: 'drush @site.test sql:create', description: 'Create the database as specified for @site.test.')]
     #[CLI\Usage(name: 'drush sql:create --db-su=root --db-su-pw=rootpassword --db-url="mysql://drupal_db_user:drupal_db_password@127.0.0.1/drupal_db"', description: 'Create the database as specified in the db-url option.')]
     #[CLI\Bootstrap(level: DrupalBootLevels::MAX, max_level: DrupalBootLevels::CONFIGURATION)]
     #[CLI\OptionsetSql]
-    public function createDb($options = ['db-su' => self::REQ, 'db-su-pw' => self::REQ]): void
+    public function createDb($options = ['db-su' => self::REQ, 'db-su-pw' => self::REQ, 'extra' => self::REQ]): void
     {
         $sql = SqlBase::create($options);
         $db_spec = $sql->getDbSpec();
@@ -106,9 +107,10 @@ final class SqlCommands extends DrushCommands implements StdinAwareInterface
      */
     #[CLI\Command(name: self::DROP, aliases: ['sql-drop'])]
     #[CLI\Bootstrap(level: DrupalBootLevels::MAX, max_level: DrupalBootLevels::CONFIGURATION)]
+    #[CLI\Option(name: 'extra', description: 'Add custom options to the connect string (e.g. --extra=--skip-column-names)')]
     #[CLI\OptionsetSql]
     #[CLI\Topics(topics: [DocsCommands::POLICY])]
-    public function drop($options = []): void
+    public function drop($options = ['extra' => self::REQ]): void
     {
         $sql = SqlBase::create($options);
         $db_spec = $sql->getDbSpec();


### PR DESCRIPTION
With recent versions of MariaDB, we need to add the `--extra=--skip_ssl` option in our development setup. It wasn't possible to do that with some Drush commands.

We discovered this while trying to do a site install using Drush.