### PR TITLE
Don't allow updating to incompatible psy/psysh

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
   "conflict": {
     "drupal/core": "< 10.0",
     "drupal/migrate_run": "*",
-    "drupal/migrate_tools": "<= 5"
+    "drupal/migrate_tools": "<= 5",
+    "psy/psysh": ">= 0.12.22"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9c6f617e289f95553c5b68103e8b637",
+    "content-hash": "da19a58073229f6b6ec1a64b30c5a1e0",
     "packages": [
         {
             "name": "chi-teck/drupal-code-generator",
@@ -6378,12 +6378,12 @@
             "version": "3.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
@@ -7676,7 +7676,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -7684,7 +7684,7 @@
         "ext-dom": "*",
         "composer-runtime-api": "^2.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },


### PR DESCRIPTION
psy/psysh 0.12.22 breaks compatibility with Drush 12, so don't allow it to be installed.

This should resolve #6547.