### PR TITLE
refactor: `drush cex --diff` output to stdout same as `drush cim --diff`

### DIFF
--- a/src/Commands/config/ConfigExportCommand.php
+++ b/src/Commands/config/ConfigExportCommand.php
@@ -123,7 +123,7 @@ final class ConfigExportCommand extends Command
 
             if ($input->getOption('diff')) {
                 $diff = $this->getDiff($target_storage, $this->configStorageExport, $output);
-                $this->logger->notice($preamble . $diff);
+                $output->writeln($diff);
                 $preview = $diff;
             } else {
                 $change_list = [];


### PR DESCRIPTION
I wanted to use drush cex --diff to do something conditionally on the output.

I am also very used to do its `drush cim  --diff` equivalent.

On https://github.com/drush-ops/drush/issues/6162#issuecomment-4615373283 I metioned that I use

```
drush cim --diff --no 2>/dev/null | grep -v ' !' || true
```

To jsts get the diff. I would have expected drush cex work exactly the same, but I noticed it sends it to stdout instead. I think both should behave the same [and stdout is the right place](https://github.com/drush-ops/drush/blob/bb7505d8260157fd3db168e28928ed156390ee2e/src/Commands/config/ConfigImportCommand.php#L137) for this output.