### PR TITLE
Fix 'TypeError: Laravel\Prompts\multiselect(): Argument #3 ($default) must be of type Illuminate\Support\Collection|array, null given'

### DIFF
--- a/src-symfony-compatibility/v6/Style/DrushStyle.php
+++ b/src-symfony-compatibility/v6/Style/DrushStyle.php
@@ -41,7 +41,7 @@ class DrushStyle extends SymfonyStyle
     {
         if ($multiSelect) {
             // For backward compat. Deprecated.
-            return multiselect($question, $choices, $default, $scroll, $required, $validate, $hint);
+            return multiselect($question, $choices, $default ?? [], $scroll, $required, $validate, $hint);
         } else {
             return select($question, $choices, $default, $scroll, $validate, $hint, $required);
         }


### PR DESCRIPTION
> TypeError: Laravel\Prompts\multiselect(): Argument #3 ($default) must be of type Illuminate\Support\Collection|array, null given, called in /[..]/vendor/drush/drush/src-symfony-compatibility/v6/Style/DrushStyle.php on line 44 in Laravel\Prompts\multiselect()