### PR TITLE
Fix #6310. Provide one-time login links after site install

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -623,7 +623,8 @@ final class SiteInstallCommands extends DrushCommands
     private function getLoginLinks(UserInterface $account): array
     {
         $timestamp = \Drupal::time()->getRequestTime();
-        $data = ['' => dt('Home'), 'admin' => dt('Admin')];
+        // @todo Add Homepage if we can find a way to get there via destimation= or otherwise.
+        $data = ['admin' => dt('Admin')];
         foreach ($data as $path => $text) {
             $link = Url::fromRoute(
                 'user.reset.login',

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -641,6 +641,6 @@ final class SiteInstallCommands extends DrushCommands
             $links[] = sprintf('<href=%s>%s</>', $link, $text);
         }
 
-       return $links;
+        return $links;
     }
 }

--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -16,6 +16,9 @@ use Drupal\Core\Installer\Exception\InstallerException;
 use Drupal\Core\Installer\InstallerKernel;
 use Drupal\Core\Mail\MailFormatHelper;
 use Drupal\Core\Site\Settings;
+use Drupal\Core\Url;
+use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 use Drush\Attributes as CLI;
 use Drush\Boot\BootstrapManager;
 use Drush\Boot\DrupalBootLevels;
@@ -178,10 +181,10 @@ final class SiteInstallCommands extends DrushCommands
             throw new InstallerException(MailFormatHelper::htmlToText($e->getMessage()), $e->getTitle(), $e->getCode(), ($this->output()->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) ? $e : null);
         }
 
+        $links = $this->getLoginLinks(User::load(1));
+        $this->logger()->success(dt('Installation complete. (%links)', ['%links' => implode(' - ', $links)]));
         if (empty($options['account-pass'])) {
-            $this->logger()->success(dt('Installation complete.  User name: @name  User password: @pass', ['@name' => $options['account-name'], '@pass' => $account_pass]));
-        } else {
-            $this->logger()->success(dt('Installation complete.'));
+            $this->logger()->success(dt('User name: @name  User password: @pass', ['@name' => $options['account-name'], '@pass' => $account_pass]));
         }
     }
 
@@ -615,5 +618,29 @@ final class SiteInstallCommands extends DrushCommands
             $this->logger()->warning(dt('Configuration import directory @config does not contain any configuration; will skip import.', ['@config' => $directory]));
             $commandData->input()->setOption('config-dir', '');
         }
+    }
+
+    private function getLoginLinks(UserInterface $account): array
+    {
+        $timestamp = \Drupal::time()->getRequestTime();
+        $data = ['' => dt('Home'), 'admin' => dt('Admin')];
+        foreach ($data as $path => $text) {
+            $link = Url::fromRoute(
+                'user.reset.login',
+                [
+                    'uid' => $account->id(),
+                    'timestamp' => $timestamp,
+                    'hash' => user_pass_rehash($account, $timestamp),
+                ],
+                [
+                    'absolute' => true,
+                    'query' => $path ? ['destination' => $path] : [],
+                    'language' => \Drupal::languageManager()->getLanguage($account->getPreferredLangcode()),
+                ]
+            )->toString();
+            $links[] = sprintf('<href=%s>%s</>', $link, $text);
+        }
+
+       return $links;
     }
 }


### PR DESCRIPTION
I added two links. One to /admin and one to the front page. However, the front page isn't ending up in right place. It ends up at /user/1/edit. I tried to use destination=<front> but that doesnt work. I'm not sure how to make a one time login link that ends up on the front page.

<img width="441" height="24" alt="image" src="https://github.com/user-attachments/assets/74e4d1bf-a003-4901-bac8-c72e42fbe081" />
