### PR TITLE
field-create: Remove unnecessary _none option from allowed formats list

### DIFF
--- a/src/Commands/field/FieldTextHooks.php
+++ b/src/Commands/field/FieldTextHooks.php
@@ -108,12 +108,12 @@ final class FieldTextHooks extends DrushCommands
     protected function askAllowedFormats(): array
     {
         $formats = filter_formats();
-        $choices = ['_none' => '- None -'];
+        $choices = [];
 
         foreach ($formats as $format) {
             $choices[$format->id()] = $format->label();
         }
 
-        return $this->io()->multiselect('Allowed formats', $choices, ['_none']);
+        return $this->io()->multiselect('Allowed formats', $choices);
     }
 }


### PR DESCRIPTION
I think it has become redundant since we have switched to `laravel/prompts`. Either way we have to remove it, since it causes issues when this option is selected, since `_none` is not an actual text format.