### PR TITLE
Document in Drush 13 that `updatedb` automatically sets the site in maintenance mode during the process

### DIFF
--- a/src/Commands/core/UpdateDBCommands.php
+++ b/src/Commands/core/UpdateDBCommands.php
@@ -41,7 +41,7 @@ final class UpdateDBCommands extends DrushCommands
      */
 
     /**
-     * Apply any database updates required (as with running update.php).
+     * Apply any pending database updates. Automatically enables maintenance mode during the update.
      */
     #[CLI\Command(name: self::UPDATEDB, aliases: ['updb'])]
     #[CLI\Option(name: 'cache-clear', description: 'Clear caches upon completion.')]


### PR DESCRIPTION
Follow up for Drush 13, see:
- #6486
- #6331