### PR TITLE
Add example to set default admin user account

### DIFF
--- a/examples/example.drush.yml
+++ b/examples/example.drush.yml
@@ -23,6 +23,13 @@ options:
 
 # Command-specific options.
 command:
+  # Disabling the admin super user account (uid #1) is recommended.
+  # Use this to specify another admin account for the uli command.
+  # See https://www.drupal.org/docs/administering-a-drupal-site/security-in-drupal/securing-the-admin-super-user-1
+  user:
+    login:
+      options:
+        name: newadminuser
   sql:
     dump:
       options:


### PR DESCRIPTION
- Fixes #6098

Add example on how to set the default admin account, to use with `drush uli`.