### PR TITLE
ssl-verify-server-cert is a boolean and 'empty()' doesn't work with FALSE 

### DIFF
--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -138,8 +138,8 @@ EOT;
             $parameters['ssl-key'] = $dbSpec['pdo'][$attribs['ssl_key']];
         }
 
-        if (!empty($dbSpec['pdo'][$attribs['ssl_verify_server_cert']])) {
-            $parameters['ssl-verify-server-cert'] = $dbSpec['pdo'][$attribs['ssl_verify_server_cert']];
+        if (isset($dbSpec['pdo'][$attribs['ssl_verify_server_cert']])) {
+            $parameters['ssl-verify-server-cert'] = $dbSpec['pdo'][$attribs['ssl_verify_server_cert']] ? 'true' : 'false';
         }
 
         return $this->paramsToOptions($parameters);

--- a/src/Sql/SqlMysql.php
+++ b/src/Sql/SqlMysql.php
@@ -139,7 +139,7 @@ EOT;
         }
 
         if (isset($dbSpec['pdo'][$attribs['ssl_verify_server_cert']])) {
-            $parameters['ssl-verify-server-cert'] = $dbSpec['pdo'][$attribs['ssl_verify_server_cert']] ? 'true' : 'false';
+            $parameters['ssl-verify-server-cert'] = (bool) $dbSpec['pdo'][$attribs['ssl_verify_server_cert']];
         }
 
         return $this->paramsToOptions($parameters);


### PR DESCRIPTION
This option is a boolean and behaves differently to the existing ones. Update to handle 'FALSE' being set and update the option value to be a more readable output.

Sorry for new PR, ran into issues trying to rebase.