### PR TITLE
field-create: Advertise target-type, target-bundle and allowed-formats options

### DIFF
--- a/src/Commands/field/FieldCreateCommands.php
+++ b/src/Commands/field/FieldCreateCommands.php
@@ -104,6 +104,7 @@ class FieldCreateCommands extends DrushCommands implements CustomEventAwareInter
     #[CLI\Usage(name: self::CREATE, description: 'Create a field by answering the prompts.')]
     #[CLI\Usage(name: 'field:create taxonomy_term tag', description: 'Create a field and fill in the remaining information through prompts.')]
     #[CLI\Usage(name: 'field:create taxonomy_term tag --field-name=field_tag_label --field-label=Label --field-type=string --field-widget=string_textfield --is-required=1 --cardinality=2', description: 'Create a field in a completely non-interactive way.')]
+    #[CLI\Usage(name: 'field:create node article --field-name=field_article_summary --field-label=Summary --field-type=text_long --allowed-formats=full_html --allowed-formats=basic_html', description: 'Create a formatted text field.')]
     #[CLI\Complete(method_name_or_callable: 'complete')]
     #[CLI\Version(version: '11.0')]
     public function fieldCreate(?string $entityType = null, ?string $bundle = null, array $options = [

--- a/src/Commands/field/FieldEntityReferenceHooks.php
+++ b/src/Commands/field/FieldEntityReferenceHooks.php
@@ -2,6 +2,7 @@
 
 namespace Drush\Commands\field;
 
+use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
@@ -10,7 +11,9 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drush\Attributes as CLI;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 final class FieldEntityReferenceHooks extends DrushCommands
 {
@@ -22,6 +25,24 @@ final class FieldEntityReferenceHooks extends DrushCommands
         protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,
         protected EntityFieldManagerInterface $entityFieldManager,
     ) {
+    }
+
+    #[CLI\Hook(type: HookManager::OPTION_HOOK, target: 'field:create')]
+    public function hookOption(Command $command, AnnotationData $annotationData): void
+    {
+        $command->addOption(
+            'target-type',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            'The target entity type for the entity reference field.',
+        );
+
+        $command->addOption(
+            'target-bundle',
+            '',
+            InputOption::VALUE_OPTIONAL,
+            'The target bundle for the entity reference field.',
+        );
     }
 
     #[CLI\Hook(type: HookManager::ON_EVENT, target: 'field-create-field-storage')]

--- a/src/Commands/field/FieldTextHooks.php
+++ b/src/Commands/field/FieldTextHooks.php
@@ -29,15 +29,6 @@ final class FieldTextHooks extends DrushCommands
     #[CLI\Hook(type: HookManager::OPTION_HOOK, target: FieldCreateCommands::CREATE)]
     public function hookOption(Command $command, AnnotationData $annotationData): void
     {
-        // The options hook is called by mk:docs - avoid an exception.
-        if (!$this->input()->hasOption('field-type')) {
-            return;
-        }
-
-        if (!$this->hasAllowedFormats($this->input()->getOption('field-type'))) {
-            return;
-        }
-
         $command->addOption(
             'allowed-formats',
             '',

--- a/tests/functional/FieldTest.php
+++ b/tests/functional/FieldTest.php
@@ -67,8 +67,6 @@ class FieldTest extends CommandUnishTestCase
             $this->markTestSkipped('Allowed formats available since Drupal 10.1.0');
         }
         // Allowed formats
-        $this->drush(FieldCreateCommands::CREATE, ['unish_article', 'alpha'], ['field-name' => 'field_test_allowed_formats', 'field-label' => 'Text', 'field-type' => 'string', 'allowed-formats' => 'minimal'], null, null, self::EXIT_ERROR);
-        $this->assertStringContainsString('The "--allowed-formats" option does not exist.', $this->getSimplifiedErrorOutput());
         $this->drush(FieldCreateCommands::CREATE, ['unish_article', 'alpha'], ['field-name' => 'field_test_allowed_formats', 'field-label' => 'Text', 'field-type' => 'text_long', 'cardinality' => 1, 'allowed-formats' => 'baz'], null, null, self::EXIT_ERROR);
         $this->assertStringContainsString('The following text formats do not exist: baz', $this->getSimplifiedErrorOutput());
         $this->drush(FieldCreateCommands::CREATE, ['unish_article', 'alpha'], ['field-name' => 'field_test_allowed_formats', 'field-label' => 'Text', 'field-type' => 'text_long', 'cardinality' => 1, 'allowed-formats' => 'plain_text']);


### PR DESCRIPTION
As discussed in #5692.