### PR TITLE
Issue #6470 Fixes inconsistent use of self vs static in AutowireTrait

### DIFF
--- a/src/Commands/AutowireTrait.php
+++ b/src/Commands/AutowireTrait.php
@@ -44,6 +44,7 @@ trait AutowireTrait
             }
         }
 
-        return new self(...$args);
+        // @phpstan-ignore-next-line new.static
+        return new static(...$args);
     }
 }


### PR DESCRIPTION
Issue #6470