### PR TITLE
#6345: Fix performance issues in 'locale:export' command for large .po exports

### DIFF
--- a/src/Commands/core/LocaleCommands.php
+++ b/src/Commands/core/LocaleCommands.php
@@ -19,6 +19,7 @@ use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
 use Drush\Exceptions\CommandFailedException;
 use Drush\Utils\StringUtils;
+use Symfony\Component\Console\Output\OutputInterface;
 
 final class LocaleCommands extends DrushCommands
 {
@@ -175,7 +176,7 @@ final class LocaleCommands extends DrushCommands
 
         $file_uri = drush_tempnam('drush_', null, '.po');
         if ($this->writePoFile($file_uri, $language, $poreader_options)) {
-            $this->output()->writeln(file_get_contents($file_uri));
+            $this->output()->writeln(file_get_contents($file_uri), OutputInterface::OUTPUT_RAW);
         } else {
             $this->logger()->success(dt('Nothing to export.'));
         }


### PR DESCRIPTION
Here is the pull request for #6345 - current target is 13.x, but this also has to be backported to 12.x.