### PR TITLE
Document dt() return type

### DIFF
--- a/includes/output.inc
+++ b/includes/output.inc
@@ -16,7 +16,7 @@ use Drush\Utils\StringUtils;
  * @param array
  *  An associative array of replacement items.
  *
- * @return
+ * @return string
  *   The processed string.
  */
 function dt($string, $args = []) {


### PR DESCRIPTION
Documenting the dt() return type should resolve phpstan errors that callers hit when passing dt() output to a string param.