### PR TITLE
Add support for Guzzle 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "consolidation/site-process": "^5.4.2 || ^6.1",
     "dflydev/dot-access-data": "^3.0.2",
     "grasmash/yaml-cli": "4.x-dev",
-    "guzzlehttp/guzzle": "^7.0",
+    "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
     "laravel/prompts": "^0.3.5",
     "league/container": "^4.2",
     "psy/psysh": "~0.12",


### PR DESCRIPTION
Guzzle 8.0.0 was released on July 20th. Lots of people want to use it, and thus popular packages in the ecosystem like this one need to be updated to support it, so here I am, adding support. :)