### PR TITLE
Increase accuracy of progress bars

### DIFF
--- a/src/Commands/entity/EntityDeleteCommand.php
+++ b/src/Commands/entity/EntityDeleteCommand.php
@@ -80,10 +80,10 @@ final class EntityDeleteCommand extends Command
             }
 
             $chunks = array_chunk($result, (int) $options['chunks'], true);
-            $io->progressStart(count($chunks));
+            $io->progressStart(count($result));
             foreach ($chunks as $chunk) {
                 drush_op($this->doDelete(...), $entity_type, $chunk);
-                $io->progressAdvance();
+                $io->progressAdvance(count($chunk));
             }
             $io->progressFinish();
             $io->success(dt("Deleted !type entity Ids: !ids", ['!type' => $entity_type, '!ids' => implode(', ', array_values($result))]));

--- a/src/Commands/entity/EntitySaveCommand.php
+++ b/src/Commands/entity/EntitySaveCommand.php
@@ -107,10 +107,10 @@ final class EntitySaveCommand extends Command
             $io->success(dt('No matching entities found.'));
         } else {
             $chunks = array_chunk($result, (int) $options['chunks'], true);
-            $io->progressStart(count($chunks));
+            $io->progressStart(count($result));
             foreach ($chunks as $chunk) {
                 drush_op($this->doSave(...), $entity_type, $chunk, $action, $state);
-                $io->progressAdvance();
+                $io->progressAdvance(count($chunk));
             }
             $io->progressFinish();
             $io->success(dt("Saved !type entity ids: !ids", ['!type' => $entity_type, '!ids' => implode(', ', array_values($result))]));


### PR DESCRIPTION
After this change, the progress bar of the `entity:delete` and `entity:save` commands shows the amount of entities to be deleted instead of the amount of chunks. The progress bar itself also progresses a lot smoother.