### PR TITLE
docs console

### DIFF
--- a/docs/examples/XkcdCommands.php.md
+++ b/docs/examples/XkcdCommands.php.md
@@ -2,5 +2,5 @@
 edit_url: https://github.com/drush-ops/drush/blob/13.x/examples/Commands/XkcdCommands.php
 ---
 ```php
---8<-- "examples/Commands/XkcdFetchCommands.php"
+--8<-- "examples/Commands/XkcdCommands.php"
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -31,7 +31,7 @@ Drupal Compatibility
     <td> Drush 14 </td>
     <td> 8.3+ </td>
     <td> TBD </td>
-    <td></td> <td></td> <td></td> <td><b>✓ 10.2+</b></td> <td><b>✅11.2+</b></td>
+    <td></td> <td></td> <td></td> <td><b>✓ 10.5+</b></td> <td><b>✅11.2+</b></td>
   </tr>
   <tr>
     <td> Drush 13 </td>


### PR DESCRIPTION
- **Fix example link**
- **Bump min Drupal version for Drush 14**
