### PR TITLE
Explain usage of --fields option for user:create command

### DIFF
--- a/src/Commands/core/UserCommands.php
+++ b/src/Commands/core/UserCommands.php
@@ -215,6 +215,7 @@ final class UserCommands extends DrushCommands
     #[CLI\DefaultTableFields(fields: self::INF_DEFAULT_FIELDS)]
     #[CLI\FilterDefaultField(field: 'name')]
     #[CLI\Usage(name: "drush user:create newuser --mail='person@example.com' --password='letmein'", description: 'Create a new user account with the name newuser, the email address person@example.com, and the password letmein')]
+    #[CLI\Usage(name: "drush user:create anotheruser --fields=uuid,langcode", description: 'Create a new user account with the name anotheruser and report back the values of the UUID and Language code fields (note it is not possible to set field values)')]
     public function createUser(string $name, $options = ['format' => 'table', 'password' => self::REQ, 'mail' => self::REQ]): RowsOfFields|CommandError
     {
         $new_user = [


### PR DESCRIPTION
People are likely to want to set the value for user fields while creating a user, so it is good to be explicit that it is reporting-only by including a `--fields` example.