### PR TITLE
Fix theme:install when a theme depends on an uninstalled module (Drupal 10)

### DIFF
--- a/src/Commands/pm/ThemeCommands.php
+++ b/src/Commands/pm/ThemeCommands.php
@@ -72,6 +72,11 @@ final class ThemeCommands extends DrushCommands
                 if (!$this->getModuleInstaller()->install($modules, true)) {
                     throw new \Exception('Unable to install modules.');
                 }
+                // Installing modules rebuilds the container. The injected theme
+                // installer still holds the old config factory, whose cached
+                // core.extension predates the module install, so it would
+                // report the modules we just installed as unmet dependencies.
+                $this->themeInstaller = \Drupal::service('theme_installer');
             }
         }
 

--- a/sut/themes/unish/drush_theme_with_dependency/drush_theme_with_dependency.info.yml
+++ b/sut/themes/unish/drush_theme_with_dependency/drush_theme_with_dependency.info.yml
@@ -1,9 +1,9 @@
 name: Drush theme with dependency
 description: 'Drush theme with dependency'
 core: 8.x
-core_version_requirement: ^8 || ^9 || ^10 || ^11
+core_version_requirement: ^8 || ^9 || ^10 || ^11 || ^12
 type: theme
 base theme: stark
 dependencies:
   - drupal:filter
-  - drush_empty_module:drush_empty_module
+  - dependent1:dependent1

--- a/tests/functional/PmInUnListInfoTest.php
+++ b/tests/functional/PmInUnListInfoTest.php
@@ -52,7 +52,7 @@ class PmInUnListInfoTest extends CommandUnishTestCase
         $this->drush(ThemeCommands::INSTALL, ['drush_theme_with_dependency']);
         $this->drush(PmCommands::LIST, [], ['status' => 'enabled']);
         $out = $this->getOutput();
-        $this->assertStringContainsString('drush_empty_module', $out);
+        $this->assertStringContainsString('dependent1', $out);
 
         $this->drush(StatusCommands::STATUS, [], ['field' => 'drupal-version']);
         $drupal_version = $this->getOutputRaw();
@@ -81,9 +81,6 @@ class PmInUnListInfoTest extends CommandUnishTestCase
         $this->assertEquals($extensionProperties['drush_empty_module']['package'], 'Other');
         $this->assertEquals($extensionProperties['drush_empty_module']['status'], 'Enabled');
         $this->assertEquals($extensionProperties['drush_empty_module']['type'], 'module');
-
-        // Drupal 11.x refuses to uninstall a module a theme depends on.
-        $this->drush(ThemeCommands::UNINSTALL, ['drush_theme_with_dependency']);
 
         // Test uninstall of installed module.
         $this->drush(PmCommands::UNINSTALL, ['drush_empty_module']);


### PR DESCRIPTION
Found while working on #6614: on Drupal 10.4/10.5 `drush theme:install drush_theme_with_dependency` installs the missing modules and then fails with

    Unable to install theme: 'drush_theme_with_dependency' due to unmet module dependencies: 'filter, dependent1'.

Cause: on Drupal 10 the module installer rebuilds the container, but the theme installer injected into `ThemeCommands` keeps the old config factory. Its static cache of `core.extension` (populated by `addInstallDependencies()`) predates the module install, so core sees the freshly installed modules as missing. Drupal 11 resets the container in place, which is why the highest jobs pass.

Fix: after installing modules, fetch `theme_installer` from the current container.

Test: ports the 14.x fixture so `drush_theme_with_dependency` depends on `dependent1`, a module not yet installed, and asserts it in `pm:list`. Verified locally with `composer update --prefer-lowest` (Drupal 10.5.x-dev): the test fails before the fix and passes after.
