### PR TITLE
Use the search input for select lists with lots of options

### DIFF
--- a/src-symfony-compatibility/v6/Style/DrushStyle.php
+++ b/src-symfony-compatibility/v6/Style/DrushStyle.php
@@ -82,8 +82,13 @@ class DrushStyle extends SymfonyStyle
      * @param  array<int|string, string>  $options
      * @param  true|string  $required
      */
-    public function select(string $label, array $options, int|string|null $default = null, int $scroll = 10, ?\Closure $validate = null, string $hint = '', bool|string $required = true): int|string
+    public function select(string $label, array $options, int|string|null $default = null, int $scroll = 10, ?\Closure $validate = null, string $hint = '', bool|string $required = true, bool $search = true, int $searchThreshold = 20): int|string
     {
+        if ($search && count($options) >= $searchThreshold) {
+            // Use the search prompt if there are many options.
+            return $this->search($label, fn (string $input) => array_filter($options, fn ($option) => str_contains(strtolower($option), strtolower($input))), '', $scroll, $validate, $hint, $required);
+        }
+
         return (new SelectPrompt($label, $options, $default, $scroll, $validate, $hint, $required))->prompt();
     }
 

--- a/src-symfony-compatibility/v6/Style/DrushStyle.php
+++ b/src-symfony-compatibility/v6/Style/DrushStyle.php
@@ -99,8 +99,13 @@ class DrushStyle extends SymfonyStyle
      * @param  array<int|string>  $default
      * @return array<int|string>
      */
-    public function multiselect(string $label, array $options, array $default = [], int $scroll = 10, bool|string $required = false, ?\Closure $validate = null, string $hint = 'Use the space bar to select options.'): array
+    public function multiselect(string $label, array $options, array $default = [], int $scroll = 10, bool|string $required = false, ?\Closure $validate = null, string $hint = 'Use the space bar to select options.', bool $search = true, int $searchThreshold = 20): array
     {
+        if ($search && count($options) >= $searchThreshold) {
+            // Use the search prompt if there are many options.
+            return $this->multisearch($label, fn (string $input) => array_filter($options, fn ($option) => str_contains(strtolower($option), strtolower($input))), '', $scroll, $required, $validate, $hint);
+        }
+
         return (new MultiSelectPrompt($label, $options, $default, $scroll, $required, $validate, $hint))->prompt();
     }
 


### PR DESCRIPTION
Symfony Console has the possibility to filter option lists by default. This functionality was lost when we started using Laravel Prompts. Laravel Prompts does offer this functionality, but under the search input instead of the select input and the multisearch input instead of the multiselect input. I propose using the search inputs in cases where the option lists are (potentially) long, to improve UX.