### PR TITLE
12.x backport - #6345: Fix performance issues in 'locale:export' command for large .po exports

### DIFF
--- a/src/Commands/core/LocaleCommands.php
+++ b/src/Commands/core/LocaleCommands.php
@@ -18,6 +18,7 @@ use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
 use Drush\Exceptions\CommandFailedException;
 use Drush\Utils\StringUtils;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 final class LocaleCommands extends DrushCommands
@@ -185,7 +186,7 @@ final class LocaleCommands extends DrushCommands
 
         $file_uri = drush_tempnam('drush_', null, '.po');
         if ($this->writePoFile($file_uri, $language, $poreader_options)) {
-            $this->output()->writeln(file_get_contents($file_uri));
+          $this->output()->writeln(file_get_contents($file_uri), OutputInterface::OUTPUT_RAW);
         } else {
             $this->logger()->success(dt('Nothing to export.'));
         }

--- a/src/Commands/core/LocaleCommands.php
+++ b/src/Commands/core/LocaleCommands.php
@@ -186,7 +186,7 @@ final class LocaleCommands extends DrushCommands
 
         $file_uri = drush_tempnam('drush_', null, '.po');
         if ($this->writePoFile($file_uri, $language, $poreader_options)) {
-          $this->output()->writeln(file_get_contents($file_uri), OutputInterface::OUTPUT_RAW);
+            $this->output()->writeln(file_get_contents($file_uri), OutputInterface::OUTPUT_RAW);
         } else {
             $this->logger()->success(dt('Nothing to export.'));
         }


### PR DESCRIPTION
And here is the corresponding pull request for the 12.x backport of the fix.

Resolves #6345 