### PR TITLE
Ensure the order of database updates shown is consistent with how it would actually run

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -494,28 +494,38 @@ final class UpdateDBCommands extends DrushCommands
         require_once DRUPAL_ROOT . '/core/includes/update.inc';
         $pending = \update_get_update_list();
 
+        $start = $this->getUpdateList();
+        // Resolve any update dependencies to determine the actual updates that will
+        // be run and the order they will be run in.
+        $upcoming_updates = update_resolve_dependencies($start);
+
         $return = [];
         $warnings = [];
 
         // Ensure system module's updates run first.
         $start['system'] = [];
 
-        foreach ($pending as $module => $updates) {
-            if (isset($updates['start'])) {
-                $start[$module] = $updates['start'];
-                foreach ($updates['pending'] as $update_id => $description) {
-                    // Strip cruft from front.
-                    $description = str_replace($update_id . ' -   ', '', $description);
-                    $return[$module . "_update_$update_id"] = [
-                        'module' => $module,
-                        'update_id' => $update_id,
-                        'description' => $description,
-                        'type' => 'hook_update_n'
-                    ];
-                }
+        foreach ($upcoming_updates as $upcoming_update) {
+            $module = $upcoming_update['module'];
+            $update_id = $upcoming_update['number'];
+            $description = $pending[$module]['pending'][$update_id];
+            // Strip cruft from front.
+            $description = str_replace($update_id . ' -   ', '', $description);
+            if (empty($upcoming_update['allowed'])) {
+                // This should rarely happen, but it's a good idea to have it
+                // shown rather than silently skipped.
+                $description = dt('[SKIPPED] @description', [
+                    '@description' => $description,
+                ]);
             }
-            if (isset($updates['warning'])) {
-                $warnings[$module] = $updates['warning'];
+            $return[$module . "_update_$update_id"] = [
+                'module' => $module,
+                'update_id' => $update_id,
+                'description' => $description,
+                'type' => 'hook_update_n'
+            ];
+            if (isset($pending[$module]['warning'])) {
+                $warnings[$module] = $pending[$module]['warning'];
             }
         }
 

--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -109,7 +109,8 @@ final class UpdateDBCommands extends DrushCommands
         'module' => 'Module',
         'update_id' => 'Update ID',
         'description' => 'Description',
-        'type' => 'Type'
+        'type' => 'Type',
+        'allowed' => 'Allowed',
     ])]
     #[CLI\DefaultTableFields(fields: ['module', 'update_id', 'type', 'description'])]
     #[CLI\FilterDefaultField(field: 'type')]
@@ -127,6 +128,17 @@ final class UpdateDBCommands extends DrushCommands
         if (empty($pending)) {
             $this->logger()->success(dt("No database updates required."));
         } else {
+            if (empty($options['filter'])) {
+                // Show only allowed updates by default.
+                // Would ideally set a default filter in the parameter, however
+                // there's an upstream issue in
+                // https://github.com/consolidation/filter-via-dot-access-data/pull/51
+                // that needs to be addressed before that's possible, so
+                // manually handling the filter for now.
+                $pending = array_filter($pending, static function ($update_hook) {
+                    return empty($update_hook['allowed']) || $update_hook['allowed'] === 'yes';
+                });
+            }
             $return = new RowsOfFields($pending);
         }
         return $return;
@@ -511,19 +523,34 @@ final class UpdateDBCommands extends DrushCommands
             $description = $pending[$module]['pending'][$update_id];
             // Strip cruft from front.
             $description = str_replace($update_id . ' -   ', '', $description);
-            if (empty($upcoming_update['allowed'])) {
-                // This should rarely happen, but it's a good idea to have it
-                // shown rather than silently skipped.
-                $description = dt('[SKIPPED] @description', [
-                    '@description' => $description,
-                ]);
-            }
-            $return[$module . "_update_$update_id"] = [
+            $module_update_function = $module . "_update_$update_id";
+            $return[$module_update_function] = [
                 'module' => $module,
                 'update_id' => $update_id,
                 'description' => $description,
-                'type' => 'hook_update_n'
+                'type' => 'hook_update_n',
+                'allowed' => !empty($upcoming_update['allowed']) ? 'yes' : 'no',
             ];
+            if (empty($upcoming_update['allowed'])) {
+                if ($upcoming_update['missing_dependencies']) {
+                    // This should rarely happen, but the user should be notified
+                    // since skipping them can potentially put the database in an
+                    // inconsistent state.
+                    $missing_warning = dt('Skipping @update_function due to missing dependencies: @missing_dependencies.', [
+                        '@update_function' => "{$module_update_function}()",
+                        '@missing_dependencies' => implode('(), ', $upcoming_update['missing_dependencies']) . '()',
+                    ]);
+                } else {
+                    $missing_warning = dt("Skipping @update_function due to an error in the module's code.", [
+                        '@update_function' => "{$module_update_function}()",
+                    ]);
+                }
+                if (isset($pending[$module]['warning'])) {
+                    $pending[$module]['warning'] .= "\n$missing_warning";
+                } else {
+                    $pending[$module]['warning'] = $missing_warning;
+                }
+            }
             if (isset($pending[$module]['warning'])) {
                 $warnings[$module] = $pending[$module]['warning'];
             }
@@ -541,7 +568,8 @@ final class UpdateDBCommands extends DrushCommands
                             'module' => $module,
                             'update_id' => $id,
                             'description' => trim($item),
-                            'type' => 'post-update'
+                            'type' => 'post-update',
+                            'allowed' => 'yes',
                         ];
                     }
                 }

--- a/sut/modules/unish/drush_empty_module/drush_empty_module.install
+++ b/sut/modules/unish/drush_empty_module/drush_empty_module.install
@@ -33,3 +33,17 @@ function drush_empty_module_requirements($phase) {
 function drush_empty_module_update_8001() {
   return 'The update ran';
 }
+
+/**
+ * Fake update hook 2.
+ */
+function drush_empty_module_update_8002() {
+  return 'The second update ran';
+}
+
+/**
+ * Fake update hook 3.
+ */
+function drush_empty_module_update_8003() {
+  return 'The third update ran';
+}

--- a/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency/drush_missing_update_dependency.info.yml
+++ b/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency/drush_missing_update_dependency.info.yml
@@ -1,0 +1,6 @@
+name: Missing Drush update
+type: module
+description: Module to always trigger a missing update dependency.
+core_version_requirement: '>=8'
+package: Other
+dependencies: []

--- a/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency/drush_missing_update_dependency.install
+++ b/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency/drush_missing_update_dependency.install
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Provides install and update functions for drush_missing_update_dependency.
+ */
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function drush_missing_update_dependency_update_dependencies() {
+  // Flag that update hooks in this module will never resolve due to the
+  // missing "drush_non_existent_update_dependency" module dependency.
+  $dependencies['drush_missing_update_dependency'][8001] = [
+    'drush_non_existent_update_dependency' => 8001,
+  ];
+  $dependencies['drush_missing_update_dependency'][8002] = [
+    'drush_non_existent_update_dependency' => 8002,
+  ];
+  return $dependencies;
+}
+
+
+/**
+ * This should never have run (missing dependency).
+ */
+function drush_missing_update_dependency_update_8001() {
+  throw new \LogicException('This update function is not allowed to run, since the schema version should already be at least 8001.');
+}
+
+/**
+ * This should never run (missing dependency).
+ */
+function drush_missing_update_dependency_update_8002() {
+  throw new \LogicException('This update function is not allowed to run, since it has a direct dependency on a missing update.');
+}
+

--- a/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency1/drush_missing_update_dependency1.info.yml
+++ b/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency1/drush_missing_update_dependency1.info.yml
@@ -1,0 +1,6 @@
+name: Missing Drush update dependency 1
+type: module
+description: Module to trigger missing update dependency.
+core_version_requirement: '>=8'
+package: Other
+dependencies: []

--- a/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency1/drush_missing_update_dependency1.install
+++ b/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency1/drush_missing_update_dependency1.install
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Provides install and update functions for drush_missing_update_dependency1.
+ */
+
+/**
+ * Update hook 1.
+ */
+function drush_missing_update_dependency1_update_8001() {
+  return 'The first update ran';
+}
+
+/**
+ * Update hook 2.
+ */
+function drush_missing_update_dependency1_update_8002() {
+  return 'The second update ran';
+}

--- a/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency2/drush_missing_update_dependency2.info.yml
+++ b/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency2/drush_missing_update_dependency2.info.yml
@@ -1,0 +1,6 @@
+name: Missing Drush update dependency 2
+type: module
+description: Module to trigger missing update dependency.
+core_version_requirement: '>=8'
+package: Other
+dependencies: []

--- a/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency2/drush_missing_update_dependency2.install
+++ b/sut/modules/unish/drush_update_dependency/drush_missing_update_dependency2/drush_missing_update_dependency2.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Provides install and update functions for drush_missing_update_dependency2.
+ */
+
+/**
+ * Update hook 1.
+ */
+function drush_missing_update_dependency2_update_8001() {
+  return 'The first update ran';
+}
+

--- a/sut/modules/unish/drush_update_dependency/drush_update_dependency.info.yml
+++ b/sut/modules/unish/drush_update_dependency/drush_update_dependency.info.yml
@@ -1,0 +1,6 @@
+name: Drush update dependency
+type: module
+description: Module with hook_update_dependencies() entry.
+core_version_requirement: '>=8'
+package: Other
+dependencies: []

--- a/sut/modules/unish/drush_update_dependency/drush_update_dependency.install
+++ b/sut/modules/unish/drush_update_dependency/drush_update_dependency.install
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @file
+ * Provides install and update functions for drush_update_dependency.
+ */
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function drush_update_dependency_update_dependencies() {
+  // When this module is enabled, we are declaring here that modules run
+  // updates in the following order:
+  // 1. drush_empty_module_update_8001()
+  // 2. drush_update_dependency_update_8001()
+  // 3. drush_update_dependency_update_8002()
+  // ...
+  // 7. drush_empty_module_update_8002()
+  $dependencies['drush_update_dependency'][8001] = [
+    'drush_empty_module' => 8001,
+  ];
+
+  // These are coordinated with the corresponding dependencies declared in
+  // update_test_1_update_dependencies().
+  $dependencies['drush_missing_update_dependency1'][8002] = [
+    'drush_update_dependency' => 8002,
+  ];
+  // Ensure the two update hooks won't run until the module exists.
+  $dependencies['drush_update_dependency'][8003] = [
+    'drush_missing_update_dependency1' => 8001,
+  ];
+  $dependencies['drush_update_dependency'][8004] = [
+    'drush_missing_update_dependency2' => 8001,
+  ];
+
+  return $dependencies;
+}
+
+/**
+ * Dependency update hook 1.
+ */
+function drush_update_dependency_update_8001() {
+  return 'The first update ran';
+}
+
+/**
+ * Dependency update hook 2.
+ */
+function drush_update_dependency_update_8002() {
+  return 'The second update ran';
+}
+
+/**
+ * Dependency update hook 3.
+ */
+function drush_update_dependency_update_8003() {
+  return 'The third update ran';
+}
+
+/**
+ * Dependency update hook 4.
+ */
+function drush_update_dependency_update_8004() {
+  return 'The fourth update ran';
+}
+
+/**
+ * Dependency update hook 5 (blocked).
+ */
+function drush_update_dependency_update_8005() {
+  // This will not be ran until the previous hooks have been successfully ran.
+  return 'The fifth update ran';
+}

--- a/tests/functional/UpdateDBTest.php
+++ b/tests/functional/UpdateDBTest.php
@@ -23,26 +23,119 @@ class UpdateDBTest extends CommandUnishTestCase
     public function testUpdateDBStatus()
     {
         $this->setUpDrupal(1, true);
-        $this->drush(PmCommands::INSTALL, ['drush_empty_module']);
+        $this->drush(PmCommands::INSTALL, ['drush_empty_module', 'drush_update_dependency']);
         $this->drush(UpdateDBCommands::STATUS);
         $err = $this->getErrorOutput();
         $this->assertStringContainsString('[success] No database updates required.', $err);
 
-        // Force a pending update.
-        $this->drush(PhpCommands::SCRIPT, ['updatedb_script'], ['script-path' => __DIR__ . '/resources']);
+        // Force pending updates.
+        $this->drush(PhpCommands::SCRIPT, [
+            'updatedb_script',
+            'drush_empty_module',
+            'drush_update_dependency',
+        ], ['script-path' => __DIR__ . '/resources']);
 
-        // Assert that pending hook_update_n appears
+        // Assert that pending hook_update_n appears and in the right order
         $this->drush(UpdateDBCommands::STATUS, [], ['format' => 'json']);
         $out = $this->getOutputFromJSON('drush_empty_module_update_8001');
         $this->assertStringContainsString('Fake update hook', trim($out['description']));
 
+        // Show only allowed updates by default
+        $expected_update_order = [
+            'drush_empty_module_update_8001',
+            'drush_update_dependency_update_8001',
+            'drush_update_dependency_update_8002',
+            'drush_empty_module_update_8002',
+            'drush_empty_module_update_8003',
+        ];
+        $this->assertEquals($expected_update_order, array_keys($this->getOutputFromJSON()));
+
+        // Ensure skipped dependencies are shown as warnings.
+        $err = $this->getErrorOutput();
+        $this->assertStringContainsString('Skipping drush_update_dependency_update_8003() due to missing dependencies: drush_missing_update_dependency1_update_8001().', $err);
+        $this->assertStringContainsString('Skipping drush_update_dependency_update_8004() due to missing dependencies: drush_missing_update_dependency2_update_8001(), drush_missing_update_dependency1_update_8001().', $err);
+        $this->assertStringContainsString('Skipping drush_update_dependency_update_8005() due to missing dependencies: drush_missing_update_dependency2_update_8001(), drush_missing_update_dependency1_update_8001().', $err);
+
+        // Show just the ones which have been skipped
+        $this->drush(UpdateDBCommands::STATUS, [], ['format' => 'json', 'filter' => 'allowed=no']);
+        $expected_update_order = [
+            'drush_update_dependency_update_8003',
+            'drush_update_dependency_update_8004',
+            'drush_update_dependency_update_8005',
+        ];
+        $this->assertEquals($expected_update_order, array_keys($this->getOutputFromJSON()));
+
+        // Show both allowed and not allowed updates
+        $this->drush(UpdateDBCommands::STATUS, [], ['format' => 'json', 'filter' => 'allowed=yes||allowed=no']);
+        $expected_update_order = [
+            'drush_empty_module_update_8001',
+            'drush_update_dependency_update_8001',
+            'drush_update_dependency_update_8002',
+            'drush_update_dependency_update_8003',
+            'drush_update_dependency_update_8004',
+            'drush_update_dependency_update_8005',
+            'drush_empty_module_update_8002',
+            'drush_empty_module_update_8003',
+        ];
+        $this->assertEquals($expected_update_order, array_keys($this->getOutputFromJSON()));
+
+        // Install the missing dependencies and force pending updates for them
+        $this->drush(PmCommands::INSTALL, ['drush_missing_update_dependency1', 'drush_missing_update_dependency2']);
+        $this->drush(PhpCommands::SCRIPT, [
+            'updatedb_script',
+            'drush_missing_update_dependency1',
+            'drush_missing_update_dependency2',
+        ], ['script-path' => __DIR__ . '/resources']);
+        $this->drush(UpdateDBCommands::STATUS, [], ['format' => 'json']);
+        $err = $this->getErrorOutput();
+        // There should be no warnings since all the main dependencies are
+        // available to run
+        $this->assertEmpty($err);
+        $expected_update_order = [
+            // The initial dependency1 and dependency2 hooks must be run before
+            // drush_update_dependency_update_8003() update
+            'drush_missing_update_dependency2_update_8001',
+            'drush_missing_update_dependency1_update_8001',
+            'drush_empty_module_update_8001',
+            'drush_update_dependency_update_8001',
+            'drush_update_dependency_update_8002',
+            'drush_missing_update_dependency1_update_8002',
+            'drush_update_dependency_update_8003',
+            'drush_update_dependency_update_8004',
+            'drush_update_dependency_update_8005',
+            'drush_empty_module_update_8002',
+            'drush_empty_module_update_8003',
+        ];
+        $this->assertEquals($expected_update_order, array_keys($this->getOutputFromJSON()));
+
         // Run hook_update_n
         $this->drush(UpdateDBCommands::UPDATEDB, []);
+
+        // Ensure the update order matches the summary.
+        $err = $this->getErrorOutput();
+        $output_offset = 0;
+        foreach ($expected_update_order as $expected_update) {
+            $update_completed_string = "Update completed: $expected_update";
+            $output_offset = strpos($err, $update_completed_string, $output_offset);
+            $this->assertIsInt($output_offset, "Could not find update hook: $expected_update");
+            $this->assertStringContainsString($update_completed_string, substr($err, $output_offset));
+          // Move the offset for the next update to search.
+            $output_offset += strlen($update_completed_string);
+        }
 
         // Assert that we ran hook_update_n properly
         $this->drush(UpdateDBCommands::STATUS);
         $err = $this->getErrorOutput();
         $this->assertStringContainsString('[success] No database updates required.', $err);
+
+        // Force a pending update for the module that can't run update hooks
+        // due to a missing dependency.
+        $this->drush(PmCommands::INSTALL, ['drush_missing_update_dependency']);
+        $this->drush(PhpCommands::SCRIPT, ['updatedb_script', 'drush_missing_update_dependency'], [
+            'script-path' => __DIR__ . '/resources',
+            '--' => null,
+            'schema-version' => 8001,
+        ]);
 
         // Assure that a pending post-update is reported.
         $this->pathPostUpdate = Path::join($this->webroot(), 'modules/unish/drush_empty_module/drush_empty_module.post_update.php');
@@ -50,6 +143,9 @@ class UpdateDBTest extends CommandUnishTestCase
         $this->drush(UpdateDBCommands::STATUS, [], ['format' => 'json']);
         $out = $this->getOutputFromJSON('drush_empty_module-post-null_op');
         $this->assertStringContainsString('This is a test of the emergency broadcast system.', trim($out['description']));
+        // The missing dependency warning is still shown.
+        $err = $this->getErrorOutput();
+        $this->assertStringContainsString('[warning] drush_missing_update_dependency: Skipping drush_missing_update_dependency_update_8002() due to missing dependencies: drush_non_existent_update_dependency_update_8002().', $err);
     }
 
     /**

--- a/tests/functional/UpdateDBTest.php
+++ b/tests/functional/UpdateDBTest.php
@@ -119,7 +119,7 @@ class UpdateDBTest extends CommandUnishTestCase
             $output_offset = strpos($err, $update_completed_string, $output_offset);
             $this->assertIsInt($output_offset, "Could not find update hook: $expected_update");
             $this->assertStringContainsString($update_completed_string, substr($err, $output_offset));
-          // Move the offset for the next update to search.
+            // Move the offset for the next update to search.
             $output_offset += strlen($update_completed_string);
         }
 

--- a/tests/functional/resources/updatedb_script.php
+++ b/tests/functional/resources/updatedb_script.php
@@ -2,7 +2,44 @@
 
 declare(strict_types=1);
 
-// Set the schema version of drush_empty_module to a lower version, so we have a
-// pending update.
-$current = \Drupal::service('update.update_hook_registry')->getInstalledVersion('drush_empty_module');
-\Drupal::service('update.update_hook_registry')->setInstalledVersion('drush_empty_module', $current - 1);
+use Symfony\Component\Console\Helper\DescriptorHelper;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+
+/** @var \Drush\Commands\core\PhpCommands $this */
+$input_definition = new InputDefinition();
+$input_definition->addArgument(new InputArgument('modules', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The modules to update schema versions for.', ['drush_empty_module']));
+$input_definition->addOptions([
+  new InputOption('--schema-version', null, InputOption::VALUE_REQUIRED, 'The schema version to use.', 8000),
+  new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display this help message'),
+]);
+
+$arguments = new ArgvInput($this->input()
+  ->getArgument('extra'), $input_definition);
+
+if ($arguments->getOption('help')) {
+    $output = $this->output();
+    $output->writeln('<comment>Usage:</comment>');
+    $output->writeln(sprintf(
+        "  drush php-script %s -- [options] [...modules]\n",
+        $this->input()->getArgument('extra')[0]
+    ));
+    $helper = new DescriptorHelper();
+    $helper->describe($output, $input_definition);
+    $output->writeln('');
+    return;
+}
+
+/** @var \Drupal\Core\Update\UpdateHookRegistry $update_hook_registry */
+$update_hook_registry = \Drupal::service('update.update_hook_registry');
+$module_handler = \Drupal::moduleHandler();
+
+// The schema version to set it to.
+$schema_version = (int) $arguments->getOption('schema-version');
+$modules = $arguments->getArgument('modules');
+foreach ($modules as $module) {
+    // Set the installed version for the specific modules.
+    $update_hook_registry->setInstalledVersion($module, $schema_version);
+}

--- a/tests/unish/CommandUnishTestCase.php
+++ b/tests/unish/CommandUnishTestCase.php
@@ -175,7 +175,9 @@ abstract class CommandUnishTestCase extends UnishTestCase
             foreach ($values as $value) {
                 $dashes = strlen($key) == 1 ? '-' : '--';
                 $equals = strlen($key) == 1 ? '' : '=';
-                if (!isset($value)) {
+                if ($key === '--') {
+                    $cmd[] = '--';
+                } elseif (!isset($value)) {
                     $cmd[] = "$dashes$key";
                 } else {
                     // Cast because the CLI sends only strings.


### PR DESCRIPTION
Currently the database update is listed in alphabetical order, rather than the actual order it would run.

This is especially the case when the [`hook_update_dependencies`](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_update_dependencies/11.x) hook is incorporated.

Still need tests and some minor coding standards fixes, but pushing this up just so I don't lose/forget it.