### PR TITLE
fix(updatedb): support RequirementSeverity enum in updateCheckRequirements

### DIFF
--- a/includes/legacy.inc
+++ b/includes/legacy.inc
@@ -21,6 +21,19 @@ function drush_drupal_requirements_severity(&$requirements) {
     }
 }
 
+/**
+ * Normalizes a single requirement severity to an integer.
+ *
+ * Drupal 11.2+ uses RequirementSeverity enums; older versions use integer
+ * constants (REQUIREMENT_OK=0, REQUIREMENT_WARNING=1, REQUIREMENT_ERROR=2).
+ */
+function drush_drupal_requirement_severity_int(mixed $severity): int {
+    if ($severity instanceof RequirementSeverityAlias) {
+        return $severity->value;
+    }
+    return (int) $severity;
+}
+
 function drush_locale_translation_default_update_options() {
     if (function_exists('_locale_translation_default_update_options')) {
         return _locale_translation_default_update_options();

--- a/src/Commands/updatedb/UpdateDBCommand.php
+++ b/src/Commands/updatedb/UpdateDBCommand.php
@@ -129,18 +129,17 @@ final class UpdateDBCommand extends Command
         $severity = drush_drupal_requirements_severity($requirements);
 
         // If there are issues, report them.
-        // @todo - use enum values instead of ints when we drop support for d11.
         if ($severity != 0) {
             if ($severity === 2) {
                 $return = false;
             }
             foreach ($requirements as $requirement) {
-                if (isset($requirement['severity']) && $requirement['severity'] != 0) {
+                if (isset($requirement['severity']) && drush_drupal_requirement_severity_int($requirement['severity']) !== 0) {
                     $message = isset($requirement['description']) ? DrupalUtil::drushRender($requirement['description']) : '';
                     if (isset($requirement['value']) && $requirement['value']) {
                         $message .= ' (Currently using ' . $requirement['title'] . ' ' . DrupalUtil::drushRender($requirement['value']) . ')';
                     }
-                    $log_level = $requirement['severity'] === 2 ? LogLevel::ERROR : LogLevel::WARNING;
+                    $log_level = drush_drupal_requirement_severity_int($requirement['severity']) === 2 ? LogLevel::ERROR : LogLevel::WARNING;
                     $this->logger->log($log_level, $message);
                 }
             }

--- a/src/Commands/watchdog/WatchdogDeleteCommand.php
+++ b/src/Commands/watchdog/WatchdogDeleteCommand.php
@@ -66,7 +66,7 @@ final class WatchdogDeleteCommand extends Command
             if (!$io->confirm('Do you really want to continue?')) {
                 throw new UserAbortException();
             }
-            $ret = $this->connection->truncate('watchdog')->execute();
+            $this->connection->truncate('watchdog')->execute();
             $io->success('All watchdog messages have been deleted.');
         } elseif (is_numeric($substring)) {
             $output->writeln(sprintf('Watchdog message #%s will be deleted.', $substring));


### PR DESCRIPTION
Fixes #6528

Drupal 11.2+ replaced integer-based requirement severity constants with a backed enum (`RequirementSeverity`). The inner loop in `updateCheckRequirements()` compared `$requirement['severity']` directly against integers `0` and `2`, causing enum values to never match `REQUIREMENT_OK` and always fall through as `[warning]`.

Adds `drush_drupal_requirement_severity_int()` to `legacy.inc` — mirroring the existing `drush_drupal_requirements_severity()` pattern — and uses it for both comparisons in the inner loop.