### PR TITLE
assert_options() and assert.* INI configs are deprecated in PHP 8.3

### DIFF
--- a/src/Commands/core/CliCommands.php
+++ b/src/Commands/core/CliCommands.php
@@ -90,8 +90,14 @@ final class CliCommands extends DrushCommands
         // Register the assertion handler so exceptions are thrown instead of
         // errors being triggered. This plays nicer with PsySH. Since we're
         // using exceptions, turn error warnings off.
-        assert_options(ASSERT_EXCEPTION, true);
-        assert_options(ASSERT_WARNING, false);
+        if (version_compare(PHP_VERSION, '8.3', '<')) {
+            // assert_options() and assert.* INI configuration directives are
+            // all deprecated in PHP 8.3.
+            // @see https://www.php.net/manual/en/function.assert-options.php
+            // @see https://www.php.net/manual/en/info.configuration.php
+            assert_options(ASSERT_EXCEPTION, TRUE);
+            assert_options(ASSERT_WARNING, FALSE);
+        }
 
         $shell->setScopeVariables(['container' => \Drupal::getContainer()]);
 

--- a/src/Commands/core/CliCommands.php
+++ b/src/Commands/core/CliCommands.php
@@ -95,8 +95,8 @@ final class CliCommands extends DrushCommands
             // all deprecated in PHP 8.3.
             // @see https://www.php.net/manual/en/function.assert-options.php
             // @see https://www.php.net/manual/en/info.configuration.php
-            assert_options(ASSERT_EXCEPTION, TRUE);
-            assert_options(ASSERT_WARNING, FALSE);
+            assert_options(ASSERT_EXCEPTION, true);
+            assert_options(ASSERT_WARNING, false);
         }
 
         $shell->setScopeVariables(['container' => \Drupal::getContainer()]);


### PR DESCRIPTION
* See https://www.php.net/manual/en/function.assert-options.php
* See https://www.php.net/manual/en/info.configuration.php

When I exit `drush php`, I'm getting:

```
[error]  Message: /Deprecated function/: Constant ASSERT_EXCEPTION is deprecated in /Drush\Commands\core\CliCommands->cli()/ (line /98/ of //var/www/html/vendor/drush/drush/src/Commands/core/CliCommands.php/).Drush\Commands\core\CliCommands->cli() call_user_func_array() (Line: 276)
Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback() (Line: 212)
Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter() (Line: 175)
Consolidation\AnnotatedCommand\CommandProcessor->process() (Line: 387)
Consolidation\AnnotatedCommand\AnnotatedCommand->execute() (Line: 326)
Symfony\Component\Console\Command\Command->run() (Line: 1096)
Symfony\Component\Console\Application->doRunCommand() (Line: 324)
Symfony\Component\Console\Application->doRun() (Line: 175)
Symfony\Component\Console\Application->run() (Line: 110)
Drush\Runtime\Runtime->doRun() (Line: 40)
Drush\Runtime\Runtime->run() (Line: 140)
include() (Line: 119)

 [error]  Message: /Deprecated function/: Function assert_options() is deprecated in /Drush\Commands\core\CliCommands->cli()/ (line /98/ of //var/www/html/vendor/drush/drush/src/Commands/core/CliCommands.php/).Drush\Commands\core\CliCommands->cli() call_user_func_array() (Line: 276)
Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback() (Line: 212)
Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter() (Line: 175)
Consolidation\AnnotatedCommand\CommandProcessor->process() (Line: 387)
Consolidation\AnnotatedCommand\AnnotatedCommand->execute() (Line: 326)
Symfony\Component\Console\Command\Command->run() (Line: 1096)
Symfony\Component\Console\Application->doRunCommand() (Line: 324)
Symfony\Component\Console\Application->doRun() (Line: 175)
Symfony\Component\Console\Application->run() (Line: 110)
Drush\Runtime\Runtime->doRun() (Line: 40)
Drush\Runtime\Runtime->run() (Line: 140)
include() (Line: 119)

 [error]  Message: /Deprecated function/: Constant ASSERT_WARNING is deprecated in /Drush\Commands\core\CliCommands->cli()/ (line /99/ of //var/www/html/vendor/drush/drush/src/Commands/core/CliCommands.php/).Drush\Commands\core\CliCommands->cli() call_user_func_array() (Line: 276)
Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback() (Line: 212)
Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter() (Line: 175)
Consolidation\AnnotatedCommand\CommandProcessor->process() (Line: 387)
Consolidation\AnnotatedCommand\AnnotatedCommand->execute() (Line: 326)
Symfony\Component\Console\Command\Command->run() (Line: 1096)
Symfony\Component\Console\Application->doRunCommand() (Line: 324)
Symfony\Component\Console\Application->doRun() (Line: 175)
Symfony\Component\Console\Application->run() (Line: 110)
Drush\Runtime\Runtime->doRun() (Line: 40)
Drush\Runtime\Runtime->run() (Line: 140)
include() (Line: 119)
```