### PR TITLE
Importing dumps with drush sql:cli can be very slow

### DIFF
--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -141,20 +141,18 @@ final class SqlCommands extends DrushCommands implements StdinAwareInterface
         if (!Tty::isTtySupported()) {
             // Fast path for non-interactive mode (e.g. piped SQL dump).
             // Use direct passthru to avoid PHP I/O buffering.
-            $env = $sql->getEnv();
             $env_str = '';
-            foreach ($env as $k => $v) {
+            foreach ($sql->getEnv() as $k => $v) {
                 $env_str .= "$k=" . escapeshellarg($v) . ' ';
             }
 
             passthru($env_str . $sql_cmd);
-            exit(0);
-        } else {
-            // Interactive mode (TTY): use ProcessManager for better control.
-            $process = $this->processManager()->shell($sql_cmd, null, $sql->getEnv());
-            $process->setTty((bool) $this->getConfig()->get('ssh.tty', $input->isInteractive()));
-            $process->mustRun($process->showRealtime());
+            return;
         }
+        // Interactive mode (TTY): use ProcessManager for better control.
+        $process = $this->processManager()->shell($sql_cmd, null, $sql->getEnv());
+        $process->setTty((bool) $this->getConfig()->get('ssh.tty', $input->isInteractive()));
+        $process->mustRun($process->showRealtime());
     }
 
     /**

--- a/src/Commands/sql/SqlCommands.php
+++ b/src/Commands/sql/SqlCommands.php
@@ -137,13 +137,24 @@ final class SqlCommands extends DrushCommands implements StdinAwareInterface
     public function cli(InputInterface $input, $options = ['extra' => self::REQ]): void
     {
         $sql = SqlBase::create($options);
-        $process = $this->processManager()->shell($sql->connect(), null, $sql->getEnv());
+        $sql_cmd = $sql->connect();
         if (!Tty::isTtySupported()) {
-            $process->setInput($this->stdin()->getStream());
+            // Fast path for non-interactive mode (e.g. piped SQL dump).
+            // Use direct passthru to avoid PHP I/O buffering.
+            $env = $sql->getEnv();
+            $env_str = '';
+            foreach ($env as $k => $v) {
+                $env_str .= "$k=" . escapeshellarg($v) . ' ';
+            }
+
+            passthru($env_str . $sql_cmd);
+            exit(0);
         } else {
+            // Interactive mode (TTY): use ProcessManager for better control.
+            $process = $this->processManager()->shell($sql_cmd, null, $sql->getEnv());
             $process->setTty((bool) $this->getConfig()->get('ssh.tty', $input->isInteractive()));
+            $process->mustRun($process->showRealtime());
         }
-        $process->mustRun($process->showRealtime());
     }
 
     /**


### PR DESCRIPTION
We've noticed that importing a dump using `drush sql:cli` is significantly slower than using `mysql` directly. After some investigation we found out that this seems to be caused by the buffering in PHP.

In a specific use case we measured the following times:

drush sqlc: 3min 39s
mysql: 19s

In this PR we improve the performance by using the `passthru()` function in case of the non-interactive mode (e.g. piped SQL dump).