### PR TITLE
Add deployment identifier to status output

### DIFF
--- a/src/Commands/core/StatusCommand.php
+++ b/src/Commands/core/StatusCommand.php
@@ -72,9 +72,10 @@ use Symfony\Component\Filesystem\Path;
     // config-sync is deprecated. Use 'config' instead.
     'config-sync' => 'Drupal config',
     'config' => 'Drupal config',
+    'deployment-identifier' => 'Deployment identifier',
     '%paths' => 'Other paths'
 ])]
-#[CLI\DefaultTableFields(fields: ['drupal-version', 'uri', 'db-driver', 'db-hostname', 'db-port', 'db-username', 'db-name', 'db-status', 'bootstrap', 'theme', 'admin-theme', 'php-bin', 'php-conf', 'php-os', 'php-version', 'drush-script', 'drush-version', 'drush-temp', 'drush-conf', 'install-profile', 'root', 'site', 'files', 'private', 'temp', 'config'])]
+#[CLI\DefaultTableFields(fields: ['drupal-version', 'deployment-identifier', 'uri', 'db-driver', 'db-hostname', 'db-port', 'db-username', 'db-name', 'db-status', 'bootstrap', 'theme', 'admin-theme', 'php-bin', 'php-conf', 'php-os', 'php-version', 'drush-script', 'drush-version', 'drush-temp', 'drush-conf', 'install-profile', 'root', 'site', 'files', 'private', 'temp', 'config'])]
 #[CLI\HelpLinks(links: [HelpLinks::Readme])]
 class StatusCommand extends Command
 {
@@ -143,6 +144,7 @@ class StatusCommand extends Command
                         $status_table['db-port'] = $db_spec['port'] ?? null;
                     }
                     if ($this->bootstrapManager->hasBootstrapped(DrupalBootLevels::CONFIGURATION)) {
+                        $status_table['deployment-identifier'] = Settings::get('deployment_identifier');
                         $status_table['install-profile'] = \Drupal::installProfile();
                         if ($this->bootstrapManager->hasBootstrapped(DrupalBootLevels::DATABASE)) {
                             $status_table['db-status'] = 'Connected';

--- a/tests/functional/FunctionalCoreTest.php
+++ b/tests/functional/FunctionalCoreTest.php
@@ -207,4 +207,52 @@ class FunctionalCoreTest extends CommandUnishTestCase
             unlink($drush_config_file);
         }
     }
+
+    /**
+     * Tests that status exposes the deployment identifier.
+     */
+    public function testDeploymentIdentifierStatus(): void
+    {
+        $settings_file = $this->webroot()
+          . '/sites/dev/settings.php';
+        $original_settings = file_get_contents($settings_file);
+
+        $this->assertNotFalse($original_settings);
+
+        chmod(dirname($settings_file), 0777);
+        chmod($settings_file, 0777);
+
+        try {
+            $write_result = file_put_contents(
+                $settings_file,
+                "\n\$settings['deployment_identifier']"
+                  . " = 'test-deployment';\n",
+                FILE_APPEND,
+            );
+
+            $this->assertNotFalse($write_result);
+
+            $this->drush(
+                StatusCommand::NAME,
+                [],
+                [
+                  'uri' => 'dev',
+                  'format' => 'json',
+                  'fields' => 'deployment-identifier',
+                ],
+            );
+
+            $output = $this->getOutputFromJSON();
+
+            $this->assertSame(
+                'test-deployment',
+                $output['deployment-identifier'],
+            );
+        } finally {
+            file_put_contents(
+                $settings_file,
+                $original_settings,
+            );
+        }
+    }
 }


### PR DESCRIPTION
Fixes #6554.

Adds the evaluated Drupal deployment identifier to the core:status
property list.

The new field is included in the default table output and is also available
through structured formats. For example:
```

drush status \
  --fields=deployment-identifier \
  --format=json
```

A functional test verifies that the value configured in settings.php is
returned correctly and restores the original settings after execution.

Testing performed:

```
composer cs
composer functional -- --filter testDeploymentIdentifierStatus
Manual verification with drush status
```