### PR TITLE
fix(pgsql): Replace DROP TABLE with DROP SCHEMA CASCADE to handle extension-owned tables

### DIFF
--- a/src/Sql/SqlPgsql.php
+++ b/src/Sql/SqlPgsql.php
@@ -92,12 +92,20 @@ class SqlPgsql extends SqlBase
 
     public function drop(array $tables): ?bool
     {
-        $return = true;
         if ($tables) {
-            $sql = 'DROP TABLE ' . implode(', ', $tables) . ' CASCADE';
-            $return = $this->query($sql);
+            $return = $this->alwaysQuery('DROP SCHEMA public CASCADE');
+            if ($return) {
+                $return = $this->alwaysQuery('CREATE SCHEMA public');
+            }
+            if ($return) {
+                $dbSpec = $this->getDbSpec();
+                $username = $dbSpec['username'] ?? 'public';
+                $this->alwaysQuery("GRANT ALL ON SCHEMA public TO {$username}");
+                $this->alwaysQuery('GRANT ALL ON SCHEMA public TO public');
+            }
+            return $return;
         }
-        return $return;
+        return true;
     }
 
     public function createdbSql($dbname, $quoted = false): string


### PR DESCRIPTION
Problem
drush sql-drop silently fails on PostgreSQL databases that have extensions installed (e.g. PostGIS, pgvector).

The current implementation generates:

When PostgreSQL extensions own certain tables (e.g. spatial_ref_sys from PostGIS), attempting to DROP TABLE them raises an error:

Since command() sets ON_ERROR_STOP=1, psql aborts on that error and no tables are dropped — but Drush reports success.

Fix
Replace the per-table DROP TABLE loop with a schema-level reset:

This approach:

Drops all user tables, views, sequences, and extension-owned objects in one atomic operation
Avoids conflicts with extension-managed tables
Restores the schema and grants so Drupal can reinstall immediately after
Testing
Verified on:

PostgreSQL with PostGIS, pg_trgm, and pgvector extensions installed
drush sql-drop -y && drush site:install -y completes successfully