### PR TITLE
Fix return type hint for dt() in output.inc

### DIFF
--- a/includes/output.inc
+++ b/includes/output.inc
@@ -19,7 +19,7 @@ use Drush\Utils\StringUtils;
  * @return string
  *   The processed string.
  */
-function dt($string, $args = []) {
+function dt($string, $args = []): string {
   return StringUtils::interpolate($string, $args);
 }
 
@@ -35,7 +35,7 @@ function dt($string, $args = []) {
  * @return string
  *   The plain-text representation of the input.
  */
-function drush_html_to_text($html, $allowed_tags = NULL) {
+function drush_html_to_text($html, $allowed_tags = NULL): string {
   $replacements = [
     '<hr>' => '------------------------------------------------------------------------------',
     '<li>' => '  * ',

--- a/includes/output.inc
+++ b/includes/output.inc
@@ -16,7 +16,7 @@ use Drush\Utils\StringUtils;
  * @param array
  *  An associative array of replacement items.
  *
- * @return
+ * @return string
  *   The processed string.
  */
 function dt($string, $args = []) {


### PR DESCRIPTION
Intelephense detects the return type of `dt()` as "The" without the fix.