### PR TITLE
Raise dependency lower bounds so the lowest set is clean on PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,17 +37,17 @@
     "chi-teck/drupal-code-generator": "^3.6 || ^4@alpha",
     "composer/semver": "^1.4 || ^3",
     "consolidation/annotated-command": "^4.10.2",
-    "consolidation/config": "^2.1.2 || ^3.1.1",
+    "consolidation/config": "^3.1.1",
     "consolidation/filter-via-dot-access-data": "^2.0.2",
     "consolidation/output-formatters": "^4.6.1",
-    "consolidation/robo": "^4.0.6 || ^5.1.0",
+    "consolidation/robo": "^5.1.0",
     "consolidation/site-alias": "^4.1.1",
     "consolidation/site-process": "^5.4.2 || ^6.1",
     "dflydev/dot-access-data": "^3.0.2",
     "grasmash/yaml-cli": "^3.2",
     "guzzlehttp/guzzle": "^7.0",
     "laravel/prompts": "^0.3.5",
-    "league/container": "^4.2",
+    "league/container": "^4.2.5",
     "psy/psysh": "~0.12",
     "symfony/event-dispatcher": "^6 || ^7",
     "symfony/filesystem": "^6.1 || ^7",
@@ -67,6 +67,7 @@
     "squizlabs/php_codesniffer": "^3.7"
   },
   "conflict": {
+    "grasmash/expander": "<3.0.1",
     "drupal/core": "<10.4 <12.0",
     "drupal/migrate_run": "*",
     "drupal/migrate_tools": "<= 5"


### PR DESCRIPTION
Follow-up to #6615. Drush 13 supports PHP 8.3 and newer, but the lowest allowed versions of several dependencies emit "implicitly marking parameter as nullable" deprecations on PHP 8.4. They print to stdout and break JSON output, so the functional suite cannot run locally with `composer update --prefer-lowest` on PHP 8.4 (the DDEV default for this branch). CI does not catch it because the lowest jobs run PHP 8.3.

| Package | Lowest before | Now | Note |
|---|---|---|---|
| consolidation/robo | 4.0.6 | ^5.1.0 | last 4.x has no fix |
| consolidation/config | 2.1.2 | ^3.1.1 | required by robo 5 anyway |
| league/container | 4.2.0 | ^4.2.5 | first 4.x with the fix |
| grasmash/expander | 3.0.0 | conflict <3.0.1 | transitive via config; 3.0.1 has the fix |

Verified in DDEV on PHP 8.4 with `--prefer-lowest` (Drupal 10.5.x-dev): `drush version` emits zero deprecations, and the unit suite plus the JSON-output functional test pass without any ini override.
