### PR TITLE
Add wildcard/glob pattern support to pm:install and pm:uninstall

### DIFF
--- a/src/Commands/pm/PmInstallCommand.php
+++ b/src/Commands/pm/PmInstallCommand.php
@@ -45,9 +45,10 @@ final class PmInstallCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('modules', InputArgument::IS_ARRAY, 'A comma delimited list of modules.')
+            ->addArgument('modules', InputArgument::IS_ARRAY, 'A comma delimited list of modules. Wildcard patterns (e.g. "views*") are supported.')
             ->addOption(name: 'dry-run', mode: InputOption::VALUE_NONE, description: 'Outputs the operations but will not execute anything.')
-            ->addUsage('pm:install --dry-run content_moderation');
+            ->addUsage('pm:install --dry-run content_moderation')
+            ->addUsage('pm:install "views*"');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -57,6 +58,7 @@ final class PmInstallCommand extends Command
 
         $modules = $input->getArgument('modules');
         $modules = StringUtils::csvToArray($modules);
+        $modules = $this->expandWildcards($modules);
         $todo = $this->addInstallDependencies($modules);
 
         if ($todo === []) {
@@ -97,6 +99,7 @@ final class PmInstallCommand extends Command
     {
         $modules = $input->getArgument('modules');
         $modules = StringUtils::csvToArray($modules);
+        $modules = $this->expandWildcards($modules);
         $modules = $this->addInstallDependencies($modules);
         if ($modules === []) {
             return;

--- a/src/Commands/pm/PmTrait.php
+++ b/src/Commands/pm/PmTrait.php
@@ -116,6 +116,42 @@ trait PmTrait
         return $extension->status == 1 ? 'enabled' : 'disabled';
     }
 
+    /**
+     * Expand wildcard patterns (e.g. "views*") to matching module names.
+     *
+     * Supports glob-style '*' wildcards anywhere in the module name. If no
+     * wildcard characters are present, the input is returned unchanged with
+     * zero overhead (no extension list lookup).
+     *
+     * @param string[] $modules
+     *   Module names, possibly containing '*' glob characters.
+     *
+     * @return string[]
+     *   Expanded list of module names with wildcards resolved.
+     */
+    protected function expandWildcards(array $modules): array
+    {
+        if (!array_filter($modules, fn($m) => str_contains($m, '*'))) {
+            return $modules;
+        }
+
+        $all = array_keys($this->extensionListModule->reset()->getList());
+        $expanded = [];
+        foreach ($modules as $module) {
+            if (str_contains($module, '*')) {
+                $pattern = '/^' . str_replace('\\*', '.*', preg_quote($module, '/')) . '$/';
+                $matches = preg_grep($pattern, $all);
+                if ($matches === []) {
+                    $this->logger->warning('No modules found matching pattern: {pattern}', ['pattern' => $module]);
+                }
+                array_push($expanded, ...array_values($matches));
+            } else {
+                $expanded[] = $module;
+            }
+        }
+        return array_unique($expanded);
+    }
+
     protected function getModuleLinks(Extension $module): array
     {
         $links = [];

--- a/src/Commands/pm/PmUninstallCommand.php
+++ b/src/Commands/pm/PmUninstallCommand.php
@@ -48,9 +48,10 @@ final class PmUninstallCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('modules', InputArgument::IS_ARRAY, 'A comma delimited list of modules.')
+            ->addArgument('modules', InputArgument::IS_ARRAY, 'A comma delimited list of modules. Wildcard patterns (e.g. "views*") are supported.')
             ->addOption(name: 'dry-run', mode: InputOption::VALUE_NONE, description: 'Outputs the operations but will not execute anything.')
-            ->addUsage('pm:uninstall --dry-run field_ui');
+            ->addUsage('pm:uninstall --dry-run field_ui')
+            ->addUsage('pm:uninstall "views*"');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -59,6 +60,7 @@ final class PmUninstallCommand extends Command
 
         $modules = $input->getArgument('modules');
         $modules = StringUtils::csvToArray($modules);
+        $modules = $this->expandWildcards($modules);
 
         $installed_modules = array_filter($modules, $this->moduleHandler->moduleExists(...));
         if ($installed_modules === []) {
@@ -94,6 +96,7 @@ final class PmUninstallCommand extends Command
         $list = [];
         if ($modules = $commandData->input()->getArgument('modules')) {
             $modules = StringUtils::csvToArray($modules);
+            $modules = $this->expandWildcards($modules);
             if ($validation_reasons = $this->moduleInstaller->validateUninstall($modules)) {
                 foreach ($validation_reasons as $module => $reasons) {
                     foreach ($reasons as $reason) {


### PR DESCRIPTION
## Summary

Re-adds wildcard expansion for module names in `pm:install` and `pm:uninstall` commands. This feature existed in Drush 7 ([drupal.org #779612](https://www.drupal.org/project/drush/issues/779612)) but was lost during the Drush 9 rewrite.

Closes #6526

## Changes

- **`PmTrait::expandWildcards()`** — New protected method that expands `*` glob patterns against the available module extension list using regex matching
- **`PmInstallCommand`** — Calls `expandWildcards()` after CSV parsing in both `execute()` and `validateModules()`
- **`PmUninstallCommand`** — Calls `expandWildcards()` after CSV parsing in both `execute()` and `validateUninstall()`
- Updated argument descriptions and added usage examples documenting wildcard support

## Design Decisions

- **Placed in `PmTrait`** so both install and uninstall inherit it without duplication
- **Zero overhead when unused** — short-circuits immediately if no `*` characters are present (no extension list lookup)
- **Warning on no matches** — logs a warning rather than silently doing nothing when a pattern matches zero modules
- **Full glob support** — `*` can appear anywhere in the name (prefix, suffix, or middle), not just trailing

## Examples

```bash
drush pm:install "views*"            # Install all views-related modules
drush pm:install "commerce*"         # Install all commerce modules
drush pm:uninstall "devel*"          # Uninstall devel and related modules
drush pm:install --dry-run "field*"  # Preview what would be installed
```

## Test Plan

- [ ] `drush pm:install --dry-run "views*"` expands to matching modules
- [ ] `drush pm:uninstall --dry-run "nonexistent*"` shows warning
- [ ] `drush pm:install admin_toolbar` (no wildcard) works unchanged
- [ ] Patterns with `*` in the middle work (e.g. `field_*_storage`)