### PR TITLE
Restore CI on 13.x against Drupal 11.x-dev

### DIFF
--- a/src/Commands/core/DeployHookCommands.php
+++ b/src/Commands/core/DeployHookCommands.php
@@ -61,6 +61,12 @@ final class DeployHookCommands extends DrushCommands
                 $this->enabledExtensions = array_merge(array_keys($module_list), array_keys($theme_handler->listInfo()));
                 $this->keyValue = $key_value_factory->get('deploy_hook');
                 $this->updateType = 'deploy';
+                // Drupal 11.5+ adds a typed $memoryCache property that the
+                // parent constructor would normally set. Older core has
+                // neither the property nor the cache.memory service.
+                if (property_exists(UpdateRegistry::class, 'memoryCache')) {
+                    $this->memoryCache = \Drupal::service('cache.memory');
+                }
             }
         };
     }

--- a/tests/functional/ConfigTest.php
+++ b/tests/functional/ConfigTest.php
@@ -165,8 +165,7 @@ YAML_FRAGMENT;
         $this->assertFileExists($extensionFile);
         $extension = Yaml::decode(file_get_contents($extensionFile));
         $extension['module']['drush_empty_module'] = 0;
-        require_once $root . "/core/includes/module.inc";
-        $extension['module'] = module_config_sort($extension['module']);
+        $extension['module'] = self::sortModules($extension['module']);
         file_put_contents($extensionFile, Yaml::encode($extension));
 
         // When importing config, the 'woot' module should warn about a validation error.
@@ -186,6 +185,27 @@ YAML_FRAGMENT;
         // We make sure that the service inside the newly enabled module exists now. A fatal
         // error will be thrown by Drupal if the service does not exist.
         $this->drush(PhpCommands::EVAL, ['Drupal::service("drush_empty_module.service");']);
+    }
+
+    /**
+     * Sorts a module list by weight and then name.
+     *
+     * Mirrors the sorting that Drupal applies when writing core.extension.yml.
+     * Drupal's module_config_sort() is not used because it is deprecated and
+     * now proxies to a container service, which is not available in this
+     * process.
+     */
+    protected static function sortModules(array $modules): array
+    {
+        $sort = [];
+        foreach ($modules as $name => $weight) {
+            // Prefix negative weights with 0, positive weights with 1, since
+            // the +/- signs cannot be used for a string sort.
+            $prefix = (int) ($weight >= 0);
+            $sort[] = $prefix . sprintf('%019d', abs($weight)) . $name;
+        }
+        array_multisort($sort, SORT_STRING, $modules);
+        return $modules;
     }
 
     protected function getConfigSyncDir()

--- a/tests/integration/CoreTest.php
+++ b/tests/integration/CoreTest.php
@@ -80,7 +80,9 @@ class CoreTest extends UnishIntegrationTestCase
         $json = $this->getOutputFromJSON();
         $this->assertSame('/user/login', $json['path']);
         $this->assertSame('user.login', $json['name']);
-        $this->assertSame('\Drupal\user\Form\UserLoginForm', $json['defaults']['_form']);
+        // Core declares this route via a PHP attribute, so the class name has
+        // no leading backslash. Older core declared it in YAML, with one.
+        $this->assertSame('Drupal\user\Form\UserLoginForm', ltrim($json['defaults']['_form'], '\\'));
         $this->assertSame("FALSE", $json['requirements']['_user_is_logged_in']);
         $this->assertSame('access_check.user.login_status', $json['options']['_access_checks'][0]);
 


### PR DESCRIPTION
Backport of the test fixes from #6608. All six highest jobs (Drupal 11.x-dev) were failing; lowest passed.

- **`CoreTest::testRoute`** — core moved `user.login` to a `#[Route]` attribute, so `_form` has no leading backslash. Normalized to pass on both.
- **`ConfigTest::testConfigImport`** — `module_config_sort()` now proxies to a container service and throws from the PHPUnit process. Sorts locally instead.
- **`UpdateDBTest` Twig fatal** — no change needed. Twig 3.x briefly added `: void` to `Node::compile()` (breaking core's `TwigNodeCheckDeprecations`) and reverted it on Aug 27; a fresh resolve no longer hits it.

Verified on lowest deps in DDEV (PHP 8.3, MySQL): unit 81, integration 43, functional 67; phpcs clean.