### PR TITLE
Document that `updatedb` automatically sets the site in maintenance mode during the process

### DIFF
--- a/src/Commands/updatedb/UpdateDBCommand.php
+++ b/src/Commands/updatedb/UpdateDBCommand.php
@@ -32,7 +32,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
     name: self::NAME,
-    description: 'Apply any database updates required (as with running update.php).',
+    description: 'Apply any database updates required (as with running update.php). Automatically sets the site in maintenance mode, during the update.',
     aliases: ['updb'],
 )]
 #[CLI\Bootstrap(DrupalBootLevels::NONE)]

--- a/src/Commands/updatedb/UpdateDBCommand.php
+++ b/src/Commands/updatedb/UpdateDBCommand.php
@@ -32,7 +32,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
     name: self::NAME,
-    description: 'Apply any database updates required (as with running update.php). Automatically sets the site in maintenance mode, during the update.',
+    description: 'Apply any pending database updates. Automatically enables maintenance mode during the update.',
     aliases: ['updb'],
 )]
 #[CLI\Bootstrap(DrupalBootLevels::NONE)]


### PR DESCRIPTION
## Documentation page

`updatedb`: https://www.drush.org/latest/commands/updatedb/

## Problem

Some users may manually enable and disable maintenance mode via GUI or with Drush, before and after running a database update with `drush updatedb`.

## Solution

`drush updatedb` automatically sets the site in maintenance mode during the process, and we could document this, since many users can then skip the enable/disable maintenance mode steps.

## Extra info

Idea originated from this related issue, raised by @mglaman: 

- https://github.com/drush-ops/drush/issues/6331