### PR TITLE
Refs: #6278 fix to use the root of the system as the working directory for diff commands.

### DIFF
--- a/src/Commands/config/ConfigCommands.php
+++ b/src/Commands/config/ConfigCommands.php
@@ -529,7 +529,7 @@ final class ConfigCommands extends DrushCommands implements StdinAwareInterface
             }
         }
         $args = array_merge($prefix, ['-u', $temp_destination_dir, $temp_source_dir]);
-        $process = Drush::process($args);
+        $process = Drush::process($args, "/");
         $process->run();
         return $process->getOutput();
     }


### PR DESCRIPTION
 - Fixes the wrong behaviour of running a diff on non-project root files while running git form the project-root, by changing the working directory for this command to be '/'.