### PR TITLE
Check mariadb and mariadb-dump before using SqlMariaDB

### DIFF
--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -25,7 +25,7 @@ class SqlMysql extends SqlBase
         $process = Drush::shell('mysql --version');
         $process->setSimulated(false);
         $process->run();
-        if ((!$process->isSuccessful() || str_contains($process->getOutput(), 'MariaDB')) && self::programExists('mariadb')) {
+        if ((!$process->isSuccessful() || str_contains($process->getOutput(), 'MariaDB')) && self::programExists('mariadb') && self::programExists('mariadb-dump')) {
             $instance = new SqlMariaDB($dbSpec, $options);
         } else {
             $instance = new self($dbSpec, $options);


### PR DESCRIPTION
The ```mariadb-dump``` binary is not available on Ubuntu 20.04 LTS. This leads to broken ```drush sql:dump``` command. Ubuntu 22.04 and 24.04 are not affected. It may cause issues in other distros. 

- 20.04 LTS, Focal, Package: mariadb-client-core-10.3 https://packages.ubuntu.com/focal/amd64/mariadb-client-core-10.3/filelist

- 22.04 LTS, Jammy, Package: mariadb-client-core-10.6 https://packages.ubuntu.com/jammy/amd64/mariadb-client-10.6/filelist 

- 24.04 LTS, Noble, Package: mariadb-client https://packages.ubuntu.com/noble/amd64/mariadb-client/filelist

---

Check for both binaries before selecting the MariaDB class. Other ideas:

- Add ``programExists`` in ```\Drush\Sql\SqlMariaDB::command``` and ```\Drush\Sql\SqlMariaDB::\Drush\Sql\SqlMariaDB::dumpProgram```. But calls are not cached atm. 