### PR TITLE
Support form option arrays in SiteInstall arguments

### DIFF
--- a/src/Commands/core/SiteInstallCommands.php
+++ b/src/Commands/core/SiteInstallCommands.php
@@ -89,6 +89,8 @@ final class SiteInstallCommands extends DrushCommands
                 $value = intval($value);
             } elseif ($value == 'NULL') {
                 $value = null;
+            } elseif (preg_match('/^\[.*\]$/', $value)) {
+                $value = explode(',', trim($value, '[]'));
             }
 
             $form_options[$key] = $value;


### PR DESCRIPTION
When using drush si with installation profiles that define complex form elements, some form options are arrays which Drush does not handle correctly.