### PR TITLE
Fix helpLinks on www.drush.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ sut/drush/sites/synctest.site.yml
 
 # Code tools
 .claude
+
+# mkdocs
+.cache

--- a/src/Command/HelpLinks.php
+++ b/src/Command/HelpLinks.php
@@ -2,6 +2,8 @@
 
 namespace Drush\Command;
 
+use Drush\Drush;
+
 enum HelpLinks
 {
     case Aliases;
@@ -24,8 +26,8 @@ enum HelpLinks
             self::Aliases => new ConsoleLink('site-aliases', 'Creating site aliases for running Drush on remote sites'),
             self::Deploy => new ConsoleLink('deploy', 'Deploy command for Drupal.'),
             self::DrushConfiguration => new ConsoleLink('using-drush-configuration', 'Drush configuration'),
-            self::Policy => new ConsoleLink('examples/PolicyCommands.php', 'Example policy file'),
-            self::ConfigExporting => new ConsoleLink('config-exporting', 'Example policy file'),
+            self::Policy => new ConsoleLink('examples/PolicyListener.php', 'Example policy file'),
+            self::ConfigExporting => new ConsoleLink('config-exporting', 'Drupal config export instructions, including customizing config by environment.'),
             self::Repl => new ConsoleLink('repl', 'Drush\'s PHP Shell'),
             self::Cron => new ConsoleLink('cron', 'Crontab instructions for running your Drupal cron tasks via `drush cron`.'),
             self::Migrate => new ConsoleLink('migrate', 'Defining and running migrations.'),
@@ -40,8 +42,9 @@ enum HelpLinks
     /**
      * A base URL for help links.
      */
-    public static function getDocsUrlBase($branch = 'latest'): string
+    public static function getDocsUrlBase(): string
     {
+        $branch = Drush::getMajorVersion() . '.x';
         return "https://www.drush.org/$branch";
     }
 
@@ -51,6 +54,6 @@ enum HelpLinks
     public function consoleLink(): string
     {
         $link = $this->getConsoleLink();
-        return sprintf('* <href=%s/%s>%s</>', self::getDocsUrlBase(), $link->path, $link->text);
+        return sprintf('  * <href=%s/%s>%s</>', self::getDocsUrlBase(), $link->path, $link->text);
     }
 }

--- a/src/Commands/core/MkCommands.php
+++ b/src/Commands/core/MkCommands.php
@@ -7,6 +7,7 @@ namespace Drush\Commands\core;
 use Consolidation\AnnotatedCommand\AnnotatedCommand;
 use Consolidation\AnnotatedCommand\AnnotationData;
 use Drush\Boot\BootstrapManager;
+use Drush\Command\HelpLinks;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\generate\ApplicationFactory;
 use Drush\Commands\help\HelpCLIFormatter;
@@ -50,6 +51,7 @@ final class MkCommands extends Command
         $destination_path = Path::join($dir_root, 'docs', $destination);
         $this->prepare($destination_path);
         $this->logger->debug('Writing to {path}', ['path' => $destination_path]);
+        $this->getApplication()->get('completion')->setHidden(true);
         $all = $this->getApplication()->all();
         $namespaced = ListCommands::categorize($all);
         [$nav_commands, $pages_commands, $map_commands] = $this->writeContentFilesAndBuildNavAndBuildRedirectMap($namespaced, $destination, $dir_root, $destination_path);
@@ -344,7 +346,11 @@ EOT;
     public static function cliTextToMarkdown(string $text): string
     {
         $text = str_replace(['<info>', '</info>'], '*', $text);
-        $text = preg_replace('/<href=([^>]+)>([^<]+)<\/>/', '[$2]($1)', $text);
+        // If we need to separate the texts from the URLs
+        // preg_match_all('/<href=([^>]+)>([^<]+)<\/>/', $text, $matches);
+        $text = preg_replace('/<href=([^>]+)>([^<]+)<\/>/', '[$2]($1.md)', $text);
+        // Strip the baseUrl and let mkdocs make relative links.
+        $text = str_replace(HelpLinks::getDocsUrlBase(), '..', $text);
         return $text;
     }
 

--- a/src/Listeners/HelpLinksListener.php
+++ b/src/Listeners/HelpLinksListener.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Drush\Listeners;
 
-use Drush\Attributes\HelpLinks;
 use Drush\Attributes as CLI;
+use Drush\Attributes\HelpLinks;
 use Drush\Boot\DrupalBootLevels;
 use Drush\Event\ConsoleDefinitionsEvent;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
@@ -38,6 +38,6 @@ final class HelpLinksListener
 
     public static function bullets(array $links): string
     {
-        return "Help topics:\n" . implode("\n", $links);
+        return "Help topics:\n\n" . implode("\n", $links);
     }
 }


### PR DESCRIPTION
- **Convert console links to Markdown during mkdocs build**
- **Fix helplinks in command help on www.drush.org**
