### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/docs/contribute/CONTRIBUTING.md
+++ b/docs/contribute/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Drush is built by people like you! Please [join us](https://github.com/drush-ops
 * Do write comments. You don't have to comment every line, but if you come up with something that's a bit complex/weird, just leave a comment. Bear in mind that you will probably leave the project at some point and that other people will read your code. Undocumented huge amounts of code are nearly worthless!
 * We use [PSR-12](https://www.php-fig.org/psr/psr-12/).
 * Keep it compatible. Do not introduce changes to the public API, or configurations too casually. Don't make incompatible changes without good reasons!
-* Run `composer cs` to check the project for coding style issues and run `composer cbf` to fix them automatically where possible. These scripts use [`PHP_CodeSniffer`](https://github.com/squizlabs/PHP_CodeSniffer) in background.
+* Run `composer cs` to check the project for coding style issues and run `composer cbf` to fix them automatically where possible. These scripts use [`PHP_CodeSniffer`](https://github.com/PHPCSStandards/PHP_CodeSniffer) in background.
 
 ## Documentation
 * The docs are on our [web site](https://www.drush.org). You may also read these from within Drush, with the `drush topic` command.


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932