### PR TITLE
field-create: Get defaults from existing field

### DIFF
--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -15,6 +15,7 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Field\FieldTypePluginManagerInterface;
 use Drupal\Core\Field\WidgetPluginManager;
@@ -302,12 +303,14 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
 
     protected function askFieldLabel(): string
     {
-        return $this->io()->ask('Field label', required: true);
+        $default = $this->getExistingFieldForDefaults()?->getLabel();
+        return $this->io()->ask('Field label', $default, required: true);
     }
 
     protected function askFieldDescription(): ?string
     {
-        return $this->io()->ask('Field description');
+        $default = $this->getExistingFieldForDefaults()?->getDescription();
+        return $this->io()->ask('Field description', $default);
     }
 
     protected function askFieldType(): string
@@ -353,14 +356,16 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
             $choices[$name] = $label;
         }
 
-        $default = $this->input->getOption('show-machine-names') ? key($choices) : current($choices);
+        $fieldName = $this->input->getOption('field-name');
+        $default = $this->getExistingEntityDisplayForDefaults('form')?->getComponent($fieldName)['type'] ?? null;
 
         return $this->io()->select('Field widget', $choices, $default);
     }
 
     protected function askRequired(): bool
     {
-        return $this->io()->confirm('Required', false);
+        $default = $this->getExistingFieldForDefaults()?->isRequired() ?? false;
+        return $this->io()->confirm('Required', $default);
     }
 
     protected function askTranslatable(): bool
@@ -621,5 +626,54 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         }
 
         $this->input->setOption($name, $value);
+    }
+
+    protected function getExistingFieldForDefaults(): ?FieldDefinitionInterface
+    {
+        $entityTypeId = $this->input->getArgument('entityType');
+        $existingBundle = $this->getExistingBundleForDefaults();
+        $fieldName = $this->input->getOption('field-name');
+
+        return $this->entityFieldManager->getFieldDefinitions($entityTypeId, $existingBundle)[$fieldName];
+    }
+
+    protected function getExistingEntityDisplayForDefaults(string $context): ?EntityDisplayInterface
+    {
+        $entityTypeId = $this->input->getArgument('entityType');
+        $fieldName = $this->input->getOption('field-name');
+        $existingBundle = $this->getExistingBundleForDefaults();
+
+        $storage = $this->entityTypeManager
+            ->getStorage(sprintf('entity_%s_display', $context));
+        $displays = $storage->loadByProperties([
+            'targetEntityType' => $entityTypeId,
+            'bundle' => $existingBundle,
+        ]);
+
+        foreach ($displays as $display) {
+            if ($settings = $display->getComponent($fieldName)) {
+                return $display;
+            }
+        }
+
+        return null;
+    }
+
+    protected function getExistingBundleForDefaults(): ?string
+    {
+        $entityTypeId = $this->input->getArgument('entityType');
+        $fieldName = $this->input->getOption('field-name');
+        $fieldMap = $this->entityFieldManager->getFieldMap();
+
+        if (empty($fieldMap[$entityTypeId][$fieldName]['bundles'])) {
+            return null;
+        }
+
+        $bundles = $fieldMap[$entityTypeId][$fieldName]['bundles'];
+
+        // Sort bundles to ensure deterministic behavior.
+        sort($bundles);
+
+        return reset($bundles);
     }
 }

--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -630,8 +630,12 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
 
     protected function getExistingFieldForDefaults(): ?FieldDefinitionInterface
     {
-        $entityTypeId = $this->input->getArgument('entityType');
         $existingBundle = $this->getExistingBundleForDefaults();
+        if ($existingBundle === null) {
+            return null;
+        }
+
+        $entityTypeId = $this->input->getArgument('entityType');
         $fieldName = $this->input->getOption('field-name');
 
         return $this->entityFieldManager->getFieldDefinitions($entityTypeId, $existingBundle)[$fieldName];
@@ -639,10 +643,13 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
 
     protected function getExistingEntityDisplayForDefaults(string $context): ?EntityDisplayInterface
     {
+        $existingBundle = $this->getExistingBundleForDefaults();
+        if ($existingBundle === null) {
+            return null;
+        }
+
         $entityTypeId = $this->input->getArgument('entityType');
         $fieldName = $this->input->getOption('field-name');
-        $existingBundle = $this->getExistingBundleForDefaults();
-
         $storage = $this->entityTypeManager
             ->getStorage(sprintf('entity_%s_display', $context));
         $displays = $storage->loadByProperties([

--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -658,7 +658,8 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
         ]);
 
         foreach ($displays as $display) {
-            if ($settings = $display->getComponent($fieldName)) {
+            assert($display instanceof EntityDisplayInterface);
+            if ($display->getComponent($fieldName)) {
                 return $display;
             }
         }

--- a/src/Commands/field/FieldEntityReferenceHooks.php
+++ b/src/Commands/field/FieldEntityReferenceHooks.php
@@ -3,8 +3,11 @@
 namespace Drush\Commands\field;
 
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
+use Drupal\Core\Entity\Display\EntityDisplayInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drush\Attributes as CLI;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
@@ -18,6 +21,7 @@ final class FieldEntityReferenceHooks extends DrushCommands
     public function __construct(
         protected EntityTypeManagerInterface $entityTypeManager,
         protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,
+        protected EntityFieldManagerInterface $entityFieldManager,
     ) {
     }
 
@@ -100,7 +104,7 @@ final class FieldEntityReferenceHooks extends DrushCommands
         return $this->io()->select('Referenced entity type', $choices);
     }
 
-    protected function askReferencedBundles(string $targetType): array
+    protected function askReferencedBundles(string $targetType): ?array
     {
         $choices = [];
         $bundleInfo = $this->entityTypeBundleInfo->getBundleInfo($targetType);
@@ -114,6 +118,41 @@ final class FieldEntityReferenceHooks extends DrushCommands
             $choices[$bundle] = $label;
         }
 
-        return $this->io()->multiselect('Referenced bundles', $choices);
+        $default = $this->getExistingFieldForDefaults()?->getSetting('handler_settings')['target_bundles'] ?? [];
+
+        return $this->io()->multiselect('Referenced bundles', $choices, $default);
     }
+
+    protected function getExistingFieldForDefaults(): ?FieldDefinitionInterface
+    {
+        $existingBundle = $this->getExistingBundleForDefaults();
+        if ($existingBundle === null) {
+            return null;
+        }
+
+        $entityTypeId = $this->input->getArgument('entityType');
+        $fieldName = $this->input->getOption('field-name');
+
+        return $this->entityFieldManager->getFieldDefinitions($entityTypeId, $existingBundle)[$fieldName];
+    }
+
+
+    protected function getExistingBundleForDefaults(): ?string
+    {
+        $entityTypeId = $this->input->getArgument('entityType');
+        $fieldName = $this->input->getOption('field-name');
+        $fieldMap = $this->entityFieldManager->getFieldMap();
+
+        if (empty($fieldMap[$entityTypeId][$fieldName]['bundles'])) {
+            return null;
+        }
+
+        $bundles = $fieldMap[$entityTypeId][$fieldName]['bundles'];
+
+        // Sort bundles to ensure deterministic behavior.
+        sort($bundles);
+
+        return reset($bundles);
+    }
+
 }

--- a/src/Commands/field/FieldEntityReferenceHooks.php
+++ b/src/Commands/field/FieldEntityReferenceHooks.php
@@ -154,5 +154,4 @@ final class FieldEntityReferenceHooks extends DrushCommands
 
         return reset($bundles);
     }
-
 }

--- a/src/Commands/field/FieldEntityReferenceHooks.php
+++ b/src/Commands/field/FieldEntityReferenceHooks.php
@@ -104,7 +104,7 @@ final class FieldEntityReferenceHooks extends DrushCommands
         return $this->io()->select('Referenced entity type', $choices);
     }
 
-    protected function askReferencedBundles(string $targetType): ?array
+    protected function askReferencedBundles(string $targetType): array
     {
         $choices = [];
         $bundleInfo = $this->entityTypeBundleInfo->getBundleInfo($targetType);


### PR DESCRIPTION
I changed it so default values are taken from an existing bundle field, which nowadays is the default behaviour for the re-use field form in the UI as well.