### PR TITLE
Add tty/interactive options to kubectl docs

### DIFF
--- a/docs/site-aliases.md
+++ b/docs/site-aliases.md
@@ -284,12 +284,17 @@ Drush provides transport for running drush commands on your Kubernetes cluster v
  ```
 
 #### Key options
+
   * **namespace:** The namespace where your Drupal deployment resides.
   * **resource:**  Kubernetes resource type (usually 'pods').
   * **container:** The specific container within the pod where Drupal runs.
   * **kubeconfig:** The kubeconfig file to use for authentication.
   * **entrypoint:** The command to use as the container entrypoint.
 
+Drush will attempt to use the status of the connection to determine if it is tty/interactive, but in some complex cases that status may not be available. These options can be used to force those flags:
+
+  * **tty:** Set to `true` to force a tty connection using the `kubectl --tty` flag.
+  * **interactive:** Set to `true` to force an interactive connection using the `kubectl --stdin` flag.
 
 ### Example of rsync with exclude-paths
 


### PR DESCRIPTION
As per https://github.com/consolidation/site-process/blob/e7fafc40ebfddc1a5ee99ee66e5d186fc1bed4da/src/Transport/KubectlTransport.php#L41-L42, `tty` and `interactive` can be used to force the connection state.

This adds those options to the docs to other devs don't have to dive into the code to find them like I did.