### PR TITLE
Wrong class is created

### DIFF
--- a/src/Commands/AutowireTrait.php
+++ b/src/Commands/AutowireTrait.php
@@ -44,6 +44,6 @@ trait AutowireTrait
             }
         }
 
-        return new self(...$args);
+        return new static(...$args);
     }
 }


### PR DESCRIPTION
1. Have an abstract base class which uses autowiretrait
2. Have a command extend this class but doesn't use autowiretrait
3. kaboom

Workaround: add `use AutowireTrait` to children classes.