### PR TITLE
Fix line break in PmCommands::validateUninstall() output.

### DIFF
--- a/src/Commands/pm/PmCommands.php
+++ b/src/Commands/pm/PmCommands.php
@@ -221,7 +221,7 @@ final class PmCommands extends DrushCommands
                         $list[] = "$module: " . (string)$reason;
                     }
                 }
-                throw new \Exception(implode("/n", $list));
+                throw new \Exception(implode("\n", $list));
             }
         }
     }


### PR DESCRIPTION
Before: Multiple "cannot uninstall" reasons are all on the same line, separated with "/n".
After: Multiple "cannot uninstall" reasons appear on separate lines.

I don't know if this is tested somewhere..