### PR TITLE
Raise dependency lower bounds so the lowest set is clean on PHP 8.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "chi-teck/drupal-code-generator": "^3.6 || ^4@dev",
     "composer/semver": "^1.4 || ^3",
     "consolidation/annotated-command": "^4.10.2",
-    "consolidation/config": "^2.1.2 || ^3.1.1",
+    "consolidation/config": "^3.1.1",
     "consolidation/filter-via-dot-access-data": "^2.0.2",
     "consolidation/log": "^3",
     "consolidation/output-formatters": "^4.6.1",
@@ -47,7 +47,7 @@
     "grasmash/yaml-cli": "4.x-dev",
     "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
     "laravel/prompts": "^0.3.5",
-    "league/container": "^4.2",
+    "league/container": "^4.2.5",
     "psy/psysh": "~0.12",
     "symfony/event-dispatcher": "^7 || ^8",
     "symfony/filesystem": "^7 || ^8",
@@ -67,6 +67,7 @@
     "squizlabs/php_codesniffer": "^3.7"
   },
   "conflict": {
+    "grasmash/expander": "<3.0.1",
     "drupal/core": "< 11.3",
     "drupal/migrate_run": "*",
     "drupal/migrate_tools": "<= 5"


### PR DESCRIPTION
14.x counterpart of #6616. The lowest allowed versions of several dependencies emit "implicitly marking parameter as nullable" deprecations on PHP 8.4 and 8.5. They print to stdout and break JSON output, so the functional suite cannot run locally with `composer update --prefer-lowest` on the DDEV default PHP 8.5.

| Package | Lowest before | Now | Note |
|---|---|---|---|
| consolidation/config | 2.1.2 | ^3.1.1 | last 2.x has no fix |
| league/container | 4.2.0 | ^4.2.5 | first 4.x with the fix |
| grasmash/expander | 3.0.0 | conflict <3.0.1 | transitive via config; 3.0.1 has the fix |

Robo is not a dependency on 14.x, so nothing to change there.

Verified locally on PHP 8.5 with `--prefer-lowest`: `drush version` emits zero deprecations, and the unit suite plus the JSON-output functional test pass.
